### PR TITLE
backend.LoadAll: return nil on expected error

### DIFF
--- a/backend/test/tests.go
+++ b/backend/test/tests.go
@@ -245,6 +245,17 @@ func TestLoad(t testing.TB) {
 		}
 	}
 
+	// load with a too-large buffer, this should return io.ErrUnexpectedEOF
+	buf := make([]byte, length+100)
+	n, err := b.Load(handle, buf, 0)
+	if n != length {
+		t.Errorf("wrong length for larger buffer returned, want %d, got %d", length, n)
+	}
+
+	if err != io.ErrUnexpectedEOF {
+		t.Errorf("wrong error returned for larger buffer: want io.ErrUnexpectedEOF, got %#v", err)
+	}
+
 	OK(t, b.Remove(backend.Data, id.String()))
 }
 

--- a/backend/utils.go
+++ b/backend/utils.go
@@ -1,7 +1,11 @@
 package backend
 
+import "io"
+
 // LoadAll reads all data stored in the backend for the handle. The buffer buf
-// is resized to accomodate all data in the blob.
+// is resized to accomodate all data in the blob. Errors returned by be.Load()
+// are passed on, except io.ErrUnexpectedEOF is silenced and nil returned
+// instead, since it means this function is working properly.
 func LoadAll(be Backend, h Handle, buf []byte) ([]byte, error) {
 	fi, err := be.Stat(h)
 	if err != nil {
@@ -13,6 +17,9 @@ func LoadAll(be Backend, h Handle, buf []byte) ([]byte, error) {
 	}
 
 	n, err := be.Load(h, buf, 0)
+	if err == io.ErrUnexpectedEOF {
+		err = nil
+	}
 	buf = buf[:n]
 	return buf, err
 }

--- a/backend/utils_test.go
+++ b/backend/utils_test.go
@@ -37,3 +37,55 @@ func TestLoadAll(t *testing.T) {
 		}
 	}
 }
+
+func TestLoadSmallBuffer(t *testing.T) {
+	b := mem.New()
+
+	for i := 0; i < 20; i++ {
+		data := Random(23+i, rand.Intn(MiB)+500*KiB)
+
+		id := backend.Hash(data)
+		err := b.Save(backend.Handle{Name: id.String(), Type: backend.Data}, data)
+		OK(t, err)
+
+		buf := make([]byte, len(data)-23)
+		buf, err = backend.LoadAll(b, backend.Handle{Type: backend.Data, Name: id.String()}, buf)
+		OK(t, err)
+
+		if len(buf) != len(data) {
+			t.Errorf("length of returned buffer does not match, want %d, got %d", len(data), len(buf))
+			continue
+		}
+
+		if !bytes.Equal(buf, data) {
+			t.Errorf("wrong data returned")
+			continue
+		}
+	}
+}
+
+func TestLoadLargeBuffer(t *testing.T) {
+	b := mem.New()
+
+	for i := 0; i < 20; i++ {
+		data := Random(23+i, rand.Intn(MiB)+500*KiB)
+
+		id := backend.Hash(data)
+		err := b.Save(backend.Handle{Name: id.String(), Type: backend.Data}, data)
+		OK(t, err)
+
+		buf := make([]byte, len(data)+100)
+		buf, err = backend.LoadAll(b, backend.Handle{Type: backend.Data, Name: id.String()}, buf)
+		OK(t, err)
+
+		if len(buf) != len(data) {
+			t.Errorf("length of returned buffer does not match, want %d, got %d", len(data), len(buf))
+			continue
+		}
+
+		if !bytes.Equal(buf, data) {
+			t.Errorf("wrong data returned")
+			continue
+		}
+	}
+}


### PR DESCRIPTION
The current code returns io.ErrUnexpectedEOF, but it is the normal, expected behaviour of the function LoadAll() to load until the item is completely loaded. Therefore, the io.ErrUnexpectedEOF is not returned to the caller.
