### PR TITLE
Record exclude patterns in snapshot

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -36,6 +36,7 @@ type Archiver struct {
 
 	Error        func(dir string, fi os.FileInfo, err error) error
 	SelectFilter pipe.SelectFunc
+	Excludes     []string
 }
 
 // NewArchiver returns a new archiver.
@@ -549,6 +550,7 @@ func (arch *Archiver) Snapshot(p *Progress, paths []string, parentID backend.ID)
 	if err != nil {
 		return nil, nil, err
 	}
+	sn.Excludes = arch.Excludes
 
 	jobs := archivePipe{}
 

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -16,9 +16,9 @@ import (
 )
 
 type CmdBackup struct {
-	Parent  string   `short:"p" long:"parent"  description:"use this parent snapshot (default: last snapshot in repo that has the same target)"`
-	Force   bool     `short:"f" long:"force"   description:"Force re-reading the target. Overrides the \"parent\" flag"`
-	Exclude []string `short:"e" long:"exclude" description:"Exclude a pattern (can be specified multiple times)"`
+	Parent   string   `short:"p" long:"parent"  description:"use this parent snapshot (default: last snapshot in repo that has the same target)"`
+	Force    bool     `short:"f" long:"force"   description:"Force re-reading the target. Overrides the \"parent\" flag"`
+	Excludes []string `short:"e" long:"exclude" description:"Exclude a pattern (can be specified multiple times)"`
 
 	global *GlobalOptions
 }
@@ -285,7 +285,7 @@ func (cmd CmdBackup) Execute(args []string) error {
 	cmd.global.Verbosef("scan %v\n", target)
 
 	selectFilter := func(item string, fi os.FileInfo) bool {
-		matched, err := filter.List(cmd.Exclude, item)
+		matched, err := filter.List(cmd.Excludes, item)
 		if err != nil {
 			cmd.global.Warnf("error for exclude pattern: %v", err)
 		}
@@ -299,6 +299,7 @@ func (cmd CmdBackup) Execute(args []string) error {
 	}
 
 	arch := restic.NewArchiver(repo)
+	arch.Excludes = cmd.Excludes
 	arch.SelectFilter = selectFilter
 
 	arch.Error = func(dir string, fi os.FileInfo, err error) error {

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -50,7 +50,7 @@ func cmdBackup(t testing.TB, global GlobalOptions, target []string, parentID bac
 }
 
 func cmdBackupExcludes(t testing.TB, global GlobalOptions, target []string, parentID backend.ID, excludes []string) {
-	cmd := &CmdBackup{global: &global, Exclude: excludes}
+	cmd := &CmdBackup{global: &global, Excludes: excludes}
 	cmd.Parent = parentID.String()
 
 	t.Logf("backing up %v", target)

--- a/snapshot.go
+++ b/snapshot.go
@@ -21,6 +21,7 @@ type Snapshot struct {
 	Username string     `json:"username,omitempty"`
 	UID      uint32     `json:"uid,omitempty"`
 	GID      uint32     `json:"gid,omitempty"`
+	Excludes []string   `json:"excludes,omitempty"`
 
 	id backend.ID // plaintext ID, used during restore
 }


### PR DESCRIPTION
This adds the exclude patterns used to create a backup in the snapshot,
so we can later compute statistics (like git does) on the data
structure, e.g. added/removed files etc. For that, we need the exclude
pattern.
