### PR TITLE
Detect a devel version correctly in LDFlags()

### DIFF
--- a/build.go
+++ b/build.go
@@ -265,7 +265,7 @@ func (cs Constants) LDFlags() string {
 	l := make([]string, 0, len(cs))
 
 	v := runtime.Version()
-	if strings.HasPrefix(v, "go1.5") || strings.HasPrefix(v, "go1.6") || strings.HasPrefix(v, "go1.7") {
+	if strings.HasPrefix(v, "devel") || strings.HasPrefix(v, "go1.5") || strings.HasPrefix(v, "go1.6") || strings.HasPrefix(v, "go1.7") {
 		for k, v := range cs {
 			l = append(l, fmt.Sprintf(`-X "%s=%s"`, k, v))
 		}


### PR DESCRIPTION
I use a tip build where `runtime.Version()` return something like this

```
devel +111d590 Fri Jul 29 01:09:55 2016 +0000
```

This patch detects these builds.
