### PR TITLE
Traverse paths in the same order as parent snapshot

### DIFF
--- a/src/restic/archiver.go
+++ b/src/restic/archiver.go
@@ -622,23 +622,23 @@ func unique(items []string) []string {
 	return items
 }
 
-// BaseNameSlice allows sorting paths by basename.
+// baseNameSlice allows sorting paths by basename.
 //
 // Snapshots have contents sorted by basename, but we receive full paths.
 // For the archivePipe to advance them in pairs, we traverse the given
 // paths in the same order as the snapshot.
-type BaseNameSlice []string
+type baseNameSlice []string
 
-func (p BaseNameSlice) Len() int           { return len(p) }
-func (p BaseNameSlice) Less(i, j int) bool { return filepath.Base(p[i]) < filepath.Base(p[j]) }
-func (p BaseNameSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+func (p baseNameSlice) Len() int           { return len(p) }
+func (p baseNameSlice) Less(i, j int) bool { return filepath.Base(p[i]) < filepath.Base(p[j]) }
+func (p baseNameSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
 // Snapshot creates a snapshot of the given paths. If parentID is set, this is
 // used to compare the files to the ones archived at the time this snapshot was
 // taken.
 func (arch *Archiver) Snapshot(p *Progress, paths []string, parentID *backend.ID) (*Snapshot, backend.ID, error) {
 	paths = unique(paths)
-	sort.Sort(BaseNameSlice(paths))
+	sort.Sort(baseNameSlice(paths))
 
 	debug.Log("Archiver.Snapshot", "start for %v", paths)
 

--- a/src/restic/archiver.go
+++ b/src/restic/archiver.go
@@ -622,12 +622,21 @@ func unique(items []string) []string {
 	return items
 }
 
+// Snapshots have contents sorted by basename, but we receive full paths.
+// For the archivePipe to advance them in pairs, we traverse the given
+// paths in the same order as the snapshot.
+type BaseNameSlice []string
+
+func (p BaseNameSlice) Len() int           { return len(p) }
+func (p BaseNameSlice) Less(i, j int) bool { return filepath.Base(p[i]) < filepath.Base(p[j]) }
+func (p BaseNameSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
+
 // Snapshot creates a snapshot of the given paths. If parentID is set, this is
 // used to compare the files to the ones archived at the time this snapshot was
 // taken.
 func (arch *Archiver) Snapshot(p *Progress, paths []string, parentID *backend.ID) (*Snapshot, backend.ID, error) {
 	paths = unique(paths)
-	sort.Strings(paths)
+	sort.Sort(BaseNameSlice(paths))
 
 	debug.Log("Archiver.Snapshot", "start for %v", paths)
 

--- a/src/restic/archiver.go
+++ b/src/restic/archiver.go
@@ -622,6 +622,8 @@ func unique(items []string) []string {
 	return items
 }
 
+// BaseNameSlice allows sorting paths by basename.
+//
 // Snapshots have contents sorted by basename, but we receive full paths.
 // For the archivePipe to advance them in pairs, we traverse the given
 // paths in the same order as the snapshot.


### PR DESCRIPTION
This is the 2nd partial fix to #513.

The archivepipe requires the snapshot paths and the backup paths to be
traversed in the same order, and they were sorted differently: the backup paths
by full path, and the snapshot by basename path.
