### PR TITLE
idset.go: micro-optimise away redundant scan

### DIFF
--- a/src/restic/backend/idset.go
+++ b/src/restic/backend/idset.go
@@ -55,11 +55,7 @@ func (s IDSet) Equals(other IDSet) bool {
 		}
 	}
 
-	for id := range other {
-		if _, ok := s[id]; !ok {
-			return false
-		}
-	}
+	// length + one-way comparison is sufficient implication of equality
 
 	return true
 }


### PR DESCRIPTION
I saw this small thing when studying the code.
