### PR TITLE
Remove tests for directories

### DIFF
--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -62,13 +62,6 @@ func Create(dir string) (*Local, error) {
 		return nil, errors.New("config file already exists")
 	}
 
-	// test if directories already exist
-	for _, d := range dirs[1:] {
-		if _, err := os.Stat(d); err == nil {
-			return nil, fmt.Errorf("dir %s already exists", d)
-		}
-	}
-
 	// create paths for data, refs and temp
 	for _, d := range dirs {
 		err := os.MkdirAll(d, backend.Modes.Dir)

--- a/backend/local/local.go
+++ b/backend/local/local.go
@@ -57,7 +57,7 @@ func Create(dir string) (*Local, error) {
 	}
 
 	// test if config file already exists
-	_, err := os.Lstat(backend.Paths.Config)
+	_, err := os.Lstat(filepath.Join(dir, backend.Paths.Config))
 	if err == nil {
 		return nil, errors.New("config file already exists")
 	}

--- a/backend/local_test.go
+++ b/backend/local_test.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"testing"
 
+	"github.com/restic/restic/backend"
 	"github.com/restic/restic/backend/local"
 	. "github.com/restic/restic/test"
 )
@@ -46,11 +47,13 @@ func TestLocalBackendCreationFailures(t *testing.T) {
 	b := setupLocalBackend(t)
 	defer teardownLocalBackend(t, b)
 
+	// create a fake config file
+	blob, err := b.Create()
+	OK(t, err)
+	fmt.Fprintf(blob, "config\n")
+	OK(t, blob.Finalize(backend.Config, ""))
+
 	// test failure to create a new repository at the same location
 	b2, err := local.Create(b.Location())
-	Assert(t, err != nil && b2 == nil, fmt.Sprintf("creating a repository at %s for the second time should have failed", b.Location()))
-
-	// test failure to create a new repository at the same location without a config file
-	b2, err = local.Create(b.Location())
 	Assert(t, err != nil && b2 == nil, fmt.Sprintf("creating a repository at %s for the second time should have failed", b.Location()))
 }

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -115,13 +115,6 @@ func Create(dir string, program string, args ...string) (*SFTP, error) {
 		return nil, errors.New("config file already exists")
 	}
 
-	// test if directories already exist
-	for _, d := range dirs[1:] {
-		if _, err := sftp.c.Lstat(d); err == nil {
-			return nil, fmt.Errorf("dir %s already exists", d)
-		}
-	}
-
 	// create paths for data, refs and temp blobs
 	for _, d := range dirs {
 		err = sftp.mkdirAll(d, backend.Modes.Dir)

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -110,7 +110,7 @@ func Create(dir string, program string, args ...string) (*SFTP, error) {
 	}
 
 	// test if config file already exists
-	_, err = sftp.c.Lstat(backend.Paths.Config)
+	_, err = sftp.c.Lstat(filepath.Join(dir, backend.Paths.Config))
 	if err == nil {
 		return nil, errors.New("config file already exists")
 	}


### PR DESCRIPTION
For testing whether a repository already exists it is sufficient to test if the config file (and therefore the master key) exists.

Closes #279
