### PR TITLE
Fix progress off-by-1

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -515,7 +515,7 @@ func (arch *Archiver) dirWorker(wg *sync.WaitGroup, p *Progress, done <-chan str
 				// if this is the top-level dir, only create a stub node
 				node = &Node{}
 			} else {
-				// else create note from path and fi
+				// else create node from path and fi
 				node, err = NodeFromFileInfo(dir.Path(), dir.Info())
 				if err != nil {
 					node.Error = err.Error()
@@ -534,7 +534,9 @@ func (arch *Archiver) dirWorker(wg *sync.WaitGroup, p *Progress, done <-chan str
 			node.blobs = Blobs{blob}
 
 			dir.Result() <- node
-			p.Report(Stat{Dirs: 1})
+			if dir.Path() != "" {
+				p.Report(Stat{Dirs: 1})
+			}
 		case <-done:
 			// pipeline was cancelled
 			return


### PR DESCRIPTION
Fixes this:

```
[0:00] NaN%  0B/s  0B / 0B  2 / 1 items  ETA 0:00
```

The number of "done" items is always one bigger than the number of "todo" items.

Looks like the root node is counted twice. I didn't quite understand the code, but I guess you are creating one node with an empty Path() and then another node below that with the name of the actual directory? 

Not sure if this is the best way to fix it, but it does seem to work :-) Please suggest something else if there is a cleaner solution. This does feel kinda hacky.
