### PR TITLE
Use a new buffer for each pack in rebuild-index

### DIFF
--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -125,7 +125,6 @@ func (cmd CmdRebuildIndex) RebuildIndex() error {
 
 	cmd.global.Printf("checking for additional packs\n")
 	newPacks := 0
-	var buf []byte
 	for packID := range cmd.repo.List(backend.Data, done) {
 		if packsDone.Has(packID) {
 			continue
@@ -137,6 +136,7 @@ func (cmd CmdRebuildIndex) RebuildIndex() error {
 		var err error
 
 		h := backend.Handle{Type: backend.Data, Name: packID.String()}
+		buf := make([]byte, 0)
 		buf, err = backend.LoadAll(cmd.repo.Backend(), h, buf)
 		if err != nil {
 			debug.Log("RebuildIndex.RebuildIndex", "error while loading pack %v", packID.Str())


### PR DESCRIPTION
The same buffer was being used for downloading multiple packs and
when a bigger-sized buffer was reused to download a new pack, the call
to `io.ReadFull` from some backends would fail with an `unexpected EOF`
error because the number of bytes read would be smaller than the buffer
size.
