### PR TITLE
local/sftp: Fix broken error handling

### DIFF
--- a/src/restic/backend/local/local.go
+++ b/src/restic/backend/local/local.go
@@ -176,6 +176,9 @@ func (b *Local) Save(h backend.Handle, p []byte) (err error) {
 
 	tmpfile, err := writeToTempfile(filepath.Join(b.p, backend.Paths.Temp), p)
 	debug.Log("local.Save", "saved %v (%d bytes) to %v", h, len(p), tmpfile)
+	if err != nil {
+		return err
+	}
 
 	filename := filename(b.p, h.Type, h.Name)
 

--- a/src/restic/backend/sftp/sftp.go
+++ b/src/restic/backend/sftp/sftp.go
@@ -5,7 +5,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"os/exec"
 	"path"
@@ -44,22 +43,22 @@ func startClient(program string, args ...string) (*SFTP, error) {
 	// get stdin and stdout
 	wr, err := cmd.StdinPipe()
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 	rd, err := cmd.StdoutPipe()
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	// start the process
 	if err := cmd.Start(); err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	// open the SFTP session
 	client, err := sftp.NewClientPipe(rd, wr)
 	if err != nil {
-		log.Fatal(err)
+		return nil, err
 	}
 
 	return &SFTP{c: client, cmd: cmd}, nil
@@ -329,6 +328,10 @@ func (r *SFTP) Save(h backend.Handle, p []byte) (err error) {
 	}
 
 	filename, tmpfile, err := r.tempFile()
+	if err != nil {
+		return err
+	}
+
 	debug.Log("sftp.Save", "save %v (%d bytes) to %v", h, len(p), filename)
 
 	n, err := tmpfile.Write(p)


### PR DESCRIPTION
This yields the error messages for a full backup location:

```
panic: write /home/fd0/mnt/temp/tmp/temp-987810174: no space left on device
```

Closes #540

Also connected to #574
