### PR TITLE
Fix backup of root directory

### DIFF
--- a/archiver.go
+++ b/archiver.go
@@ -366,6 +366,7 @@ func (arch *Archiver) dirWorker(wg *sync.WaitGroup, p *Progress, done <-chan str
 				// if we get a nil pointer here, an error has happened while
 				// processing this entry. Ignore it for now.
 				if res == nil {
+					debug.Log("Archiver.dirWorker", "got nil result?")
 					continue
 				}
 
@@ -374,7 +375,7 @@ func (arch *Archiver) dirWorker(wg *sync.WaitGroup, p *Progress, done <-chan str
 				tree.Insert(node)
 
 				if node.Type == "dir" {
-					debug.Log("Archiver.dirWorker", "got tree node for %s: %v", node.path, node.blobs)
+					debug.Log("Archiver.dirWorker", "got tree node for %s: %v", node.path, node.Subtree)
 
 					if node.Subtree.IsNull() {
 						panic("invalid null subtree ID")

--- a/archiver.go
+++ b/archiver.go
@@ -350,6 +350,7 @@ func (arch *Archiver) dirWorker(wg *sync.WaitGroup, p *Progress, done <-chan str
 
 			// ignore dir nodes with errors
 			if dir.Error() != nil {
+				fmt.Fprintf(os.Stderr, "error walking dir %v: %v\n", dir.Path(), dir.Error())
 				dir.Result() <- nil
 				p.Report(Stat{Errors: 1})
 				continue

--- a/pipe/pipe.go
+++ b/pipe/pipe.go
@@ -174,7 +174,16 @@ func cleanupPath(path string) ([]string, error) {
 		return []string{path}, nil
 	}
 
-	return readDirNames(path)
+	paths, err := readDirNames(path)
+	if err != nil {
+		return nil, err
+	}
+
+	for i, p := range paths {
+		paths[i] = filepath.Join(path, p)
+	}
+
+	return paths, nil
 }
 
 // Walk sends a Job for each file and directory it finds below the paths. When


### PR DESCRIPTION
After c6a1f2e2f3b21c27aebc86484eb9787e62346c91, backups of `/` were empty, because cleanupPath() did not take care to add the old directory as a prefix. This fixes that and adds more debug.
