### PR TITLE
Refactor node.go

### DIFF
--- a/node.go
+++ b/node.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/juju/arrar"
 	"github.com/restic/restic/backend"
+	"github.com/restic/restic/debug"
 	"github.com/restic/restic/server"
 )
 
@@ -307,4 +308,32 @@ func (node Node) sameContent(other Node) bool {
 	}
 
 	return true
+}
+
+func (node *Node) isNewer(path string, fi os.FileInfo) bool {
+	if node.Type != "file" {
+		debug.Log("node.isNewer", "node %v is newer: not file", path)
+		return true
+	}
+
+	tpe := nodeTypeFromFileInfo(fi)
+	if node.Name != fi.Name() || node.Type != tpe {
+		debug.Log("node.isNewer", "node %v is newer: name or type changed", path)
+		return true
+	}
+
+	extendedStat := fi.Sys().(*syscall.Stat_t)
+	inode := extendedStat.Ino
+	size := uint64(extendedStat.Size)
+
+	if node.ModTime != fi.ModTime() ||
+		node.ChangeTime != changeTime(extendedStat) ||
+		node.Inode != inode ||
+		node.Size != size {
+		debug.Log("node.isNewer", "node %v is newer: timestamp, size or inode changed", path)
+		return true
+	}
+
+	debug.Log("node.isNewer", "node %v is not newer", path)
+	return false
 }

