### PR TITLE
Improve error message for 'forget'

### DIFF
--- a/src/cmds/restic/cmd_forget.go
+++ b/src/cmds/restic/cmd_forget.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/hex"
 	"fmt"
 	"io"
 	"restic"
@@ -116,11 +117,24 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 		return err
 	}
 
-	// first, process all snapshot IDs given as arguments
+	// parse arguments as hex strings
+	var ids []string
 	for _, s := range args {
+		_, err := hex.DecodeString(s)
+		if err != nil {
+			Warnf("argument %q is not a snapshot ID, ignoring\n", s)
+			continue
+		}
+
+		ids = append(ids, s)
+	}
+
+	// process all snapshot IDs given as arguments
+	for _, s := range ids {
 		id, err := restic.FindSnapshot(repo, s)
 		if err != nil {
-			return err
+			Warnf("cound not find a snapshot for ID %q, ignoring\n", s)
+			continue
 		}
 
 		if !opts.DryRun {


### PR DESCRIPTION
```
$ bin/restic forget /d 7 /w 4 /m 12
argument "/d" is not a snapshot ID, ignoring
argument "7" is not a snapshot ID, ignoring
argument "/w" is not a snapshot ID, ignoring
argument "4" is not a snapshot ID, ignoring
argument "/m" is not a snapshot ID, ignoring
cound not find a snapshot for ID "12", ignoring
```

Closes #640
