### PR TITLE
Update debug message

### DIFF
--- a/src/restic/backend/s3/s3.go
+++ b/src/restic/backend/s3/s3.go
@@ -37,13 +37,13 @@ func Open(cfg Config) (restic.Backend, error) {
 	be := &s3{client: client, bucketname: cfg.Bucket, prefix: cfg.Prefix}
 	be.createConnections()
 
-	ok, err := client.BucketExists(cfg.Bucket)
+	found, err := client.BucketExists(cfg.Bucket)
 	if err != nil {
-		debug.Log("BucketExists(%v) returned err %v, trying to create the bucket", cfg.Bucket, err)
+		debug.Log("BucketExists(%v) returned err %v", cfg.Bucket, err)
 		return nil, errors.Wrap(err, "client.BucketExists")
 	}
 
-	if !ok {
+	if !found {
 		// create new bucket with default ACL in default region
 		err = client.MakeBucket(cfg.Bucket, "")
 		if err != nil {


### PR DESCRIPTION
Since client.BucketExists was changed to return a separate 'found' value, instead of reporting an error when the bucket doesn't exist, the error code path does no longer imply a call to client.MakeBucket. So the second part of the debug message, "...trying to create the bucket" doesn't apply any more.
Also, changed the name of the return value from 'ok' to 'found', matching the API documentation at https://docs.minio.io/docs/golang-client-api-reference#BucketExists.