### PR TITLE
This should fix #82

### DIFF
--- a/tree.go
+++ b/tree.go
@@ -489,6 +489,7 @@ func (t Tree) CreateNodeAt(node *Node, s Server, path string) error {
 		}
 	case "socket":
 		// nothing to do, we do not restore sockets
+		return nil
 	default:
 		return fmt.Errorf("filetype %q not implemented!\n", node.Type)
 	}


### PR DESCRIPTION
Sockets where just not created, but CreateNodeAt still tried
to run chmod on them.
Now, CreateNodeAt directly returns when finding a socket.
