### PR TITLE
Fix restoring symlink timestamps for linux

### DIFF
--- a/node.go
+++ b/node.go
@@ -171,7 +171,7 @@ func (node Node) RestoreTimestamps(path string) error {
 
 	if node.Type == "symlink" {
 		if err := node.restoreSymlinkTimestamps(path, utimes); err != nil {
-			return errors.Annotate(err, "UtimesNano")
+			return err
 		}
 
 		return nil

--- a/node_darwin.go
+++ b/node_darwin.go
@@ -18,3 +18,7 @@ func (node *Node) fillTimes(stat *syscall.Stat_t) {
 	node.ChangeTime = time.Unix(stat.Ctimespec.Unix())
 	node.AccessTime = time.Unix(stat.Atimespec.Unix())
 }
+
+func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
+	return nil
+}

--- a/node_freebsd.go
+++ b/node_freebsd.go
@@ -18,3 +18,7 @@ func (node *Node) fillTimes(stat *syscall.Stat_t) {
 func changeTime(stat *syscall.Stat_t) time.Time {
 	return time.Unix(stat.Ctimespec.Unix())
 }
+
+func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
+	return nil
+}

--- a/node_linux.go
+++ b/node_linux.go
@@ -2,8 +2,10 @@ package restic
 
 import (
 	"os"
+	"path/filepath"
 	"syscall"
 	"time"
+	"unsafe"
 )
 
 func (node *Node) OpenForReading() (*os.File, error) {
@@ -21,4 +23,37 @@ func (node *Node) fillTimes(stat *syscall.Stat_t) {
 
 func changeTime(stat *syscall.Stat_t) time.Time {
 	return time.Unix(stat.Ctim.Unix())
+}
+
+func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
+	dir, err := os.Open(filepath.Dir(path))
+	defer dir.Close()
+	if err != nil {
+		return err
+	}
+
+	return utimesNanoAt(int(dir.Fd()), filepath.Base(path), utimes, AT_SYMLINK_NOFOLLOW)
+}
+
+// very lowlevel below
+
+const AT_SYMLINK_NOFOLLOW = 0x100
+
+func utimensat(dirfd int, path string, times *[2]syscall.Timespec, flags int) (err error) {
+	var _p0 *byte
+	_p0, err = syscall.BytePtrFromString(path)
+	if err != nil {
+		return
+	}
+	_, _, e1 := syscall.Syscall6(syscall.SYS_UTIMENSAT, uintptr(dirfd), uintptr(unsafe.Pointer(_p0)), uintptr(unsafe.Pointer(times)), uintptr(flags), 0, 0)
+	if e1 != 0 {
+		err = e1
+	}
+	return
+}
+
+//sys	utimensat(dirfd int, path string, times *[2]Timespec, flags int) (err error)
+
+func utimesNanoAt(dirfd int, path string, ts [2]syscall.Timespec, flags int) (err error) {
+	return utimensat(dirfd, path, (*[2]syscall.Timespec)(unsafe.Pointer(&ts[0])), flags)
 }

--- a/node_linux.go
+++ b/node_linux.go
@@ -6,6 +6,8 @@ import (
 	"syscall"
 	"time"
 	"unsafe"
+
+	"github.com/juju/errors"
 )
 
 func (node *Node) OpenForReading() (*os.File, error) {
@@ -32,7 +34,13 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 		return err
 	}
 
-	return utimesNanoAt(int(dir.Fd()), filepath.Base(path), utimes, AT_SYMLINK_NOFOLLOW)
+	err = utimesNanoAt(int(dir.Fd()), filepath.Base(path), utimes, AT_SYMLINK_NOFOLLOW)
+
+	if err != nil {
+		return errors.Annotate(err, "UtimesNanoAt")
+	}
+
+	return nil
 }
 
 // very lowlevel below

--- a/node_openbsd.go
+++ b/node_openbsd.go
@@ -22,3 +22,7 @@ func (node *Node) fillTimes(stat *syscall.Stat_t) {
 func changeTime(stat *syscall.Stat_t) time.Time {
 	return time.Unix(stat.Ctim.Unix())
 }
+
+func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
+	return nil
+}

--- a/node_test.go
+++ b/node_test.go
@@ -1,8 +1,15 @@
-package restic
+package restic_test
 
 import (
 	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
+
+	"github.com/restic/restic"
+	"github.com/restic/restic/backend"
+	. "github.com/restic/restic/test"
 )
 
 func BenchmarkNodeFillUser(t *testing.B) {
@@ -17,13 +24,12 @@ func BenchmarkNodeFillUser(t *testing.B) {
 		t.Fatal(err)
 	}
 
-	node := &Node{}
 	path := tempfile.Name()
 
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		node.fillExtra(path, fi)
+		restic.NodeFromFileInfo(path, fi)
 	}
 }
 
