### PR TITLE
Use array instead of hash for backend.ID

### DIFF
--- a/backend/generic.go
+++ b/backend/generic.go
@@ -23,10 +23,7 @@ const hashSize = sha256.Size
 
 // Hash returns the ID for data.
 func Hash(data []byte) ID {
-	h := hashData(data)
-	id := make([]byte, IDSize)
-	copy(id, h[:])
-	return id
+	return hashData(data)
 }
 
 // Find loads the list of all blobs of type t and searches for names which

--- a/backend/id_int_test.go
+++ b/backend/id_int_test.go
@@ -1,0 +1,16 @@
+package backend
+
+import "testing"
+
+func TestIDMethods(t *testing.T) {
+	var id ID
+
+	if id.Str() != "[null]" {
+		t.Errorf("ID.Str() returned wrong value, want %v, got %v", "[null]", id.Str())
+	}
+
+	var pid *ID
+	if pid.Str() != "[nil]" {
+		t.Errorf("ID.Str() returned wrong value, want %v, got %v", "[nil]", pid.Str())
+	}
+}

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -185,21 +185,29 @@ func samePaths(expected, actual []string) bool {
 	return true
 }
 
+var errNoSnapshotFound = errors.New("no snapshot found")
+
 func findLatestSnapshot(repo *repository.Repository, targets []string) (backend.ID, error) {
 	var (
 		latest   time.Time
 		latestID backend.ID
+		found    bool
 	)
 
 	for snapshotID := range repo.List(backend.Snapshot, make(chan struct{})) {
 		snapshot, err := restic.LoadSnapshot(repo, snapshotID)
 		if err != nil {
-			return nil, fmt.Errorf("Error listing snapshot: %v", err)
+			return backend.ID{}, fmt.Errorf("Error listing snapshot: %v", err)
 		}
 		if snapshot.Time.After(latest) && samePaths(snapshot.Paths, targets) {
 			latest = snapshot.Time
 			latestID = snapshotID
+			found = true
 		}
+	}
+
+	if !found {
+		return backend.ID{}, errNoSnapshotFound
 	}
 
 	return latestID, nil
@@ -258,27 +266,27 @@ func (cmd CmdBackup) Execute(args []string) error {
 		return err
 	}
 
-	var parentSnapshotID backend.ID
+	var parentSnapshotID *backend.ID
 
 	// Force using a parent
 	if !cmd.Force && cmd.Parent != "" {
-		parentSnapshotID, err = restic.FindSnapshot(repo, cmd.Parent)
+		id, err := restic.FindSnapshot(repo, cmd.Parent)
 		if err != nil {
 			return fmt.Errorf("invalid id %q: %v", cmd.Parent, err)
 		}
 
+		parentSnapshotID = &id
 		cmd.global.Verbosef("found parent snapshot %v\n", parentSnapshotID.Str())
 	}
 
 	// Find last snapshot to set it as parent, if not already set
 	if !cmd.Force && parentSnapshotID == nil {
-		parentSnapshotID, err = findLatestSnapshot(repo, target)
-		if err != nil {
-			return err
-		}
-
-		if parentSnapshotID != nil {
+		id, err := findLatestSnapshot(repo, target)
+		if err == nil {
 			cmd.global.Verbosef("using parent snapshot %v\n", parentSnapshotID)
+			parentSnapshotID = &id
+		} else if err != errNoSnapshotFound {
+			return err
 		}
 	}
 

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -276,18 +276,20 @@ func (cmd CmdBackup) Execute(args []string) error {
 		}
 
 		parentSnapshotID = &id
-		cmd.global.Verbosef("found parent snapshot %v\n", parentSnapshotID.Str())
 	}
 
 	// Find last snapshot to set it as parent, if not already set
 	if !cmd.Force && parentSnapshotID == nil {
 		id, err := findLatestSnapshot(repo, target)
 		if err == nil {
-			cmd.global.Verbosef("using parent snapshot %v\n", parentSnapshotID)
 			parentSnapshotID = &id
 		} else if err != errNoSnapshotFound {
 			return err
 		}
+	}
+
+	if parentSnapshotID != nil {
+		cmd.global.Verbosef("using parent snapshot %v\n", parentSnapshotID.Str())
 	}
 
 	cmd.global.Verbosef("scan %v\n", target)

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -54,8 +54,6 @@ func (cmd CmdCat) Execute(args []string) error {
 	if tpe != "masterkey" && tpe != "config" {
 		id, err = backend.ParseID(args[1])
 		if err != nil {
-			id = nil
-
 			if tpe != "snapshot" {
 				return err
 			}

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -114,7 +114,7 @@ func (c CmdFind) findInSnapshot(repo *repository.Repository, id backend.ID) erro
 		return err
 	}
 
-	results, err := c.findInTree(repo, sn.Tree, "")
+	results, err := c.findInTree(repo, *sn.Tree, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -56,7 +56,7 @@ func (cmd CmdLs) printTree(prefix string, repo *repository.Repository, id backen
 		cmd.global.Printf(cmd.printNode(prefix, entry) + "\n")
 
 		if entry.Type == "dir" && entry.Subtree != nil {
-			err = cmd.printTree(filepath.Join(prefix, entry.Name), repo, entry.Subtree)
+			err = cmd.printTree(filepath.Join(prefix, entry.Name), repo, *entry.Subtree)
 			if err != nil {
 				return err
 			}
@@ -97,5 +97,5 @@ func (cmd CmdLs) Execute(args []string) error {
 
 	cmd.global.Verbosef("snapshot of %v at %s:\n", sn.Paths, sn.Time)
 
-	return cmd.printTree("", repo, sn.Tree)
+	return cmd.printTree("", repo, *sn.Tree)
 }

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -142,7 +143,8 @@ func (cmd CmdSnapshots) Execute(args []string) error {
 		if len(sn.Paths) == 0 {
 			continue
 		}
-		tab.Rows = append(tab.Rows, []interface{}{sn.ID()[:plen/2], sn.Time.Format(TimeFormat), sn.Hostname, sn.Paths[0]})
+		id := sn.ID()
+		tab.Rows = append(tab.Rows, []interface{}{hex.EncodeToString(id[:plen/2]), sn.Time.Format(TimeFormat), sn.Hostname, sn.Paths[0]})
 
 		if len(sn.Paths) > 1 {
 			for _, path := range sn.Paths[1:] {

--- a/cmd/restic/fuse/dir.go
+++ b/cmd/restic/fuse/dir.go
@@ -22,7 +22,7 @@ type dir struct {
 }
 
 func newDir(repo *repository.Repository, node *restic.Node) (*dir, error) {
-	tree, err := restic.LoadTree(repo, node.Subtree)
+	tree, err := restic.LoadTree(repo, *node.Subtree)
 	if err != nil {
 		return nil, err
 	}
@@ -39,7 +39,7 @@ func newDir(repo *repository.Repository, node *restic.Node) (*dir, error) {
 }
 
 func newDirFromSnapshot(repo *repository.Repository, snapshot SnapshotWithId) (*dir, error) {
-	tree, err := restic.LoadTree(repo, snapshot.Tree)
+	tree, err := restic.LoadTree(repo, *snapshot.Tree)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/restic/integration_fuse_test.go
+++ b/cmd/restic/integration_fuse_test.go
@@ -147,7 +147,7 @@ func TestMount(t *testing.T) {
 		checkSnapshots(repo, mountpoint, snapshotIDs)
 
 		// third backup, explicit incremental
-		cmdBackup(t, global, []string{env.testdata}, snapshotIDs[0])
+		cmdBackup(t, global, []string{env.testdata}, &snapshotIDs[0])
 		snapshotIDs = cmdList(t, global, "snapshots")
 		Assert(t, len(snapshotIDs) == 3,
 			"expected three snapshots, got %v", snapshotIDs)

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -45,13 +45,15 @@ func cmdInit(t testing.TB, global GlobalOptions) {
 	t.Logf("repository initialized at %v", global.Repo)
 }
 
-func cmdBackup(t testing.TB, global GlobalOptions, target []string, parentID backend.ID) {
+func cmdBackup(t testing.TB, global GlobalOptions, target []string, parentID *backend.ID) {
 	cmdBackupExcludes(t, global, target, parentID, nil)
 }
 
-func cmdBackupExcludes(t testing.TB, global GlobalOptions, target []string, parentID backend.ID, excludes []string) {
+func cmdBackupExcludes(t testing.TB, global GlobalOptions, target []string, parentID *backend.ID, excludes []string) {
 	cmd := &CmdBackup{global: &global, Excludes: excludes}
-	cmd.Parent = parentID.String()
+	if parentID != nil {
+		cmd.Parent = parentID.String()
+	}
 
 	t.Logf("backing up %v", target)
 
@@ -136,7 +138,7 @@ func TestBackup(t *testing.T) {
 
 		cmdCheck(t, global)
 		// third backup, explicit incremental
-		cmdBackup(t, global, []string{env.testdata}, snapshotIDs[0])
+		cmdBackup(t, global, []string{env.testdata}, &snapshotIDs[0])
 		snapshotIDs = cmdList(t, global, "snapshots")
 		Assert(t, len(snapshotIDs) == 3,
 			"expected three snapshots, got %v", snapshotIDs)

--- a/lock_test.go
+++ b/lock_test.go
@@ -203,25 +203,25 @@ func TestLockRefresh(t *testing.T) {
 	lock, err := restic.NewLock(repo)
 	OK(t, err)
 
-	var lockID backend.ID
+	var lockID *backend.ID
 	for id := range repo.List(backend.Lock, nil) {
 		if lockID != nil {
 			t.Error("more than one lock found")
 		}
-		lockID = id
+		lockID = &id
 	}
 
 	OK(t, lock.Refresh())
 
-	var lockID2 backend.ID
+	var lockID2 *backend.ID
 	for id := range repo.List(backend.Lock, nil) {
 		if lockID2 != nil {
 			t.Error("more than one lock found")
 		}
-		lockID2 = id
+		lockID2 = &id
 	}
 
-	Assert(t, !lockID.Equal(lockID2),
+	Assert(t, !lockID.Equal(*lockID2),
 		"expected a new ID after lock refresh, got the same")
 	OK(t, lock.Unlock())
 }

--- a/node.go
+++ b/node.go
@@ -35,7 +35,7 @@ type Node struct {
 	LinkTarget string       `json:"linktarget,omitempty"`
 	Device     uint64       `json:"device,omitempty"`
 	Content    []backend.ID `json:"content"`
-	Subtree    backend.ID   `json:"subtree,omitempty"`
+	Subtree    *backend.ID  `json:"subtree,omitempty"`
 
 	Error string `json:"error,omitempty"`
 
@@ -316,8 +316,18 @@ func (node Node) Equals(other Node) bool {
 	if !node.sameContent(other) {
 		return false
 	}
-	if !node.Subtree.Equal(other.Subtree) {
-		return false
+	if node.Subtree != nil {
+		if other.Subtree == nil {
+			return false
+		}
+
+		if !node.Subtree.Equal(*other.Subtree) {
+			return false
+		}
+	} else {
+		if other.Subtree != nil {
+			return false
+		}
 	}
 	if node.Error != other.Error {
 		return false

--- a/pack/pack.go
+++ b/pack/pack.go
@@ -165,8 +165,8 @@ func (p *Packer) writeHeader(wr io.Writer) (bytesWritten uint, err error) {
 		entry := headerEntry{
 			Type:   b.Type,
 			Length: b.Length,
+			ID:     b.ID,
 		}
-		copy(entry.ID[:], b.ID)
 
 		err := binary.Write(wr, binary.LittleEndian, entry)
 		if err != nil {
@@ -184,7 +184,11 @@ func (p *Packer) ID() backend.ID {
 	p.m.Lock()
 	defer p.m.Unlock()
 
-	return p.hw.Sum(nil)
+	hash := p.hw.Sum(nil)
+	id := backend.ID{}
+	copy(id[:], hash)
+
+	return id
 }
 
 // Size returns the number of bytes written so far.
@@ -273,7 +277,7 @@ func NewUnpacker(k *crypto.Key, entries []Blob, rd io.ReadSeeker) (*Unpacker, er
 			entries = append(entries, Blob{
 				Type:   e.Type,
 				Length: e.Length,
-				ID:     e.ID[:],
+				ID:     e.ID,
 				Offset: pos,
 			})
 

--- a/pack/pack_test.go
+++ b/pack/pack_test.go
@@ -31,7 +31,7 @@ func TestCreatePack(t *testing.T) {
 		_, err := io.ReadFull(rand.Reader, b)
 		OK(t, err)
 		h := sha256.Sum256(b)
-		bufs = append(bufs, Buf{data: b, id: h[:]})
+		bufs = append(bufs, Buf{data: b, id: h})
 	}
 
 	file := bytes.NewBuffer(nil)

--- a/repository/blob.go
+++ b/repository/blob.go
@@ -1,17 +1,16 @@
 package repository
 
 import (
-	"bytes"
 	"fmt"
 
 	"github.com/restic/restic/backend"
 )
 
 type Blob struct {
-	ID          backend.ID `json:"id,omitempty"`
-	Size        uint64     `json:"size,omitempty"`
-	Storage     backend.ID `json:"sid,omitempty"`   // encrypted ID
-	StorageSize uint64     `json:"ssize,omitempty"` // encrypted Size
+	ID          *backend.ID `json:"id,omitempty"`
+	Size        uint64      `json:"size,omitempty"`
+	Storage     *backend.ID `json:"sid,omitempty"`   // encrypted ID
+	StorageSize uint64      `json:"ssize,omitempty"` // encrypted Size
 }
 
 type Blobs []Blob
@@ -32,15 +31,15 @@ func (b Blob) String() string {
 
 // Compare compares two blobs by comparing the ID and the size. It returns -1,
 // 0, or 1.
-func (blob Blob) Compare(other Blob) int {
-	if res := bytes.Compare(other.ID, blob.ID); res != 0 {
+func (b Blob) Compare(other Blob) int {
+	if res := b.ID.Compare(*other.ID); res != 0 {
 		return res
 	}
 
-	if blob.Size < other.Size {
+	if b.Size < other.Size {
 		return -1
 	}
-	if blob.Size > other.Size {
+	if b.Size > other.Size {
 		return 1
 	}
 

--- a/repository/config.go
+++ b/repository/config.go
@@ -70,7 +70,7 @@ func LoadConfig(r JSONUnpackedLoader) (Config, error) {
 		cfg Config
 	)
 
-	err := r.LoadJSONUnpacked(backend.Config, nil, &cfg)
+	err := r.LoadJSONUnpacked(backend.Config, backend.ID{}, &cfg)
 	if err != nil {
 		return Config{}, err
 	}

--- a/repository/index_test.go
+++ b/repository/index_test.go
@@ -13,12 +13,12 @@ import (
 )
 
 func randomID() backend.ID {
-	buf := make([]byte, backend.IDSize)
-	_, err := io.ReadFull(rand.Reader, buf)
+	id := backend.ID{}
+	_, err := io.ReadFull(rand.Reader, id[:])
 	if err != nil {
 		panic(err)
 	}
-	return buf
+	return id
 }
 
 func TestIndexSerialize(t *testing.T) {
@@ -40,7 +40,7 @@ func TestIndexSerialize(t *testing.T) {
 		for j := 0; j < 20; j++ {
 			id := randomID()
 			length := uint(i*100 + j)
-			idx.Store(pack.Data, id, packID, pos, length)
+			idx.Store(pack.Data, id, &packID, pos, length)
 
 			tests = append(tests, testEntry{
 				id:     id,
@@ -71,7 +71,7 @@ func TestIndexSerialize(t *testing.T) {
 		packID, tpe, offset, length, err := idx.Lookup(testBlob.id)
 		OK(t, err)
 
-		Equals(t, testBlob.pack, packID)
+		Equals(t, testBlob.pack, *packID)
 		Equals(t, testBlob.tpe, tpe)
 		Equals(t, testBlob.offset, offset)
 		Equals(t, testBlob.length, length)
@@ -79,7 +79,7 @@ func TestIndexSerialize(t *testing.T) {
 		packID, tpe, offset, length, err = idx2.Lookup(testBlob.id)
 		OK(t, err)
 
-		Equals(t, testBlob.pack, packID)
+		Equals(t, testBlob.pack, *packID)
 		Equals(t, testBlob.tpe, tpe)
 		Equals(t, testBlob.offset, offset)
 		Equals(t, testBlob.length, length)
@@ -94,7 +94,7 @@ func TestIndexSerialize(t *testing.T) {
 		for j := 0; j < 10; j++ {
 			id := randomID()
 			length := uint(i*100 + j)
-			idx2.Store(pack.Data, id, packID, pos, length)
+			idx2.Store(pack.Data, id, &packID, pos, length)
 
 			newtests = append(newtests, testEntry{
 				id:     id,
@@ -130,7 +130,7 @@ func TestIndexSerialize(t *testing.T) {
 		packID, tpe, offset, length, err := idx3.Lookup(testBlob.id)
 		OK(t, err)
 
-		Equals(t, testBlob.pack, packID)
+		Equals(t, testBlob.pack, *packID)
 		Equals(t, testBlob.tpe, tpe)
 		Equals(t, testBlob.offset, offset)
 		Equals(t, testBlob.length, length)
@@ -149,7 +149,7 @@ func TestIndexSize(t *testing.T) {
 		for j := 0; j < blobs; j++ {
 			id := randomID()
 			length := uint(i*100 + j)
-			idx.Store(pack.Data, id, packID, pos, length)
+			idx.Store(pack.Data, id, &packID, pos, length)
 
 			pos += length
 		}
@@ -217,7 +217,7 @@ func TestIndexUnserialize(t *testing.T) {
 		packID, tpe, offset, length, err := idx.Lookup(test.id)
 		OK(t, err)
 
-		Equals(t, test.packID, packID)
+		Equals(t, test.packID, *packID)
 		Equals(t, test.tpe, tpe)
 		Equals(t, test.offset, offset)
 		Equals(t, test.length, length)

--- a/repository/key.go
+++ b/repository/key.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -199,7 +200,7 @@ func AddKey(s *Repository, password string, template *crypto.Key) (*Key, error) 
 		return nil, err
 	}
 
-	name := backend.ID(plainhw.Sum(nil)).String()
+	name := hex.EncodeToString(plainhw.Sum(nil))
 
 	err = blob.Finalize(backend.Key, name)
 	if err != nil {

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -39,7 +39,7 @@ func TestSaveJSON(t *testing.T) {
 		id, err := repo.SaveJSON(pack.Tree, obj)
 		OK(t, err)
 
-		Assert(t, bytes.Equal(h[:], id),
+		Assert(t, h == id,
 			"TestSaveJSON: wrong plaintext ID: expected %02x, got %02x",
 			h, id)
 	}
@@ -62,7 +62,7 @@ func BenchmarkSaveJSON(t *testing.B) {
 		id, err := repo.SaveJSON(pack.Tree, obj)
 		OK(t, err)
 
-		Assert(t, bytes.Equal(h[:], id),
+		Assert(t, h == id,
 			"TestSaveJSON: wrong plaintext ID: expected %02x, got %02x",
 			h, id)
 	}
@@ -114,13 +114,13 @@ func TestSaveFrom(t *testing.T) {
 		id := backend.Hash(data)
 
 		// save
-		err = repo.SaveFrom(pack.Data, id[:], uint(size), bytes.NewReader(data))
+		err = repo.SaveFrom(pack.Data, &id, uint(size), bytes.NewReader(data))
 		OK(t, err)
 
 		OK(t, repo.Flush())
 
 		// read back
-		buf, err := repo.LoadBlob(pack.Data, id[:])
+		buf, err := repo.LoadBlob(pack.Data, id)
 
 		Assert(t, len(buf) == len(data),
 			"number of bytes read back does not match: expected %d, got %d",
@@ -142,14 +142,14 @@ func BenchmarkSaveFrom(t *testing.B) {
 	_, err := io.ReadFull(rand.Reader, data)
 	OK(t, err)
 
-	id := sha256.Sum256(data)
+	id := backend.ID(sha256.Sum256(data))
 
 	t.ResetTimer()
 	t.SetBytes(int64(size))
 
 	for i := 0; i < t.N; i++ {
 		// save
-		err = repo.SaveFrom(pack.Data, id[:], uint(size), bytes.NewReader(data))
+		err = repo.SaveFrom(pack.Data, &id, uint(size), bytes.NewReader(data))
 		OK(t, err)
 	}
 }
@@ -167,7 +167,7 @@ func TestLoadJSONPack(t *testing.T) {
 	OK(t, repo.Flush())
 
 	tree := restic.NewTree()
-	err := repo.LoadJSONPack(pack.Tree, sn.Tree, &tree)
+	err := repo.LoadJSONPack(pack.Tree, *sn.Tree, &tree)
 	OK(t, err)
 }
 

--- a/restorer.go
+++ b/restorer.go
@@ -65,7 +65,7 @@ func (res *Restorer) restoreTo(dst string, dir string, treeID backend.ID) error 
 			}
 
 			subp := filepath.Join(dir, node.Name)
-			err = res.restoreTo(dst, subp, node.Subtree)
+			err = res.restoreTo(dst, subp, *node.Subtree)
 			if err != nil {
 				err = res.Error(subp, node, errors.Annotate(err, "restore subtree"))
 				if err != nil {
@@ -125,7 +125,7 @@ func (res *Restorer) restoreNodeTo(node *Node, dir string, dst string) error {
 // RestoreTo creates the directories and files in the snapshot below dir.
 // Before an item is created, res.Filter is called.
 func (res *Restorer) RestoreTo(dir string) error {
-	return res.restoreTo(dir, "", res.sn.Tree)
+	return res.restoreTo(dir, "", *res.sn.Tree)
 }
 
 // Snapshot returns the snapshot this restorer is configured to use.

--- a/snapshot.go
+++ b/snapshot.go
@@ -13,17 +13,17 @@ import (
 )
 
 type Snapshot struct {
-	Time     time.Time  `json:"time"`
-	Parent   backend.ID `json:"parent,omitempty"`
-	Tree     backend.ID `json:"tree"`
-	Paths    []string   `json:"paths"`
-	Hostname string     `json:"hostname,omitempty"`
-	Username string     `json:"username,omitempty"`
-	UID      uint32     `json:"uid,omitempty"`
-	GID      uint32     `json:"gid,omitempty"`
-	Excludes []string   `json:"excludes,omitempty"`
+	Time     time.Time   `json:"time"`
+	Parent   *backend.ID `json:"parent,omitempty"`
+	Tree     *backend.ID `json:"tree"`
+	Paths    []string    `json:"paths"`
+	Hostname string      `json:"hostname,omitempty"`
+	Username string      `json:"username,omitempty"`
+	UID      uint32      `json:"uid,omitempty"`
+	GID      uint32      `json:"gid,omitempty"`
+	Excludes []string    `json:"excludes,omitempty"`
 
-	id backend.ID // plaintext ID, used during restore
+	id *backend.ID // plaintext ID, used during restore
 }
 
 func NewSnapshot(paths []string) (*Snapshot, error) {
@@ -52,7 +52,7 @@ func NewSnapshot(paths []string) (*Snapshot, error) {
 }
 
 func LoadSnapshot(repo *repository.Repository, id backend.ID) (*Snapshot, error) {
-	sn := &Snapshot{id: id}
+	sn := &Snapshot{id: &id}
 	err := repo.LoadJSONUnpacked(backend.Snapshot, id, sn)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (sn Snapshot) String() string {
 	return fmt.Sprintf("<Snapshot of %v at %s>", sn.Paths, sn.Time)
 }
 
-func (sn Snapshot) ID() backend.ID {
+func (sn Snapshot) ID() *backend.ID {
 	return sn.id
 }
 
@@ -97,7 +97,7 @@ func FindSnapshot(repo *repository.Repository, s string) (backend.ID, error) {
 	// find snapshot id with prefix
 	name, err := backend.Find(repo.Backend(), backend.Snapshot, s)
 	if err != nil {
-		return nil, err
+		return backend.ID{}, err
 	}
 
 	return backend.ParseID(name)

--- a/test/backend.go
+++ b/test/backend.go
@@ -81,7 +81,7 @@ func TeardownRepo(repo *repository.Repository) {
 	}
 }
 
-func SnapshotDir(t testing.TB, repo *repository.Repository, path string, parent backend.ID) *restic.Snapshot {
+func SnapshotDir(t testing.TB, repo *repository.Repository, path string, parent *backend.ID) *restic.Snapshot {
 	arch := restic.NewArchiver(repo)
 	sn, _, err := arch.Snapshot(nil, []string{path}, parent)
 	OK(t, err)

--- a/tree.go
+++ b/tree.go
@@ -94,7 +94,7 @@ func (t Tree) Find(name string) (*Node, error) {
 func (t Tree) Subtrees() (trees backend.IDs) {
 	for _, node := range t.Nodes {
 		if node.Type == "dir" && node.Subtree != nil {
-			trees = append(trees, node.Subtree)
+			trees = append(trees, *node.Subtree)
 		}
 	}
 

--- a/walk.go
+++ b/walk.go
@@ -32,7 +32,7 @@ func walkTree(repo *repository.Repository, path string, treeID backend.ID, done 
 	for _, node := range t.Nodes {
 		p := filepath.Join(path, node.Name)
 		if node.Type == "dir" {
-			walkTree(repo, p, node.Subtree, done, jobCh)
+			walkTree(repo, p, *node.Subtree, done, jobCh)
 		} else {
 			select {
 			case jobCh <- WalkTreeJob{Path: p, Node: node}:

--- a/walk_test.go
+++ b/walk_test.go
@@ -29,7 +29,7 @@ func TestWalkTree(t *testing.T) {
 
 	// start tree walker
 	treeJobs := make(chan restic.WalkTreeJob)
-	go restic.WalkTree(repo, sn.Tree, done, treeJobs)
+	go restic.WalkTree(repo, *sn.Tree, done, treeJobs)
 
 	// start filesystem walker
 	fsJobs := make(chan pipe.Job)


### PR DESCRIPTION
Since backend.ID is always a slice of constant length, use an array instead of a slice. Mostly, arrays behave as slices, except that an array cannot be nil, so use `*backend.ID` instead of `backend.ID` in places where the absence of an ID is possible (e.g. for the Subtree of a Node, which may not present when the node is a file node).

This change allows to directly use backend.ID as the the key for a map, so that arbitrary data structures (e.g. a Set implemented as a `map[backend.ID]struct{}`) can easily be formed.
