### PR TITLE
debug: Add location to log, improve formatting

### DIFF
--- a/debug/debug.go
+++ b/debug/debug.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"syscall"
@@ -145,6 +146,8 @@ func getPosition() string {
 	return fmt.Sprintf("%3d %s:%3d", goroutine, filepath.Base(file), line)
 }
 
+var maxTagLen = 10
+
 func Log(tag string, f string, args ...interface{}) {
 	opts.m.Lock()
 	defer opts.m.Unlock()
@@ -153,7 +156,12 @@ func Log(tag string, f string, args ...interface{}) {
 		f += "\n"
 	}
 
-	formatString := fmt.Sprintf("[% 25s] %-20s %s", tag, getPosition(), f)
+	if len(tag) > maxTagLen {
+		maxTagLen = len(tag)
+	}
+
+	formatStringTag := "[%" + strconv.FormatInt(int64(maxTagLen), 10) + "s]"
+	formatString := fmt.Sprintf(formatStringTag+" %s %s", tag, getPosition(), f)
 
 	dbgprint := func() {
 		fmt.Fprintf(os.Stderr, formatString, args...)


### PR DESCRIPTION
Before:

```
2015/05/02 00:38:46 [restic] main []string{"./restic", "backup", "."}
```

After:

```
2015/05/02 00:47:42 [  restic]   1 main.go:176    main []string{"./restic", "backup", "-f", "."}
```
