### PR TITLE
Command `snapshots`: do not list first dir twice

### DIFF
--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -145,7 +145,7 @@ func (cmd CmdSnapshots) Execute(args []string) error {
 		tab.Rows = append(tab.Rows, []interface{}{sn.ID()[:plen/2], sn.Time.Format(TimeFormat), sn.Hostname, sn.Paths[0]})
 
 		if len(sn.Paths) > 1 {
-			for _, path := range sn.Paths {
+			for _, path := range sn.Paths[1:] {
 				tab.Rows = append(tab.Rows, []interface{}{"", "", "", path})
 			}
 		}


### PR DESCRIPTION
This fixes #215.
