### PR TITLE
Allow reading data from stdin

### DIFF
--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -182,6 +182,22 @@ see [`filepath.Match`](https://golang.org/pkg/path/filepath/#Match) for syntax.
 Additionally `**` exludes arbitrary subdirectories.  
 Environment-variables in exclude-files are expanded with [`os.ExpandEnv`](https://golang.org/pkg/os/#ExpandEnv).
 
+## Reading data from stdin
+
+Sometimes it can be nice to directly save the output of a program, e.g.
+`mysqldump` so that the SQL can later be restored. Restic supports this mode of
+operation, just supply the option `--stdin` to the `backup` command like this:
+
+    $ mysqldump [...] | restic -r /tmp/backup backup --stdin
+
+This creates a new snapshot of the output of `mqsqldump`. You can then use e.g.
+the fuse mounting option (see below) to mount the repository and read the file.
+
+By default, the file name `stdin` is used, a different name can be specified
+with `--stdin-filename`, e.g. like this:
+
+    $ mysqldump [...] | restic -r /tmp/backup backup --stdin --stdin-filenam production.sql
+
 # List all snapshots
 
 Now, you can list all the snapshots stored in the repository:

--- a/src/restic/archive_reader.go
+++ b/src/restic/archive_reader.go
@@ -44,6 +44,7 @@ func ArchiveReader(repo *repository.Repository, p *Progress, rd io.Reader, name 
 	chnker := chunker.New(rd, repo.Config.ChunkerPolynomial)
 
 	var ids backend.IDs
+	var fileSize uint64
 
 	for {
 		chunk, err := chnker.Next(getBuf())
@@ -72,6 +73,7 @@ func ArchiveReader(repo *repository.Repository, p *Progress, rd io.Reader, name 
 		ids = append(ids, id)
 
 		p.Report(Stat{Bytes: uint64(chunk.Length)})
+		fileSize += uint64(chunk.Length)
 	}
 
 	tree := &Tree{
@@ -82,6 +84,7 @@ func ArchiveReader(repo *repository.Repository, p *Progress, rd io.Reader, name 
 				ModTime:    time.Now(),
 				Type:       "file",
 				Mode:       0644,
+				Size:       fileSize,
 				UID:        sn.UID,
 				GID:        sn.GID,
 				User:       sn.Username,

--- a/src/restic/archive_reader.go
+++ b/src/restic/archive_reader.go
@@ -1,0 +1,119 @@
+package restic
+
+import (
+	"encoding/json"
+	"io"
+	"restic/backend"
+	"restic/debug"
+	"restic/pack"
+	"restic/repository"
+	"time"
+
+	"github.com/restic/chunker"
+)
+
+// saveTreeJSON stores a tree in the repository.
+func saveTreeJSON(repo *repository.Repository, item interface{}) (backend.ID, error) {
+	data, err := json.Marshal(item)
+	if err != nil {
+		return backend.ID{}, err
+	}
+	data = append(data, '\n')
+
+	// check if tree has been saved before
+	id := backend.Hash(data)
+	if repo.Index().Has(id) {
+		return id, nil
+	}
+
+	return repo.SaveJSON(pack.Tree, item)
+}
+
+// ArchiveReader reads from the reader and archives the data. Returned is the
+// resulting snapshot and its ID.
+func ArchiveReader(repo *repository.Repository, p *Progress, rd io.Reader, name string) (*Snapshot, backend.ID, error) {
+	debug.Log("ArchiveReader", "start archiving %s", name)
+	sn, err := NewSnapshot([]string{name})
+	if err != nil {
+		return nil, backend.ID{}, err
+	}
+
+	p.Start()
+	defer p.Done()
+
+	chnker := chunker.New(rd, repo.Config.ChunkerPolynomial)
+
+	var ids backend.IDs
+
+	for {
+		chunk, err := chnker.Next(getBuf())
+		if err == io.EOF {
+			break
+		}
+
+		if err != nil {
+			return nil, backend.ID{}, err
+		}
+
+		id := backend.Hash(chunk.Data)
+
+		if !repo.Index().Has(id) {
+			_, err := repo.SaveAndEncrypt(pack.Data, chunk.Data, nil)
+			if err != nil {
+				return nil, backend.ID{}, err
+			}
+			debug.Log("ArchiveReader", "saved blob %v (%d bytes)\n", id.Str(), chunk.Length)
+		} else {
+			debug.Log("ArchiveReader", "blob %v already saved in the repo\n", id.Str())
+		}
+
+		freeBuf(chunk.Data)
+
+		ids = append(ids, id)
+
+		p.Report(Stat{Bytes: uint64(chunk.Length)})
+	}
+
+	tree := &Tree{
+		Nodes: []*Node{
+			&Node{
+				Name:       name,
+				AccessTime: time.Now(),
+				ModTime:    time.Now(),
+				Type:       "file",
+				Mode:       0644,
+				UID:        sn.UID,
+				GID:        sn.GID,
+				User:       sn.Username,
+				Content:    ids,
+			},
+		},
+	}
+
+	treeID, err := saveTreeJSON(repo, tree)
+	if err != nil {
+		return nil, backend.ID{}, err
+	}
+	sn.Tree = &treeID
+	debug.Log("ArchiveReader", "tree saved as %v", treeID.Str())
+
+	id, err := repo.SaveJSONUnpacked(backend.Snapshot, sn)
+	if err != nil {
+		return nil, backend.ID{}, err
+	}
+
+	sn.id = &id
+	debug.Log("ArchiveReader", "snapshot saved as %v", id.Str())
+
+	err = repo.Flush()
+	if err != nil {
+		return nil, backend.ID{}, err
+	}
+
+	err = repo.SaveIndex()
+	if err != nil {
+		return nil, backend.ID{}, err
+	}
+
+	return sn, id, nil
+}

--- a/src/restic/archive_reader_test.go
+++ b/src/restic/archive_reader_test.go
@@ -1,0 +1,77 @@
+package restic
+
+import (
+	"bytes"
+	"io"
+	"math/rand"
+	"restic/backend"
+	"restic/pack"
+	"restic/repository"
+	"testing"
+
+	"github.com/restic/chunker"
+)
+
+func loadBlob(t *testing.T, repo *repository.Repository, id backend.ID, buf []byte) []byte {
+	buf, err := repo.LoadBlob(pack.Data, id, buf)
+	if err != nil {
+		t.Fatalf("LoadBlob(%v) returned error %v", id, err)
+	}
+
+	return buf
+}
+
+func TestArchiveReader(t *testing.T) {
+	repo, cleanup := repository.TestRepository(t)
+	defer cleanup()
+
+	seed := rand.Int63()
+	size := int64(rand.Intn(50*1024*1024) + 50*1024*1024)
+	t.Logf("seed is 0x%016x, size is %v", seed, size)
+
+	f := fakeFile(t, seed, size)
+
+	sn, id, err := ArchiveReader(repo, nil, f, "fakefile")
+	if err != nil {
+		t.Fatalf("ArchiveReader() returned error %v", err)
+	}
+
+	if id.IsNull() {
+		t.Fatalf("ArchiveReader() returned null ID")
+	}
+
+	t.Logf("snapshot saved as %v, tree is %v", id.Str(), sn.Tree.Str())
+
+	tree, err := LoadTree(repo, *sn.Tree)
+	if err != nil {
+		t.Fatalf("LoadTree() returned error %v", err)
+	}
+
+	if len(tree.Nodes) != 1 {
+		t.Fatalf("wrong number of nodes for tree, want %v, got %v", 1, len(tree.Nodes))
+	}
+
+	node := tree.Nodes[0]
+	if node.Name != "fakefile" {
+		t.Fatalf("wrong filename, want %v, got %v", "fakefile", node.Name)
+	}
+
+	if len(node.Content) == 0 {
+		t.Fatalf("node.Content has length 0")
+	}
+
+	// check blobs
+	f = fakeFile(t, seed, size)
+	buf := make([]byte, chunker.MaxSize)
+	buf2 := make([]byte, chunker.MaxSize)
+	for i, id := range node.Content {
+		buf = loadBlob(t, repo, id, buf)
+
+		buf2 = buf2[:len(buf)]
+		_, err = io.ReadFull(f, buf2)
+
+		if !bytes.Equal(buf, buf2) {
+			t.Fatalf("blob %d (%v) is wrong", i, id.Str())
+		}
+	}
+}

--- a/src/restic/fuse/file.go
+++ b/src/restic/fuse/file.go
@@ -49,6 +49,7 @@ var blobPool = sync.Pool{
 
 func newFile(repo BlobLoader, node *restic.Node, ownerIsRoot bool) (*file, error) {
 	debug.Log("newFile", "create new file for %v with %d blobs", node.Name, len(node.Content))
+	var bytes uint64
 	sizes := make([]uint, len(node.Content))
 	for i, id := range node.Content {
 		size, err := repo.LookupBlobSize(id)
@@ -57,6 +58,12 @@ func newFile(repo BlobLoader, node *restic.Node, ownerIsRoot bool) (*file, error
 		}
 
 		sizes[i] = size
+		bytes += uint64(size)
+	}
+
+	if bytes != node.Size {
+		debug.Log("newFile", "sizes do not match: node.Size %v != size %v, using real size", node.Size, bytes)
+		node.Size = bytes
 	}
 
 	return &file{


### PR DESCRIPTION
This PR adds the options `--stdin` and `--stdin-filename` to the `backup` command. It allows reading backup data from stdin, so the following use case becomes possible:

```
$ mysqldump | restic backup --stdin --stdin-filename production.sql
```

It's not yet fully optimized, it only reads chunks sequentially.

TODO:
- [x] Add a test
- [x] Add documentation

Closes #255
