### PR TITLE
Reduce jobs run on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,20 @@ go:
   - 1.3.3
   - 1.4.3
   - 1.5.3
-  - 1.6rc1
+  - 1.6rc2
 
 os:
   - linux
   - osx
+
+matrix:
+  exclude:
+    - os: osx
+      go: 1.3.3
+    - os: osx
+      go: 1.4.3
+    - os: osx
+      go: 1.6rc2
 
 notifications:
   irc:


### PR DESCRIPTION
Skip building and testing restic with Go 1.3, 1.4 and 1.6 on osx.
