### PR TITLE
Umount fuse in tests

### DIFF
--- a/src/cmds/restic/cmd_mount.go
+++ b/src/cmds/restic/cmd_mount.go
@@ -98,10 +98,10 @@ func (cmd CmdMount) Execute(args []string) error {
 	case err := <-errServe:
 		return err
 	case <-cmd.done:
-		err := c.Close()
+		err := systemFuse.Unmount(mountpoint)
 		if err != nil {
-			cmd.global.Printf("Error closing fuse connection: %s\n", err)
+			cmd.global.Printf("Error umounting: %s\n", err)
 		}
-		return systemFuse.Unmount(mountpoint)
+		return c.Close()
 	}
 }


### PR DESCRIPTION
This corrects the order when the fuse mount is terminated by closing the
done channel: Before, restic would close the fuse connection and only
afterwards try to remove the mount, that does not work.

Closes #494
