### PR TITLE
Don't consider a pre-existing directory in the restore path to be a failure

### DIFF
--- a/src/restic/node.go
+++ b/src/restic/node.go
@@ -184,7 +184,7 @@ func (node Node) RestoreTimestamps(path string) error {
 
 func (node Node) createDirAt(path string) error {
 	err := fs.Mkdir(path, node.Mode)
-	if err != nil {
+	if err != nil && !os.IsExist(err) {
 		return errors.Wrap(err, "Mkdir")
 	}
 

--- a/src/restic/node_test.go
+++ b/src/restic/node_test.go
@@ -137,6 +137,31 @@ var nodeTests = []restic.Node{
 		AccessTime: parseTime("2015-05-14 21:07:24.222"),
 		ChangeTime: parseTime("2015-05-14 21:07:25.333"),
 	},
+
+	// include "testFile" and "testDir" again with slightly different
+	// metadata, so we can test if CreateAt works with pre-existing files.
+	restic.Node{
+		Name:       "testFile",
+		Type:       "file",
+		Content:    restic.IDs{},
+		UID:        uint32(os.Getuid()),
+		GID:        uint32(os.Getgid()),
+		Mode:       0604,
+		ModTime:    parseTime("2005-05-14 21:07:03.111"),
+		AccessTime: parseTime("2005-05-14 21:07:04.222"),
+		ChangeTime: parseTime("2005-05-14 21:07:05.333"),
+	},
+	restic.Node{
+		Name:       "testDir",
+		Type:       "dir",
+		Subtree:    nil,
+		UID:        uint32(os.Getuid()),
+		GID:        uint32(os.Getgid()),
+		Mode:       0750 | os.ModeDir,
+		ModTime:    parseTime("2005-05-14 21:07:03.111"),
+		AccessTime: parseTime("2005-05-14 21:07:04.222"),
+		ChangeTime: parseTime("2005-05-14 21:07:05.333"),
+	},
 }
 
 func TestNodeRestoreAt(t *testing.T) {


### PR DESCRIPTION
* When a directory already exists, `CreateDirAt` returns an error stating so
  * This means that the `restoreMetadata` function is skipped, so for directories which already exist no file permissions, owners, groups, etc will be restored on them
* Not returning the error if it's a "directory exists" error means the metadata will get restored
  * It also removes the superfluous `error for ...: mkdir ...: file exists` messages
* This makes the behaviour of directories consistent with that of files (which always have their content & metadata restored, regardless of whether they existed or not)

I wanted to include a test with this PR, but couldn't work out the best way to do it.
* Trying to test uid and gid breaks the build of the integration tests file on Windows because we need to use the OS specific `syscall.Stat_t` struct in `FileInfo`
* I could test the other metadata (modification time or file mode), but I couldn't figure out how to access this for a specific directory given the snapshot ID

Any ideas? I'm not super familiar with Go sorry :(

This should resolve #564.