### PR TITLE
fuse: Display symlinks properly

### DIFF
--- a/cmd/restic/fuse/dir.go
+++ b/cmd/restic/fuse/dir.go
@@ -66,10 +66,10 @@ func (d *dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 
 	for _, node := range d.children {
 		var typ fuse.DirentType
-		switch {
-		case node.Mode.IsDir():
+		switch node.Type {
+		case "dir":
 			typ = fuse.DT_Dir
-		case node.Mode.IsRegular():
+		case "file":
 			typ = fuse.DT_File
 		}
 
@@ -88,10 +88,10 @@ func (d *dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	if !ok {
 		return nil, fuse.ENOENT
 	}
-	switch {
-	case child.Mode.IsDir():
+	switch child.Type {
+	case "dir":
 		return newDir(d.repo, child)
-	case child.Mode.IsRegular():
+	case "file":
 		return newFile(d.repo, child)
 	default:
 		return nil, fuse.ENOENT

--- a/cmd/restic/fuse/dir.go
+++ b/cmd/restic/fuse/dir.go
@@ -16,9 +16,9 @@ var _ = fs.HandleReadDirAller(&dir{})
 var _ = fs.NodeStringLookuper(&dir{})
 
 type dir struct {
-	repo     *repository.Repository
-	children map[string]*restic.Node
-	inode    uint64
+	repo  *repository.Repository
+	items map[string]*restic.Node
+	inode uint64
 }
 
 func newDir(repo *repository.Repository, node *restic.Node) (*dir, error) {
@@ -26,15 +26,15 @@ func newDir(repo *repository.Repository, node *restic.Node) (*dir, error) {
 	if err != nil {
 		return nil, err
 	}
-	children := make(map[string]*restic.Node)
-	for _, child := range tree.Nodes {
-		children[child.Name] = child
+	items := make(map[string]*restic.Node)
+	for _, node := range tree.Nodes {
+		items[node.Name] = node
 	}
 
 	return &dir{
-		repo:     repo,
-		children: children,
-		inode:    node.Inode,
+		repo:  repo,
+		items: items,
+		inode: node.Inode,
 	}, nil
 }
 
@@ -43,15 +43,15 @@ func newDirFromSnapshot(repo *repository.Repository, snapshot SnapshotWithId) (*
 	if err != nil {
 		return nil, err
 	}
-	children := make(map[string]*restic.Node)
+	items := make(map[string]*restic.Node)
 	for _, node := range tree.Nodes {
-		children[node.Name] = node
+		items[node.Name] = node
 	}
 
 	return &dir{
-		repo:     repo,
-		children: children,
-		inode:    inodeFromBackendId(snapshot.ID),
+		repo:  repo,
+		items: items,
+		inode: inodeFromBackendId(snapshot.ID),
 	}, nil
 }
 
@@ -62,9 +62,9 @@ func (d *dir) Attr(ctx context.Context, a *fuse.Attr) error {
 }
 
 func (d *dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
-	ret := make([]fuse.Dirent, 0, len(d.children))
+	ret := make([]fuse.Dirent, 0, len(d.items))
 
-	for _, node := range d.children {
+	for _, node := range d.items {
 		var typ fuse.DirentType
 		switch node.Type {
 		case "dir":
@@ -86,17 +86,17 @@ func (d *dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 }
 
 func (d *dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
-	child, ok := d.children[name]
+	node, ok := d.items[name]
 	if !ok {
 		return nil, fuse.ENOENT
 	}
-	switch child.Type {
+	switch node.Type {
 	case "dir":
-		return newDir(d.repo, child)
+		return newDir(d.repo, node)
 	case "file":
-		return newFile(d.repo, child)
+		return newFile(d.repo, node)
 	case "symlink":
-		return newLink(d.repo, child)
+		return newLink(d.repo, node)
 	default:
 		return nil, fuse.ENOENT
 	}

--- a/cmd/restic/fuse/dir.go
+++ b/cmd/restic/fuse/dir.go
@@ -71,6 +71,8 @@ func (d *dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 			typ = fuse.DT_Dir
 		case "file":
 			typ = fuse.DT_File
+		case "symlink":
+			typ = fuse.DT_Link
 		}
 
 		ret = append(ret, fuse.Dirent{
@@ -93,6 +95,8 @@ func (d *dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 		return newDir(d.repo, child)
 	case "file":
 		return newFile(d.repo, child)
+	case "symlink":
+		return newLink(d.repo, child)
 	default:
 		return nil, fuse.ENOENT
 	}

--- a/cmd/restic/fuse/file.go
+++ b/cmd/restic/fuse/file.go
@@ -23,8 +23,8 @@ type file struct {
 
 func newFile(repo *repository.Repository, node *restic.Node) (*file, error) {
 	sizes := make([]uint32, len(node.Content))
-	for i, blobId := range node.Content {
-		length, err := repo.Index().LookupSize(blobId)
+	for i, blobID := range node.Content {
+		length, err := repo.Index().LookupSize(blobID)
 		if err != nil {
 			return nil, err
 		}

--- a/cmd/restic/fuse/link.go
+++ b/cmd/restic/fuse/link.go
@@ -1,0 +1,30 @@
+package fuse
+
+import (
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"github.com/restic/restic"
+	"github.com/restic/restic/repository"
+	"golang.org/x/net/context"
+)
+
+// Statically ensure that *file implements the given interface
+var _ = fs.NodeReadlinker(&link{})
+
+type link struct {
+	node *restic.Node
+}
+
+func newLink(repo *repository.Repository, node *restic.Node) (*link, error) {
+	return &link{node: node}, nil
+}
+
+func (l *link) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (string, error) {
+	return l.node.LinkTarget, nil
+}
+
+func (l *link) Attr(ctx context.Context, a *fuse.Attr) error {
+	a.Inode = l.node.Inode
+	a.Mode = l.node.Mode
+	return nil
+}


### PR DESCRIPTION
This adds displaying symlinks in the fuse mount.

Before:

```
$ ls ~/mnt/backup/snapshots/2015-07-21T20:57:29+02:00
[...]
?????????? ? ?    ?            ?            ? .zkbd
?????????? ? ?    ?            ?            ? .zsh-custom
?????????? ? ?    ?            ?            ? .zsh_functions
```

After:

```
$ ls ~/mnt/backup/snapshots/2015-07-21T20:57:29+02:00
[...]
lrwxrwxrwx 1 root root         0 Jul 21 21:31 .zkbd -> /home/user/shared/dotfiles/.zkbd
lrwxrwxrwx 1 root root         0 Jul 21 21:31 .zsh-custom -> shared/essentials/.zsh-custom
lrwxrwxrwx 1 root root         0 Jul 21 21:31 .zsh_functions -> /home/user/shared/dotfiles/.zsh_functions
```
