### PR TITLE
Remove dead code

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -155,25 +155,6 @@ func packIDTester(repo *repository.Repository, inChan <-chan backend.ID, errChan
 	}
 }
 
-func collectErrors(in <-chan error, out chan<- []error, done <-chan struct{}) {
-	var errs []error
-
-outer:
-	for {
-		select {
-		case err, ok := <-in:
-			if !ok {
-				break outer
-			}
-			errs = append(errs, err)
-		case <-done:
-			break outer
-		}
-	}
-
-	out <- errs
-}
-
 // Packs checks that all packs referenced in the index are still available and
 // there are no packs that aren't in an index. errChan is closed after all
 // packs have been checked.

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -29,11 +29,6 @@ func init() {
 	}
 }
 
-func dumpIndex(r *repository.Repository, wr io.Writer) error {
-	fmt.Fprintln(wr, "foo")
-	return nil
-}
-
 func (cmd CmdDump) Usage() string {
 	return "[index|snapshots|trees|all]"
 }

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -7,17 +7,9 @@ import (
 	"os"
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/restic/restic"
 	"github.com/restic/restic/backend"
-)
-
-const (
-	minute = 60
-	hour   = 60 * minute
-	day    = 24 * hour
-	week   = 7 * day
 )
 
 type Table struct {
@@ -54,23 +46,6 @@ func (t Table) Write(w io.Writer) error {
 }
 
 const TimeFormat = "2006-01-02 15:04:05"
-
-func reltime(t time.Time) string {
-	sec := uint64(time.Since(t).Seconds())
-
-	switch {
-	case sec > week:
-		return t.Format(TimeFormat)
-	case sec > day:
-		return fmt.Sprintf("%d days ago", sec/day)
-	case sec > hour:
-		return fmt.Sprintf("%d hours ago", sec/hour)
-	case sec > minute:
-		return fmt.Sprintf("%d minutes ago", sec/minute)
-	default:
-		return fmt.Sprintf("%d seconds ago", sec)
-	}
-}
 
 type CmdSnapshots struct {
 	global *GlobalOptions

--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -76,10 +76,6 @@ func isDir(fi os.FileInfo) bool {
 	return fi.IsDir()
 }
 
-func isFile(fi os.FileInfo) bool {
-	return fi.Mode()&(os.ModeType|os.ModeCharDevice) == 0
-}
-
 var errCancelled = errors.New("walk cancelled")
 
 // SelectFunc returns true for all items that should be included (files and


### PR DESCRIPTION
This removes dead code (functions that aren't called) detected with `deadcode`.
