### PR TITLE
Support custom SSH ports in URL of SFTP-repo

### DIFF
--- a/backend/sftp/config_test.go
+++ b/backend/sftp/config_test.go
@@ -19,6 +19,14 @@ var configTests = []struct {
 		"sftp://host//dir/subdir",
 		Config{Host: "host", Dir: "/dir/subdir"},
 	},
+	{
+		"sftp://host:10022//dir/subdir",
+		Config{Host: "host:10022", Dir: "/dir/subdir"},
+	},
+	{
+		"sftp://user@host:10022//dir/subdir",
+		Config{User: "user", Host: "host:10022", Dir: "/dir/subdir"},
+	},
 
 	// second form, user specified sftp:user@host:/dir
 	{

--- a/backend/sftp/sftp.go
+++ b/backend/sftp/sftp.go
@@ -97,7 +97,11 @@ func Open(dir string, program string, args ...string) (*SFTP, error) {
 }
 
 func buildSSHCommand(cfg Config) []string {
-	args := []string{cfg.Host}
+	hostport := strings.Split(cfg.Host, ":")
+	args := []string{hostport[0]}
+	if len(hostport) > 1 {
+		args = append(args, "-p", hostport[1])
+	}
 	if cfg.User != "" {
 		args = append(args, "-l")
 		args = append(args, cfg.User)

--- a/backend/sftp/sshcmd_test.go
+++ b/backend/sftp/sshcmd_test.go
@@ -1,0 +1,46 @@
+package sftp
+
+import "testing"
+
+var sshcmdTests = []struct {
+	cfg Config
+	s   []string
+}{
+	{
+		Config{User: "user", Host: "host", Dir: "dir/subdir"},
+		[]string{"host", "-l", "user", "-s", "sftp"},
+	},
+	{
+		Config{Host: "host", Dir: "dir/subdir"},
+		[]string{"host", "-s", "sftp"},
+	},
+	{
+		Config{Host: "host:10022", Dir: "/dir/subdir"},
+		[]string{"host", "-p", "10022", "-s", "sftp"},
+	},
+	{
+		Config{User: "user", Host: "host:10022", Dir: "/dir/subdir"},
+		[]string{"host", "-p", "10022", "-l", "user", "-s", "sftp"},
+	},
+}
+
+func TestBuildSSHCommand(t *testing.T) {
+	for i, test := range sshcmdTests {
+		cmd := buildSSHCommand(test.cfg)
+		failed := false
+		if len(cmd) != len(test.s) {
+			failed = true
+		} else {
+			for l := range test.s {
+				if test.s[l] != cmd[l] {
+					failed = true
+					break
+				}
+			}
+		}
+		if failed {
+			t.Errorf("test %d: wrong cmd, want:\n  %v\ngot:\n  %v",
+				i, test.s, cmd)
+		}
+	}
+}


### PR DESCRIPTION
Allow supplying an override for the default port (or the one configured in SSH config) similar to the way the user override is possible. When needing to specify a custom port,  the sftp.//... format must be used.
