### PR TITLE
Better backup parent snapshot search. Part of #513

### DIFF
--- a/src/cmds/restic/cmd_backup.go
+++ b/src/cmds/restic/cmd_backup.go
@@ -180,11 +180,15 @@ func samePaths(expected, actual []string) bool {
 		return true
 	}
 
-	if len(expected) != len(actual) {
-		return false
-	}
 	for i := range expected {
-		if expected[i] != actual[i] {
+               found := false
+               for j := range actual {
+                       if expected[i] == actual[j] {
+                               found = true
+                               break
+                       }
+               }
+               if !found {
 			return false
 		}
 	}

--- a/src/cmds/restic/cmd_backup.go
+++ b/src/cmds/restic/cmd_backup.go
@@ -181,14 +181,14 @@ func samePaths(expected, actual []string) bool {
 	}
 
 	for i := range expected {
-               found := false
-               for j := range actual {
-                       if expected[i] == actual[j] {
-                               found = true
-                               break
-                       }
-               }
-               if !found {
+		found := false
+		for j := range actual {
+			if expected[i] == actual[j] {
+				found = true
+				break
+			}
+		}
+		if !found {
 			return false
 		}
 	}


### PR DESCRIPTION
I look for the newest snapshot that contains all supplied paths to backup.

This fixes the finding of good parent if 1) there are a different number of paths supplied, but contained in a snapshot, and 2) if cmdline paths are not given in alphabetical order.
