### PR TITLE
More useful error messages

### DIFF
--- a/node_test.go
+++ b/node_test.go
@@ -129,20 +129,20 @@ func TestNodeRestoreAt(t *testing.T) {
 		OK(t, err)
 
 		Assert(t, test.Name == n2.Name,
-			"%v: name doesn't match", test.Type)
+			"%v: name doesn't match (%v != %v)", test.Type, test.Name, n2.Name)
 		Assert(t, test.Type == n2.Type,
-			"%v: type doesn't match", test.Type)
+			"%v: type doesn't match (%v != %v)", test.Type, test.Type, n2.Type)
 		Assert(t, test.Size == n2.Size,
-			"%v: size doesn't match", test.Size)
+			"%v: size doesn't match (%v != %v)", test.Size, test.Size, n2.Size)
 		Assert(t, test.UID == n2.UID,
-			"%v: UID doesn't match", test.Type)
+			"%v: UID doesn't match (%v != %v)", test.Type, test.UID, n2.UID)
 		Assert(t, test.GID == n2.GID,
-			"%v: GID doesn't match", test.Type)
+			"%v: GID doesn't match (%v != %v)", test.Type, test.GID, n2.GID)
 		Assert(t, test.Mode == n2.Mode,
-			"%v: mode doesn't match", test.Type)
+			"%v: mode doesn't match (%v != %v)", test.Type, test.Mode, n2.Mode)
 		Assert(t, test.ModTime == n2.ModTime,
-			"%v: ModTime dosn't match", test.Type)
+			"%v: ModTime dosn't match (%v != %v)", test.Type, test.ModTime, n2.ModTime)
 		Assert(t, test.AccessTime == n2.AccessTime,
-			"%v: AccessTime doesn't match", test.Type)
+			"%v: AccessTime doesn't match (%v != %v)", test.Type, test.AccessTime, n2.AccessTime)
 	}
 }


### PR DESCRIPTION
Tests are currently failing on OS X. This PR makes it more clear why:

```
node_test.go:144: file: ModTime dosn't match (2015-05-14 17:07:23.111 -0400 EDT != 2015-05-14 17:07:23 -0400 EDT)
```

Looks like there is an issue with the nanoseconds not being read correctly (I'm curious if the same problem exists on FreeBSD/OpenBSD).

Other people ran into similar problems before, maybe it's the same root cause and fix as [this](https://lists.gnu.org/archive/html/bug-make/2011-10/msg00030.html).

I suggest we merge this PR for now so that we get better errors and address the actual OS X test fail in a separate PR.
