### PR TITLE
Fix fsck orphaned check, add debug command 'dump', cleanup

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -254,7 +254,7 @@ func (arch *Archiver) fileWorker(wg *sync.WaitGroup, p *Progress, done <-chan st
 				// check if all content is still available in the repository
 				contentMissing := false
 				for _, blob := range oldNode.blobs {
-					if ok, err := arch.repo.Test(backend.Data, blob.Storage.String()); !ok || err != nil {
+					if ok, err := arch.repo.Backend().Test(backend.Data, blob.Storage.String()); !ok || err != nil {
 						debug.Log("Archiver.fileWorker", "   %v not using old data, %v (%v) is missing", e.Path(), blob.ID.Str(), blob.Storage.Str())
 						contentMissing = true
 						break

--- a/backend/generic.go
+++ b/backend/generic.go
@@ -56,18 +56,6 @@ func Find(be Lister, t Type, prefix string) (string, error) {
 	return "", ErrNoIDPrefixFound
 }
 
-// FindSnapshot takes a string and tries to find a snapshot whose ID matches
-// the string as closely as possible.
-func FindSnapshot(be Lister, s string) (string, error) {
-	// find snapshot id with prefix
-	name, err := Find(be, Snapshot, s)
-	if err != nil {
-		return "", err
-	}
-
-	return name, nil
-}
-
 // PrefixLength returns the number of bytes required so that all prefixes of
 // all names of type t are unique.
 func PrefixLength(be Lister, t Type) (int, error) {

--- a/cache.go
+++ b/cache.go
@@ -115,7 +115,7 @@ func (c *Cache) Clear(repo *repository.Repository) error {
 	for _, entry := range list {
 		debug.Log("Cache.Clear", "found entry %v", entry)
 
-		if ok, err := repo.Test(backend.Snapshot, entry.ID.String()); !ok || err != nil {
+		if ok, err := repo.Backend().Test(backend.Snapshot, entry.ID.String()); !ok || err != nil {
 			debug.Log("Cache.Clear", "snapshot %v doesn't exist any more, removing %v", entry.ID, entry)
 
 			err = c.purge(backend.Snapshot, entry.Subtype, entry.ID)

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -53,12 +53,7 @@ func (cmd CmdCat) Execute(args []string) error {
 			}
 
 			// find snapshot id with prefix
-			name, err := s.FindSnapshot(args[1])
-			if err != nil {
-				return err
-			}
-
-			id, err = backend.ParseID(name)
+			id, err = restic.FindSnapshot(s, args[1])
 			if err != nil {
 				return err
 			}

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -1,0 +1,149 @@
+// +build debug
+
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/juju/errors"
+	"github.com/restic/restic"
+	"github.com/restic/restic/backend"
+	"github.com/restic/restic/pack"
+	"github.com/restic/restic/repository"
+)
+
+type CmdDump struct{}
+
+func init() {
+	_, err := parser.AddCommand("dump",
+		"dump data structures",
+		"The dump command dumps data structures from a repository as JSON documents",
+		&CmdDump{})
+	if err != nil {
+		panic(err)
+	}
+}
+
+func dumpIndex(r *repository.Repository, wr io.Writer) error {
+	fmt.Fprintln(wr, "foo")
+	return nil
+}
+
+func (cmd CmdDump) Usage() string {
+	return "[index|snapshots|trees|all]"
+}
+
+func prettyPrintJSON(wr io.Writer, item interface{}) error {
+	buf, err := json.MarshalIndent(item, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	_, err = wr.Write(append(buf, '\n'))
+	return err
+}
+
+func printSnapshots(repo *repository.Repository, wr io.Writer) error {
+	done := make(chan struct{})
+	defer close(done)
+
+	for id := range repo.List(backend.Snapshot, done) {
+		snapshot, err := restic.LoadSnapshot(repo, id)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "LoadSnapshot(%v): %v", id.Str(), err)
+			continue
+		}
+
+		fmt.Fprintf(wr, "snapshot_id: %v\n", id)
+
+		err = prettyPrintJSON(wr, snapshot)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func printTrees(repo *repository.Repository, wr io.Writer) error {
+	done := make(chan struct{})
+	defer close(done)
+
+	trees := []backend.ID{}
+
+	for blob := range repo.Index().Each(done) {
+		if blob.Type != pack.Tree {
+			continue
+		}
+
+		trees = append(trees, blob.ID)
+	}
+
+	for _, id := range trees {
+		tree, err := restic.LoadTree(repo, id)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "LoadTree(%v): %v", id.Str(), err)
+			continue
+		}
+
+		fmt.Fprintf(wr, "tree_id: %v\n", id)
+
+		prettyPrintJSON(wr, tree)
+	}
+
+	return nil
+}
+
+func (cmd CmdDump) Execute(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("type not specified, Usage: %s", cmd.Usage())
+	}
+
+	repo, err := OpenRepo()
+	if err != nil {
+		return err
+	}
+
+	err = repo.LoadIndex()
+	if err != nil {
+		return err
+	}
+
+	tpe := args[0]
+
+	switch tpe {
+	case "index":
+		return repo.Index().Dump(os.Stdout)
+	case "snapshots":
+		return printSnapshots(repo, os.Stdout)
+	case "trees":
+		return printTrees(repo, os.Stdout)
+	case "all":
+		fmt.Printf("snapshots:\n")
+		err := printSnapshots(repo, os.Stdout)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("\ntrees:\n")
+
+		err = printTrees(repo, os.Stdout)
+		if err != nil {
+			return err
+		}
+
+		fmt.Printf("\nindex:\n")
+
+		err = repo.Index().Dump(os.Stdout)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	default:
+		return errors.Errorf("no such type %q", tpe)
+	}
+}

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -105,13 +105,8 @@ func (c CmdFind) findInTree(repo *repository.Repository, id backend.ID, path str
 	return results, nil
 }
 
-func (c CmdFind) findInSnapshot(repo *repository.Repository, name string) error {
-	debug.Log("restic.find", "searching in snapshot %s\n  for entries within [%s %s]", name, c.oldest, c.newest)
-
-	id, err := backend.ParseID(name)
-	if err != nil {
-		return err
-	}
+func (c CmdFind) findInSnapshot(repo *repository.Repository, id backend.ID) error {
+	debug.Log("restic.find", "searching in snapshot %s\n  for entries within [%s %s]", id.Str(), c.oldest, c.newest)
 
 	sn, err := restic.LoadSnapshot(repo, id)
 	if err != nil {
@@ -169,7 +164,7 @@ func (c CmdFind) Execute(args []string) error {
 	c.pattern = args[0]
 
 	if c.Snapshot != "" {
-		snapshotID, err := backend.FindSnapshot(s, c.Snapshot)
+		snapshotID, err := restic.FindSnapshot(s, c.Snapshot)
 		if err != nil {
 			return fmt.Errorf("invalid id %q: %v", args[1], err)
 		}

--- a/cmd/restic/cmd_fsck.go
+++ b/cmd/restic/cmd_fsck.go
@@ -198,14 +198,9 @@ func (cmd CmdFsck) Execute(args []string) error {
 	}
 
 	if cmd.Snapshot != "" {
-		name, err := s.FindSnapshot(cmd.Snapshot)
+		id, err := restic.FindSnapshot(s, cmd.Snapshot)
 		if err != nil {
 			return fmt.Errorf("invalid id %q: %v", cmd.Snapshot, err)
-		}
-
-		id, err := backend.ParseID(name)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "invalid snapshot id %v\n", name)
 		}
 
 		err = fsckSnapshot(cmd, s, id)
@@ -225,13 +220,7 @@ func (cmd CmdFsck) Execute(args []string) error {
 	defer close(done)
 
 	var firstErr error
-	for name := range s.List(backend.Snapshot, done) {
-		id, err := backend.ParseID(name)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "invalid snapshot id %v\n", name)
-			continue
-		}
-
+	for id := range s.List(backend.Snapshot, done) {
 		err = fsckSnapshot(cmd, s, id)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "check for snapshot %v failed\n", id)

--- a/cmd/restic/cmd_fsck.go
+++ b/cmd/restic/cmd_fsck.go
@@ -58,7 +58,7 @@ func fsckFile(opts CmdFsck, repo *repository.Repository, IDs []backend.ID) (uint
 			}
 		} else {
 			// test if data blob is there
-			ok, err := repo.Test(backend.Data, packID.String())
+			ok, err := repo.Backend().Test(backend.Data, packID.String())
 			if err != nil {
 				return 0, err
 			}

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -79,7 +79,7 @@ func deleteKey(repo *repository.Repository, name string) error {
 		return errors.New("refusing to remove key currently used to access repository")
 	}
 
-	err := repo.Remove(backend.Key, name)
+	err := repo.Backend().Remove(backend.Key, name)
 	if err != nil {
 		return err
 	}
@@ -103,7 +103,7 @@ func changePassword(s *repository.Repository) error {
 	}
 
 	// remove old key
-	err = s.Remove(backend.Key, s.KeyName())
+	err = s.Backend().Remove(backend.Key, s.KeyName())
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -34,20 +34,20 @@ func listKeys(s *repository.Repository) error {
 	done := make(chan struct{})
 	defer close(done)
 
-	for name := range s.List(backend.Key, done) {
-		k, err := repository.LoadKey(s, name)
+	for id := range s.List(backend.Key, done) {
+		k, err := repository.LoadKey(s, id.String())
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "LoadKey() failed: %v\n", err)
 			continue
 		}
 
 		var current string
-		if name == s.KeyName() {
+		if id.String() == s.KeyName() {
 			current = "*"
 		} else {
 			current = " "
 		}
-		tab.Rows = append(tab.Rows, []interface{}{current, name[:plen],
+		tab.Rows = append(tab.Rows, []interface{}{current, id.String()[:plen],
 			k.Username, k.Hostname, k.Created.Format(TimeFormat)})
 	}
 
@@ -133,7 +133,7 @@ func (cmd CmdKey) Execute(args []string) error {
 	case "add":
 		return addKey(s)
 	case "rm":
-		id, err := backend.Find(s, backend.Key, args[1])
+		id, err := backend.Find(s.Backend(), backend.Key, args[1])
 		if err != nil {
 			return err
 		}

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -77,12 +77,7 @@ func (cmd CmdLs) Execute(args []string) error {
 		return err
 	}
 
-	name, err := backend.FindSnapshot(s, args[0])
-	if err != nil {
-		return err
-	}
-
-	id, err := backend.ParseID(name)
+	id, err := restic.FindSnapshot(s, args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 
 	"github.com/restic/restic"
-	"github.com/restic/restic/backend"
 )
 
 type CmdRestore struct{}
@@ -40,12 +39,7 @@ func (cmd CmdRestore) Execute(args []string) error {
 		return err
 	}
 
-	name, err := backend.FindSnapshot(s, args[0])
-	if err != nil {
-		errx(1, "invalid id %q: %v", args[0], err)
-	}
-
-	id, err := backend.ParseID(name)
+	id, err := restic.FindSnapshot(s, args[0])
 	if err != nil {
 		errx(1, "invalid id %q: %v", args[0], err)
 	}

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -105,13 +105,7 @@ func (cmd CmdSnapshots) Execute(args []string) error {
 	defer close(done)
 
 	list := []*restic.Snapshot{}
-	for name := range s.List(backend.Snapshot, done) {
-		id, err := backend.ParseID(name)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "error parsing id: %v", name)
-			continue
-		}
-
+	for id := range s.List(backend.Snapshot, done) {
 		sn, err := restic.LoadSnapshot(s, id)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "error loading snapshot %s: %v\n", id, err)

--- a/repository/key.go
+++ b/repository/key.go
@@ -98,7 +98,7 @@ func SearchKey(s *Repository, password string) (*Key, error) {
 	// try all keys in repo
 	done := make(chan struct{})
 	defer close(done)
-	for name := range s.List(backend.Key, done) {
+	for name := range s.Backend().List(backend.Key, done) {
 		key, err := OpenKey(s, name, password)
 		if err != nil {
 			continue

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -676,10 +676,6 @@ func (s *Repository) List(t backend.Type, done <-chan struct{}) <-chan backend.I
 	return outCh
 }
 
-func (s *Repository) Remove(t backend.Type, name string) error {
-	return s.be.Remove(t, name)
-}
-
 func (s *Repository) Close() error {
 	return s.be.Close()
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -676,10 +676,6 @@ func (s *Repository) List(t backend.Type, done <-chan struct{}) <-chan backend.I
 	return outCh
 }
 
-func (s *Repository) Close() error {
-	return s.be.Close()
-}
-
 func (s *Repository) Delete() error {
 	if b, ok := s.be.(backend.Deleter); ok {
 		return b.Delete()
@@ -688,6 +684,6 @@ func (s *Repository) Delete() error {
 	return errors.New("Delete() called for backend that does not implement this method")
 }
 
-func (s *Repository) Location() string {
-	return s.be.Location()
+func (s *Repository) Close() error {
+	return s.be.Close()
 }

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -580,7 +580,7 @@ func (s *Repository) SearchKey(password string) error {
 // Init creates a new master key with the supplied password and initializes the
 // repository config.
 func (s *Repository) Init(password string) error {
-	has, err := s.Test(backend.Config, "")
+	has, err := s.be.Test(backend.Config, "")
 	if err != nil {
 		return err
 	}
@@ -674,10 +674,6 @@ func (s *Repository) List(t backend.Type, done <-chan struct{}) <-chan backend.I
 	go s.list(t, done, outCh)
 
 	return outCh
-}
-
-func (s *Repository) Test(t backend.Type, name string) (bool, error) {
-	return s.be.Test(t, name)
 }
 
 func (s *Repository) Remove(t backend.Type, name string) error {

--- a/snapshot.go
+++ b/snapshot.go
@@ -89,3 +89,15 @@ func (sn *Snapshot) fillUserInfo() error {
 
 	return nil
 }
+
+// FindSnapshot takes a string and tries to find a snapshot whose ID matches
+// the string as closely as possible.
+func FindSnapshot(repo *repository.Repository, s string) (backend.ID, error) {
+	// find snapshot id with prefix
+	name, err := backend.Find(repo.Backend(), backend.Snapshot, s)
+	if err != nil {
+		return nil, err
+	}
+
+	return backend.ParseID(name)
+}


### PR DESCRIPTION
These commits add a command 'dump' that's available in debug builds. 'dump'
writes internal data structes pretty-printed as JSON to stdout for (manual)
inspection.

In contrast to the 'cat' command, this one prints the data structures as
there are interpreted by restic, not as they are stored in the repository.
This means that only the merged index from all the index files is printed
out.

The first few commits are just little cleanup.
