### PR TITLE
fs.DeviceID(): Return errors whehn fi is nil

### DIFF
--- a/src/cmds/restic/cmd_backup.go
+++ b/src/cmds/restic/cmd_backup.go
@@ -359,7 +359,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 			return false
 		}
 
-		if !opts.ExcludeOtherFS {
+		if !opts.ExcludeOtherFS || fi == nil {
 			return true
 		}
 

--- a/src/restic/fs/deviceid_unix.go
+++ b/src/restic/fs/deviceid_unix.go
@@ -12,10 +12,19 @@ import (
 // DeviceID extracts the device ID from an os.FileInfo object by casting it
 // to syscall.Stat_t
 func DeviceID(fi os.FileInfo) (deviceID uint64, err error) {
+	if fi == nil {
+		return 0, errors.New("unable to determine device: fi is nil")
+	}
+
+	if fi.Sys() == nil {
+		return 0, errors.New("unable to determine device: fi.Sys() is nil")
+	}
+
 	if st, ok := fi.Sys().(*syscall.Stat_t); ok {
 		// st.Dev is uint32 on Darwin and uint64 on Linux. Just cast
 		// everything to uint64.
 		return uint64(st.Dev), nil
 	}
+
 	return 0, errors.New("Could not cast to syscall.Stat_t")
 }


### PR DESCRIPTION
Fixes the crash on FreeBSD: http://pastebin.com/yG3tbfDi