### PR TITLE
golint

### DIFF
--- a/map.go
+++ b/map.go
@@ -188,16 +188,16 @@ func (bl *Map) Len() int {
 }
 
 // Prune deletes all IDs from the map except the ones listed in ids.
-func (m *Map) Prune(ids *backend.IDSet) {
-	m.m.Lock()
-	defer m.m.Unlock()
+func (bl *Map) Prune(ids *backend.IDSet) {
+	bl.m.Lock()
+	defer bl.m.Unlock()
 
 	pos := 0
-	for pos < len(m.list) {
-		blob := m.list[pos]
+	for pos < len(bl.list) {
+		blob := bl.list[pos]
 		if ids.Find(blob.ID) != nil {
 			// remove element
-			m.list = append(m.list[:pos], m.list[pos+1:]...)
+			bl.list = append(bl.list[:pos], bl.list[pos+1:]...)
 			continue
 		}
 
@@ -206,14 +206,14 @@ func (m *Map) Prune(ids *backend.IDSet) {
 }
 
 // DeleteID removes the plaintext ID id from the map.
-func (m *Map) DeleteID(id backend.ID) {
-	m.m.Lock()
-	defer m.m.Unlock()
+func (bl *Map) DeleteID(id backend.ID) {
+	bl.m.Lock()
+	defer bl.m.Unlock()
 
-	pos, _, err := m.find(server.Blob{ID: id}, false)
+	pos, _, err := bl.find(server.Blob{ID: id}, false)
 	if err != nil {
 		return
 	}
 
-	m.list = append(m.list[:pos], m.list[pos+1:]...)
+	bl.list = append(bl.list[:pos], bl.list[pos+1:]...)
 }

--- a/node.go
+++ b/node.go
@@ -41,17 +41,17 @@ type Node struct {
 	blobs server.Blobs
 }
 
-func (n Node) String() string {
-	switch n.Type {
+func (node Node) String() string {
+	switch node.Type {
 	case "file":
 		return fmt.Sprintf("%s %5d %5d %6d %s %s",
-			n.Mode, n.UID, n.GID, n.Size, n.ModTime, n.Name)
+			node.Mode, node.UID, node.GID, node.Size, node.ModTime, node.Name)
 	case "dir":
 		return fmt.Sprintf("%s %5d %5d %6d %s %s",
-			n.Mode|os.ModeDir, n.UID, n.GID, n.Size, n.ModTime, n.Name)
+			node.Mode|os.ModeDir, node.UID, node.GID, node.Size, node.ModTime, node.Name)
 	}
 
-	return fmt.Sprintf("<Node(%s) %s>", n.Type, n.Name)
+	return fmt.Sprintf("<Node(%s) %s>", node.Type, node.Name)
 }
 
 func (node Node) Tree() *Tree {
@@ -258,7 +258,7 @@ func (node Node) MarshalJSON() ([]byte, error) {
 
 func (node *Node) UnmarshalJSON(data []byte) error {
 	type nodeJSON Node
-	var nj *nodeJSON = (*nodeJSON)(node)
+	nj := (*nodeJSON)(node)
 
 	err := json.Unmarshal(data, nj)
 	if err != nil {

--- a/pools.go
+++ b/pools.go
@@ -27,7 +27,7 @@ func (s *poolStats) Get(k string) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	s.get += 1
+	s.get++
 	cur := s.get - s.put
 	if cur > s.max {
 		s.max = cur
@@ -53,7 +53,7 @@ func (s *poolStats) Put(k string) {
 	s.m.Lock()
 	defer s.m.Unlock()
 
-	s.put += 1
+	s.put++
 
 	if k != "" {
 		s.mput[k]++

--- a/restorer.go
+++ b/restorer.go
@@ -1,7 +1,6 @@
 package restic
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -75,7 +74,7 @@ func (res *Restorer) to(dst string, dir string, treeBlob server.Blob) error {
 
 		if node.Type == "dir" {
 			if node.Subtree == nil {
-				return errors.New(fmt.Sprintf("Dir without subtree in tree %s", treeBlob))
+				return fmt.Errorf("Dir without subtree in tree %s", treeBlob)
 			}
 
 			subp := filepath.Join(dir, node.Name)


### PR DESCRIPTION
Fixes a few minor style issues that [golint](https://github.com/golang/lint) is complaining about, like consistent naming for receivers, etc.

Everything that's still left is about missing documentation on exported fields/functions.