--- a/node.go
+++ b/node.go
@@ -373,9 +373,9 @@ func (node *Node) fillExtra(path string, fi os.FileInfo) error {
 	case "symlink":
 		node.LinkTarget, err = os.Readlink(path)
 	case "dev":
-		node.fillDevice(stat)
+		node.Device = uint64(stat.Rdev)
 	case "chardev":
-		node.fillDevice(stat)
+		node.Device = uint64(stat.Rdev)
 	case "fifo":
 	case "socket":
 	default:

--- a/node_darwin.go
+++ b/node_darwin.go
@@ -15,10 +15,10 @@ func (node *Node) OpenForReading() (*os.File, error) {
 	return os.Open(node.path)
 }
 
-func (node *Node) fillExtra(path string, fi os.FileInfo) (err error) {
+func (node *Node) fillExtra(path string, fi os.FileInfo) error {
 	stat, ok := fi.Sys().(*syscall.Stat_t)
 	if !ok {
-		return
+		return nil
 	}
 
 	node.ChangeTime = time.Unix(stat.Ctimespec.Unix())
@@ -26,24 +26,19 @@ func (node *Node) fillExtra(path string, fi os.FileInfo) (err error) {
 	node.UID = stat.Uid
 	node.GID = stat.Gid
 
-	// TODO: cache uid lookup
-	if u, nil := user.LookupId(strconv.Itoa(int(stat.Uid))); err == nil {
+	if u, err := user.LookupId(strconv.Itoa(int(stat.Uid))); err == nil {
 		node.User = u.Username
 	}
 
-	// TODO: implement getgrnam() or use https://github.com/kless/osutil
-	// if g, nil := user.LookupId(strconv.Itoa(int(stat.Uid))); err == nil {
-	// 	node.User = u.Username
-	// }
-
 	node.Inode = stat.Ino
+
+	var err error
 
 	switch node.Type {
 	case "file":
 		node.Size = uint64(stat.Size)
 		node.Links = uint64(stat.Nlink)
 	case "dir":
-		// nothing to do
 	case "symlink":
 		node.LinkTarget, err = os.Readlink(path)
 	case "dev":
@@ -51,11 +46,9 @@ func (node *Node) fillExtra(path string, fi os.FileInfo) (err error) {
 	case "chardev":
 		node.Device = uint64(stat.Rdev)
 	case "fifo":
-		// nothing to do
 	case "socket":
-		// nothing to do
 	default:
-		panic(fmt.Sprintf("invalid node type %q", node.Type))
+		err = fmt.Errorf("invalid node type %q", node.Type)
 	}
 
 	return err
@@ -74,27 +67,22 @@ func (node *Node) createFifoAt(path string) error {
 }
 
 func (node *Node) isNewer(path string, fi os.FileInfo) bool {
-	// if this node has a type other than "file", treat as if content has changed
 	if node.Type != "file" {
 		debug.Log("node.isNewer", "node %v is newer: not file", path)
 		return true
 	}
 
-	// if the name or type has changed, this is surely something different
-	tpe := nodeTypeFromFileInfo(path, fi)
+	tpe := nodeTypeFromFileInfo(fi)
 	if node.Name != fi.Name() || node.Type != tpe {
 		debug.Log("node.isNewer", "node %v is newer: name or type changed", path)
 		return false
 	}
 
-	// collect extended stat
-	stat := fi.Sys().(*syscall.Stat_t)
+	extendedStat := fi.Sys().(*syscall.Stat_t)
+	changeTime := time.Unix(extendedStat.Ctimespec.Unix())
+	inode := extendedStat.Ino
+	size := uint64(extendedStat.Size)
 
-	changeTime := time.Unix(stat.Ctimespec.Unix())
-	inode := stat.Ino
-	size := uint64(stat.Size)
-
-	// if timestamps or inodes differ, content has changed
 	if node.ModTime != fi.ModTime() ||
 		node.ChangeTime != changeTime ||
 		node.Inode != inode ||
@@ -103,7 +91,6 @@ func (node *Node) isNewer(path string, fi os.FileInfo) bool {
 		return false
 	}
 
-	// otherwise the node is assumed to have the same content
 	debug.Log("node.isNewer", "node %v is not newer", path)
 	return false
 }

--- a/node_darwin.go
+++ b/node_darwin.go
@@ -66,31 +66,6 @@ func (node *Node) createFifoAt(path string) error {
 	return syscall.Mkfifo(path, 0600)
 }
 
-func (node *Node) isNewer(path string, fi os.FileInfo) bool {
-	if node.Type != "file" {
-		debug.Log("node.isNewer", "node %v is newer: not file", path)
-		return true
-	}
-
-	tpe := nodeTypeFromFileInfo(fi)
-	if node.Name != fi.Name() || node.Type != tpe {
-		debug.Log("node.isNewer", "node %v is newer: name or type changed", path)
-		return false
-	}
-
-	extendedStat := fi.Sys().(*syscall.Stat_t)
-	changeTime := time.Unix(extendedStat.Ctimespec.Unix())
-	inode := extendedStat.Ino
-	size := uint64(extendedStat.Size)
-
-	if node.ModTime != fi.ModTime() ||
-		node.ChangeTime != changeTime ||
-		node.Inode != inode ||
-		node.Size != size {
-		debug.Log("node.isNewer", "node %v is newer: timestamp or inode changed", path)
-		return false
-	}
-
-	debug.Log("node.isNewer", "node %v is not newer", path)
-	return false
+func changeTime(stat *syscall.Stat_t) time.Unix {
+	return time.Unix(stat.Ctimespec.Unix())
 }

--- a/node_darwin.go
+++ b/node_darwin.go
@@ -1,27 +1,13 @@
 package restic
 
 import (
-	"fmt"
 	"os"
-	"os/user"
-	"strconv"
 	"syscall"
 	"time"
-
-	"github.com/restic/restic/debug"
 )
 
 func (node *Node) OpenForReading() (*os.File, error) {
 	return os.Open(node.path)
-}
-
-func (node *Node) fillTimes(stat *syscall.Stat_t) {
-	node.ChangeTime = time.Unix(stat.Ctimespec.Unix())
-	node.AccessTime = time.Unix(stat.Atimespec.Unix())
-}
-
-func (node *Node) fillDevice(stat *syscall.Stat_t) {
-	node.Device = uint64(stat.Rdev)
 }
 
 func (node *Node) createDevAt(path string) error {
@@ -36,6 +22,11 @@ func (node *Node) createFifoAt(path string) error {
 	return syscall.Mkfifo(path, 0600)
 }
 
-func changeTime(stat *syscall.Stat_t) time.Unix {
+func changeTime(stat *syscall.Stat_t) time.Time {
 	return time.Unix(stat.Ctimespec.Unix())
+}
+
+func (node *Node) fillTimes(stat *syscall.Stat_t) {
+	node.ChangeTime = time.Unix(stat.Ctimespec.Unix())
+	node.AccessTime = time.Unix(stat.Atimespec.Unix())
 }

--- a/node_linux.go
+++ b/node_linux.go
@@ -7,8 +7,6 @@ import (
 	"strconv"
 	"syscall"
 	"time"
-
-	"github.com/restic/restic/debug"
 )
 
 func (node *Node) OpenForReading() (*os.File, error) {
@@ -70,31 +68,6 @@ func (node *Node) createFifoAt(path string) error {
 	return syscall.Mkfifo(path, 0600)
 }
 
-func (node *Node) isNewer(path string, fi os.FileInfo) bool {
-	if node.Type != "file" {
-		debug.Log("node.isNewer", "node %v is newer: not file", path)
-		return true
-	}
-
-	tpe := nodeTypeFromFileInfo(fi)
-	if node.Name != fi.Name() || node.Type != tpe {
-		debug.Log("node.isNewer", "node %v is newer: name or type changed", path)
-		return true
-	}
-
-	extendedStat := fi.Sys().(*syscall.Stat_t)
-	changeTime := time.Unix(extendedStat.Ctim.Unix())
-	inode := extendedStat.Ino
-	size := uint64(extendedStat.Size)
-
-	if node.ModTime != fi.ModTime() ||
-		node.ChangeTime != changeTime ||
-		node.Inode != inode ||
-		node.Size != size {
-		debug.Log("node.isNewer", "node %v is newer: timestamp, size or inode changed", path)
-		return true
-	}
-
-	debug.Log("node.isNewer", "node %v is not newer", path)
-	return false
+func changeTime(stat *syscall.Stat_t) time.Time {
+	return time.Unix(stat.Ctim.Unix())
 }

--- a/node_linux.go
+++ b/node_linux.go
@@ -30,15 +30,9 @@ func (node *Node) fillExtra(path string, fi os.FileInfo) error {
 	node.UID = stat.Uid
 	node.GID = stat.Gid
 
-	// TODO: cache uid lookup
 	if u, err := user.LookupId(strconv.Itoa(int(stat.Uid))); err == nil {
 		node.User = u.Username
 	}
-
-	// TODO: implement getgrnam() or use https://github.com/kless/osutil
-	// if g, nil := user.LookupId(strconv.Itoa(int(stat.Uid))); err == nil {
-	// 	node.User = u.Username
-	// }
 
 	node.Inode = stat.Ino
 
@@ -49,7 +43,6 @@ func (node *Node) fillExtra(path string, fi os.FileInfo) error {
 		node.Size = uint64(stat.Size)
 		node.Links = uint64(stat.Nlink)
 	case "dir":
-		// nothing to do
 	case "symlink":
 		node.LinkTarget, err = os.Readlink(path)
 	case "dev":
@@ -57,11 +50,9 @@ func (node *Node) fillExtra(path string, fi os.FileInfo) error {
 	case "chardev":
 		node.Device = stat.Rdev
 	case "fifo":
-		// nothing to do
 	case "socket":
-		// nothing to do
 	default:
-		panic(fmt.Sprintf("invalid node type %q", node.Type))
+		err = fmt.Errorf("invalid node type %q", node.Type)
 	}
 
 	return err
@@ -80,27 +71,22 @@ func (node *Node) createFifoAt(path string) error {
 }
 
 func (node *Node) isNewer(path string, fi os.FileInfo) bool {
-	// if this node has a type other than "file", treat as if content has changed
 	if node.Type != "file" {
 		debug.Log("node.isNewer", "node %v is newer: not file", path)
 		return true
 	}
 
-	// if the name or type has changed, this is surely something different
-	tpe := nodeTypeFromFileInfo(path, fi)
+	tpe := nodeTypeFromFileInfo(fi)
 	if node.Name != fi.Name() || node.Type != tpe {
 		debug.Log("node.isNewer", "node %v is newer: name or type changed", path)
 		return true
 	}
 
-	// collect extended stat
-	stat := fi.Sys().(*syscall.Stat_t)
+	extendedStat := fi.Sys().(*syscall.Stat_t)
+	changeTime := time.Unix(extendedStat.Ctim.Unix())
+	inode := extendedStat.Ino
+	size := uint64(extendedStat.Size)
 
-	changeTime := time.Unix(stat.Ctim.Unix())
-	inode := stat.Ino
-	size := uint64(stat.Size)
-
-	// if timestamps or inodes differ, content has changed
 	if node.ModTime != fi.ModTime() ||
 		node.ChangeTime != changeTime ||
 		node.Inode != inode ||
@@ -109,7 +95,6 @@ func (node *Node) isNewer(path string, fi os.FileInfo) bool {
 		return true
 	}
 
-	// otherwise the node is assumed to have the same content
 	debug.Log("node.isNewer", "node %v is not newer", path)
 	return false
 }

--- a/node_linux.go
+++ b/node_linux.go
@@ -14,15 +14,6 @@ func (node *Node) OpenForReading() (*os.File, error) {
 	return file, err
 }
 
-func (node *Node) fillTimes(stat *syscall.Stat_t) {
-	node.ChangeTime = time.Unix(stat.Ctim.Unix())
-	node.AccessTime = time.Unix(stat.Atim.Unix())
-}
-
-func (node *Node) fillDevice(stat *syscall.Stat_t) {
-	node.Device = stat.Rdev
-}
-
 func (node *Node) createDevAt(path string) error {
 	return syscall.Mknod(path, syscall.S_IFBLK|0600, int(node.Device))
 }
@@ -33,6 +24,11 @@ func (node *Node) createCharDevAt(path string) error {
 
 func (node *Node) createFifoAt(path string) error {
 	return syscall.Mkfifo(path, 0600)
+}
+
+func (node *Node) fillTimes(stat *syscall.Stat_t) {
+	node.ChangeTime = time.Unix(stat.Ctim.Unix())
+	node.AccessTime = time.Unix(stat.Atim.Unix())
 }
 
 func changeTime(stat *syscall.Stat_t) time.Time {

--- a/restorer.go
+++ b/restorer.go
@@ -47,7 +47,7 @@ func (res *Restorer) to(dst string, dir string, treeBlob server.Blob) error {
 
 		if res.Filter == nil ||
 			res.Filter(filepath.Join(dir, node.Name), dstpath, node) {
-			err := CreateNodeAt(node, tree.Map, res.s, dstpath)
+			err := node.CreateAt(dstpath, tree.Map, res.s)
 
 			// Did it fail because of ENOENT?
 			if arrar.Check(err, func(err error) bool {
@@ -60,7 +60,7 @@ func (res *Restorer) to(dst string, dir string, treeBlob server.Blob) error {
 				// Create parent directories and retry
 				err = os.MkdirAll(filepath.Dir(dstpath), 0700)
 				if err == nil || err == os.ErrExist {
-					err = CreateNodeAt(node, tree.Map, res.s, dstpath)
+					err = node.CreateAt(dstpath, tree.Map, res.s)
 				}
 			}
 


### PR DESCRIPTION
This refactors node.go in a couple of different ways. I find the changes make the file much easier to read (and I removed some code that I think was redundant).

I made the following changes. Sorry it's so many in one PR. I can try to break it into several smaller PRs if necessary.
- `nodeTypeFromFileInfo` was taking a `path` argument that wasn't used. I removed it.
- Renamed `CreateNodeAt(node, things, path)` to `node.CreateAt(path, things)`, since I think that's more idiomatic.
- Split the `CreateAt` function into several smaller functions, such that `CreateAt` itself operates on only one level of abstraction. I think this makes the function easier to understand.
- Remove a bunch of obvious (and therefore imho useless) comments as well as a few TODO comments. (I think TODO comments are a code smell and those things should be moved into GitHub issues, not pollute the codebase).
- Get rid of a couple of useless `Chown` calls (for example the previous code was calling `Lchown` when creating directories and files and then a few lines later down it was calling `Chown` again. The new code always just calls `Lchown` once, since I think that should work as expected for all types).
- The old code was calling `Utimesnano` and then later calling `Chtimes` again. That was probably redudant too, right? I removed the `Chtimes` call.
- Break some part of the `Equals` function out into a `sameContent` function.
- Delete the `SameContent` function since it wasn't being called anywhere.
- Change a few other small style issues that I consider to be cleaner now.
- Change a `panic` to be an error instead. Not sure if this is ok, but the issue seemed to me not severe enough to crash the whole program (unknown node type).

GitHub is not doing the greatest job at displaying the diff. Maybe try the side-by-side view... Or just look at the new file on it's own. Probably easier to review.
