### PR TITLE
Issue-535: restic respect GOMAXPROCS env variable depending on go version

### DIFF
--- a/src/cmds/restic/main.go
+++ b/src/cmds/restic/main.go
@@ -2,17 +2,23 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"runtime"
-
 	"github.com/jessevdk/go-flags"
+	"os"
 	"restic"
 	"restic/debug"
+	"runtime"
 )
 
 func init() {
 	// set GOMAXPROCS to number of CPUs
-	runtime.GOMAXPROCS(runtime.NumCPU())
+	if runtime.Version() < "go1.5" {
+		gomaxprocs := os.Getenv("GOMAXPROCS")
+		debug.Log("restic", "read GOMAXPROCS from env variable, value: %s", gomaxprocs)
+		if gomaxprocs == "" {
+			runtime.GOMAXPROCS(runtime.NumCPU())
+		}
+	}
+
 }
 
 func main() {


### PR DESCRIPTION
I've tested it on go1.4 and 1.6. It works, but I don't like expression like "if version < "go1.5". If you have any suggestions please let me know, I'll change them.

Closes #535 
