### PR TITLE
Ignore invalid index files

### DIFF
--- a/src/cmds/restic/cmd_dump.go
+++ b/src/cmds/restic/cmd_dump.go
@@ -105,7 +105,7 @@ func (cmd CmdDump) DumpIndexes() error {
 	for id := range cmd.repo.List(backend.Index, done) {
 		fmt.Printf("index_id: %v\n", id)
 
-		idx, err := repository.LoadIndex(cmd.repo, id.String())
+		idx, err := repository.LoadIndex(cmd.repo, id)
 		if err != nil {
 			return err
 		}

--- a/src/cmds/restic/cmd_rebuild_index.go
+++ b/src/cmds/restic/cmd_rebuild_index.go
@@ -71,7 +71,7 @@ func (cmd CmdRebuildIndex) RebuildIndex() error {
 		cmd.global.Printf("  loading index %v\n", i)
 
 		debug.Log("RebuildIndex.RebuildIndex", "load index %v", indexID.Str())
-		idx, err := repository.LoadIndex(cmd.repo, indexID.String())
+		idx, err := repository.LoadIndex(cmd.repo, indexID)
 		if err != nil {
 			return err
 		}

--- a/src/restic/checker/checker.go
+++ b/src/restic/checker/checker.go
@@ -83,12 +83,12 @@ func (c *Checker) LoadIndex() (hints []error, errs []error) {
 
 	worker := func(id backend.ID, done <-chan struct{}) error {
 		debug.Log("LoadIndex", "worker got index %v", id)
-		idx, err := repository.LoadIndexWithDecoder(c.repo, id.String(), repository.DecodeIndex)
+		idx, err := repository.LoadIndexWithDecoder(c.repo, id, repository.DecodeIndex)
 		if err == repository.ErrOldIndexFormat {
 			debug.Log("LoadIndex", "index %v has old format", id.Str())
 			hints = append(hints, ErrOldIndexFormat{id})
 
-			idx, err = repository.LoadIndexWithDecoder(c.repo, id.String(), repository.DecodeOldIndex)
+			idx, err = repository.LoadIndexWithDecoder(c.repo, id, repository.DecodeOldIndex)
 		}
 
 		if err != nil {

--- a/src/restic/repository/index.go
+++ b/src/restic/repository/index.go
@@ -557,15 +557,10 @@ func DecodeOldIndex(rd io.Reader) (idx *Index, err error) {
 }
 
 // LoadIndexWithDecoder loads the index and decodes it with fn.
-func LoadIndexWithDecoder(repo *Repository, id string, fn func(io.Reader) (*Index, error)) (idx *Index, err error) {
+func LoadIndexWithDecoder(repo *Repository, id backend.ID, fn func(io.Reader) (*Index, error)) (idx *Index, err error) {
 	debug.Log("LoadIndexWithDecoder", "Loading index %v", id[:8])
 
-	idxID, err := backend.ParseID(id)
-	if err != nil {
-		return nil, err
-	}
-
-	buf, err := repo.LoadAndDecrypt(backend.Index, idxID)
+	buf, err := repo.LoadAndDecrypt(backend.Index, id)
 	if err != nil {
 		return nil, err
 	}
@@ -576,7 +571,7 @@ func LoadIndexWithDecoder(repo *Repository, id string, fn func(io.Reader) (*Inde
 		return nil, err
 	}
 
-	idx.id = idxID
+	idx.id = id
 
 	return idx, nil
 }
@@ -588,7 +583,7 @@ func LoadIndexWithDecoder(repo *Repository, id string, fn func(io.Reader) (*Inde
 func ConvertIndex(repo *Repository, id backend.ID) (backend.ID, error) {
 	debug.Log("ConvertIndex", "checking index %v", id.Str())
 
-	idx, err := LoadIndexWithDecoder(repo, id.String(), DecodeOldIndex)
+	idx, err := LoadIndexWithDecoder(repo, id, DecodeOldIndex)
 	if err != nil {
 		debug.Log("ConvertIndex", "LoadIndexWithDecoder(%v) returned error: %v", id.Str(), err)
 		return id, err

--- a/src/restic/repository/parallel.go
+++ b/src/restic/repository/parallel.go
@@ -4,6 +4,7 @@ import (
 	"sync"
 
 	"restic/backend"
+	"restic/debug"
 )
 
 func closeIfOpen(ch chan struct{}) {
@@ -75,12 +76,14 @@ func FilesInParallel(repo backend.Lister, t backend.Type, n uint, f ParallelWork
 }
 
 // ParallelWorkFuncParseID converts a function that takes a backend.ID to a
-// function that takes a string.
+// function that takes a string. Filenames that do not parse as a backend.ID
+// are ignored.
 func ParallelWorkFuncParseID(f ParallelIDWorkFunc) ParallelWorkFunc {
 	return func(s string, done <-chan struct{}) error {
 		id, err := backend.ParseID(s)
 		if err != nil {
-			return err
+			debug.Log("repository.ParallelWorkFuncParseID", "invalid ID %q: %v", id, err)
+			return nil
 		}
 
 		return f(id, done)

--- a/src/restic/repository/repository_test.go
+++ b/src/restic/repository/repository_test.go
@@ -292,7 +292,7 @@ func TestRepositoryIncrementalIndex(t *testing.T) {
 	packEntries := make(map[backend.ID]map[backend.ID]struct{})
 
 	for id := range repo.List(backend.Index, nil) {
-		idx, err := repository.LoadIndex(repo, id.String())
+		idx, err := repository.LoadIndex(repo, id)
 		OK(t, err)
 
 		for pb := range idx.Each(nil) {


### PR DESCRIPTION
This ignores all index files that don't parse as an ID.

Closes #475
