### PR TITLE
Cleanup CI tests for fuse

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,8 @@ matrix:
   exclude:
     - os: osx
       go: 1.6.3
+    - os: linux
+      go: 1.7.1
   include:
     - os: linux
       go: 1.7.1

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,16 +3,27 @@ sudo: false
 
 go:
   - 1.6.3
-  - 1.7
+  - 1.7.1
 
 os:
   - linux
   - osx
 
+env:
+  matrix:
+    RESTIC_TEST_FUSE=0
+
 matrix:
   exclude:
     - os: osx
       go: 1.6.3
+  include:
+    - os: linux
+      go: 1.7.1
+      sudo: true
+      env:
+        RESTIC_TEST_FUSE=1
+
 
 notifications:
   irc:

--- a/run_integration_tests.go
+++ b/run_integration_tests.go
@@ -165,19 +165,6 @@ func (env *TravisEnvironment) Prepare() error {
 		return err
 	}
 
-	if runtime.GOOS == "darwin" {
-		// install the libraries necessary for fuse
-		for _, cmd := range [][]string{
-			{"brew", "update"},
-			{"brew", "tap", "caskroom/cask"},
-			{"brew", "cask", "install", "osxfuse"},
-		} {
-			if err := run(cmd[0], cmd[1:]...); err != nil {
-				return err
-			}
-		}
-	}
-
 	if *runCrossCompile && !(runtime.Version() < "go1.7") {
 		// only test cross compilation on linux with Travis
 		if err := run("go", "get", "github.com/mitchellh/gox"); err != nil {
@@ -314,8 +301,8 @@ func StartBackgroundCommand(env map[string]string, cmd string, args ...string) (
 
 // RunTests starts the tests for Travis.
 func (env *TravisEnvironment) RunTests() error {
-	// run fuse tests on darwin
-	if runtime.GOOS != "darwin" {
+	// do not run fuse tests on darwin
+	if runtime.GOOS == "darwin" {
 		msg("skip fuse integration tests on %v\n", runtime.GOOS)
 		os.Setenv("RESTIC_TEST_FUSE", "0")
 	}

--- a/src/cmds/restic/cleanup.go
+++ b/src/cmds/restic/cleanup.go
@@ -32,6 +32,9 @@ func AddCleanupHandler(f func() error) {
 	cleanupHandlers.Lock()
 	defer cleanupHandlers.Unlock()
 
+	// reset the done flag for integration tests
+	cleanupHandlers.done = false
+
 	cleanupHandlers.list = append(cleanupHandlers.list, f)
 }
 
@@ -51,6 +54,7 @@ func RunCleanupHandlers() {
 			fmt.Fprintf(stderr, "error in cleanup handler: %v\n", err)
 		}
 	}
+	cleanupHandlers.list = nil
 }
 
 // CleanupHandler handles the SIGINT signal.

--- a/src/cmds/restic/cmd_mount.go
+++ b/src/cmds/restic/cmd_mount.go
@@ -6,6 +6,7 @@ package main
 import (
 	"os"
 
+	"restic/debug"
 	"restic/errors"
 
 	resticfs "restic/fs"
@@ -19,7 +20,6 @@ type CmdMount struct {
 	Root bool `long:"owner-root" description:"use 'root' as the owner of files and dirs" default:"false"`
 
 	global *GlobalOptions
-	ready  chan struct{}
 }
 
 func init() {
@@ -28,7 +28,6 @@ func init() {
 		"The mount command mounts a repository read-only to a given directory",
 		&CmdMount{
 			global: &globalOpts,
-			ready:  make(chan struct{}),
 		})
 	if err != nil {
 		panic(err)
@@ -39,10 +38,9 @@ func (cmd CmdMount) Usage() string {
 	return "MOUNTPOINT"
 }
 
-func (cmd CmdMount) Execute(args []string) error {
-	if len(args) == 0 {
-		return errors.Fatalf("wrong number of parameters, Usage: %s", cmd.Usage())
-	}
+func (cmd CmdMount) Mount(mountpoint string) error {
+	debug.Log("mount", "start mount")
+	defer debug.Log("mount", "finish mount")
 
 	repo, err := cmd.global.OpenRepository()
 	if err != nil {
@@ -54,7 +52,6 @@ func (cmd CmdMount) Execute(args []string) error {
 		return err
 	}
 
-	mountpoint := args[0]
 	if _, err := resticfs.Stat(mountpoint); os.IsNotExist(errors.Cause(err)) {
 		cmd.global.Verbosef("Mountpoint %s doesn't exist, creating it\n", mountpoint)
 		err = resticfs.Mkdir(mountpoint, os.ModeDir|0700)
@@ -74,19 +71,7 @@ func (cmd CmdMount) Execute(args []string) error {
 	root := fs.Tree{}
 	root.Add("snapshots", fuse.NewSnapshotsDir(repo, cmd.Root))
 
-	cmd.global.Printf("Now serving %s at %s\n", repo.Backend().Location(), mountpoint)
-	cmd.global.Printf("Don't forget to umount after quitting!\n")
-
-	AddCleanupHandler(func() error {
-		err := systemFuse.Unmount(mountpoint)
-		if err != nil {
-			cmd.global.Warnf("unable to umount (maybe already umounted?): %v\n", err)
-		}
-		return nil
-	})
-
-	close(cmd.ready)
-
+	debug.Log("mount", "serving mount at %v", mountpoint)
 	err = fs.Serve(c, &root)
 	if err != nil {
 		return err
@@ -94,4 +79,30 @@ func (cmd CmdMount) Execute(args []string) error {
 
 	<-c.Ready
 	return c.MountError
+}
+
+func (cmd CmdMount) Umount(mountpoint string) error {
+	return systemFuse.Unmount(mountpoint)
+}
+
+func (cmd CmdMount) Execute(args []string) error {
+	if len(args) == 0 {
+		return errors.Fatalf("wrong number of parameters, Usage: %s", cmd.Usage())
+	}
+
+	mountpoint := args[0]
+
+	AddCleanupHandler(func() error {
+		debug.Log("mount", "running umount cleanup handler for mount at %v", mountpoint)
+		err := cmd.Umount(mountpoint)
+		if err != nil {
+			cmd.global.Warnf("unable to umount (maybe already umounted?): %v\n", err)
+		}
+		return nil
+	})
+
+	cmd.global.Printf("Now serving the repository at %s\n", mountpoint)
+	cmd.global.Printf("Don't forget to umount after quitting!\n")
+
+	return cmd.Mount(mountpoint)
 }

--- a/src/cmds/restic/integration_fuse_test.go
+++ b/src/cmds/restic/integration_fuse_test.go
@@ -60,7 +60,18 @@ func mount(t testing.TB, global GlobalOptions, dir string) {
 
 func umount(t testing.TB, global GlobalOptions, dir string) {
 	cmd := &CmdMount{global: &global}
-	OK(t, cmd.Umount(dir))
+
+	var err error
+	for i := 0; i < mountWait; i++ {
+		if err = cmd.Umount(dir); err == nil {
+			t.Logf("directory %v umounted", dir)
+			return
+		}
+
+		time.Sleep(mountSleep)
+	}
+
+	t.Errorf("unable to umount dir %v, last error was: %v", dir, err)
 }
 
 func listSnapshots(t testing.TB, dir string) []string {


### PR DESCRIPTION
This runs the CI tests for fuse on Travis only on the Linux, and not on OS X. The latter caused problems, because osxfuse must be installed for each test and that fails often.

In addition, this fixes #606. The fuse test failed sometimes when several snapshots are created with exactly the same timestamp, and the code checks that for each snapshot there is a dir in the fuse mount. This fails for colliding timestamps, so we now add a suffix "-1", "-2" etc for each duplicate timestamp.
