### PR TITLE
Add local index for metadata

### DIFF
--- a/src/cmds/restic/global.go
+++ b/src/cmds/restic/global.go
@@ -13,6 +13,7 @@ import (
 	"restic/backend/rest"
 	"restic/backend/s3"
 	"restic/backend/sftp"
+	"restic/cache"
 	"restic/debug"
 	"restic/location"
 	"restic/repository"
@@ -265,6 +266,13 @@ func (o GlobalOptions) OpenRepository() (*repository.Repository, error) {
 	if err != nil {
 		return nil, errors.Fatalf("unable to open repo: %v", err)
 	}
+
+	cache, err := cache.New(o.CacheDir, s.Config().ID)
+	if err != nil {
+		return nil, err
+	}
+
+	s.UseCache(cache)
 
 	return s, nil
 }

--- a/src/restic/cache.go
+++ b/src/restic/cache.go
@@ -1,0 +1,9 @@
+package restic
+
+// Cache stores blobs locally.
+type Cache interface {
+	GetBlob(BlobHandle, []byte) (bool, error)
+	PutBlob(BlobHandle, []byte) error
+	DeleteBlob(BlobHandle) error
+	HasBlob(BlobHandle) bool
+}

--- a/src/restic/cache.go
+++ b/src/restic/cache.go
@@ -1,15 +1,26 @@
 package restic
 
-// Cache stores blobs locally.
+// Cache stores files and blobs locally.
 type Cache interface {
 	GetBlob(BlobHandle, []byte) (bool, error)
 	PutBlob(BlobHandle, []byte) error
 	DeleteBlob(BlobHandle) error
 	HasBlob(BlobHandle) bool
 	UpdateBlobs(idx BlobIndex) error
+
+	GetFile(Handle, []byte) (bool, error)
+	PutFile(Handle, []byte) error
+	DeleteFile(Handle) error
+	HasFile(Handle) bool
+	UpdateFiles(idx FileIndex) error
 }
 
 // BlobIndex returns information about blobs stored in a repo.
 type BlobIndex interface {
 	Has(id ID, t BlobType) bool
+}
+
+// FileIndex returns information about files in a backend.
+type FileIndex interface {
+	Test(t FileType, name string) (bool, error)
 }

--- a/src/restic/cache.go
+++ b/src/restic/cache.go
@@ -6,4 +6,10 @@ type Cache interface {
 	PutBlob(BlobHandle, []byte) error
 	DeleteBlob(BlobHandle) error
 	HasBlob(BlobHandle) bool
+	UpdateBlobs(idx BlobIndex) error
+}
+
+// BlobIndex returns information about blobs stored in a repo.
+type BlobIndex interface {
+	Has(id ID, t BlobType) bool
 }

--- a/src/restic/cache/cache.go
+++ b/src/restic/cache/cache.go
@@ -1,0 +1,118 @@
+// Package cache implements a local cache for data.
+package cache
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"restic"
+	"restic/errors"
+)
+
+// Cache is a local cache implementation.
+type Cache struct {
+	dir string
+}
+
+// make sure that Cache implement restic.Cache
+var _ restic.Cache = &Cache{}
+
+// NewCache creates a new cache in the given directory. If it is the empty
+// string, the cache directory for the current user is used instead.
+func NewCache(dir string) restic.Cache {
+	return &Cache{dir: dir}
+}
+
+func fn(dir string, h restic.BlobHandle) string {
+	return filepath.Join(dir, string(h.Type), h.ID.String())
+}
+
+// GetBlob returns a blob from the cache. If the blob is not in the cache, ok
+// is set to false.
+func (c *Cache) GetBlob(h restic.BlobHandle, buf []byte) (ok bool, err error) {
+	filename := fn(c.dir, h)
+
+	fi, err := os.Stat(filename)
+	if os.IsNotExist(errors.Cause(err)) {
+		return false, nil
+	}
+
+	if fi.Size() != int64(len(buf)) {
+		return false, errors.Errorf("wrong bufsize: %d != %d", fi.Size(), len(buf))
+	}
+
+	if err != nil {
+		return false, errors.Wrap(err, "Stat")
+	}
+
+	var f *os.File
+	f, err = os.Open(filename)
+	if err != nil {
+		return false, errors.Wrap(err, "Open")
+	}
+
+	defer func() {
+		e := f.Close()
+		if err == nil {
+			err = e
+		}
+	}()
+
+	_, err = io.ReadFull(f, buf)
+	if err != nil {
+		return false, err
+	}
+
+	return true, nil
+}
+
+func createDirs(filename string) error {
+	dir := filepath.Dir(filename)
+	fi, err := os.Stat(dir)
+	if err != nil && os.IsNotExist(errors.Cause(err)) {
+		err = os.MkdirAll(dir, 0700)
+		return errors.Wrap(err, "mkdir cache dir")
+	}
+
+	if err != nil {
+		return err
+	}
+
+	if !fi.IsDir() {
+		return errors.Errorf("is not a directory: %v", dir)
+	}
+
+	return nil
+}
+
+// PutBlob saves a blob in the cache.
+func (c *Cache) PutBlob(h restic.BlobHandle, buf []byte) error {
+	filename := fn(c.dir, h)
+
+	if err := createDirs(filename); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filename, buf, 0700)
+}
+
+// DeleteBlob removes a blob from the cache. If it isn't included in the cache,
+// a nil error is returned.
+func (c *Cache) DeleteBlob(h restic.BlobHandle) error {
+	err := os.Remove(fn(c.dir, h))
+	if err != nil && os.IsNotExist(errors.Cause(err)) {
+		err = nil
+	}
+	return err
+}
+
+// HasBlob check whether the cache has a particular blob.
+func (c *Cache) HasBlob(h restic.BlobHandle) bool {
+	_, err := os.Stat(fn(c.dir, h))
+	if err != nil {
+		return false
+	}
+
+	return true
+}

