### PR TITLE
Small typo in dry-run of remove snapshot

### DIFF
--- a/src/cmds/restic/cmd_forget.go
+++ b/src/cmds/restic/cmd_forget.go
@@ -140,7 +140,7 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 
 			Verbosef("removed snapshot %v\n", id.Str())
 		} else {
-			Verbosef("would removed snapshot %v\n", id.Str())
+			Verbosef("would remove snapshot %v\n", id.Str())
 		}
 	}
 


### PR DESCRIPTION
This PR fixes a small typo in the diagnostic message of a dry-run forget command.