### PR TITLE
Fix O_NOATIME permission error

### DIFF
--- a/node_linux.go
+++ b/node_linux.go
@@ -12,7 +12,11 @@ import (
 )
 
 func (node *Node) OpenForReading() (*os.File, error) {
-	return os.OpenFile(node.path, os.O_RDONLY|syscall.O_NOATIME, 0)
+	file, err := os.OpenFile(node.path, os.O_RDONLY|syscall.O_NOATIME, 0)
+	if os.IsPermission(err) {
+		return os.OpenFile(node.path, os.O_RDONLY, 0)
+	}
+	return file, err
 }
 
 func (node *Node) fillExtra(path string, fi os.FileInfo) error {


### PR DESCRIPTION
NOATIME is only allowed if you are the owner of a file (or root).

This PR retries without the flag if it fails because of permission errors.