--- a/src/restic/cache/cache.go
+++ b/src/restic/cache/cache.go
@@ -14,7 +14,8 @@ import (
 
 // Cache is a local cache implementation.
 type Cache struct {
-	dir string
+	blobdir string
+	filedir string
 }
 
 // make sure that Cache implement restic.Cache
@@ -75,20 +76,15 @@ func New(dir, repoID string) (cache restic.Cache, err error) {
 
 	dir = filepath.Join(dir, repoID)
 
-	return &Cache{dir: dir}, nil
+	c := &Cache{
+		blobdir: filepath.Join(dir, "blob"),
+		filedir: filepath.Join(dir, "file"),
+	}
+
+	return c, nil
 }
 
-func fn(dir string, h restic.BlobHandle) string {
-	id := h.ID.String()
-	subdir := id[:2]
-	return filepath.Join(dir, h.Type.String(), subdir, id)
-}
-
-// GetBlob returns a blob from the cache. If the blob is not in the cache, ok
-// is set to false.
-func (c *Cache) GetBlob(h restic.BlobHandle, buf []byte) (ok bool, err error) {
-	filename := fn(c.dir, h)
-
+func (c *Cache) get(filename string, buf []byte) (ok bool, err error) {
 	fi, err := os.Stat(filename)
 	if os.IsNotExist(errors.Cause(err)) {
 		return false, nil
@@ -142,9 +138,22 @@ func createDirs(filename string) error {
 	return nil
 }
 
+func (c *Cache) blobFn(h restic.BlobHandle) string {
+	id := h.ID.String()
+	subdir := id[:2]
+	return filepath.Join(c.blobdir, h.Type.String(), subdir, id)
+}
+
+// GetBlob returns a blob from the cache. If the blob is not in the cache, ok
+// is set to false.
+func (c *Cache) GetBlob(h restic.BlobHandle, buf []byte) (ok bool, err error) {
+	filename := c.blobFn(h)
+	return c.get(filename, buf)
+}
+
 // PutBlob saves a blob in the cache.
 func (c *Cache) PutBlob(h restic.BlobHandle, buf []byte) error {
-	filename := fn(c.dir, h)
+	filename := c.blobFn(h)
 
 	if err := createDirs(filename); err != nil {
 		return err
@@ -156,7 +165,7 @@ func (c *Cache) PutBlob(h restic.BlobHandle, buf []byte) error {
 // DeleteBlob removes a blob from the cache. If it isn't included in the cache,
 // a nil error is returned.
 func (c *Cache) DeleteBlob(h restic.BlobHandle) error {
-	err := os.Remove(fn(c.dir, h))
+	err := os.Remove(c.blobFn(h))
 	if err != nil && os.IsNotExist(errors.Cause(err)) {
 		err = nil
 	}
@@ -165,7 +174,7 @@ func (c *Cache) DeleteBlob(h restic.BlobHandle) error {
 
 // HasBlob check whether the cache has a particular blob.
 func (c *Cache) HasBlob(h restic.BlobHandle) bool {
-	_, err := os.Stat(fn(c.dir, h))
+	_, err := os.Stat(c.blobFn(h))
 	if err != nil {
 		return false
 	}
@@ -173,33 +182,45 @@ func (c *Cache) HasBlob(h restic.BlobHandle) bool {
 	return true
 }
 
-func (c *Cache) updateBlobs(idx restic.BlobIndex, t restic.BlobType) (err error) {
-	dir := filepath.Dir(fn(c.dir, restic.BlobHandle{Type: t}))
+func isFile(fi os.FileInfo) bool {
+	return fi.Mode()&(os.ModeType|os.ModeCharDevice) == 0
+}
 
-	var d *os.File
-	d, err = os.Open(dir)
-	if err != nil && os.IsNotExist(errors.Cause(err)) {
-		return nil
-	}
-
-	if err != nil {
-		return errors.Wrap(err, "Open")
-	}
-
-	defer func() {
-		e := d.Close()
-		if err == nil {
-			err = errors.Wrap(e, "Close")
+func listDir(dir string) (entries []string, err error) {
+	err = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if info == nil {
+			return nil
 		}
-	}()
 
-	entries, err := d.Readdirnames(-1)
+		if isFile(info) {
+			p, err := filepath.Rel(dir, path)
+			if err != nil {
+				return errors.Wrap(err, "filepath.Rel")
+			}
+			entries = append(entries, p)
+		}
+
+		return nil
+	})
+
 	if err != nil {
-		return errors.Wrap(err, "Readdirnames")
+		return nil, errors.Wrap(err, "Walk")
+	}
+
+	return entries, nil
+}
+
+func (c *Cache) updateBlobs(idx restic.BlobIndex, t restic.BlobType) (err error) {
+	basedir := filepath.Join(c.blobdir, t.String())
+
+	entries, err := listDir(basedir)
+	if err != nil {
+		return err
 	}
 
 	debug.Log("Cache.UpdateBlobs", "checking %v/%d entries", t, len(entries))
-	for _, name := range entries {
+	for _, path := range entries {
+		name := filepath.Base(path)
 		id, err := restic.ParseID(name)
 		if err != nil {
 			debug.Log("Cache.UpdateBlobs", "  cache entry %q does not parse as id: %v", name, err)
@@ -208,8 +229,7 @@ func (c *Cache) updateBlobs(idx restic.BlobIndex, t restic.BlobType) (err error)
 
 		if !idx.Has(id, t) {
 			debug.Log("Cache.UpdateBlobs", "  remove %v/%v", t, name)
-
-			err = os.Remove(filepath.Join(dir, name))
+			err = os.Remove(c.blobFn(restic.BlobHandle{Type: t, ID: id}))
 			if err != nil {
 				return errors.Wrap(err, "Remove")
 			}
@@ -228,4 +248,98 @@ func (c *Cache) UpdateBlobs(idx restic.BlobIndex) (err error) {
 	}
 
 	return c.updateBlobs(idx, restic.DataBlob)
+}
+
+func (c *Cache) fileFn(h restic.Handle) string {
+	id := h.Name
+	subdir := id[:2]
+	return filepath.Join(c.filedir, h.Type.String(), subdir, id)
+}
+
+// GetFile returns a file from the cache. If the file is not in the cache, ok
+// is set to false.
+func (c *Cache) GetFile(h restic.Handle, buf []byte) (ok bool, err error) {
+	filename := c.fileFn(h)
+	return c.get(filename, buf)
+}
+
+var allowedFileTypes = map[restic.FileType]struct{}{
+	restic.SnapshotFile: struct{}{},
+	restic.IndexFile:    struct{}{},
+}
+
+// PutFile saves a file in the cache.
+func (c *Cache) PutFile(h restic.Handle, buf []byte) error {
+	if _, ok := allowedFileTypes[h.Type]; !ok {
+		return errors.Errorf("filetype %v not allowed for cache", h.Type)
+	}
+
+	filename := c.fileFn(h)
+
+	if err := createDirs(filename); err != nil {
+		return err
+	}
+
+	return ioutil.WriteFile(filename, buf, 0600)
+}
+
+// DeleteFile removes a file from the cache. If it isn't included in the cache,
+// a nil error is returned.
+func (c *Cache) DeleteFile(h restic.Handle) error {
+	err := os.Remove(c.fileFn(h))
+	if err != nil && os.IsNotExist(errors.Cause(err)) {
+		err = nil
+	}
+	return err
+}
+
+// HasFile check whether the cache has a particular file.
+func (c *Cache) HasFile(h restic.Handle) bool {
+	_, err := os.Stat(c.fileFn(h))
+	if err != nil {
+		return false
+	}
+
+	return true
+}
+
+func (c *Cache) updateFiles(idx restic.FileIndex, t restic.FileType) (err error) {
+	entries, err := listDir(filepath.Join(c.filedir, t.String()))
+	if err != nil {
+		return err
+	}
+
+	debug.Log("Cache.UpdateFiles", "checking %v/%d entries", t, len(entries))
+	for _, path := range entries {
+		name := filepath.Base(path)
+		ok, err := idx.Test(t, name)
+		if err != nil {
+			return errors.Wrap(err, "Test")
+		}
+
+		if !ok {
+			debug.Log("Cache.UpdateFiles", "  remove %v/%v", t, name)
+
+			h := restic.Handle{Name: name, Type: t}
+			err = os.Remove(c.fileFn(h))
+			if err != nil {
+				return errors.Wrap(err, "Remove")
+			}
+		}
+	}
+
+	return nil
+}
+
+// UpdateFiles takes an index and removes files from the local cache which are
+// not in the repo any more.
+func (c *Cache) UpdateFiles(idx restic.FileIndex) (err error) {
+	for t := range allowedFileTypes {
+		err = c.updateFiles(idx, t)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
 }

--- a/src/restic/cache/cache.go
+++ b/src/restic/cache/cache.go
@@ -7,7 +7,9 @@ import (
 	"os"
 	"path/filepath"
 	"restic"
+	"restic/debug"
 	"restic/errors"
+	"restic/fs"
 )
 
 // Cache is a local cache implementation.
@@ -18,14 +20,68 @@ type Cache struct {
 // make sure that Cache implement restic.Cache
 var _ restic.Cache = &Cache{}
 
-// NewCache creates a new cache in the given directory. If it is the empty
+// getXDGCacheDir returns the cache directory according to XDG basedir spec, see
+// http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+func getXDGCacheDir() (string, error) {
+	xdgcache := os.Getenv("XDG_CACHE_HOME")
+	home := os.Getenv("HOME")
+
+	if xdgcache == "" && home == "" {
+		return "", errors.New("unable to locate cache directory (XDG_CACHE_HOME and HOME unset)")
+	}
+
+	cachedir := ""
+	if xdgcache != "" {
+		cachedir = filepath.Join(xdgcache, "restic")
+	} else if home != "" {
+		cachedir = filepath.Join(home, ".cache", "restic")
+	}
+
+	fi, err := fs.Stat(cachedir)
+	if os.IsNotExist(errors.Cause(err)) {
+		err = fs.MkdirAll(cachedir, 0700)
+		if err != nil {
+			return "", errors.Wrap(err, "MkdirAll")
+		}
+
+		fi, err = fs.Stat(cachedir)
+		debug.Log("getCacheDir", "create cache dir %v", cachedir)
+	}
+
+	if err != nil {
+		return "", errors.Wrap(err, "Stat")
+	}
+
+	if !fi.IsDir() {
+		return "", errors.Errorf("cache dir %v is not a directory", cachedir)
+	}
+
+	return cachedir, nil
+}
+
+// New creates a new cache in the given directory. If it is the empty
 // string, the cache directory for the current user is used instead.
-func NewCache(dir string) restic.Cache {
-	return &Cache{dir: dir}
+func New(dir, repoID string) (cache restic.Cache, err error) {
+	if dir == "" {
+		dir, err = getXDGCacheDir()
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	if repoID == "" {
+		return nil, errors.New("cache: empty repo id")
+	}
+
+	dir = filepath.Join(dir, repoID)
+
+	return &Cache{dir: dir}, nil
 }
 
 func fn(dir string, h restic.BlobHandle) string {
-	return filepath.Join(dir, string(h.Type), h.ID.String())
+	id := h.ID.String()
+	subdir := id[:2]
+	return filepath.Join(dir, h.Type.String(), subdir, id)
 }
 
 // GetBlob returns a blob from the cache. If the blob is not in the cache, ok
@@ -94,7 +150,7 @@ func (c *Cache) PutBlob(h restic.BlobHandle, buf []byte) error {
 		return err
 	}
 
-	return ioutil.WriteFile(filename, buf, 0700)
+	return ioutil.WriteFile(filename, buf, 0600)
 }
 
 // DeleteBlob removes a blob from the cache. If it isn't included in the cache,
@@ -115,4 +171,61 @@ func (c *Cache) HasBlob(h restic.BlobHandle) bool {
 	}
 
 	return true
+}
+
+func (c *Cache) updateBlobs(idx restic.BlobIndex, t restic.BlobType) (err error) {
+	dir := filepath.Dir(fn(c.dir, restic.BlobHandle{Type: t}))
+
+	var d *os.File
+	d, err = os.Open(dir)
+	if err != nil && os.IsNotExist(errors.Cause(err)) {
+		return nil
+	}
+
+	if err != nil {
+		return errors.Wrap(err, "Open")
+	}
+
+	defer func() {
+		e := d.Close()
+		if err == nil {
+			err = errors.Wrap(e, "Close")
+		}
+	}()
+
+	entries, err := d.Readdirnames(-1)
+	if err != nil {
+		return errors.Wrap(err, "Readdirnames")
+	}
+
+	debug.Log("Cache.UpdateBlobs", "checking %v/%d entries", t, len(entries))
+	for _, name := range entries {
+		id, err := restic.ParseID(name)
+		if err != nil {
+			debug.Log("Cache.UpdateBlobs", "  cache entry %q does not parse as id: %v", name, err)
+			continue
+		}
+
+		if !idx.Has(id, t) {
+			debug.Log("Cache.UpdateBlobs", "  remove %v/%v", t, name)
+
+			err = os.Remove(filepath.Join(dir, name))
+			if err != nil {
+				return errors.Wrap(err, "Remove")
+			}
+		}
+	}
+
+	return nil
+}
+
+// UpdateBlobs takes an index and removes blobs from the local cache which are
+// not in the repo any more.
+func (c *Cache) UpdateBlobs(idx restic.BlobIndex) (err error) {
+	err = c.updateBlobs(idx, restic.TreeBlob)
+	if err != nil {
+		return err
+	}
+
+	return c.updateBlobs(idx, restic.DataBlob)
 }

--- a/src/restic/cache/cache_test.go
+++ b/src/restic/cache/cache_test.go
@@ -1,0 +1,75 @@
+package cache
+
+import (
+	"restic"
+	"restic/test"
+	"testing"
+)
+
+func TestCache(t *testing.T) {
+	c, cleanup := TestNewCache(t)
+	defer cleanup()
+
+	buf := test.Random(23, 2*1024*1024)
+	id := restic.Hash(buf)
+
+	h := restic.BlobHandle{ID: id, Type: restic.DataBlob}
+	if c.HasBlob(h) {
+		t.Errorf("cache has blob before storing it")
+	}
+
+	test.OK(t, c.PutBlob(h, buf))
+
+	if !c.HasBlob(h) {
+		t.Errorf("cache does not have blob after store")
+	}
+
+	treeHandle := restic.BlobHandle{ID: id, Type: restic.TreeBlob}
+	if c.HasBlob(treeHandle) {
+		t.Errorf("cache has tree blob although only a data blob was stored")
+	}
+
+	buf2 := make([]byte, len(buf))
+	ok, err := c.GetBlob(h, buf2)
+	test.OK(t, err)
+	if !ok {
+		t.Errorf("could not get blob from cache")
+	}
+
+	ok, err = c.GetBlob(treeHandle, buf2)
+	test.OK(t, err)
+	test.Assert(t, !ok, "got blob for tree that was never stored")
+
+	err = c.DeleteBlob(treeHandle)
+
+	test.OK(t, c.DeleteBlob(h))
+
+	if c.HasBlob(h) {
+		t.Errorf("cache still has blob after delete")
+	}
+}
+
+func TestCacheBufsize(t *testing.T) {
+	c, cleanup := TestNewCache(t)
+	defer cleanup()
+
+	h := restic.BlobHandle{ID: restic.NewRandomID(), Type: restic.TreeBlob}
+	buf := test.Random(5, 1000)
+
+	test.OK(t, c.PutBlob(h, buf))
+
+	for i := len(buf) - 1; i <= len(buf)+1; i++ {
+		buf2 := make([]byte, i)
+		ok, err := c.GetBlob(h, buf2)
+
+		if i == len(buf) {
+			test.OK(t, err)
+			test.Assert(t, ok, "unable to get blob for correct buf size")
+			test.Equals(t, buf, buf2)
+			continue
+		}
+
+		test.Assert(t, !ok, "ok is true for wrong buffer size %v", i)
+		test.Assert(t, err != nil, "error is nil, although buffer size is wrong")
+	}
+}

--- a/src/restic/cache/testing.go
+++ b/src/restic/cache/testing.go
@@ -12,7 +12,8 @@ func TestNewCache(t testing.TB) (restic.Cache, func()) {
 	tempdir, cleanup := test.TempDir(t)
 
 	cachedir := filepath.Join(tempdir, "cache")
-	c := NewCache(cachedir)
+	c, err := New(cachedir, "test")
+	test.OK(t, err)
 
 	return c, cleanup
 }

--- a/src/restic/cache/testing.go
+++ b/src/restic/cache/testing.go
@@ -1,0 +1,18 @@
+package cache
+
+import (
+	"path/filepath"
+	"restic"
+	"restic/test"
+	"testing"
+)
+
+// TestNewCache creates a cache usable for testing.
+func TestNewCache(t testing.TB) (restic.Cache, func()) {
+	tempdir, cleanup := test.TempDir(t)
+
+	cachedir := filepath.Join(tempdir, "cache")
+	c := NewCache(cachedir)
+
+	return c, cleanup
+}

--- a/src/restic/file.go
+++ b/src/restic/file.go
@@ -9,6 +9,10 @@ import (
 // FileType is the type of a file in the backend.
 type FileType string
 
+func (f FileType) String() string {
+	return string(f)
+}
+
 // These are the different data types a backend can store.
 const (
 	DataFile     FileType = "data"

--- a/src/restic/mock/repository.go
+++ b/src/restic/mock/repository.go
@@ -13,6 +13,8 @@ type Repository struct {
 
 	SetIndexFn func(restic.Index)
 
+	UseCacheFn func(restic.Cache)
+
 	IndexFn         func() restic.Index
 	SaveFullIndexFn func() error
 	SaveIndexFn     func() error
@@ -53,6 +55,11 @@ func (repo Repository) Key() *crypto.Key {
 // SetIndex is a stub method.
 func (repo Repository) SetIndex(idx restic.Index) {
 	repo.SetIndexFn(idx)
+}
+
+// UseCache is a stub method.
+func (repo Repository) UseCache(cache restic.Cache) {
+	repo.UseCacheFn(cache)
 }
 
 // Index is a stub method.

--- a/src/restic/repository.go
+++ b/src/restic/repository.go
@@ -11,6 +11,8 @@ type Repository interface {
 
 	Key() *crypto.Key
 
+	UseCache(Cache)
+
 	SetIndex(Index)
 
 	Index() Index

--- a/src/restic/repository/repository.go
+++ b/src/restic/repository/repository.go
@@ -441,7 +441,14 @@ func (r *Repository) LoadIndex() error {
 
 	// update cache
 	if r.cache != nil {
-		r.cache.UpdateBlobs(r.idx)
+		err := r.cache.UpdateBlobs(r.idx)
+		if err != nil {
+			return err
+		}
+		err = r.cache.UpdateFiles(r.Backend())
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/src/restic/repository/repository.go
+++ b/src/restic/repository/repository.go
@@ -322,7 +322,17 @@ func (r *Repository) SaveUnpacked(t restic.FileType, p []byte) (id restic.ID, er
 		return restic.ID{}, err
 	}
 
-	debug.Log("Repo.SaveJSONUnpacked", "blob %v saved", h)
+	// store file in the cache
+	if r.cache != nil && (t == restic.IndexFile || t == restic.SnapshotFile) {
+		h := restic.Handle{Name: id.String(), Type: t}
+		err := r.cache.PutFile(h, p)
+		if err != nil {
+			return restic.ID{}, err
+		}
+		debug.Log("Repo.Save", "updated file %v in cache", h)
+	}
+
+	debug.Log("Repo.SaveJSONUnpacked", "file %v saved", h)
 	return id, nil
 }
 

--- a/src/restic/test/helpers.go
+++ b/src/restic/test/helpers.go
@@ -170,6 +170,25 @@ func SetupTarTestFixture(t testing.TB, outputDir, tarFile string) {
 	OK(t, cmd.Run())
 }
 
+func cleanupDir(t testing.TB, dir string) {
+	if !TestCleanupTempDirs {
+		t.Logf("leaving temporary directory %v used for test", dir)
+		return
+	}
+
+	RemoveAll(t, dir)
+}
+
+// TempDir returns a temporary directory.
+func TempDir(t testing.TB) (string, func()) {
+	tempdir, err := ioutil.TempDir(TestTempDir, "restic-test-")
+	OK(t, err)
+
+	return tempdir, func() {
+		cleanupDir(t, tempdir)
+	}
+}
+
 // Env creates a test environment and extracts the repository fixture.
 // Returned is the repo path and a cleanup function.
 func Env(t testing.TB, repoFixture string) (repodir string, cleanup func()) {
@@ -185,12 +204,7 @@ func Env(t testing.TB, repoFixture string) (repodir string, cleanup func()) {
 	SetupTarTestFixture(t, tempdir, repoFixture)
 
 	return filepath.Join(tempdir, "repo"), func() {
-		if !TestCleanupTempDirs {
-			t.Logf("leaving temporary directory %v used for test", tempdir)
-			return
-		}
-
-		RemoveAll(t, tempdir)
+		cleanupDir(t, tempdir)
 	}
 }
 


### PR DESCRIPTION
The code in this PR adds a local metadata cache for tree blobs, index and snapshot files.

Closes #386
Closes #454
