### PR TITLE
Even if file changes size during backup, still save it

### DIFF
--- a/src/restic/archiver/archiver.go
+++ b/src/restic/archiver/archiver.go
@@ -197,7 +197,7 @@ func updateNodeContent(node *restic.Node, results []saveResult) error {
 	}
 
 	if bytes != node.Size {
-		return errors.Errorf("errors saving node %q: saved %d bytes, wanted %d bytes", node.Path, bytes, node.Size)
+		fmt.Fprintf(os.Stderr, "warning for %v: expected %d bytes, saved %d bytes\n", node.Path, node.Size, bytes)
 	}
 
 	debug.Log("SaveFile(%q): %v blobs\n", node.Path, len(results))


### PR DESCRIPTION
Previously such files (typically log files) wouldn't be backed up at all!

The proper behaviour is to backup what we can, and warn the operator that file is possibly not complete. But it is a warning, not an error.

Closes #689