### PR TITLE
show progress every second when run non interactively

### DIFF
--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -89,6 +89,14 @@ them, e.g. for the `backup` command:
           -f, --force    Force re-reading the target. Overrides the "parent" flag
           -e, --exclude= Exclude a pattern (can be specified multiple times)
 
+Subcommand that support showing progress information such as `backup`, `check` and `prune` will do so unless
+the quiet flag `-q` or `--quiet` is set. When running from a non-interactive console progress reporting will
+be limited to once every 10 seconds to not fill your logs.
+
+Additionally on Unix systems if `restic` receives a SIGUSR signal the current progress will written to the
+standard output so you can check up on the status at will.
+
+
 # Initialize a repository
 
 First, we need to create a "repository". This is the place where your backups

--- a/src/cmds/restic/cmd_backup.go
+++ b/src/cmds/restic/cmd_backup.go
@@ -112,12 +112,12 @@ func (cmd CmdBackup) newScanProgress() *restic.Progress {
 		return nil
 	}
 
-	p := restic.NewProgress(time.Second)
+	p := restic.NewProgress()
 	p.OnUpdate = func(s restic.Stat, d time.Duration, ticker bool) {
-		fmt.Printf("%s[%s] %d directories, %d files, %s\r", ClearLine(), formatDuration(d), s.Dirs, s.Files, formatBytes(s.Bytes))
+		PrintProgress("[%s] %d directories, %d files, %s", formatDuration(d), s.Dirs, s.Files, formatBytes(s.Bytes))
 	}
 	p.OnDone = func(s restic.Stat, d time.Duration, ticker bool) {
-		fmt.Printf("%sscanned %d directories, %d files in %s\n", ClearLine(), s.Dirs, s.Files, formatDuration(d))
+		PrintProgress("scanned %d directories, %d files in %s\n", s.Dirs, s.Files, formatDuration(d))
 	}
 
 	return p
@@ -128,7 +128,7 @@ func (cmd CmdBackup) newArchiveProgress(todo restic.Stat) *restic.Progress {
 		return nil
 	}
 
-	archiveProgress := restic.NewProgress(time.Second)
+	archiveProgress := restic.NewProgress()
 
 	var bps, eta uint64
 	itemsTodo := todo.Files + todo.Dirs
@@ -167,7 +167,7 @@ func (cmd CmdBackup) newArchiveProgress(todo restic.Stat) *restic.Progress {
 			}
 		}
 
-		fmt.Printf("%s%s%s\r", ClearLine(), status1, status2)
+		PrintProgress("%s%s", status1, status2)
 	}
 
 	archiveProgress.OnDone = func(s restic.Stat, d time.Duration, ticker bool) {
@@ -182,7 +182,7 @@ func (cmd CmdBackup) newArchiveStdinProgress() *restic.Progress {
 		return nil
 	}
 
-	archiveProgress := restic.NewProgress(time.Second)
+	archiveProgress := restic.NewProgress()
 
 	var bps uint64
 
@@ -208,7 +208,7 @@ func (cmd CmdBackup) newArchiveStdinProgress() *restic.Progress {
 			}
 		}
 
