### PR TITLE
Fix build on linux/arm

### DIFF
--- a/run_integration_tests.go
+++ b/run_integration_tests.go
@@ -323,11 +323,14 @@ func (env *TravisEnvironment) RunTests() error {
 	if *runCrossCompile && !(runtime.Version() < "go1.7") {
 		// compile for all target architectures with tags
 		for _, tags := range []string{"release", "debug"} {
-			runWithEnv(env.env, "gox", "-verbose",
+			err := runWithEnv(env.env, "gox", "-verbose",
 				"-osarch", strings.Join(env.goxOSArch, " "),
 				"-tags", tags,
 				"-output", "/tmp/{{.Dir}}_{{.OS}}_{{.Arch}}",
 				"cmds/restic")
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/vendor/src/golang.org/x/sys/unix/ztypes_linux_arm.go
+++ b/vendor/src/golang.org/x/sys/unix/ztypes_linux_arm.go
@@ -145,6 +145,15 @@ type Fsid struct {
 	X__val [2]int32
 }
 
+const (
+	FADV_NORMAL     = 0x0
+	FADV_RANDOM     = 0x1
+	FADV_SEQUENTIAL = 0x2
+	FADV_WILLNEED   = 0x3
+	FADV_DONTNEED   = 0x4
+	FADV_NOREUSE    = 0x5
+)
+
 type Flock_t struct {
 	Type      int16
 	Whence    int16


### PR DESCRIPTION
The constants removed in b20921d836fda758143c8c10362ca5dfd170d5b2 are not there for ARM yet, this broke compilation on arm.

This PR adds code to test for compilation errors and introduces the constants for ARM manually.