@@ -44,9 +50,99 @@ func BenchmarkNodeFromFileInfo(t *testing.B) {
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		_, err := NodeFromFileInfo(path, fi)
+		_, err := restic.NodeFromFileInfo(path, fi)
 		if err != nil {
 			t.Fatal(err)
 		}
+	}
+}
+
+func parseTime(s string) time.Time {
+	t, err := time.Parse("2006-01-02 15:04:05.999", s)
+	if err != nil {
+		panic(err)
+	}
+
+	return t.Local()
+}
+
+var nodeTests = []restic.Node{
+	restic.Node{
+		Name:       "testFile",
+		Type:       "file",
+		Content:    []backend.ID{},
+		UID:        uint32(os.Getuid()),
+		GID:        uint32(os.Getgid()),
+		Mode:       0604,
+		ModTime:    parseTime("2015-05-14 21:07:23.111"),
+		AccessTime: parseTime("2015-05-14 21:07:24.222"),
+		ChangeTime: parseTime("2015-05-14 21:07:25.333"),
+	},
+	restic.Node{
+		Name:       "testDir",
+		Type:       "dir",
+		Subtree:    nil,
+		UID:        uint32(os.Getuid()),
+		GID:        uint32(os.Getgid()),
+		Mode:       020000000750,
+		ModTime:    parseTime("2015-05-14 21:07:23.111"),
+		AccessTime: parseTime("2015-05-14 21:07:24.222"),
+		ChangeTime: parseTime("2015-05-14 21:07:25.333"),
+	},
+	restic.Node{
+		Name:       "testSymlink",
+		Type:       "symlink",
+		LinkTarget: "invalid",
+		UID:        uint32(os.Getuid()),
+		GID:        uint32(os.Getgid()),
+		Mode:       01000000777,
+		ModTime:    parseTime("2015-05-14 21:07:23.111"),
+		AccessTime: parseTime("2015-05-14 21:07:24.222"),
+		ChangeTime: parseTime("2015-05-14 21:07:25.333"),
+	},
+}
+
+func TestNodeRestoreAt(t *testing.T) {
+	tempdir, err := ioutil.TempDir(*TestTempDir, "restic-test-")
+	OK(t, err)
+
+	defer func() {
+		if *TestCleanup {
+			OK(t, os.RemoveAll(tempdir))
+		} else {
+			t.Logf("leaving tempdir at %v", tempdir)
+		}
+	}()
+
+	for _, test := range nodeTests {
+		nodePath := filepath.Join(tempdir, test.Name)
+		OK(t, test.CreateAt(nodePath, nil))
+
+		if test.Type == "dir" {
+			OK(t, test.RestoreTimestamps(nodePath))
+		}
+
+		fi, err := os.Lstat(nodePath)
+		OK(t, err)
+
+		n2, err := restic.NodeFromFileInfo(nodePath, fi)
+		OK(t, err)
+
+		Assert(t, test.Name == n2.Name,
+			"%v: name doesn't match", test.Type)
+		Assert(t, test.Type == n2.Type,
+			"%v: type doesn't match", test.Type)
+		Assert(t, test.Size == n2.Size,
+			"%v: size doesn't match", test.Size)
+		Assert(t, test.UID == n2.UID,
+			"%v: UID doesn't match", test.Type)
+		Assert(t, test.GID == n2.GID,
+			"%v: GID doesn't match", test.Type)
+		Assert(t, test.Mode == n2.Mode,
+			"%v: mode doesn't match", test.Type)
+		Assert(t, test.ModTime == n2.ModTime,
+			"%v: ModTime dosn't match", test.Type)
+		Assert(t, test.AccessTime == n2.AccessTime,
+			"%v: AccessTime doesn't match", test.Type)
 	}
 }


### PR DESCRIPTION
This adds a test and fixes restoring symlink timestamps for Linux. We need to figure out how to do this on darwin and *bsd.
