### PR TITLE
Add verbose error when marshalling a node fails

### DIFF
--- a/src/restic/archiver/archiver.go
+++ b/src/restic/archiver/archiver.go
@@ -109,8 +109,8 @@ func (arch *Archiver) Save(t restic.BlobType, data []byte, id restic.ID) error {
 }
 
 // SaveTreeJSON stores a tree in the repository.
-func (arch *Archiver) SaveTreeJSON(item interface{}) (restic.ID, error) {
-	data, err := json.Marshal(item)
+func (arch *Archiver) SaveTreeJSON(tree *restic.Tree) (restic.ID, error) {
+	data, err := json.Marshal(tree)
 	if err != nil {
 		return restic.ID{}, errors.Wrap(err, "Marshal")
 	}

--- a/src/restic/node.go
+++ b/src/restic/node.go
@@ -260,6 +260,24 @@ func (node *Node) createFifoAt(path string) error {
 }
 
 func (node Node) MarshalJSON() ([]byte, error) {
+	if node.ModTime.Year() < 0 || node.ModTime.Year() > 9999 {
+		err := errors.Errorf("node %v has invalid ModTime year %d: %v",
+			node.Path, node.ModTime.Year(), node.ModTime)
+		return nil, err
+	}
+
+	if node.ChangeTime.Year() < 0 || node.ChangeTime.Year() > 9999 {
+		err := errors.Errorf("node %v has invalid ChangeTime year %d: %v",
+			node.Path, node.ChangeTime.Year(), node.ChangeTime)
+		return nil, err
+	}
+
+	if node.AccessTime.Year() < 0 || node.AccessTime.Year() > 9999 {
+		err := errors.Errorf("node %v has invalid AccessTime year %d: %v",
+			node.Path, node.AccessTime.Year(), node.AccessTime)
+		return nil, err
+	}
+
 	type nodeJSON Node
 	nj := nodeJSON(node)
 	name := strconv.Quote(node.Name)


### PR DESCRIPTION
This code is introduced to watch for issue #529, in which two users describe that restic failed encoding a time in a node to JSON with the error message:

```
panic: json: error calling MarshalJSON for type *restic.Node: json: error calling MarshalJSON for type time.Time: Time.MarshalJSON: year outside of range [0,9999]
```

The error message now is:

```
panic: Marshal: json: error calling MarshalJSON for type *restic.Node: node /home/fd0/shared/work/restic/restic/.git/hooks/applypatch-msg.sample has invalid ModTime year -1: -0001-01-02 03:04:05.000000006 +0053 LMT
```
