### PR TITLE
Remove unused struct fields

### DIFF
--- a/snapshot.go
+++ b/snapshot.go
@@ -19,8 +19,6 @@ type Snapshot struct {
 	Username string      `json:"username,omitempty"`
 	UID      uint32      `json:"uid,omitempty"`
 	GID      uint32      `json:"gid,omitempty"`
-	UserID   string      `json:"userid,omitempty"`
-	GroupID  string      `json:"groupid,omitempty"`
 
 	id backend.ID // plaintext ID, used during restore
 }


### PR DESCRIPTION
These fields were only used on windows, which support was removed for in e0fbd83a2d756d04ec1df3108fe5b9c69f0f183f.
