### PR TITLE
Test and fix for #405

### DIFF
--- a/checker/repacker.go
+++ b/checker/repacker.go
@@ -136,7 +136,7 @@ func repackBlob(src, dst *repository.Repository, id backend.ID) error {
 		return errors.New("LoadBlob returned wrong data, len() doesn't match")
 	}
 
-	_, err = dst.SaveAndEncrypt(blob.Type, buf, &id, true)
+	_, err = dst.SaveAndEncrypt(blob.Type, buf, &id)
 	if err != nil {
 		return err
 	}

--- a/repository/master_index_test.go
+++ b/repository/master_index_test.go
@@ -1,0 +1,146 @@
+package repository
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"io"
+	mrand "math/rand"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/restic/restic/backend"
+	"github.com/restic/restic/pack"
+)
+
+const parallelSaves = 20
+const saveIndexTime = 100 * time.Millisecond
+const testTimeout = 1 * time.Second
+
+var DupID backend.ID
+
+func randomID() backend.ID {
+	if mrand.Float32() < 0.5 {
+		return DupID
+	}
+
+	id := backend.ID{}
+	_, err := io.ReadFull(rand.Reader, id[:])
+	if err != nil {
+		panic(err)
+	}
+	return id
+}
+
+// forgetfulBackend returns a backend that forgets everything.
+func forgetfulBackend() backend.Backend {
+	be := &backend.MockBackend{}
+
+	be.TestFn = func(t backend.Type, name string) (bool, error) {
+		return false, nil
+	}
+
+	be.LoadFn = func(h backend.Handle, p []byte, off int64) (int, error) {
+		return 0, errors.New("not found")
+	}
+
+	be.SaveFn = func(h backend.Handle, p []byte) error {
+		return nil
+	}
+
+	be.StatFn = func(h backend.Handle) (backend.BlobInfo, error) {
+		return backend.BlobInfo{}, errors.New("not found")
+	}
+
+	be.RemoveFn = func(t backend.Type, name string) error {
+		return nil
+	}
+
+	be.ListFn = func(t backend.Type, done <-chan struct{}) <-chan string {
+		ch := make(chan string)
+		close(ch)
+		return ch
+	}
+
+	be.DeleteFn = func() error {
+		return nil
+	}
+
+	return be
+}
+
+func testMasterIndex(t *testing.T) {
+	_, err := io.ReadFull(rand.Reader, DupID[:])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	repo := New(forgetfulBackend())
+	err = repo.Init("foo")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wg := &sync.WaitGroup{}
+	done := make(chan struct{})
+	for i := 0; i < parallelSaves; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-done:
+					return
+				default:
+				}
+
+				id := randomID()
+
+				if repo.Index().Has(id) {
+					continue
+				}
+
+				buf := make([]byte, 50)
+
+				err := repo.SaveFrom(pack.Data, &id, uint(len(buf)), bytes.NewReader(buf))
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		}()
+	}
+
+	saveIndexes := func() {
+		defer wg.Done()
+
+		ticker := time.NewTicker(saveIndexTime)
+		defer ticker.Stop()
+
+		for {
+			select {
+			case <-done:
+				return
+			case <-ticker.C:
+				err := repo.SaveFullIndex()
+				if err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+	}
+
+	wg.Add(1)
+	go saveIndexes()
+
+	<-time.After(testTimeout)
+	close(done)
+
+	wg.Wait()
+}
+
+func TestMasterIndex(t *testing.T) {
+	for i := 0; i < 5; i++ {
+		testMasterIndex(t)
+	}
+}

--- a/repository/packer_manager.go
+++ b/repository/packer_manager.go
@@ -84,7 +84,6 @@ func (r *Repository) savePacker(p *pack.Packer) error {
 			Offset: b.Offset,
 			Length: uint(b.Length),
 		})
-		r.idx.RemoveFromInFlight(b.ID)
 	}
 
 	return nil

--- a/repository/repository_test.go
+++ b/repository/repository_test.go
@@ -83,7 +83,7 @@ func TestSave(t *testing.T) {
 		id := backend.Hash(data)
 
 		// save
-		sid, err := repo.SaveAndEncrypt(pack.Data, data, nil, false)
+		sid, err := repo.SaveAndEncrypt(pack.Data, data, nil)
 		OK(t, err)
 
 		Equals(t, id, sid)
@@ -253,7 +253,7 @@ func saveRandomDataBlobs(t testing.TB, repo *repository.Repository, num int, siz
 		_, err := io.ReadFull(rand.Reader, buf)
 		OK(t, err)
 
-		_, err = repo.SaveAndEncrypt(pack.Data, buf, nil, false)
+		_, err = repo.SaveAndEncrypt(pack.Data, buf, nil)
 		OK(t, err)
 	}
 }


### PR DESCRIPTION
This PR contains commits which add a test and the fix for #405.

This removes the list of in-flight blobs from the master index and instead keeps a list of "known" blobs in the Archiver. "known" here means: either already processed, or included in an index. This property is tested atomically, when the blob is not in the list of "known" blobs, it is added to the list and the caller is responsible to make this happen (i.e. save the blob).

Closes #405
