### PR TITLE
Change ErrNoKeyFound message

### DIFF
--- a/src/restic/repository/key.go
+++ b/src/restic/repository/key.go
@@ -16,7 +16,7 @@ import (
 
 var (
 	// ErrNoKeyFound is returned when no key for the repository could be decrypted.
-	ErrNoKeyFound = errors.New("no key could be found")
+	ErrNoKeyFound = errors.New("wrong password or no key found")
 )
 
 // TODO: figure out scrypt values on the fly depending on the current


### PR DESCRIPTION
For #438. I was just going to change it to "wrong password" but then I saw that it might actually be the case that no key could be found, so I changed it to what I did. Let me know if you'd like something different!
