### PR TITLE
gitignore binary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+cmd/dirdiff/dirdiff
+cmd/gentestdata/gentestdata
+cmd/restic/restic


### PR DESCRIPTION
I keep accidentally `git add .`ing those binary files... :-/

This PR adds the files that are generated by `make` to the gitignore list.
