### PR TITLE
Fix #442: set blocks and blocksize in fuse

### DIFF
--- a/fuse/file.go
+++ b/fuse/file.go
@@ -15,6 +15,9 @@ import (
 	"golang.org/x/net/context"
 )
 
+// The default block size to report in stat
+const blockSize = 512
+
 // Statically ensure that *file implements the given interface
 var _ = fs.HandleReader(&file{})
 var _ = fs.HandleReleaser(&file{})
@@ -67,6 +70,8 @@ func (f *file) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Inode = f.node.Inode
 	a.Mode = f.node.Mode
 	a.Size = f.node.Size
+	a.Blocks = (f.node.Size / blockSize) + 1
+	a.BlockSize = blockSize
 
 	if !f.ownerIsRoot {
 		a.Uid = f.node.UID

--- a/fuse/file_test.go
+++ b/fuse/file_test.go
@@ -132,6 +132,7 @@ func TestFuseFile(t *testing.T) {
 	Equals(t, node.Inode, attr.Inode)
 	Equals(t, node.Mode, attr.Mode)
 	Equals(t, node.Size, attr.Size)
+	Equals(t, (node.Size/uint64(attr.BlockSize))+1, attr.Blocks)
 
 	for i, test := range offsetReadsTests {
 		b := memfile[test.offset : test.offset+test.length]


### PR DESCRIPTION
I added code to set the blocks and blocksize similar to [ MediaFire/mediafire-fuse#15](https://github.com/MediaFire/mediafire-fuse/issues/15). Also added a test.

I cannot test if this fixes the issue on my machine, since I cannot reproduce the original problem. OS X does not report 0 file sizes, even when using the "du" from the GNU coreutils. Maybe the OS X fuse layer does a similar calculation?

Maybe someone can test this on another OS? 
