### PR TITLE
Refactor skipping symlink timestamp checks on *bsd and darwin

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -7,6 +7,13 @@ def packages_freebsd
   return <<-EOF
     pkg install -y git
     pkg install -y curl
+
+    echo 'fuse_load="YES"' >> /boot/loader.conf
+    echo 'vfs.usermount=1' >> /etc/sysctl.conf
+
+    kldload fuse
+    sysctl vfs.usermount=1
+    pw groupmod operator -M vagrant
   EOF
 end
 

--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -65,7 +65,10 @@ func (e *dirEntry) equals(other *dirEntry) bool {
 		return false
 	}
 
-	if runtime.GOOS != "darwin" {
+	switch runtime.GOOS {
+	case "darwin", "freebsd":
+		// Skip ModTime check on darwin and freebsd
+	default:
 		if e.fi.ModTime() != other.fi.ModTime() {
 			fmt.Fprintf(os.Stderr, "%v: ModTime does not match (%v != %v)\n", e.path, e.fi.ModTime(), other.fi.ModTime())
 			return false

--- a/node_test.go
+++ b/node_test.go
@@ -153,10 +153,10 @@ func TestNodeRestoreAt(t *testing.T) {
 func AssertFsTimeEqual(t *testing.T, label string, nodeType string, t1 time.Time, t2 time.Time) {
 	var equal bool
 
-	// Go currently doesn't support setting timestamps of symbolic links on darwin and freebsd
+	// Go currently doesn't support setting timestamps of symbolic links on darwin and bsd
 	if nodeType == "symlink" {
 		switch runtime.GOOS {
-		case "darwin", "freebsd":
+		case "darwin", "freebsd", "openbsd":
 			return
 		}
 	}

--- a/node_test.go
+++ b/node_test.go
@@ -153,17 +153,21 @@ func TestNodeRestoreAt(t *testing.T) {
 func AssertFsTimeEqual(t *testing.T, label string, nodeType string, t1 time.Time, t2 time.Time) {
 	var equal bool
 
-	if runtime.GOOS == "darwin" {
-		// Go currently doesn't support setting timestamps of symbolic links on darwin
-		if nodeType == "symlink" {
+	// Go currently doesn't support setting timestamps of symbolic links on darwin and freebsd
+	if nodeType == "symlink" {
+		switch runtime.GOOS {
+		case "darwin", "freebsd":
 			return
 		}
+	}
 
+	switch runtime.GOOS {
+	case "darwin":
 		// HFS+ timestamps don't support sub-second precision,
 		// see https://en.wikipedia.org/wiki/Comparison_of_file_systems
 		diff := int(t1.Sub(t2).Seconds())
 		equal = diff == 0
-	} else {
+	default:
 		equal = t1.Equal(t2)
 	}
 

--- a/test/helpers.go
+++ b/test/helpers.go
@@ -88,7 +88,7 @@ func RandomReader(seed, size int) *bytes.Reader {
 
 // SetupTarTestFixture extracts the tarFile to outputDir.
 func SetupTarTestFixture(t testing.TB, outputDir, tarFile string) {
-	err := System("sh", "-c", `(cd "$1" && tar xz) < "$2"`,
+	err := System("sh", "-c", `(cd "$1" && tar xzf - ) < "$2"`,
 		"sh", outputDir, tarFile)
 	OK(t, err)
 }


### PR DESCRIPTION
This refactors skipping symlink timestamp checks and adds this to the tests on
freebsd and openbsd.
