### PR TITLE
Cleaned up patch for #55.

### DIFF
--- a/src/restic/archiver.go
+++ b/src/restic/archiver.go
@@ -11,12 +11,13 @@ import (
 	"sync"
 	"time"
 
-	"github.com/restic/chunker"
 	"restic/backend"
 	"restic/debug"
 	"restic/pack"
 	"restic/pipe"
 	"restic/repository"
+
+	"github.com/restic/chunker"
 
 	"github.com/juju/errors"
 )
@@ -624,7 +625,7 @@ func unique(items []string) []string {
 // Snapshot creates a snapshot of the given paths. If parentID is set, this is
 // used to compare the files to the ones archived at the time this snapshot was
 // taken.
-func (arch *Archiver) Snapshot(p *Progress, paths []string, parentID *backend.ID) (*Snapshot, backend.ID, error) {
+func (arch *Archiver) Snapshot(p *Progress, paths []string, parentID *backend.ID, comment string) (*Snapshot, backend.ID, error) {
 	paths = unique(paths)
 	sort.Strings(paths)
 
@@ -644,6 +645,7 @@ func (arch *Archiver) Snapshot(p *Progress, paths []string, parentID *backend.ID
 	if err != nil {
 		return nil, backend.ID{}, err
 	}
+	sn.Comment = comment
 	sn.Excludes = arch.Excludes
 
 	jobs := archivePipe{}

--- a/src/restic/archiver_test.go
+++ b/src/restic/archiver_test.go
@@ -7,7 +7,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/restic/chunker"
 	"restic"
 	"restic/backend"
 	"restic/checker"
@@ -15,6 +14,8 @@ import (
 	"restic/pack"
 	"restic/repository"
 	. "restic/test"
+
+	"github.com/restic/chunker"
 )
 
 var testPol = chunker.Pol(0x3DA3358B4DC173)
@@ -112,7 +113,7 @@ func archiveDirectory(b testing.TB) {
 
 	arch := restic.NewArchiver(repo)
 
-	_, id, err := arch.Snapshot(nil, []string{BenchArchiveDirectory}, nil)
+	_, id, err := arch.Snapshot(nil, []string{BenchArchiveDirectory}, nil, "")
 	OK(b, err)
 
 	b.Logf("snapshot archived as %v", id)
@@ -210,7 +211,7 @@ func BenchmarkLoadTree(t *testing.B) {
 
 	// archive a few files
 	arch := restic.NewArchiver(repo)
-	sn, _, err := arch.Snapshot(nil, []string{BenchArchiveDirectory}, nil)
+	sn, _, err := arch.Snapshot(nil, []string{BenchArchiveDirectory}, nil, "")
 	OK(t, err)
 	t.Logf("archived snapshot %v", sn.ID())
 

--- a/src/restic/cache_test.go
+++ b/src/restic/cache_test.go
@@ -17,7 +17,7 @@ func TestCache(t *testing.T) {
 	arch := restic.NewArchiver(repo)
 
 	// archive some files, this should automatically cache all blobs from the snapshot
-	_, _, err = arch.Snapshot(nil, []string{BenchArchiveDirectory}, nil)
+	_, _, err = arch.Snapshot(nil, []string{BenchArchiveDirectory}, nil, "")
 
 	// TODO: test caching index
 }

--- a/src/restic/checker/checker_test.go
+++ b/src/restic/checker/checker_test.go
@@ -243,7 +243,7 @@ func TestCheckerModifiedData(t *testing.T) {
 	OK(t, repo.Init(TestPassword))
 
 	arch := restic.NewArchiver(repo)
-	_, id, err := arch.Snapshot(nil, []string{"."}, nil)
+	_, id, err := arch.Snapshot(nil, []string{"."}, nil, "")
 	OK(t, err)
 	t.Logf("archived as %v", id.Str())
 

--- a/src/restic/cmd/restic/cmd_backup.go
+++ b/src/restic/cmd/restic/cmd_backup.go
@@ -20,6 +20,7 @@ type CmdBackup struct {
 	Parent   string   `short:"p" long:"parent"  description:"use this parent snapshot (default: last snapshot in repo that has the same target)"`
 	Force    bool     `short:"f" long:"force"   description:"Force re-reading the target. Overrides the \"parent\" flag"`
 	Excludes []string `short:"e" long:"exclude" description:"Exclude a pattern (can be specified multiple times)"`
+	Comment  string   `short:"c" long:"comment" description:"Descriptive comment"`
 
 	global *GlobalOptions
 }
@@ -327,7 +328,7 @@ func (cmd CmdBackup) Execute(args []string) error {
 		return nil
 	}
 
-	_, id, err := arch.Snapshot(cmd.newArchiveProgress(stat), target, parentSnapshotID)
+	_, id, err := arch.Snapshot(cmd.newArchiveProgress(stat), target, parentSnapshotID, cmd.Comment)
 	if err != nil {
 		return err
 	}

--- a/src/restic/cmd/restic/cmd_snapshots.go
+++ b/src/restic/cmd/restic/cmd_snapshots.go
@@ -82,7 +82,7 @@ func (cmd CmdSnapshots) Execute(args []string) error {
 	}
 
 	tab := NewTable()
-	tab.Header = fmt.Sprintf("%-8s  %-19s  %-10s  %s", "ID", "Date", "Source", "Directory")
+	tab.Header = fmt.Sprintf("%-8s  %-19s  %-10s  %s", "ID", "Date", "Source", "Comment")
 	tab.RowFormat = "%-8s  %-19s  %-10s  %s"
 
 	done := make(chan struct{})
@@ -119,13 +119,7 @@ func (cmd CmdSnapshots) Execute(args []string) error {
 			continue
 		}
 		id := sn.ID()
-		tab.Rows = append(tab.Rows, []interface{}{hex.EncodeToString(id[:plen/2]), sn.Time.Format(TimeFormat), sn.Hostname, sn.Paths[0]})
-
-		if len(sn.Paths) > 1 {
-			for _, path := range sn.Paths[1:] {
-				tab.Rows = append(tab.Rows, []interface{}{"", "", "", path})
-			}
-		}
+		tab.Rows = append(tab.Rows, []interface{}{hex.EncodeToString(id[:plen/2]), sn.Time.Format(TimeFormat), sn.Hostname, sn.Comment})
 	}
 
 	tab.Write(os.Stdout)

--- a/src/restic/snapshot.go
+++ b/src/restic/snapshot.go
@@ -16,6 +16,7 @@ type Snapshot struct {
 	Parent   *backend.ID `json:"parent,omitempty"`
 	Tree     *backend.ID `json:"tree"`
 	Paths    []string    `json:"paths"`
+	Comment  string      `json:"comment"`
 	Hostname string      `json:"hostname,omitempty"`
 	Username string      `json:"username,omitempty"`
 	UID      uint32      `json:"uid,omitempty"`

--- a/src/restic/test/backend.go
+++ b/src/restic/test/backend.go
@@ -84,7 +84,7 @@ func TeardownRepo(repo *repository.Repository) {
 
 func SnapshotDir(t testing.TB, repo *repository.Repository, path string, parent *backend.ID) *restic.Snapshot {
 	arch := restic.NewArchiver(repo)
-	sn, _, err := arch.Snapshot(nil, []string{path}, parent)
+	sn, _, err := arch.Snapshot(nil, []string{path}, parent, "")
 	OK(t, err)
 	return sn
 }

--- a/src/restic/walk_test.go
+++ b/src/restic/walk_test.go
@@ -24,7 +24,7 @@ func TestWalkTree(t *testing.T) {
 
 	// archive a few files
 	arch := restic.NewArchiver(repo)
-	sn, _, err := arch.Snapshot(nil, dirs, nil)
+	sn, _, err := arch.Snapshot(nil, dirs, nil, "")
 	OK(t, err)
 
 	// flush repo, write all packs


### PR DESCRIPTION
Changes to _test.go were not part of the patch. I added them to be able
to run the tests after patching. 

All other changes are from #55, https://github.com/restic/restic/files/133561/snapshot-comments-v1.diff.txt by @mappu