-		fmt.Printf("%s%s\r", ClearLine(), status1)
+		PrintProgress("%s%s", status1)
 	}
 
 	archiveProgress.OnDone = func(s restic.Stat, d time.Duration, ticker bool) {

--- a/src/cmds/restic/cmd_check.go
+++ b/src/cmds/restic/cmd_check.go
@@ -38,7 +38,7 @@ func (cmd CmdCheck) newReadProgress(todo restic.Stat) *restic.Progress {
 		return nil
 	}
 
-	readProgress := restic.NewProgress(time.Second)
+	readProgress := restic.NewProgress()
 
 	readProgress.OnUpdate = func(s restic.Stat, d time.Duration, ticker bool) {
 		status := fmt.Sprintf("[%s] %s  %d / %d items",
@@ -54,7 +54,7 @@ func (cmd CmdCheck) newReadProgress(todo restic.Stat) *restic.Progress {
 			}
 		}
 
-		fmt.Printf("%s%s\r", ClearLine(), status)
+		PrintProgress("%s", status)
 	}
 
 	readProgress.OnDone = func(s restic.Stat, d time.Duration, ticker bool) {

--- a/src/cmds/restic/cmd_prune.go
+++ b/src/cmds/restic/cmd_prune.go
@@ -39,7 +39,7 @@ func newProgressMax(show bool, max uint64, description string) *restic.Progress 
 		return nil
 	}
 
-	p := restic.NewProgress(time.Second)
+	p := restic.NewProgress()
 
 	p.OnUpdate = func(s restic.Stat, d time.Duration, ticker bool) {
 		status := fmt.Sprintf("[%s] %s  %d / %d %s",
@@ -55,7 +55,7 @@ func newProgressMax(show bool, max uint64, description string) *restic.Progress 
 			}
 		}
 
-		fmt.Printf("%s%s\r", ClearLine(), status)
+		PrintProgress("%s", status)
 	}
 
 	p.OnDone = func(s restic.Stat, d time.Duration, ticker bool) {

--- a/src/restic/progress_unix.go
+++ b/src/restic/progress_unix.go
@@ -1,0 +1,22 @@
+// +build !windows
+
+package restic
+
+import (
+	"os"
+	"os/signal"
+	"syscall"
+
+	"restic/debug"
+)
+
+func init() {
+	c := make(chan os.Signal)
+	signal.Notify(c, syscall.SIGUSR1)
+	go func() {
+		for s := range c {
+			debug.Log("progress.handleSIGUSR1", "Signal received: %v\n", s)
+			forceUpdateProgress <- true
+		}
+	}()
+}


### PR DESCRIPTION
When running `restic` without an interactive terminal there is currently very little output.

```
$ restic backup /tmp/test_tree/ | tee /tmp/test_tree.log
using parent snapshot 81432235
scan [/tmp/test_tree]
snapshot 6964c89a saved
```

With this PR progress will be shown to the command line every second.

```
$ restic backup /tmp/test_tree/ | tee /tmp/test_tree.log
using parent snapshot 6964c89a
scan [/tmp/test_tree]
[0:01] 39255 directories, 119110 files, 1.925 GiB
[0:01] 44905 directories, 136367 files, 2.271 GiB
scanned 44905 directories, 136367 files in 0:01
[0:01] 22.08%  513.613 MiB/s  513.613 MiB / 2.271 GiB  18870 / 181272 items  0 errors  ETA 0:03
[0:02] 25.47%  296.156 MiB/s  592.312 MiB / 2.271 GiB  38935 / 181272 items  0 errors  ETA 0:05
[0:03] 29.03%  225.038 MiB/s  675.113 MiB / 2.271 GiB  57642 / 181272 items  0 errors  ETA 0:07
[0:04] 32.82%  190.800 MiB/s  763.201 MiB / 2.271 GiB  76341 / 181272 items  0 errors  ETA 0:08
[0:05] 35.93%  167.116 MiB/s  835.580 MiB / 2.271 GiB  92925 / 181272 items  0 errors  ETA 0:08
[0:06] 40.34%  156.377 MiB/s  938.262 MiB / 2.271 GiB  110168 / 181272 items  0 errors  ETA 0:08
[0:07] 51.62%  171.486 MiB/s  1.172 GiB / 2.271 GiB  133630 / 181272 items  0 errors  ETA 0:06
[0:08] 84.85%  246.672 MiB/s  1.927 GiB / 2.271 GiB  159910 / 181272 items  0 errors  ETA 0:01
[0:09] 99.28%  256.545 MiB/s  2.255 GiB / 2.271 GiB  178516 / 181272 items  0 errors  ETA 0:00
[0:09] 100.00%  256.545 MiB/s  2.271 GiB / 2.271 GiB  181272 / 181272 items  0 errors  ETA 0:00

duration: 0:09, 250.99MiB/s
snapshot 0fda6504 saved
```

Discussion:

@viric also had a very good idea to include the option to send SIGUSR1 to Restic which will force it to print its progress to the console similar to commands like `dd`.

It would also be good if the interval could be configured by something like `-o progress.display.interval=120`.
