### PR TITLE
rebuild-index: Remember already stored blobs

### DIFF
--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/restic/restic/backend"
 	"github.com/restic/restic/debug"
 	"github.com/restic/restic/filter"
+	"github.com/restic/restic/repository"
 	. "github.com/restic/restic/test"
 )
 
@@ -682,4 +683,9 @@ func TestRebuildIndex(t *testing.T) {
 			t.Fatalf("expected no output from the checker, got: %v", out)
 		}
 	})
+}
+
+func TestRebuildIndexAlwaysFull(t *testing.T) {
+	repository.IndexFull = func(*repository.Index) bool { return true }
+	TestRebuildIndex(t)
 }

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -99,6 +99,7 @@ func cmdCheckOutput(t testing.TB, global GlobalOptions) string {
 }
 
 func cmdRebuildIndex(t testing.TB, global GlobalOptions) {
+	global.stdout = ioutil.Discard
 	cmd := &CmdRebuildIndex{global: &global}
 	OK(t, cmd.Execute(nil))
 }


### PR DESCRIPTION
It was observed that a restic repository still contained overlapping indexes after `rebuild-index` has been called. This is caused by instantly forgetting what blobs have already been saved once a full index has been written during index rebuilding.

This commit adds correct handling of all blobs and a test for the corner case.
