### PR TITLE
Read password from stdin if terminal is not a tty

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"net/url"
 	"os"
+	"strings"
 
 	"github.com/jessevdk/go-flags"
 	"github.com/restic/restic/backend"
@@ -77,19 +78,55 @@ func (o GlobalOptions) Exitf(exitcode int, format string, args ...interface{}) {
 	os.Exit(exitcode)
 }
 
+// readPassword reads the password from the given reader directly.
+func readPassword(in io.Reader) (password string, err error) {
+	buf := make([]byte, 1000)
+	n, err := io.ReadFull(in, buf)
+	buf = buf[:n]
+
+	if err != nil && err != io.ErrUnexpectedEOF {
+		return "", err
+	}
+
+	return strings.TrimRight(string(buf), "\r\n"), nil
+}
+
+// readPasswordTerminal reads the password from the given reader which must be a
+// tty. Prompt is printed on the writer out before attempting to read the
+// password.
+func readPasswordTerminal(in *os.File, out io.Writer, prompt string) (password string, err error) {
+	fmt.Fprint(out, prompt)
+	buf, err := terminal.ReadPassword(int(in.Fd()))
+	fmt.Fprintln(out)
+	if err != nil {
+		return "", err
+	}
+
+	password = string(buf)
+	return password, nil
+}
+
 func (o GlobalOptions) ReadPassword(prompt string) string {
-	fmt.Fprint(os.Stderr, prompt)
-	pw, err := terminal.ReadPassword(int(os.Stdin.Fd()))
+	var (
+		password string
+		err      error
+	)
+
+	if terminal.IsTerminal(int(os.Stdin.Fd())) {
+		password, err = readPasswordTerminal(os.Stdin, os.Stderr, prompt)
+	} else {
+		password, err = readPassword(os.Stdin)
+	}
+
 	if err != nil {
 		o.Exitf(2, "unable to read password: %v", err)
 	}
-	fmt.Fprintln(os.Stderr)
 
-	if len(pw) == 0 {
+	if len(password) == 0 {
 		o.Exitf(1, "an empty password is not a password")
 	}
 
-	return string(pw)
+	return password
 }
 
 func (o GlobalOptions) ReadPasswordTwice(prompt1, prompt2 string) string {


### PR DESCRIPTION
This fixes a bug: When restic tried to read the password from stdin and stdin was not a tty, `terminal.ReadPassword()` returned an error. This PR adds code that tests whether stdin is a tty before attempting to disable echo etc.
