### PR TITLE
Fix fuse panic with empty files

### DIFF
--- a/src/restic/fuse/file.go
+++ b/src/restic/fuse/file.go
@@ -124,10 +124,9 @@ func (f *file) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadR
 	debug.Log("file.Read", "Read(%v, %v, %v), file size %v", f.node.Name, req.Size, req.Offset, f.node.Size)
 	offset := req.Offset
 
-	lastSize := f.sizes[len(f.sizes)-1]
-	if offset > int64(lastSize) {
-		debug.Log("file.Read", "Read(%v): offset is greater than file size: %v > %v, node size %v",
-			f.node.Name, req.Offset, lastSize, f.node.Size)
+	if uint64(offset) > f.node.Size {
+		debug.Log("file.Read", "Read(%v): offset is greater than file size: %v > %v",
+			f.node.Name, req.Offset, f.node.Size)
 		return errors.New("offset greater than files size")
 	}
 

--- a/src/restic/fuse/file.go
+++ b/src/restic/fuse/file.go
@@ -4,6 +4,7 @@
 package fuse
 
 import (
+	"errors"
 	"sync"
 
 	"restic"
@@ -120,8 +121,15 @@ func (f *file) getBlobAt(i int) (blob []byte, err error) {
 }
 
 func (f *file) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {
-	debug.Log("file.Read", "Read(%v), file size %v", req.Size, f.node.Size)
+	debug.Log("file.Read", "Read(%v, %v, %v), file size %v", f.node.Name, req.Size, req.Offset, f.node.Size)
 	offset := req.Offset
+
+	lastSize := f.sizes[len(f.sizes)-1]
+	if offset > int64(lastSize) {
+		debug.Log("file.Read", "Read(%v): offset is greater than file size: %v > %v, node size %v",
+			f.node.Name, req.Offset, lastSize, f.node.Size)
+		return errors.New("offset greater than files size")
+	}
 
 	// Skip blobs before the offset
 	startContent := 0

--- a/src/restic/fuse/file.go
+++ b/src/restic/fuse/file.go
@@ -130,6 +130,12 @@ func (f *file) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadR
 		return errors.New("offset greater than files size")
 	}
 
+	// handle special case: file is empty
+	if f.node.Size == 0 {
+		resp.Data = resp.Data[:0]
+		return nil
+	}
+
 	// Skip blobs before the offset
 	startContent := 0
 	for offset > int64(f.sizes[startContent]) {


### PR DESCRIPTION
This PR adds code to correctly handle empty files in the fuse mount.
