### PR TITLE
O_NOATIME on Linux

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -169,7 +169,7 @@ func (arch *Archiver) SaveTreeJSON(item interface{}) (Blob, error) {
 // SaveFile stores the content of the file on the backend as a Blob by calling
 // Save for each chunk.
 func (arch *Archiver) SaveFile(p *Progress, node *Node) (Blobs, error) {
-	file, err := os.Open(node.path)
+	file, err := node.OpenForReading()
 	defer file.Close()
 	if err != nil {
 		return nil, err

--- a/node_darwin.go
+++ b/node_darwin.go
@@ -11,6 +11,10 @@ import (
 	"github.com/restic/restic/debug"
 )
 
+func (node *Node) OpenForReading() (*os.File, error) {
+	return os.Open(n.path)
+}
+
 func (node *Node) fill_extra(path string, fi os.FileInfo) (err error) {
 	stat, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {

--- a/node_linux.go
+++ b/node_linux.go
@@ -11,6 +11,10 @@ import (
 	"github.com/restic/restic/debug"
 )
 
+func (node *Node) OpenForReading() (*os.File, error) {
+	return os.OpenFile(node.path, os.O_RDONLY|syscall.O_NOATIME, 0)
+}
+
 func (node *Node) fill_extra(path string, fi os.FileInfo) error {
 	stat, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {

--- a/node_windows.go
+++ b/node_windows.go
@@ -2,6 +2,10 @@ package restic
 
 import "os"
 
+func (node *Node) OpenForReading() (*os.File, error) {
+	return os.Open(n.path)
+}
+
 func (node *Node) fill_extra(path string, fi os.FileInfo) error {
 	return nil
 }


### PR DESCRIPTION
Fixes https://github.com/restic/restic/issues/53.

FYI: You might have to remount your filesystem with the `strictatime` option to actually see the behaviour that this PR is fixing, since Linux seems to mount with `relatime` by default nowadays (which disables updating the atime unless it's newer than the mtime), so on many (most?) Linux systems, this isn't actually an issue. But it's an easy fix, so here it is.
