### PR TITLE
s3: Disable keepalive on minio HTTP client

### DIFF
--- a/backend/s3/s3.go
+++ b/backend/s3/s3.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"errors"
 	"io"
+	"net/http"
 	"strings"
 
 	"github.com/minio/minio-go"
@@ -38,6 +39,11 @@ func Open(cfg Config) (backend.Backend, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	tr := &http.Transport{
+	    DisableKeepAlives: true,
+	}
+	client.SetCustomTransport(tr)
 
 	be := &s3{client: client, bucketname: cfg.Bucket}
 	be.createConnections()


### PR DESCRIPTION
This avoids connections being used for too long and being terminated by the
S3 endpoint.
