### PR TITLE
uid lookup cache

### DIFF
--- a/node.go
+++ b/node.go
@@ -383,10 +383,13 @@ func (node *Node) fillExtra(path string, fi os.FileInfo) error {
 
 	node.Inode = stat.Ino
 
-	node.fillUser(stat)
 	node.fillTimes(stat)
 
 	var err error
+
+	if err = node.fillUser(stat); err != nil {
+		return err
+	}
 
 	switch node.Type {
 	case "file":


### PR DESCRIPTION
Not sure if this is worth it...

I saw a very small (somewhat consistent) improvement in the naive timings I did, but nothing too crazy.

before:

```
scanned 5371 directories, 18112 files in 0:00
loading blobs
[0:26] 100.00%  30.370 MiB/s  794.115 MiB / 794.115 MiB  23484 / 23483 items  ETA 0:00
duration: 0:26, 30.54MiB/s
snapshot 95879948 saved
cmd/restic/restic -r /tmp/restic backup ~code/shopify  38.82s user 12.04s system 178% cpu 28.430 total
```

after:

```
scanned 5371 directories, 18112 files in 0:00
loading blobs
[0:25] 100.00%  30.960 MiB/s  794.115 MiB / 794.115 MiB  23484 / 23483 items  ETA 0:00
duration: 0:25, 31.76MiB/s
snapshot 88dadece saved
cmd/restic/restic -r /tmp/restic backup ~code/shopify  37.78s user 11.84s system 178% cpu 27.747 total
```
