### PR TITLE
fix:restic#292 Prevent concurrent processing of the same blob

### DIFF
--- a/repository/index_test.go
+++ b/repository/index_test.go
@@ -223,3 +223,68 @@ func TestIndexUnserialize(t *testing.T) {
 		Equals(t, test.length, length)
 	}
 }
+
+func TestStoreOverwritesPreliminaryEntry(t *testing.T) {
+	idx := repository.NewIndex()
+
+	blobID := randomID()
+	dataType := pack.Data
+	idx.StoreInProgress(dataType, blobID)
+
+	packID := randomID()
+	offset := uint(0)
+	length := uint(100)
+	idx.Store(dataType, blobID, &packID, offset, length)
+
+	actPackID, actType, actOffset, actLength, err := idx.Lookup(blobID)
+	OK(t, err)
+	Equals(t, packID, *actPackID)
+	Equals(t, dataType, actType)
+	Equals(t, offset, actOffset)
+	Equals(t, length, actLength)
+}
+
+func TestStoreInProgressAddsPreliminaryEntry(t *testing.T) {
+	idx := repository.NewIndex()
+
+	blobID := randomID()
+	dataType := pack.Data
+
+	err := idx.StoreInProgress(dataType, blobID)
+	OK(t, err)
+
+	actPackID, actType, actOffset, actLength, err := idx.Lookup(blobID)
+	OK(t, err)
+	Assert(t, actPackID == nil,
+		"Preliminary index entry illegaly associated with a pack id.")
+	Equals(t, uint(0), actOffset)
+	Equals(t, uint(0), actLength)
+	Equals(t, dataType, actType)
+}
+
+func TestStoreInProgressRefusesToOverwriteExistingFinalEntry(t *testing.T) {
+	idx := repository.NewIndex()
+
+	blobID := randomID()
+	dataType := pack.Data
+	packID := randomID()
+	offset := uint(0)
+	length := uint(100)
+	idx.Store(dataType, blobID, &packID, offset, length)
+
+	err := idx.StoreInProgress(dataType, blobID)
+	Assert(t, err != nil,
+		"index.StoreInProgress did not refuse to overwrite existing entry")
+}
+
+func TestStoreInProgressRefusesToOverwriteExistingPreliminaryEntry(t *testing.T) {
+	idx := repository.NewIndex()
+
+	blobID := randomID()
+	dataType := pack.Data
+
+	_ = idx.StoreInProgress(dataType, blobID)
+	err := idx.StoreInProgress(dataType, blobID)
+	Assert(t, err != nil,
+		"index.StoreInProgress did not refuse to overwrite existing entry")
+}


### PR DESCRIPTION
Prevent concurrent processing of the same blob by first adding a preliminary index entry: Adding a preliminary index entry fails if another goroutine is already working on the same blob. In contrast to my proposal in restic#292, index.Store has not been changed. Instead a new method index.StoreInProgress has been added.
