### PR TITLE
rename "change" to "passwd"

### DIFF
--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -114,7 +114,7 @@ func change_password(s restic.Server) error {
 }
 
 func (cmd CmdKey) Usage() string {
-	return "[list|add|rm|change] [ID]"
+	return "[list|add|rm|passwd] [ID]"
 }
 
 func (cmd CmdKey) Execute(args []string) error {
@@ -139,7 +139,7 @@ func (cmd CmdKey) Execute(args []string) error {
 		}
 
 		return delete_key(s, id)
-	case "change":
+	case "passwd":
 		return change_password(s)
 	}
 

--- a/testsuite/test-key-add-remove.sh
+++ b/testsuite/test-key-add-remove.sh
@@ -15,9 +15,9 @@ unset RESTIC_PASSWORD
 RESTIC_PASSWORD=foo run restic init
 RESTIC_PASSWORD=foo run restic key list
 
-RESTIC_PASSWORD=foo RESTIC_NEWPASSWORD=foobar run restic key change
+RESTIC_PASSWORD=foo RESTIC_NEWPASSWORD=foobar run restic key passwd
 RESTIC_PASSWORD=foobar run restic key list
-RESTIC_PASSWORD=foobar RESTIC_NEWPASSWORD=foo run restic key change
+RESTIC_PASSWORD=foobar RESTIC_NEWPASSWORD=foo run restic key passwd
 
 OLD_PWD=foo
 for i in {1..3}; do


### PR DESCRIPTION
Closes https://github.com/restic/restic/issues/76.

I think `passwd` makes more sense than the suggested `changepwd`, in analogy to the unix `passwd(1)` command.
