### PR TITLE
Count errors separately and not as files that are "done"

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -403,7 +403,7 @@ func (arch *Archiver) fileWorker(wg *sync.WaitGroup, p *Progress, done <-chan st
 				fmt.Fprintf(os.Stderr, "error for %v: %v\n", e.Path(), e.Error())
 				// ignore this file
 				e.Result() <- nil
-				p.Report(Stat{Files: 1})
+				p.Report(Stat{Errors: 1})
 				continue
 			}
 
@@ -412,7 +412,7 @@ func (arch *Archiver) fileWorker(wg *sync.WaitGroup, p *Progress, done <-chan st
 				// TODO: integrate error reporting
 				debug.Log("Archiver.fileWorker", "NodeFromFileInfo returned error for %v: %v", node.path, err)
 				e.Result() <- nil
-				p.Report(Stat{Files: 1})
+				p.Report(Stat{Errors: 1})
 				continue
 			}
 
@@ -449,7 +449,7 @@ func (arch *Archiver) fileWorker(wg *sync.WaitGroup, p *Progress, done <-chan st
 					fmt.Fprintf(os.Stderr, "error for %v: %v\n", node.path, err)
 					// ignore this file
 					e.Result() <- nil
-					p.Report(Stat{Files: 1})
+					p.Report(Stat{Errors: 1})
 					continue
 				}
 			} else {

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -139,12 +139,13 @@ func newArchiveProgress(todo restic.Stat) *restic.Progress {
 			percent = 100
 		}
 
-		status1 := fmt.Sprintf("[%s] %3.2f%%  %s/s  %s / %s  %d / %d items  ",
+		status1 := fmt.Sprintf("[%s] %3.2f%%  %s/s  %s / %s  %d / %d items  %d errors  ",
 			formatDuration(d),
 			percent,
 			formatBytes(bps),
 			formatBytes(s.Bytes), formatBytes(todo.Bytes),
-			itemsDone, itemsTodo)
+			itemsDone, itemsTodo,
+			s.Errors)
 		status2 := fmt.Sprintf("ETA %s ", formatSeconds(eta))
 
 		w, _, err := terminal.GetSize(int(os.Stdout.Fd()))

--- a/progress.go
+++ b/progress.go
@@ -24,11 +24,12 @@ type Progress struct {
 }
 
 type Stat struct {
-	Files uint64
-	Dirs  uint64
-	Bytes uint64
-	Trees uint64
-	Blobs uint64
+	Files  uint64
+	Dirs   uint64
+	Bytes  uint64
+	Trees  uint64
+	Blobs  uint64
+	Errors uint64
 }
 
 type ProgressFunc func(s Stat, runtime time.Duration, ticker bool)
@@ -173,6 +174,7 @@ func (s *Stat) Add(other Stat) {
 	s.Files += other.Files
 	s.Trees += other.Trees
 	s.Blobs += other.Blobs
+	s.Errors += other.Errors
 }
 
 func (s Stat) String() string {
@@ -192,6 +194,6 @@ func (s Stat) String() string {
 		str = fmt.Sprintf("%dB", s.Bytes)
 	}
 
-	return fmt.Sprintf("Stat(%d files, %d dirs, %v trees, %v blobs, %v)",
-		s.Files, s.Dirs, s.Trees, s.Blobs, str)
+	return fmt.Sprintf("Stat(%d files, %d dirs, %v trees, %v blobs, %d errors, %v)",
+		s.Files, s.Dirs, s.Trees, s.Blobs, s.Errors, str)
 }


### PR DESCRIPTION
Currently, files that are raising errors while trying to be backed up will be counted towards the number of files that are "done", which I think is confusing. Instead, count "errors" separately.
