### PR TITLE
initial openbsd support added

### DIFF
--- a/node_openbsd.go
+++ b/node_openbsd.go
@@ -1,0 +1,36 @@
+package restic
+
+import (
+	"os"
+	"syscall"
+	"time"
+)
+
+func (node *Node) OpenForReading() (*os.File, error) {
+	file, err := os.OpenFile(node.path, os.O_RDONLY, 0)
+	if os.IsPermission(err) {
+		return os.OpenFile(node.path, os.O_RDONLY, 0)
+	}
+	return file, err
+}
+
+func (node *Node) createDevAt(path string) error {
+	return syscall.Mknod(path, syscall.S_IFBLK|0600, int(node.Device))
+}
+
+func (node *Node) createCharDevAt(path string) error {
+	return syscall.Mknod(path, syscall.S_IFCHR|0600, int(node.Device))
+}
+
+func (node *Node) createFifoAt(path string) error {
+	return syscall.Mkfifo(path, 0600)
+}
+
+func (node *Node) fillTimes(stat *syscall.Stat_t) {
+	node.ChangeTime = time.Unix(stat.Ctim.Unix())
+	node.AccessTime = time.Unix(stat.Atim.Unix())
+}
+
+func changeTime(stat *syscall.Stat_t) time.Time {
+	return time.Unix(stat.Ctim.Unix())
+}


### PR DESCRIPTION
This is one commit that adds a mostly verbatim copy of the node_linux.go for OpenBSD. The only difference is the absence of the NOATTIME flag.

With the latest commits the unit tests and the test suite pass. Note that to run on OpenBSD you need the modifications in the openbsd_tests branch. Some of those are portable so they could move upstream until the suite has been rewritten in a proper programming language :see_no_evil:

Thanks for the awesome work on restic!
