### PR TITLE
build.go: Make `-ldflags` compatible to Go 1.5

### DIFF
--- a/build.go
+++ b/build.go
@@ -159,7 +159,7 @@ func verbosePrintf(message string, args ...interface{}) {
 		return
 	}
 
-	fmt.Printf(message, args...)
+	fmt.Printf("build: "+message, args...)
 }
 
 // cleanEnv returns a clean environment with GOPATH and GOBIN removed (if

--- a/build.go
+++ b/build.go
@@ -229,8 +229,8 @@ func gitVersion() string {
 	return version
 }
 
-// Constants represents a set constants set in the final binary to the given
-// value.
+// Constants represents a set of constants that are set in the final binary to
+// the given value via compiler flags.
 type Constants map[string]string
 
 // LDFlags returns the string that can be passed to go build's `-ldflags`.
@@ -318,7 +318,7 @@ func main() {
 				die("remove GOPATH at %s failed: %v\n", err)
 			}
 		} else {
-			fmt.Printf("leaving temporary GOPATH at %v\n", gopath)
+			verbosePrintf("leaving temporary GOPATH at %v\n", gopath)
 		}
 	}()
 
@@ -333,7 +333,7 @@ func main() {
 		constants["main.version"] = version
 	}
 	ldflags := "-s " + constants.LDFlags()
-	fmt.Printf("ldflags: %s\n", ldflags)
+	verbosePrintf("ldflags: %s\n", ldflags)
 
 	args := []string{
 		"-tags", strings.Join(buildTags, " "),


### PR DESCRIPTION
This change uses the old syntax (-ldflags "-X foo bar") for Go <= 1.4 and the new syntax for (-ldflags "-X foo=bar") for Go 1.5 (without a warning).

Closes #286
