### PR TITLE
Handle null subtree IDs

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -334,6 +334,10 @@ func (arch *Archiver) dirWorker(wg *sync.WaitGroup, p *Progress, done <-chan str
 
 				if node.Type == "dir" {
 					debug.Log("Archiver.dirWorker", "got tree node for %s: %v", node.path, node.blobs)
+
+					if node.Subtree.IsNull() {
+						panic("invalid null subtree ID")
+					}
 				}
 			}
 
@@ -359,6 +363,9 @@ func (arch *Archiver) dirWorker(wg *sync.WaitGroup, p *Progress, done <-chan str
 				panic(err)
 			}
 			debug.Log("Archiver.dirWorker", "save tree for %s: %v", dir.Path(), id.Str())
+			if id.IsNull() {
+				panic("invalid null subtree ID return from SaveTreeJSON()")
+			}
 
 			node.Subtree = &id
 

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -522,6 +522,11 @@ func (c *Checker) checkTree(id backend.ID, tree *restic.Tree) (errs []error) {
 				errs = append(errs, Error{TreeID: &id, Err: fmt.Errorf("node %d is dir but has no subtree", i)})
 				continue
 			}
+
+			if node.Subtree.IsNull() {
+				errs = append(errs, Error{TreeID: &id, Err: fmt.Errorf("node %d is dir subtree id is null", i)})
+				continue
+			}
 		}
 	}
 

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -505,13 +505,12 @@ func (c *Checker) Structure(errChan chan<- error, done <-chan struct{}) {
 	treeIDChan := make(chan backend.ID)
 	treeJobChan1 := make(chan treeJob)
 	treeJobChan2 := make(chan treeJob)
-	treeErrChan := make(chan TreeError)
 
 	var wg sync.WaitGroup
 	for i := 0; i < defaultParallelism; i++ {
 		wg.Add(2)
 		go loadTreeWorker(c.repo, treeIDChan, treeJobChan1, done, &wg)
-		go c.checkTreeWorker(treeJobChan2, treeErrChan, done, &wg)
+		go c.checkTreeWorker(treeJobChan2, errChan, done, &wg)
 	}
 
 	filterTrees(trees, treeIDChan, treeJobChan1, treeJobChan2, done)

--- a/checker/checker.go
+++ b/checker/checker.go
@@ -204,14 +204,14 @@ type Error struct {
 
 func (e Error) Error() string {
 	if e.BlobID != nil && e.TreeID != nil {
-		msg := "tree " + e.TreeID.String()
-		msg += ", blob " + e.BlobID.String()
+		msg := "tree " + e.TreeID.Str()
+		msg += ", blob " + e.BlobID.Str()
 		msg += ": " + e.Err.Error()
 		return msg
 	}
 
 	if e.TreeID != nil {
-		return "tree " + e.TreeID.String() + ": " + e.Err.Error()
+		return "tree " + e.TreeID.Str() + ": " + e.Err.Error()
 	}
 
 	return e.Err.Error()

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -79,7 +79,14 @@ func (cmd CmdCheck) Execute(args []string) error {
 
 	for err := range errChan {
 		errorsFound = true
-		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		if e, ok := err.(checker.TreeError); ok {
+			fmt.Fprintf(os.Stderr, "error for tree %v:\n", e.ID.Str())
+			for _, treeErr := range e.Errors {
+				fmt.Fprintf(os.Stderr, "  %v\n", treeErr)
+			}
+		} else {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		}
 	}
 
 	for _, id := range chkr.UnusedBlobs() {

--- a/repository/index.go
+++ b/repository/index.go
@@ -219,7 +219,7 @@ func (idx *Index) generatePackList(selectFn func(indexEntry) bool) ([]*packJSON,
 			continue
 		}
 
-		debug.Log("Index.generatePackList", "handle blob %q", id[:8])
+		debug.Log("Index.generatePackList", "handle blob %v", id.Str())
 
 		if blob.packID.IsNull() {
 			debug.Log("Index.generatePackList", "blob %q has no packID! (type %v, offset %v, length %v)",

--- a/repository/index.go
+++ b/repository/index.go
@@ -215,6 +215,10 @@ func (idx *Index) generatePackList(selectFn func(indexEntry) bool) ([]*packJSON,
 	packs := make(map[backend.ID]*packJSON)
 
 	for id, blob := range idx.pack {
+		if blob.packID == nil {
+			panic("nil pack id")
+		}
+
 		if selectFn != nil && !selectFn(blob) {
 			continue
 		}

--- a/repository/repository.go
+++ b/repository/repository.go
@@ -315,7 +315,7 @@ func (r *Repository) SaveAndEncrypt(t pack.BlobType, data []byte, id *backend.ID
 	err = r.idx.StoreInProgress(t, *id)
 	if err != nil {
 		debug.Log("Repo.Save", "another goroutine is already working on %v (%v) does already exist", id.Str, t)
-		return backend.ID{}, nil
+		return *id, nil
 	}
 
 	// find suitable packer and add blob


### PR DESCRIPTION
This PR fixes handling of repositories with trees that have a subtree ID of 000000. It seems that #308 introduced a bug that results in a null subtree ID for the empty directory when this is archived concurrently.

Closes #311
Closes #314
