### PR TITLE
Omit "archived as %v" messages in quiet mode.

### DIFF
--- a/src/cmds/restic/cmd_backup.go
+++ b/src/cmds/restic/cmd_backup.go
@@ -256,7 +256,7 @@ func readBackupFromStdin(opts BackupOptions, gopts GlobalOptions, args []string)
 		return err
 	}
 
-	fmt.Printf("archived as %v\n", id.Str())
+	Verbosef("archived as %v\n", id.Str())
 	return nil
 }
 


### PR DESCRIPTION
The message "archived as %v" is shown for backups from stdin, even in quiet mode. This leads to unwanted mails if run from cron. As quiet mode doesn't output anything for normal backups, I think the same should be done for backups from stdin.