### PR TITLE
Backblaze B2 backend support

### DIFF
--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -501,6 +501,29 @@ Please note that knowledge of your password is required to access
 the repository. Losing your password means that your data is irrecoverably lost.
 ```
 
+# Create a Backblaze B2 repository
+
+Restic can backup data to any Backblaze B2 bucket. You must first setup the
+following environment variables with the credentials you obtained when signed
+into your B2 account:
+
+```console
+$ export B2_ACCOUNT_ID=<MY_ACCOUNT_ID>
+$ export B2_ACCOUNT_KEY=<MY_SECRET_ACCOUNT_KEY>
+```
+
+You can then easily initialize a repository that uses your Backblaze B2 as a
+backend. If the bucket does not exist yet, it will be created:
+
+```console
+$ restic -r b2:bucket_name init
+enter password for new backend:
+enter password again:
+created restic backend eefee03bbd at b2:bucket_name
+Please note that knowledge of your password is required to access the repository.
+Losing your password means that your data is irrecoverably lost.
+```
+
 # Removing old snapshots
 
 All backup space is finite, so restic allows removing old snapshots. This can

--- a/src/cmds/restic/global.go
+++ b/src/cmds/restic/global.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"restic/backend/b2"
 	"restic/backend/local"
 	"restic/backend/rest"
 	"restic/backend/s3"
@@ -329,6 +330,16 @@ func open(s string) (restic.Backend, error) {
 
 		debug.Log("opening s3 repository at %#v", cfg)
 		be, err = s3.Open(cfg)
+	case "b2":
+		cfg := loc.Config.(b2.Config)
+		if cfg.AccountID == "" {
+			cfg.AccountID = os.Getenv("B2_ACCOUNT_ID")
+		}
+		if cfg.Key == "" {
+			cfg.Key = os.Getenv("B2_ACCOUNT_KEY")
+		}
+		debug.Log("opening b2 repository at %#v", cfg)
+		be, err = b2.Open(cfg)
 	case "rest":
 		be, err = rest.Open(loc.Config.(rest.Config))
 	default:
@@ -369,6 +380,18 @@ func create(s string) (restic.Backend, error) {
 
 		debug.Log("create s3 repository at %#v", loc.Config)
 		return s3.Open(cfg)
+	case "b2":
+		cfg := loc.Config.(b2.Config)
+		if cfg.AccountID == "" {
+			cfg.AccountID = os.Getenv("B2_ACCOUNT_ID")
+
+		}
+		if cfg.Key == "" {
+			cfg.Key = os.Getenv("B2_ACCOUNT_KEY")
+		}
+
+		debug.Log("create b2 repository at %#v", loc.Config)
+		return b2.Open(cfg)
 	case "rest":
 		return rest.Open(loc.Config.(rest.Config))
 	}

--- a/src/restic/backend/b2/README.md
+++ b/src/restic/backend/b2/README.md
@@ -1,0 +1,29 @@
+BackBlaze B2 backend support for restic
+=======================================
+
+This package allows using BackBlaze's B2 object storage service as a backend for
+restic. It implements kurin's [blazer](https://github.com/kurin/blazer) client
+library for integration with the B2 service.
+
+This package includes unit tests, which are included with other project tests
+and run with:
+
+```
+gb test
+```
+
+To test B2 backend support, you can run all restic integration tests against the
+actual B2 API. To do so, provide a B2 account ID and secret key when running
+tests.
+
+For example, the following shell command provides the B2 credentials in the
+`B2_ACCOUNT_ID` and `B2_ACCOUNT_KEY` environment variables, and then runs
+project tests:
+
+```
+B2_ACCOUNT_ID=1a2b3c4d5e6f B2_ACCOUNT_KEY=0123456789abcdef0123456789 gb test
+```
+
+It should be possible to run the full test suite at least once per day with a
+free B2 account. Running multiple times in one day may require raising the data
+caps, especially the download bandwidth cap.

--- a/src/restic/backend/b2/README.md
+++ b/src/restic/backend/b2/README.md
@@ -1,7 +1,7 @@
-BackBlaze B2 backend support for restic
+Backblaze B2 backend support for restic
 =======================================
 
-This package allows using BackBlaze's B2 object storage service as a backend for
+This package allows using Backblaze's B2 object storage service as a backend for
 restic. It implements kurin's [blazer](https://github.com/kurin/blazer) client
 library for integration with the B2 service.
 

--- a/src/restic/backend/b2/b2.go
+++ b/src/restic/backend/b2/b2.go
@@ -1,0 +1,288 @@
+package b2
+
+import (
+	"io"
+	"path"
+	"restic"
+	"strings"
+
+	"restic/debug"
+	"restic/errors"
+
+	blazerb2 "github.com/kurin/blazer/b2"
+
+	"golang.org/x/net/context"
+)
+
+// b2 is a backend which stores the data on a B2 endpoint.
+type b2 struct {
+	client     *blazerb2.Client
+	bucket     *blazerb2.Bucket
+	bucketName string
+	prefix     string
+	context    context.Context
+}
+
+// Open opens the B2 backend. The bucket is created if it does not exist yet.
+func Open(cfg Config) (restic.Backend, error) {
+	debug.Log("open, config %#v", cfg)
+
+	ctx := context.Background()
+
+	client, err := blazerb2.NewClient(ctx, cfg.AccountID, cfg.Key)
+	if err != nil {
+		return nil, errors.Wrap(err, "blazerb2.NewClient")
+	}
+
+	bucket, err := client.NewBucket(ctx, cfg.Bucket, blazerb2.Private)
+	if err != nil {
+		return nil, errors.Wrap(err, "blazerb2.NewBucket")
+	}
+
+	be := &b2{client: client, bucket: bucket, bucketName: cfg.Bucket, prefix: cfg.Prefix, context: ctx}
+
+	return be, nil
+}
+
+// Resolve the backend path for based on file type ane name.
+func (be *b2) b2path(t restic.FileType, name string) string {
+	if t == "key" && name == "config" {
+		t = restic.ConfigFile
+	}
+	if string(t) == restic.ConfigFile || name == "" {
+		return path.Join(be.prefix, string(t))
+	}
+	return path.Join(be.prefix, string(t), name)
+}
+
+// Location returns this backend's location (the bucket name).
+func (be *b2) Location() string {
+	return be.bucketName
+}
+
+// Load returns the data stored in the backend for h at the given offset
+// and saves it in p. Load has the same semantics as io.ReaderAt.
+func (be b2) Load(h restic.Handle, p []byte, off int64) (n int, err error) {
+	debug.Log("Load: %v, offset %v, len %v", h, off, len(p))
+	objName := be.b2path(h.Type, h.Name)
+
+	obj := be.bucket.Object(objName)
+	if err != nil {
+		debug.Log("  err %v", err)
+		return 0, errors.Wrap(err, "bucket.Object")
+	}
+
+	info, err := obj.Attrs(be.context)
+	if err != nil {
+		return 0, errors.Wrap(err, "obj.Attrs")
+	}
+
+	// handle negative offsets
+	if off < 0 {
+		// if the negative offset is larger than the object itself, read from
+		// the beginning.
+		if -off > info.Size {
+			off = 0
+		} else {
+			// otherwise compute the offset from the end of the file.
+			off = info.Size + off
+		}
+	}
+
+	// return an error if the offset is beyond the end of the file
+	if off > info.Size {
+		return 0, errors.Wrap(io.EOF, "")
+	}
+
+	var nextError error
+
+	// manually create an io.ErrUnexpectedEOF
+	if off+int64(len(p)) > info.Size {
+		newlen := info.Size - off
+		p = p[:newlen]
+
+		nextError = io.ErrUnexpectedEOF
+
+		debug.Log("  capped buffer to %v byte", len(p))
+	}
+
+	r := obj.NewRangeReader(be.context, off, int64(len(p)))
+	defer r.Close()
+
+	bufsize := int64(len(p))
+	var pos int64 = 0
+
+	// loop to read chunks until the buffer is full or EOF is reached
+	for {
+		n, err = r.Read(p[pos:])
+		pos += int64(n)
+		if pos == info.Size-off || pos == bufsize || err != nil {
+			if errors.Cause(err) == io.EOF {
+				err = nil
+			}
+			break
+		}
+	}
+
+	if err == nil {
+		err = nextError
+	}
+
+	return int(pos), err
+}
+
+// Save stores data in the backend at the handle.
+func (be b2) Save(h restic.Handle, p []byte) (err error) {
+	debug.Log("Save: %v with len %d", h, len(p))
+	if err := h.Valid(); err != nil {
+		return err
+	}
+
+	objName := be.b2path(h.Type, h.Name)
+
+	obj := be.bucket.Object(objName)
+	if err != nil {
+		debug.Log("  err %v", err)
+		return errors.Wrap(err, "bucket.Object")
+	}
+
+	_, err = obj.Attrs(be.context)
+	if err == nil {
+		debug.Log("  %v already exists", h)
+		return errors.New("key already exists")
+	}
+
+	debug.Log("  Writing to %s", objName)
+	w := obj.NewWriter(be.context)
+	n, err := w.Write(p)
+
+	if err != nil {
+		debug.Log("  Write error %v -> %v bytes, err %#v", objName, n, err)
+		w.Close()
+		return err
+	}
+
+	debug.Log("  Write successful %v -> %v bytes", objName, n)
+	w.Close()
+	return nil
+}
+
+// Stat returns information about a blob.
+func (be b2) Stat(h restic.Handle) (bi restic.FileInfo, err error) {
+	debug.Log("Stat: %v", h)
+	objName := be.b2path(h.Type, h.Name)
+	obj := be.bucket.Object(objName)
+	info, err := obj.Attrs(be.context)
+	if err != nil {
+		debug.Log("Attrs() err %v", err)
+		return restic.FileInfo{}, errors.Wrap(err, "Stat")
+	}
+	return restic.FileInfo{Size: info.Size}, nil
+}
+
+// Test returns true if a blob of the given type and name exists in the backend.
+func (be *b2) Test(t restic.FileType, name string) (bool, error) {
+	found := false
+	objName := be.b2path(t, name)
+	obj := be.bucket.Object(objName)
+	_, err := obj.Attrs(be.context)
+	if err == nil {
+		found = true
+	}
+	return found, nil
+}
+
+// Remove removes the blob with the given name and type.
+func (be *b2) Remove(t restic.FileType, name string) error {
+	objName := be.b2path(t, name)
+
+	obj := be.bucket.Object(objName)
+
+	err := obj.Delete(be.context)
+	debug.Log("%v %v -> err %v", t, name, err)
+	return errors.Wrap(err, "object.Delete")
+}
+
+// List returns a channel that yields all names of blobs of type t. A
+// goroutine is started for this. If the channel done is closed, sending
+// stops.
+func (be *b2) List(t restic.FileType, done <-chan struct{}) <-chan string {
+	debug.Log("List: %v", t)
+	ch := make(chan string)
+
+	go func() {
+		defer close(ch)
+		prefix := path.Join(be.prefix, string(t)) + "/"
+		cur := &blazerb2.Cursor{Name: prefix}
+
+		for {
+			objs, c, err := be.bucket.ListCurrentObjects(be.context, 1000, cur)
+			if err != nil && err != io.EOF {
+				return
+			}
+			for _, obj := range objs {
+				info, err := obj.Attrs(be.context)
+				if err != nil {
+					continue
+				}
+
+				// Skip objects returned that do not have the specified prefix.
+				if !strings.HasPrefix(info.Name, prefix) {
+					continue
+				}
+
+				// Remove the prefix from returned names.
+				m := strings.TrimPrefix(info.Name, prefix)
+				if m == "" {
+					continue
+				}
+
+				select {
+				case ch <- m:
+				case <-done:
+					return
+				}
+			}
+			if err == io.EOF {
+				return
+			}
+			cur = c
+		}
+	}()
+
+	return ch
+}
+
+// Remove keys for a specified backend type.
+func (be *b2) removeKeys(t restic.FileType) error {
+	done := make(chan struct{})
+	defer close(done)
+	for key := range be.List(restic.DataFile, done) {
+		err := be.Remove(restic.DataFile, key)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// Delete removes all restic keys in the bucket. It will not remove the bucket itself.
+func (be *b2) Delete() error {
+	alltypes := []restic.FileType{
+		restic.DataFile,
+		restic.KeyFile,
+		restic.LockFile,
+		restic.SnapshotFile,
+		restic.IndexFile}
+
+	for _, t := range alltypes {
+		err := be.removeKeys(t)
+		if err != nil {
+			return nil
+		}
+	}
+	return be.Remove(restic.ConfigFile, "")
+}
+
+// Close does nothing
+func (be *b2) Close() error { return nil }

--- a/src/restic/backend/b2/b2.go
+++ b/src/restic/backend/b2/b2.go
@@ -110,7 +110,7 @@ func (be b2) Load(h restic.Handle, p []byte, off int64) (n int, err error) {
 	defer r.Close()
 
 	bufsize := int64(len(p))
-	var pos int64 = 0
+	var pos int64
 
 	// loop to read chunks until the buffer is full or EOF is reached
 	for {

--- a/src/restic/backend/b2/b2.go
+++ b/src/restic/backend/b2/b2.go
@@ -221,18 +221,13 @@ func (be *b2) List(t restic.FileType, done <-chan struct{}) <-chan string {
 				return
 			}
 			for _, obj := range objs {
-				info, err := obj.Attrs(be.context)
-				if err != nil {
-					continue
-				}
-
 				// Skip objects returned that do not have the specified prefix.
-				if !strings.HasPrefix(info.Name, prefix) {
+				if !strings.HasPrefix(obj.Name(), prefix) {
 					continue
 				}
 
 				// Remove the prefix from returned names.
-				m := strings.TrimPrefix(info.Name, prefix)
+				m := strings.TrimPrefix(obj.Name(), prefix)
 				if m == "" {
 					continue
 				}

--- a/src/restic/backend/b2/b2.go
+++ b/src/restic/backend/b2/b2.go
@@ -72,8 +72,9 @@ func (be b2) Load(h restic.Handle, p []byte, off int64) (n int, err error) {
 		return 0, errors.Wrap(err, "bucket.Object")
 	}
 
+	// Ensure object attributes are loaded and status is uploaded.
 	info, err := obj.Attrs(be.context)
-	if err != nil {
+	if err != nil || info == nil || info.Status != blazerb2.Uploaded {
 		return 0, errors.Wrap(err, "obj.Attrs")
 	}
 
@@ -185,8 +186,8 @@ func (be *b2) Test(t restic.FileType, name string) (bool, error) {
 	found := false
 	objName := be.b2path(t, name)
 	obj := be.bucket.Object(objName)
-	_, err := obj.Attrs(be.context)
-	if err == nil {
+	info, err := obj.Attrs(be.context)
+	if err == nil && info != nil && info.Status == blazerb2.Uploaded {
 		found = true
 	}
 	return found, nil

--- a/src/restic/backend/b2/b2_test.go
+++ b/src/restic/backend/b2/b2_test.go
@@ -1,13 +1,15 @@
 package b2_test
 
 import (
+	"bytes"
+	"math/rand"
 	"os"
+	"time"
+
 	"restic"
-
-	"restic/errors"
-
 	"restic/backend/b2"
 	"restic/backend/test"
+	"restic/errors"
 )
 
 //go:generate go run ../test/generate_backend_tests.go
@@ -21,7 +23,7 @@ func init() {
 	cfg := b2.Config{
 		AccountID: os.Getenv("B2_ACCOUNT_ID"),
 		Key:       os.Getenv("B2_ACCOUNT_KEY"),
-		Bucket:    "restic-test",
+		Bucket:    generateBucketName(),
 		Prefix:    "test",
 	}
 
@@ -57,4 +59,18 @@ func init() {
 	// 	tempBackendDir = ""
 	// 	return err
 	// }
+}
+
+// Generates a random bucket name starting with "restic-test-".
+func generateBucketName() string {
+	const chars = "abcdefghijklmnopqrstuvwxyz0123456789"
+	const lenChars = len(chars)
+	const lenBucket = 16
+	var bucket bytes.Buffer
+	bucket.WriteString("restic-test-")
+	r := rand.New(rand.NewSource(time.Now().UTC().UnixNano()))
+	for i := 0; i < lenBucket; i++ {
+		bucket.WriteByte(chars[r.Intn(lenChars)])
+	}
+	return bucket.String()
 }

--- a/src/restic/backend/b2/b2_test.go
+++ b/src/restic/backend/b2/b2_test.go
@@ -1,0 +1,60 @@
+package b2_test
+
+import (
+	"os"
+	"restic"
+
+	"restic/errors"
+
+	"restic/backend/b2"
+	"restic/backend/test"
+)
+
+//go:generate go run ../test/generate_backend_tests.go
+
+func init() {
+	if os.Getenv("B2_ACCOUNT_ID") == "" || os.Getenv("B2_ACCOUNT_KEY") == "" {
+		SkipMessage = "No B2 credentials found. Skipping B2 backend tests."
+		return
+	}
+
+	cfg := b2.Config{
+		AccountID: os.Getenv("B2_ACCOUNT_ID"),
+		Key:       os.Getenv("B2_ACCOUNT_KEY"),
+		Bucket:    "restic-test",
+		Prefix:    "test",
+	}
+
+	test.CreateFn = func() (restic.Backend, error) {
+		be, err := b2.Open(cfg)
+		if err != nil {
+			return nil, err
+		}
+
+		exists, err := be.Test(restic.ConfigFile, "")
+		if err != nil {
+			return nil, err
+		}
+
+		if exists {
+			return nil, errors.New("config already exists")
+		}
+
+		return be, nil
+	}
+
+	test.OpenFn = func() (restic.Backend, error) {
+		return b2.Open(cfg)
+	}
+
+	// test.CleanupFn = func() error {
+	// 	if tempBackendDir == "" {
+	// 		return nil
+	// 	}
+	//
+	// 	fmt.Printf("removing test backend at %v\n", tempBackendDir)
+	// 	err := os.RemoveAll(tempBackendDir)
+	// 	tempBackendDir = ""
+	// 	return err
+	// }
+}

--- a/src/restic/backend/b2/backend_test.go
+++ b/src/restic/backend/b2/backend_test.go
@@ -1,0 +1,93 @@
+package b2_test
+
+import (
+	"testing"
+
+	"restic/backend/test"
+)
+
+var SkipMessage string
+
+func TestB2BackendCreate(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestCreate(t)
+}
+
+func TestB2BackendOpen(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestOpen(t)
+}
+
+func TestB2BackendCreateWithConfig(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestCreateWithConfig(t)
+}
+
+func TestB2BackendLocation(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestLocation(t)
+}
+
+func TestB2BackendConfig(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestConfig(t)
+}
+
+func TestB2BackendLoad(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestLoad(t)
+}
+
+func TestB2BackendLoadNegativeOffset(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestLoadNegativeOffset(t)
+}
+
+func TestB2BackendSave(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestSave(t)
+}
+
+func TestB2BackendSaveFilenames(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestSaveFilenames(t)
+}
+
+func TestB2BackendBackend(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestBackend(t)
+}
+
+func TestB2BackendDelete(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestDelete(t)
+}
+
+func TestB2BackendCleanup(t *testing.T) {
+	if SkipMessage != "" {
+		t.Skip(SkipMessage)
+	}
+	test.TestCleanup(t)
+}

--- a/src/restic/backend/b2/config.go
+++ b/src/restic/backend/b2/config.go
@@ -1,0 +1,50 @@
+package b2
+
+import (
+	"path"
+	"strings"
+
+	"restic/errors"
+)
+
+// Config contains all configuration necessary to connect to an b2 compatible
+// server.
+type Config struct {
+	AccountID string
+	Key       string
+	Bucket    string
+	Prefix    string
+}
+
+const defaultPrefix = "restic"
+
+// ParseConfig parses the string s and extracts the b2 config. The supported
+// configuration format is b2:bucketname/prefix. If no prefix is given the
+// prefix "restic" will be used.
+func ParseConfig(s string) (interface{}, error) {
+	switch {
+	case strings.HasPrefix(s, "b2:"):
+		s = s[3:]
+	default:
+		return nil, errors.New("b2: invalid format")
+	}
+	// use the remainder of the string as bucket name and prefix
+	path := strings.SplitN(s, "/", 2)
+	return createConfig(path)
+}
+
+func createConfig(p []string) (interface{}, error) {
+	var prefix string
+	switch {
+	case len(p) < 1:
+		return nil, errors.New("b2: invalid format, bucket name not found")
+	case len(p) == 1 || p[1] == "":
+		prefix = defaultPrefix
+	default:
+		prefix = path.Clean(p[1])
+	}
+	return Config{
+		Bucket: p[0],
+		Prefix: prefix,
+	}, nil
+}

--- a/src/restic/backend/b2/config_test.go
+++ b/src/restic/backend/b2/config_test.go
@@ -1,0 +1,49 @@
+package b2
+
+import "testing"
+
+var configTests = []struct {
+	s   string
+	cfg Config
+}{
+	{"b2:bucketname", Config{
+		Bucket: "bucketname",
+		Prefix: "restic",
+	}},
+	{"b2:bucketname/", Config{
+		Bucket: "bucketname",
+		Prefix: "restic",
+	}},
+	{"b2:bucketname/prefix/directory", Config{
+		Bucket: "bucketname",
+		Prefix: "prefix/directory",
+	}},
+	{"b2:bucketname/prefix/directory/", Config{
+		Bucket: "bucketname",
+		Prefix: "prefix/directory",
+	}},
+	{"b2:foobar", Config{
+		Bucket: "foobar",
+		Prefix: "restic",
+	}},
+	{"b2:foobar/", Config{
+		Bucket: "foobar",
+		Prefix: "restic",
+	}},
+}
+
+func TestParseConfig(t *testing.T) {
+	for i, test := range configTests {
+		cfg, err := ParseConfig(test.s)
+		if err != nil {
+			t.Errorf("test %d:%s failed: %v", i, test.s, err)
+			continue
+		}
+
+		if cfg != test.cfg {
+			t.Errorf("test %d:\ninput:\n  %s\n wrong config, want:\n  %v\ngot:\n  %v",
+				i, test.s, test.cfg, cfg)
+			continue
+		}
+	}
+}

--- a/src/restic/location/location.go
+++ b/src/restic/location/location.go
@@ -4,6 +4,7 @@ package location
 import (
 	"strings"
 
+	"restic/backend/b2"
 	"restic/backend/local"
 	"restic/backend/rest"
 	"restic/backend/s3"
@@ -25,6 +26,7 @@ type parser struct {
 // parsers is a list of valid config parsers for the backends. The first parser
 // is the fallback and should always be set to the local backend.
 var parsers = []parser{
+	{"b2", b2.ParseConfig},
 	{"local", local.ParseConfig},
 	{"sftp", sftp.ParseConfig},
 	{"s3", s3.ParseConfig},

--- a/src/restic/location/location_test.go
+++ b/src/restic/location/location_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"restic/backend/b2"
 	"restic/backend/rest"
 	"restic/backend/s3"
 	"restic/backend/sftp"
@@ -115,6 +116,12 @@ var parseTests = []struct {
 	{"rest:http://hostname.foo:1234/", Location{Scheme: "rest",
 		Config: rest.Config{
 			URL: parseURL("http://hostname.foo:1234/"),
+		}},
+	},
+	{"b2:bucketname/prefix", Location{Scheme: "b2",
+		Config: b2.Config{
+			Bucket: "bucketname",
+			Prefix: "prefix",
 		}},
 	},
 }

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -34,7 +34,7 @@
 		{
 			"importpath": "github.com/kurin/blazer",
 			"repository": "https://github.com/kurin/blazer",
-			"revision": "b1c2abe264719d4d2062dbeb10d17d5de28d26ca",
+			"revision": "fff096e261374c464c633ef70b264f5e9651b091",
 			"branch": "master"
 		},
 		{

--- a/vendor/manifest
+++ b/vendor/manifest
@@ -14,6 +14,12 @@
 			"branch": "master"
 		},
 		{
+			"importpath": "github.com/golang/glog",
+			"repository": "https://github.com/golang/glog",
+			"revision": "23def4e6c14b4da8ac2ed8007337bc5eb5007998",
+			"branch": "master"
+		},
+		{
 			"importpath": "github.com/inconshreveable/mousetrap",
 			"repository": "https://github.com/inconshreveable/mousetrap",
 			"revision": "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75",
@@ -23,6 +29,12 @@
 			"importpath": "github.com/kr/fs",
 			"repository": "https://github.com/kr/fs",
 			"revision": "2788f0dbd16903de03cb8186e5c7d97b69ad387b",
+			"branch": "master"
+		},
+		{
+			"importpath": "github.com/kurin/blazer",
+			"repository": "https://github.com/kurin/blazer",
+			"revision": "b1c2abe264719d4d2062dbeb10d17d5de28d26ca",
 			"branch": "master"
 		},
 		{

--- a/vendor/src/github.com/golang/glog/LICENSE
+++ b/vendor/src/github.com/golang/glog/LICENSE
@@ -1,0 +1,191 @@
+Apache License
+Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+"License" shall mean the terms and conditions for use, reproduction, and
+distribution as defined by Sections 1 through 9 of this document.
+
+"Licensor" shall mean the copyright owner or entity authorized by the copyright
+owner that is granting the License.
+
+"Legal Entity" shall mean the union of the acting entity and all other entities
+that control, are controlled by, or are under common control with that entity.
+For the purposes of this definition, "control" means (i) the power, direct or
+indirect, to cause the direction or management of such entity, whether by
+contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
+outstanding shares, or (iii) beneficial ownership of such entity.
+
+"You" (or "Your") shall mean an individual or Legal Entity exercising
+permissions granted by this License.
+
+"Source" form shall mean the preferred form for making modifications, including
+but not limited to software source code, documentation source, and configuration
+files.
+
+"Object" form shall mean any form resulting from mechanical transformation or
+translation of a Source form, including but not limited to compiled object code,
+generated documentation, and conversions to other media types.
+
+"Work" shall mean the work of authorship, whether in Source or Object form, made
+available under the License, as indicated by a copyright notice that is included
+in or attached to the work (an example is provided in the Appendix below).
+
+"Derivative Works" shall mean any work, whether in Source or Object form, that
+is based on (or derived from) the Work and for which the editorial revisions,
+annotations, elaborations, or other modifications represent, as a whole, an
+original work of authorship. For the purposes of this License, Derivative Works
+shall not include works that remain separable from, or merely link (or bind by
+name) to the interfaces of, the Work and Derivative Works thereof.
+
+"Contribution" shall mean any work of authorship, including the original version
+of the Work and any modifications or additions to that Work or Derivative Works
+thereof, that is intentionally submitted to Licensor for inclusion in the Work
+by the copyright owner or by an individual or Legal Entity authorized to submit
+on behalf of the copyright owner. For the purposes of this definition,
+"submitted" means any form of electronic, verbal, or written communication sent
+to the Licensor or its representatives, including but not limited to
+communication on electronic mailing lists, source code control systems, and
+issue tracking systems that are managed by, or on behalf of, the Licensor for
+the purpose of discussing and improving the Work, but excluding communication
+that is conspicuously marked or otherwise designated in writing by the copyright
+owner as "Not a Contribution."
+
+"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
+of whom a Contribution has been received by Licensor and subsequently
+incorporated within the Work.
+
+2. Grant of Copyright License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable copyright license to reproduce, prepare Derivative Works of,
+publicly display, publicly perform, sublicense, and distribute the Work and such
+Derivative Works in Source or Object form.
+
+3. Grant of Patent License.
+
+Subject to the terms and conditions of this License, each Contributor hereby
+grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
+irrevocable (except as stated in this section) patent license to make, have
+made, use, offer to sell, sell, import, and otherwise transfer the Work, where
+such license applies only to those patent claims licensable by such Contributor
+that are necessarily infringed by their Contribution(s) alone or by combination
+of their Contribution(s) with the Work to which such Contribution(s) was
+submitted. If You institute patent litigation against any entity (including a
+cross-claim or counterclaim in a lawsuit) alleging that the Work or a
+Contribution incorporated within the Work constitutes direct or contributory
+patent infringement, then any patent licenses granted to You under this License
+for that Work shall terminate as of the date such litigation is filed.
+
+4. Redistribution.
+
+You may reproduce and distribute copies of the Work or Derivative Works thereof
+in any medium, with or without modifications, and in Source or Object form,
+provided that You meet the following conditions:
+
+You must give any other recipients of the Work or Derivative Works a copy of
+this License; and
+You must cause any modified files to carry prominent notices stating that You
+changed the files; and
+You must retain, in the Source form of any Derivative Works that You distribute,
+all copyright, patent, trademark, and attribution notices from the Source form
+of the Work, excluding those notices that do not pertain to any part of the
+Derivative Works; and
+If the Work includes a "NOTICE" text file as part of its distribution, then any
+Derivative Works that You distribute must include a readable copy of the
+attribution notices contained within such NOTICE file, excluding those notices
+that do not pertain to any part of the Derivative Works, in at least one of the
+following places: within a NOTICE text file distributed as part of the
+Derivative Works; within the Source form or documentation, if provided along
+with the Derivative Works; or, within a display generated by the Derivative
+Works, if and wherever such third-party notices normally appear. The contents of
+the NOTICE file are for informational purposes only and do not modify the
+License. You may add Your own attribution notices within Derivative Works that
+You distribute, alongside or as an addendum to the NOTICE text from the Work,
+provided that such additional attribution notices cannot be construed as
+modifying the License.
+You may add Your own copyright statement to Your modifications and may provide
+additional or different license terms and conditions for use, reproduction, or
+distribution of Your modifications, or for any such Derivative Works as a whole,
+provided Your use, reproduction, and distribution of the Work otherwise complies
+with the conditions stated in this License.
+
+5. Submission of Contributions.
+
+Unless You explicitly state otherwise, any Contribution intentionally submitted
+for inclusion in the Work by You to the Licensor shall be under the terms and
+conditions of this License, without any additional terms or conditions.
+Notwithstanding the above, nothing herein shall supersede or modify the terms of
+any separate license agreement you may have executed with Licensor regarding
+such Contributions.
+
+6. Trademarks.
+
+This License does not grant permission to use the trade names, trademarks,
+service marks, or product names of the Licensor, except as required for
+reasonable and customary use in describing the origin of the Work and
+reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty.
+
+Unless required by applicable law or agreed to in writing, Licensor provides the
+Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
+including, without limitation, any warranties or conditions of TITLE,
+NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
+solely responsible for determining the appropriateness of using or
+redistributing the Work and assume any risks associated with Your exercise of
+permissions under this License.
+
+8. Limitation of Liability.
+
+In no event and under no legal theory, whether in tort (including negligence),
+contract, or otherwise, unless required by applicable law (such as deliberate
+and grossly negligent acts) or agreed to in writing, shall any Contributor be
+liable to You for damages, including any direct, indirect, special, incidental,
+or consequential damages of any character arising as a result of this License or
+out of the use or inability to use the Work (including but not limited to
+damages for loss of goodwill, work stoppage, computer failure or malfunction, or
+any and all other commercial damages or losses), even if such Contributor has
+been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability.
+
+While redistributing the Work or Derivative Works thereof, You may choose to
+offer, and charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this License. However,
+in accepting such obligations, You may act only on Your own behalf and on Your
+sole responsibility, not on behalf of any other Contributor, and only if You
+agree to indemnify, defend, and hold each Contributor harmless for any liability
+incurred by, or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work
+
+To apply the Apache License to your work, attach the following boilerplate
+notice, with the fields enclosed by brackets "[]" replaced with your own
+identifying information. (Don't include the brackets!) The text should be
+enclosed in the appropriate comment syntax for the file format. We also
+recommend that a file or class name and description of purpose be included on
+the same "printed page" as the copyright notice for easier identification within
+third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/src/github.com/golang/glog/README
+++ b/vendor/src/github.com/golang/glog/README
@@ -1,0 +1,44 @@
+glog
+====
+
+Leveled execution logs for Go.
+
+This is an efficient pure Go implementation of leveled logs in the
+manner of the open source C++ package
+	https://github.com/google/glog
+
+By binding methods to booleans it is possible to use the log package
+without paying the expense of evaluating the arguments to the log.
+Through the -vmodule flag, the package also provides fine-grained
+control over logging at the file level.
+
+The comment from glog.go introduces the ideas:
+
+	Package glog implements logging analogous to the Google-internal
+	C++ INFO/ERROR/V setup.  It provides functions Info, Warning,
+	Error, Fatal, plus formatting variants such as Infof. It
+	also provides V-style logging controlled by the -v and
+	-vmodule=file=2 flags.
+	
+	Basic examples:
+	
+		glog.Info("Prepare to repel boarders")
+	
+		glog.Fatalf("Initialization failed: %s", err)
+	
+	See the documentation for the V function for an explanation
+	of these examples:
+	
+		if glog.V(2) {
+			glog.Info("Starting transaction...")
+		}
+	
+		glog.V(2).Infoln("Processed", nItems, "elements")
+
+
+The repository contains an open source version of the log package
+used inside Google. The master copy of the source lives inside
+Google, not here. The code in this repo is for export only and is not itself
+under development. Feature requests will be ignored.
+
+Send bug reports to golang-nuts@googlegroups.com.

--- a/vendor/src/github.com/golang/glog/glog.go
+++ b/vendor/src/github.com/golang/glog/glog.go
@@ -1,0 +1,1180 @@
+// Go support for leveled logs, analogous to https://code.google.com/p/google-glog/
+//
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package glog implements logging analogous to the Google-internal C++ INFO/ERROR/V setup.
+// It provides functions Info, Warning, Error, Fatal, plus formatting variants such as
+// Infof. It also provides V-style logging controlled by the -v and -vmodule=file=2 flags.
+//
+// Basic examples:
+//
+//	glog.Info("Prepare to repel boarders")
+//
+//	glog.Fatalf("Initialization failed: %s", err)
+//
+// See the documentation for the V function for an explanation of these examples:
+//
+//	if glog.V(2) {
+//		glog.Info("Starting transaction...")
+//	}
+//
+//	glog.V(2).Infoln("Processed", nItems, "elements")
+//
+// Log output is buffered and written periodically using Flush. Programs
+// should call Flush before exiting to guarantee all log output is written.
+//
+// By default, all log statements write to files in a temporary directory.
+// This package provides several flags that modify this behavior.
+// As a result, flag.Parse must be called before any logging is done.
+//
+//	-logtostderr=false
+//		Logs are written to standard error instead of to files.
+//	-alsologtostderr=false
+//		Logs are written to standard error as well as to files.
+//	-stderrthreshold=ERROR
+//		Log events at or above this severity are logged to standard
+//		error as well as to files.
+//	-log_dir=""
+//		Log files will be written to this directory instead of the
+//		default temporary directory.
+//
+//	Other flags provide aids to debugging.
+//
+//	-log_backtrace_at=""
+//		When set to a file and line number holding a logging statement,
+//		such as
+//			-log_backtrace_at=gopherflakes.go:234
+//		a stack trace will be written to the Info log whenever execution
+//		hits that statement. (Unlike with -vmodule, the ".go" must be
+//		present.)
+//	-v=0
+//		Enable V-leveled logging at the specified level.
+//	-vmodule=""
+//		The syntax of the argument is a comma-separated list of pattern=N,
+//		where pattern is a literal file name (minus the ".go" suffix) or
+//		"glob" pattern and N is a V level. For instance,
+//			-vmodule=gopher*=3
+//		sets the V level to 3 in all Go files whose names begin "gopher".
+//
+package glog
+
+import (
+	"bufio"
+	"bytes"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	stdLog "log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+// severity identifies the sort of log: info, warning etc. It also implements
+// the flag.Value interface. The -stderrthreshold flag is of type severity and
+// should be modified only through the flag.Value interface. The values match
+// the corresponding constants in C++.
+type severity int32 // sync/atomic int32
+
+// These constants identify the log levels in order of increasing severity.
+// A message written to a high-severity log file is also written to each
+// lower-severity log file.
+const (
+	infoLog severity = iota
+	warningLog
+	errorLog
+	fatalLog
+	numSeverity = 4
+)
+
+const severityChar = "IWEF"
+
+var severityName = []string{
+	infoLog:    "INFO",
+	warningLog: "WARNING",
+	errorLog:   "ERROR",
+	fatalLog:   "FATAL",
+}
+
+// get returns the value of the severity.
+func (s *severity) get() severity {
+	return severity(atomic.LoadInt32((*int32)(s)))
+}
+
+// set sets the value of the severity.
+func (s *severity) set(val severity) {
+	atomic.StoreInt32((*int32)(s), int32(val))
+}
+
+// String is part of the flag.Value interface.
+func (s *severity) String() string {
+	return strconv.FormatInt(int64(*s), 10)
+}
+
+// Get is part of the flag.Value interface.
+func (s *severity) Get() interface{} {
+	return *s
+}
+
+// Set is part of the flag.Value interface.
+func (s *severity) Set(value string) error {
+	var threshold severity
+	// Is it a known name?
+	if v, ok := severityByName(value); ok {
+		threshold = v
+	} else {
+		v, err := strconv.Atoi(value)
+		if err != nil {
+			return err
+		}
+		threshold = severity(v)
+	}
+	logging.stderrThreshold.set(threshold)
+	return nil
+}
+
+func severityByName(s string) (severity, bool) {
+	s = strings.ToUpper(s)
+	for i, name := range severityName {
+		if name == s {
+			return severity(i), true
+		}
+	}
+	return 0, false
+}
+
+// OutputStats tracks the number of output lines and bytes written.
+type OutputStats struct {
+	lines int64
+	bytes int64
+}
+
+// Lines returns the number of lines written.
+func (s *OutputStats) Lines() int64 {
+	return atomic.LoadInt64(&s.lines)
+}
+
+// Bytes returns the number of bytes written.
+func (s *OutputStats) Bytes() int64 {
+	return atomic.LoadInt64(&s.bytes)
+}
+
+// Stats tracks the number of lines of output and number of bytes
+// per severity level. Values must be read with atomic.LoadInt64.
+var Stats struct {
+	Info, Warning, Error OutputStats
+}
+
+var severityStats = [numSeverity]*OutputStats{
+	infoLog:    &Stats.Info,
+	warningLog: &Stats.Warning,
+	errorLog:   &Stats.Error,
+}
+
+// Level is exported because it appears in the arguments to V and is
+// the type of the v flag, which can be set programmatically.
+// It's a distinct type because we want to discriminate it from logType.
+// Variables of type level are only changed under logging.mu.
+// The -v flag is read only with atomic ops, so the state of the logging
+// module is consistent.
+
+// Level is treated as a sync/atomic int32.
+
+// Level specifies a level of verbosity for V logs. *Level implements
+// flag.Value; the -v flag is of type Level and should be modified
+// only through the flag.Value interface.
+type Level int32
+
+// get returns the value of the Level.
+func (l *Level) get() Level {
+	return Level(atomic.LoadInt32((*int32)(l)))
+}
+
+// set sets the value of the Level.
+func (l *Level) set(val Level) {
+	atomic.StoreInt32((*int32)(l), int32(val))
+}
+
+// String is part of the flag.Value interface.
+func (l *Level) String() string {
+	return strconv.FormatInt(int64(*l), 10)
+}
+
+// Get is part of the flag.Value interface.
+func (l *Level) Get() interface{} {
+	return *l
+}
+
+// Set is part of the flag.Value interface.
+func (l *Level) Set(value string) error {
+	v, err := strconv.Atoi(value)
+	if err != nil {
+		return err
+	}
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+	logging.setVState(Level(v), logging.vmodule.filter, false)
+	return nil
+}
+
+// moduleSpec represents the setting of the -vmodule flag.
+type moduleSpec struct {
+	filter []modulePat
+}
+
+// modulePat contains a filter for the -vmodule flag.
+// It holds a verbosity level and a file pattern to match.
+type modulePat struct {
+	pattern string
+	literal bool // The pattern is a literal string
+	level   Level
+}
+
+// match reports whether the file matches the pattern. It uses a string
+// comparison if the pattern contains no metacharacters.
+func (m *modulePat) match(file string) bool {
+	if m.literal {
+		return file == m.pattern
+	}
+	match, _ := filepath.Match(m.pattern, file)
+	return match
+}
+
+func (m *moduleSpec) String() string {
+	// Lock because the type is not atomic. TODO: clean this up.
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+	var b bytes.Buffer
+	for i, f := range m.filter {
+		if i > 0 {
+			b.WriteRune(',')
+		}
+		fmt.Fprintf(&b, "%s=%d", f.pattern, f.level)
+	}
+	return b.String()
+}
+
+// Get is part of the (Go 1.2)  flag.Getter interface. It always returns nil for this flag type since the
+// struct is not exported.
+func (m *moduleSpec) Get() interface{} {
+	return nil
+}
+
+var errVmoduleSyntax = errors.New("syntax error: expect comma-separated list of filename=N")
+
+// Syntax: -vmodule=recordio=2,file=1,gfs*=3
+func (m *moduleSpec) Set(value string) error {
+	var filter []modulePat
+	for _, pat := range strings.Split(value, ",") {
+		if len(pat) == 0 {
+			// Empty strings such as from a trailing comma can be ignored.
+			continue
+		}
+		patLev := strings.Split(pat, "=")
+		if len(patLev) != 2 || len(patLev[0]) == 0 || len(patLev[1]) == 0 {
+			return errVmoduleSyntax
+		}
+		pattern := patLev[0]
+		v, err := strconv.Atoi(patLev[1])
+		if err != nil {
+			return errors.New("syntax error: expect comma-separated list of filename=N")
+		}
+		if v < 0 {
+			return errors.New("negative value for vmodule level")
+		}
+		if v == 0 {
+			continue // Ignore. It's harmless but no point in paying the overhead.
+		}
+		// TODO: check syntax of filter?
+		filter = append(filter, modulePat{pattern, isLiteral(pattern), Level(v)})
+	}
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+	logging.setVState(logging.verbosity, filter, true)
+	return nil
+}
+
+// isLiteral reports whether the pattern is a literal string, that is, has no metacharacters
+// that require filepath.Match to be called to match the pattern.
+func isLiteral(pattern string) bool {
+	return !strings.ContainsAny(pattern, `\*?[]`)
+}
+
+// traceLocation represents the setting of the -log_backtrace_at flag.
+type traceLocation struct {
+	file string
+	line int
+}
+
+// isSet reports whether the trace location has been specified.
+// logging.mu is held.
+func (t *traceLocation) isSet() bool {
+	return t.line > 0
+}
+
+// match reports whether the specified file and line matches the trace location.
+// The argument file name is the full path, not the basename specified in the flag.
+// logging.mu is held.
+func (t *traceLocation) match(file string, line int) bool {
+	if t.line != line {
+		return false
+	}
+	if i := strings.LastIndex(file, "/"); i >= 0 {
+		file = file[i+1:]
+	}
+	return t.file == file
+}
+
+func (t *traceLocation) String() string {
+	// Lock because the type is not atomic. TODO: clean this up.
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+	return fmt.Sprintf("%s:%d", t.file, t.line)
+}
+
+// Get is part of the (Go 1.2) flag.Getter interface. It always returns nil for this flag type since the
+// struct is not exported
+func (t *traceLocation) Get() interface{} {
+	return nil
+}
+
+var errTraceSyntax = errors.New("syntax error: expect file.go:234")
+
+// Syntax: -log_backtrace_at=gopherflakes.go:234
+// Note that unlike vmodule the file extension is included here.
+func (t *traceLocation) Set(value string) error {
+	if value == "" {
+		// Unset.
+		t.line = 0
+		t.file = ""
+	}
+	fields := strings.Split(value, ":")
+	if len(fields) != 2 {
+		return errTraceSyntax
+	}
+	file, line := fields[0], fields[1]
+	if !strings.Contains(file, ".") {
+		return errTraceSyntax
+	}
+	v, err := strconv.Atoi(line)
+	if err != nil {
+		return errTraceSyntax
+	}
+	if v <= 0 {
+		return errors.New("negative or zero value for level")
+	}
+	logging.mu.Lock()
+	defer logging.mu.Unlock()
+	t.line = v
+	t.file = file
+	return nil
+}
+
+// flushSyncWriter is the interface satisfied by logging destinations.
+type flushSyncWriter interface {
+	Flush() error
+	Sync() error
+	io.Writer
+}
+
+func init() {
+	flag.BoolVar(&logging.toStderr, "logtostderr", false, "log to standard error instead of files")
+	flag.BoolVar(&logging.alsoToStderr, "alsologtostderr", false, "log to standard error as well as files")
+	flag.Var(&logging.verbosity, "v", "log level for V logs")
+	flag.Var(&logging.stderrThreshold, "stderrthreshold", "logs at or above this threshold go to stderr")
+	flag.Var(&logging.vmodule, "vmodule", "comma-separated list of pattern=N settings for file-filtered logging")
+	flag.Var(&logging.traceLocation, "log_backtrace_at", "when logging hits line file:N, emit a stack trace")
+
+	// Default stderrThreshold is ERROR.
+	logging.stderrThreshold = errorLog
+
+	logging.setVState(0, nil, false)
+	go logging.flushDaemon()
+}
+
+// Flush flushes all pending log I/O.
+func Flush() {
+	logging.lockAndFlushAll()
+}
+
+// loggingT collects all the global state of the logging setup.
+type loggingT struct {
+	// Boolean flags. Not handled atomically because the flag.Value interface
+	// does not let us avoid the =true, and that shorthand is necessary for
+	// compatibility. TODO: does this matter enough to fix? Seems unlikely.
+	toStderr     bool // The -logtostderr flag.
+	alsoToStderr bool // The -alsologtostderr flag.
+
+	// Level flag. Handled atomically.
+	stderrThreshold severity // The -stderrthreshold flag.
+
+	// freeList is a list of byte buffers, maintained under freeListMu.
+	freeList *buffer
+	// freeListMu maintains the free list. It is separate from the main mutex
+	// so buffers can be grabbed and printed to without holding the main lock,
+	// for better parallelization.
+	freeListMu sync.Mutex
+
+	// mu protects the remaining elements of this structure and is
+	// used to synchronize logging.
+	mu sync.Mutex
+	// file holds writer for each of the log types.
+	file [numSeverity]flushSyncWriter
+	// pcs is used in V to avoid an allocation when computing the caller's PC.
+	pcs [1]uintptr
+	// vmap is a cache of the V Level for each V() call site, identified by PC.
+	// It is wiped whenever the vmodule flag changes state.
+	vmap map[uintptr]Level
+	// filterLength stores the length of the vmodule filter chain. If greater
+	// than zero, it means vmodule is enabled. It may be read safely
+	// using sync.LoadInt32, but is only modified under mu.
+	filterLength int32
+	// traceLocation is the state of the -log_backtrace_at flag.
+	traceLocation traceLocation
+	// These flags are modified only under lock, although verbosity may be fetched
+	// safely using atomic.LoadInt32.
+	vmodule   moduleSpec // The state of the -vmodule flag.
+	verbosity Level      // V logging level, the value of the -v flag/
+}
+
+// buffer holds a byte Buffer for reuse. The zero value is ready for use.
+type buffer struct {
+	bytes.Buffer
+	tmp  [64]byte // temporary byte array for creating headers.
+	next *buffer
+}
+
+var logging loggingT
+
+// setVState sets a consistent state for V logging.
+// l.mu is held.
+func (l *loggingT) setVState(verbosity Level, filter []modulePat, setFilter bool) {
+	// Turn verbosity off so V will not fire while we are in transition.
+	logging.verbosity.set(0)
+	// Ditto for filter length.
+	atomic.StoreInt32(&logging.filterLength, 0)
+
+	// Set the new filters and wipe the pc->Level map if the filter has changed.
+	if setFilter {
+		logging.vmodule.filter = filter
+		logging.vmap = make(map[uintptr]Level)
+	}
+
+	// Things are consistent now, so enable filtering and verbosity.
+	// They are enabled in order opposite to that in V.
+	atomic.StoreInt32(&logging.filterLength, int32(len(filter)))
+	logging.verbosity.set(verbosity)
+}
+
+// getBuffer returns a new, ready-to-use buffer.
+func (l *loggingT) getBuffer() *buffer {
+	l.freeListMu.Lock()
+	b := l.freeList
+	if b != nil {
+		l.freeList = b.next
+	}
+	l.freeListMu.Unlock()
+	if b == nil {
+		b = new(buffer)
+	} else {
+		b.next = nil
+		b.Reset()
+	}
+	return b
+}
+
+// putBuffer returns a buffer to the free list.
+func (l *loggingT) putBuffer(b *buffer) {
+	if b.Len() >= 256 {
+		// Let big buffers die a natural death.
+		return
+	}
+	l.freeListMu.Lock()
+	b.next = l.freeList
+	l.freeList = b
+	l.freeListMu.Unlock()
+}
+
+var timeNow = time.Now // Stubbed out for testing.
+
+/*
+header formats a log header as defined by the C++ implementation.
+It returns a buffer containing the formatted header and the user's file and line number.
+The depth specifies how many stack frames above lives the source line to be identified in the log message.
+
+Log lines have this form:
+	Lmmdd hh:mm:ss.uuuuuu threadid file:line] msg...
+where the fields are defined as follows:
+	L                A single character, representing the log level (eg 'I' for INFO)
+	mm               The month (zero padded; ie May is '05')
+	dd               The day (zero padded)
+	hh:mm:ss.uuuuuu  Time in hours, minutes and fractional seconds
+	threadid         The space-padded thread ID as returned by GetTID()
+	file             The file name
+	line             The line number
+	msg              The user-supplied message
+*/
+func (l *loggingT) header(s severity, depth int) (*buffer, string, int) {
+	_, file, line, ok := runtime.Caller(3 + depth)
+	if !ok {
+		file = "???"
+		line = 1
+	} else {
+		slash := strings.LastIndex(file, "/")
+		if slash >= 0 {
+			file = file[slash+1:]
+		}
+	}
+	return l.formatHeader(s, file, line), file, line
+}
+
+// formatHeader formats a log header using the provided file name and line number.
+func (l *loggingT) formatHeader(s severity, file string, line int) *buffer {
+	now := timeNow()
+	if line < 0 {
+		line = 0 // not a real line number, but acceptable to someDigits
+	}
+	if s > fatalLog {
+		s = infoLog // for safety.
+	}
+	buf := l.getBuffer()
+
+	// Avoid Fprintf, for speed. The format is so simple that we can do it quickly by hand.
+	// It's worth about 3X. Fprintf is hard.
+	_, month, day := now.Date()
+	hour, minute, second := now.Clock()
+	// Lmmdd hh:mm:ss.uuuuuu threadid file:line]
+	buf.tmp[0] = severityChar[s]
+	buf.twoDigits(1, int(month))
+	buf.twoDigits(3, day)
+	buf.tmp[5] = ' '
+	buf.twoDigits(6, hour)
+	buf.tmp[8] = ':'
+	buf.twoDigits(9, minute)
+	buf.tmp[11] = ':'
+	buf.twoDigits(12, second)
+	buf.tmp[14] = '.'
+	buf.nDigits(6, 15, now.Nanosecond()/1000, '0')
+	buf.tmp[21] = ' '
+	buf.nDigits(7, 22, pid, ' ') // TODO: should be TID
+	buf.tmp[29] = ' '
+	buf.Write(buf.tmp[:30])
+	buf.WriteString(file)
+	buf.tmp[0] = ':'
+	n := buf.someDigits(1, line)
+	buf.tmp[n+1] = ']'
+	buf.tmp[n+2] = ' '
+	buf.Write(buf.tmp[:n+3])
+	return buf
+}
+
+// Some custom tiny helper functions to print the log header efficiently.
+
+const digits = "0123456789"
+
+// twoDigits formats a zero-prefixed two-digit integer at buf.tmp[i].
+func (buf *buffer) twoDigits(i, d int) {
+	buf.tmp[i+1] = digits[d%10]
+	d /= 10
+	buf.tmp[i] = digits[d%10]
+}
+
+// nDigits formats an n-digit integer at buf.tmp[i],
+// padding with pad on the left.
+// It assumes d >= 0.
+func (buf *buffer) nDigits(n, i, d int, pad byte) {
+	j := n - 1
+	for ; j >= 0 && d > 0; j-- {
+		buf.tmp[i+j] = digits[d%10]
+		d /= 10
+	}
+	for ; j >= 0; j-- {
+		buf.tmp[i+j] = pad
+	}
+}
+
+// someDigits formats a zero-prefixed variable-width integer at buf.tmp[i].
+func (buf *buffer) someDigits(i, d int) int {
+	// Print into the top, then copy down. We know there's space for at least
+	// a 10-digit number.
+	j := len(buf.tmp)
+	for {
+		j--
+		buf.tmp[j] = digits[d%10]
+		d /= 10
+		if d == 0 {
+			break
+		}
+	}
+	return copy(buf.tmp[i:], buf.tmp[j:])
+}
+
+func (l *loggingT) println(s severity, args ...interface{}) {
+	buf, file, line := l.header(s, 0)
+	fmt.Fprintln(buf, args...)
+	l.output(s, buf, file, line, false)
+}
+
+func (l *loggingT) print(s severity, args ...interface{}) {
+	l.printDepth(s, 1, args...)
+}
+
+func (l *loggingT) printDepth(s severity, depth int, args ...interface{}) {
+	buf, file, line := l.header(s, depth)
+	fmt.Fprint(buf, args...)
+	if buf.Bytes()[buf.Len()-1] != '\n' {
+		buf.WriteByte('\n')
+	}
+	l.output(s, buf, file, line, false)
+}
+
+func (l *loggingT) printf(s severity, format string, args ...interface{}) {
+	buf, file, line := l.header(s, 0)
+	fmt.Fprintf(buf, format, args...)
+	if buf.Bytes()[buf.Len()-1] != '\n' {
+		buf.WriteByte('\n')
+	}
+	l.output(s, buf, file, line, false)
+}
+
+// printWithFileLine behaves like print but uses the provided file and line number.  If
+// alsoLogToStderr is true, the log message always appears on standard error; it
+// will also appear in the log file unless --logtostderr is set.
+func (l *loggingT) printWithFileLine(s severity, file string, line int, alsoToStderr bool, args ...interface{}) {
+	buf := l.formatHeader(s, file, line)
+	fmt.Fprint(buf, args...)
+	if buf.Bytes()[buf.Len()-1] != '\n' {
+		buf.WriteByte('\n')
+	}
+	l.output(s, buf, file, line, alsoToStderr)
+}
+
+// output writes the data to the log files and releases the buffer.
+func (l *loggingT) output(s severity, buf *buffer, file string, line int, alsoToStderr bool) {
+	l.mu.Lock()
+	if l.traceLocation.isSet() {
+		if l.traceLocation.match(file, line) {
+			buf.Write(stacks(false))
+		}
+	}
+	data := buf.Bytes()
+	if !flag.Parsed() {
+		os.Stderr.Write([]byte("ERROR: logging before flag.Parse: "))
+		os.Stderr.Write(data)
+	} else if l.toStderr {
+		os.Stderr.Write(data)
+	} else {
+		if alsoToStderr || l.alsoToStderr || s >= l.stderrThreshold.get() {
+			os.Stderr.Write(data)
+		}
+		if l.file[s] == nil {
+			if err := l.createFiles(s); err != nil {
+				os.Stderr.Write(data) // Make sure the message appears somewhere.
+				l.exit(err)
+			}
+		}
+		switch s {
+		case fatalLog:
+			l.file[fatalLog].Write(data)
+			fallthrough
+		case errorLog:
+			l.file[errorLog].Write(data)
+			fallthrough
+		case warningLog:
+			l.file[warningLog].Write(data)
+			fallthrough
+		case infoLog:
+			l.file[infoLog].Write(data)
+		}
+	}
+	if s == fatalLog {
+		// If we got here via Exit rather than Fatal, print no stacks.
+		if atomic.LoadUint32(&fatalNoStacks) > 0 {
+			l.mu.Unlock()
+			timeoutFlush(10 * time.Second)
+			os.Exit(1)
+		}
+		// Dump all goroutine stacks before exiting.
+		// First, make sure we see the trace for the current goroutine on standard error.
+		// If -logtostderr has been specified, the loop below will do that anyway
+		// as the first stack in the full dump.
+		if !l.toStderr {
+			os.Stderr.Write(stacks(false))
+		}
+		// Write the stack trace for all goroutines to the files.
+		trace := stacks(true)
+		logExitFunc = func(error) {} // If we get a write error, we'll still exit below.
+		for log := fatalLog; log >= infoLog; log-- {
+			if f := l.file[log]; f != nil { // Can be nil if -logtostderr is set.
+				f.Write(trace)
+			}
+		}
+		l.mu.Unlock()
+		timeoutFlush(10 * time.Second)
+		os.Exit(255) // C++ uses -1, which is silly because it's anded with 255 anyway.
+	}
+	l.putBuffer(buf)
+	l.mu.Unlock()
+	if stats := severityStats[s]; stats != nil {
+		atomic.AddInt64(&stats.lines, 1)
+		atomic.AddInt64(&stats.bytes, int64(len(data)))
+	}
+}
+
+// timeoutFlush calls Flush and returns when it completes or after timeout
+// elapses, whichever happens first.  This is needed because the hooks invoked
+// by Flush may deadlock when glog.Fatal is called from a hook that holds
+// a lock.
+func timeoutFlush(timeout time.Duration) {
+	done := make(chan bool, 1)
+	go func() {
+		Flush() // calls logging.lockAndFlushAll()
+		done <- true
+	}()
+	select {
+	case <-done:
+	case <-time.After(timeout):
+		fmt.Fprintln(os.Stderr, "glog: Flush took longer than", timeout)
+	}
+}
+
+// stacks is a wrapper for runtime.Stack that attempts to recover the data for all goroutines.
+func stacks(all bool) []byte {
+	// We don't know how big the traces are, so grow a few times if they don't fit. Start large, though.
+	n := 10000
+	if all {
+		n = 100000
+	}
+	var trace []byte
+	for i := 0; i < 5; i++ {
+		trace = make([]byte, n)
+		nbytes := runtime.Stack(trace, all)
+		if nbytes < len(trace) {
+			return trace[:nbytes]
+		}
+		n *= 2
+	}
+	return trace
+}
+
+// logExitFunc provides a simple mechanism to override the default behavior
+// of exiting on error. Used in testing and to guarantee we reach a required exit
+// for fatal logs. Instead, exit could be a function rather than a method but that
+// would make its use clumsier.
+var logExitFunc func(error)
+
+// exit is called if there is trouble creating or writing log files.
+// It flushes the logs and exits the program; there's no point in hanging around.
+// l.mu is held.
+func (l *loggingT) exit(err error) {
+	fmt.Fprintf(os.Stderr, "log: exiting because of error: %s\n", err)
+	// If logExitFunc is set, we do that instead of exiting.
+	if logExitFunc != nil {
+		logExitFunc(err)
+		return
+	}
+	l.flushAll()
+	os.Exit(2)
+}
+
+// syncBuffer joins a bufio.Writer to its underlying file, providing access to the
+// file's Sync method and providing a wrapper for the Write method that provides log
+// file rotation. There are conflicting methods, so the file cannot be embedded.
+// l.mu is held for all its methods.
+type syncBuffer struct {
+	logger *loggingT
+	*bufio.Writer
+	file   *os.File
+	sev    severity
+	nbytes uint64 // The number of bytes written to this file
+}
+
+func (sb *syncBuffer) Sync() error {
+	return sb.file.Sync()
+}
+
+func (sb *syncBuffer) Write(p []byte) (n int, err error) {
+	if sb.nbytes+uint64(len(p)) >= MaxSize {
+		if err := sb.rotateFile(time.Now()); err != nil {
+			sb.logger.exit(err)
+		}
+	}
+	n, err = sb.Writer.Write(p)
+	sb.nbytes += uint64(n)
+	if err != nil {
+		sb.logger.exit(err)
+	}
+	return
+}
+
+// rotateFile closes the syncBuffer's file and starts a new one.
+func (sb *syncBuffer) rotateFile(now time.Time) error {
+	if sb.file != nil {
+		sb.Flush()
+		sb.file.Close()
+	}
+	var err error
+	sb.file, _, err = create(severityName[sb.sev], now)
+	sb.nbytes = 0
+	if err != nil {
+		return err
+	}
+
+	sb.Writer = bufio.NewWriterSize(sb.file, bufferSize)
+
+	// Write header.
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "Log file created at: %s\n", now.Format("2006/01/02 15:04:05"))
+	fmt.Fprintf(&buf, "Running on machine: %s\n", host)
+	fmt.Fprintf(&buf, "Binary: Built with %s %s for %s/%s\n", runtime.Compiler, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+	fmt.Fprintf(&buf, "Log line format: [IWEF]mmdd hh:mm:ss.uuuuuu threadid file:line] msg\n")
+	n, err := sb.file.Write(buf.Bytes())
+	sb.nbytes += uint64(n)
+	return err
+}
+
+// bufferSize sizes the buffer associated with each log file. It's large
+// so that log records can accumulate without the logging thread blocking
+// on disk I/O. The flushDaemon will block instead.
+const bufferSize = 256 * 1024
+
+// createFiles creates all the log files for severity from sev down to infoLog.
+// l.mu is held.
+func (l *loggingT) createFiles(sev severity) error {
+	now := time.Now()
+	// Files are created in decreasing severity order, so as soon as we find one
+	// has already been created, we can stop.
+	for s := sev; s >= infoLog && l.file[s] == nil; s-- {
+		sb := &syncBuffer{
+			logger: l,
+			sev:    s,
+		}
+		if err := sb.rotateFile(now); err != nil {
+			return err
+		}
+		l.file[s] = sb
+	}
+	return nil
+}
+
+const flushInterval = 30 * time.Second
+
+// flushDaemon periodically flushes the log file buffers.
+func (l *loggingT) flushDaemon() {
+	for _ = range time.NewTicker(flushInterval).C {
+		l.lockAndFlushAll()
+	}
+}
+
+// lockAndFlushAll is like flushAll but locks l.mu first.
+func (l *loggingT) lockAndFlushAll() {
+	l.mu.Lock()
+	l.flushAll()
+	l.mu.Unlock()
+}
+
+// flushAll flushes all the logs and attempts to "sync" their data to disk.
+// l.mu is held.
+func (l *loggingT) flushAll() {
+	// Flush from fatal down, in case there's trouble flushing.
+	for s := fatalLog; s >= infoLog; s-- {
+		file := l.file[s]
+		if file != nil {
+			file.Flush() // ignore error
+			file.Sync()  // ignore error
+		}
+	}
+}
+
+// CopyStandardLogTo arranges for messages written to the Go "log" package's
+// default logs to also appear in the Google logs for the named and lower
+// severities.  Subsequent changes to the standard log's default output location
+// or format may break this behavior.
+//
+// Valid names are "INFO", "WARNING", "ERROR", and "FATAL".  If the name is not
+// recognized, CopyStandardLogTo panics.
+func CopyStandardLogTo(name string) {
+	sev, ok := severityByName(name)
+	if !ok {
+		panic(fmt.Sprintf("log.CopyStandardLogTo(%q): unrecognized severity name", name))
+	}
+	// Set a log format that captures the user's file and line:
+	//   d.go:23: message
+	stdLog.SetFlags(stdLog.Lshortfile)
+	stdLog.SetOutput(logBridge(sev))
+}
+
+// logBridge provides the Write method that enables CopyStandardLogTo to connect
+// Go's standard logs to the logs provided by this package.
+type logBridge severity
+
+// Write parses the standard logging line and passes its components to the
+// logger for severity(lb).
+func (lb logBridge) Write(b []byte) (n int, err error) {
+	var (
+		file = "???"
+		line = 1
+		text string
+	)
+	// Split "d.go:23: message" into "d.go", "23", and "message".
+	if parts := bytes.SplitN(b, []byte{':'}, 3); len(parts) != 3 || len(parts[0]) < 1 || len(parts[2]) < 1 {
+		text = fmt.Sprintf("bad log format: %s", b)
+	} else {
+		file = string(parts[0])
+		text = string(parts[2][1:]) // skip leading space
+		line, err = strconv.Atoi(string(parts[1]))
+		if err != nil {
+			text = fmt.Sprintf("bad line number: %s", b)
+			line = 1
+		}
+	}
+	// printWithFileLine with alsoToStderr=true, so standard log messages
+	// always appear on standard error.
+	logging.printWithFileLine(severity(lb), file, line, true, text)
+	return len(b), nil
+}
+
+// setV computes and remembers the V level for a given PC
+// when vmodule is enabled.
+// File pattern matching takes the basename of the file, stripped
+// of its .go suffix, and uses filepath.Match, which is a little more
+// general than the *? matching used in C++.
+// l.mu is held.
+func (l *loggingT) setV(pc uintptr) Level {
+	fn := runtime.FuncForPC(pc)
+	file, _ := fn.FileLine(pc)
+	// The file is something like /a/b/c/d.go. We want just the d.
+	if strings.HasSuffix(file, ".go") {
+		file = file[:len(file)-3]
+	}
+	if slash := strings.LastIndex(file, "/"); slash >= 0 {
+		file = file[slash+1:]
+	}
+	for _, filter := range l.vmodule.filter {
+		if filter.match(file) {
+			l.vmap[pc] = filter.level
+			return filter.level
+		}
+	}
+	l.vmap[pc] = 0
+	return 0
+}
+
+// Verbose is a boolean type that implements Infof (like Printf) etc.
+// See the documentation of V for more information.
+type Verbose bool
+
+// V reports whether verbosity at the call site is at least the requested level.
+// The returned value is a boolean of type Verbose, which implements Info, Infoln
+// and Infof. These methods will write to the Info log if called.
+// Thus, one may write either
+//	if glog.V(2) { glog.Info("log this") }
+// or
+//	glog.V(2).Info("log this")
+// The second form is shorter but the first is cheaper if logging is off because it does
+// not evaluate its arguments.
+//
+// Whether an individual call to V generates a log record depends on the setting of
+// the -v and --vmodule flags; both are off by default. If the level in the call to
+// V is at least the value of -v, or of -vmodule for the source file containing the
+// call, the V call will log.
+func V(level Level) Verbose {
+	// This function tries hard to be cheap unless there's work to do.
+	// The fast path is two atomic loads and compares.
+
+	// Here is a cheap but safe test to see if V logging is enabled globally.
+	if logging.verbosity.get() >= level {
+		return Verbose(true)
+	}
+
+	// It's off globally but it vmodule may still be set.
+	// Here is another cheap but safe test to see if vmodule is enabled.
+	if atomic.LoadInt32(&logging.filterLength) > 0 {
+		// Now we need a proper lock to use the logging structure. The pcs field
+		// is shared so we must lock before accessing it. This is fairly expensive,
+		// but if V logging is enabled we're slow anyway.
+		logging.mu.Lock()
+		defer logging.mu.Unlock()
+		if runtime.Callers(2, logging.pcs[:]) == 0 {
+			return Verbose(false)
+		}
+		v, ok := logging.vmap[logging.pcs[0]]
+		if !ok {
+			v = logging.setV(logging.pcs[0])
+		}
+		return Verbose(v >= level)
+	}
+	return Verbose(false)
+}
+
+// Info is equivalent to the global Info function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v Verbose) Info(args ...interface{}) {
+	if v {
+		logging.print(infoLog, args...)
+	}
+}
+
+// Infoln is equivalent to the global Infoln function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v Verbose) Infoln(args ...interface{}) {
+	if v {
+		logging.println(infoLog, args...)
+	}
+}
+
+// Infof is equivalent to the global Infof function, guarded by the value of v.
+// See the documentation of V for usage.
+func (v Verbose) Infof(format string, args ...interface{}) {
+	if v {
+		logging.printf(infoLog, format, args...)
+	}
+}
+
+// Info logs to the INFO log.
+// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+func Info(args ...interface{}) {
+	logging.print(infoLog, args...)
+}
+
+// InfoDepth acts as Info but uses depth to determine which call frame to log.
+// InfoDepth(0, "msg") is the same as Info("msg").
+func InfoDepth(depth int, args ...interface{}) {
+	logging.printDepth(infoLog, depth, args...)
+}
+
+// Infoln logs to the INFO log.
+// Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
+func Infoln(args ...interface{}) {
+	logging.println(infoLog, args...)
+}
+
+// Infof logs to the INFO log.
+// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+func Infof(format string, args ...interface{}) {
+	logging.printf(infoLog, format, args...)
+}
+
+// Warning logs to the WARNING and INFO logs.
+// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+func Warning(args ...interface{}) {
+	logging.print(warningLog, args...)
+}
+
+// WarningDepth acts as Warning but uses depth to determine which call frame to log.
+// WarningDepth(0, "msg") is the same as Warning("msg").
+func WarningDepth(depth int, args ...interface{}) {
+	logging.printDepth(warningLog, depth, args...)
+}
+
+// Warningln logs to the WARNING and INFO logs.
+// Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
+func Warningln(args ...interface{}) {
+	logging.println(warningLog, args...)
+}
+
+// Warningf logs to the WARNING and INFO logs.
+// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+func Warningf(format string, args ...interface{}) {
+	logging.printf(warningLog, format, args...)
+}
+
+// Error logs to the ERROR, WARNING, and INFO logs.
+// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+func Error(args ...interface{}) {
+	logging.print(errorLog, args...)
+}
+
+// ErrorDepth acts as Error but uses depth to determine which call frame to log.
+// ErrorDepth(0, "msg") is the same as Error("msg").
+func ErrorDepth(depth int, args ...interface{}) {
+	logging.printDepth(errorLog, depth, args...)
+}
+
+// Errorln logs to the ERROR, WARNING, and INFO logs.
+// Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
+func Errorln(args ...interface{}) {
+	logging.println(errorLog, args...)
+}
+
+// Errorf logs to the ERROR, WARNING, and INFO logs.
+// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+func Errorf(format string, args ...interface{}) {
+	logging.printf(errorLog, format, args...)
+}
+
+// Fatal logs to the FATAL, ERROR, WARNING, and INFO logs,
+// including a stack trace of all running goroutines, then calls os.Exit(255).
+// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+func Fatal(args ...interface{}) {
+	logging.print(fatalLog, args...)
+}
+
+// FatalDepth acts as Fatal but uses depth to determine which call frame to log.
+// FatalDepth(0, "msg") is the same as Fatal("msg").
+func FatalDepth(depth int, args ...interface{}) {
+	logging.printDepth(fatalLog, depth, args...)
+}
+
+// Fatalln logs to the FATAL, ERROR, WARNING, and INFO logs,
+// including a stack trace of all running goroutines, then calls os.Exit(255).
+// Arguments are handled in the manner of fmt.Println; a newline is appended if missing.
+func Fatalln(args ...interface{}) {
+	logging.println(fatalLog, args...)
+}
+
+// Fatalf logs to the FATAL, ERROR, WARNING, and INFO logs,
+// including a stack trace of all running goroutines, then calls os.Exit(255).
+// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+func Fatalf(format string, args ...interface{}) {
+	logging.printf(fatalLog, format, args...)
+}
+
+// fatalNoStacks is non-zero if we are to exit without dumping goroutine stacks.
+// It allows Exit and relatives to use the Fatal logs.
+var fatalNoStacks uint32
+
+// Exit logs to the FATAL, ERROR, WARNING, and INFO logs, then calls os.Exit(1).
+// Arguments are handled in the manner of fmt.Print; a newline is appended if missing.
+func Exit(args ...interface{}) {
+	atomic.StoreUint32(&fatalNoStacks, 1)
+	logging.print(fatalLog, args...)
+}
+
+// ExitDepth acts as Exit but uses depth to determine which call frame to log.
+// ExitDepth(0, "msg") is the same as Exit("msg").
+func ExitDepth(depth int, args ...interface{}) {
+	atomic.StoreUint32(&fatalNoStacks, 1)
+	logging.printDepth(fatalLog, depth, args...)
+}
+
+// Exitln logs to the FATAL, ERROR, WARNING, and INFO logs, then calls os.Exit(1).
+func Exitln(args ...interface{}) {
+	atomic.StoreUint32(&fatalNoStacks, 1)
+	logging.println(fatalLog, args...)
+}
+
+// Exitf logs to the FATAL, ERROR, WARNING, and INFO logs, then calls os.Exit(1).
+// Arguments are handled in the manner of fmt.Printf; a newline is appended if missing.
+func Exitf(format string, args ...interface{}) {
+	atomic.StoreUint32(&fatalNoStacks, 1)
+	logging.printf(fatalLog, format, args...)
+}

--- a/vendor/src/github.com/golang/glog/glog_file.go
+++ b/vendor/src/github.com/golang/glog/glog_file.go
@@ -1,0 +1,124 @@
+// Go support for leveled logs, analogous to https://code.google.com/p/google-glog/
+//
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// File I/O for logs.
+
+package glog
+
+import (
+	"errors"
+	"flag"
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// MaxSize is the maximum size of a log file in bytes.
+var MaxSize uint64 = 1024 * 1024 * 1800
+
+// logDirs lists the candidate directories for new log files.
+var logDirs []string
+
+// If non-empty, overrides the choice of directory in which to write logs.
+// See createLogDirs for the full list of possible destinations.
+var logDir = flag.String("log_dir", "", "If non-empty, write log files in this directory")
+
+func createLogDirs() {
+	if *logDir != "" {
+		logDirs = append(logDirs, *logDir)
+	}
+	logDirs = append(logDirs, os.TempDir())
+}
+
+var (
+	pid      = os.Getpid()
+	program  = filepath.Base(os.Args[0])
+	host     = "unknownhost"
+	userName = "unknownuser"
+)
+
+func init() {
+	h, err := os.Hostname()
+	if err == nil {
+		host = shortHostname(h)
+	}
+
+	current, err := user.Current()
+	if err == nil {
+		userName = current.Username
+	}
+
+	// Sanitize userName since it may contain filepath separators on Windows.
+	userName = strings.Replace(userName, `\`, "_", -1)
+}
+
+// shortHostname returns its argument, truncating at the first period.
+// For instance, given "www.google.com" it returns "www".
+func shortHostname(hostname string) string {
+	if i := strings.Index(hostname, "."); i >= 0 {
+		return hostname[:i]
+	}
+	return hostname
+}
+
+// logName returns a new log file name containing tag, with start time t, and
+// the name for the symlink for tag.
+func logName(tag string, t time.Time) (name, link string) {
+	name = fmt.Sprintf("%s.%s.%s.log.%s.%04d%02d%02d-%02d%02d%02d.%d",
+		program,
+		host,
+		userName,
+		tag,
+		t.Year(),
+		t.Month(),
+		t.Day(),
+		t.Hour(),
+		t.Minute(),
+		t.Second(),
+		pid)
+	return name, program + "." + tag
+}
+
+var onceLogDirs sync.Once
+
+// create creates a new log file and returns the file and its filename, which
+// contains tag ("INFO", "FATAL", etc.) and t.  If the file is created
+// successfully, create also attempts to update the symlink for that tag, ignoring
+// errors.
+func create(tag string, t time.Time) (f *os.File, filename string, err error) {
+	onceLogDirs.Do(createLogDirs)
+	if len(logDirs) == 0 {
+		return nil, "", errors.New("log: no log dirs")
+	}
+	name, link := logName(tag, t)
+	var lastErr error
+	for _, dir := range logDirs {
+		fname := filepath.Join(dir, name)
+		f, err := os.Create(fname)
+		if err == nil {
+			symlink := filepath.Join(dir, link)
+			os.Remove(symlink)        // ignore err
+			os.Symlink(name, symlink) // ignore err
+			return f, fname, nil
+		}
+		lastErr = err
+	}
+	return nil, "", fmt.Errorf("log: cannot create log: %v", lastErr)
+}

--- a/vendor/src/github.com/golang/glog/glog_test.go
+++ b/vendor/src/github.com/golang/glog/glog_test.go
@@ -1,0 +1,415 @@
+// Go support for leveled logs, analogous to https://code.google.com/p/google-glog/
+//
+// Copyright 2013 Google Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package glog
+
+import (
+	"bytes"
+	"fmt"
+	stdLog "log"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// Test that shortHostname works as advertised.
+func TestShortHostname(t *testing.T) {
+	for hostname, expect := range map[string]string{
+		"":                "",
+		"host":            "host",
+		"host.google.com": "host",
+	} {
+		if got := shortHostname(hostname); expect != got {
+			t.Errorf("shortHostname(%q): expected %q, got %q", hostname, expect, got)
+		}
+	}
+}
+
+// flushBuffer wraps a bytes.Buffer to satisfy flushSyncWriter.
+type flushBuffer struct {
+	bytes.Buffer
+}
+
+func (f *flushBuffer) Flush() error {
+	return nil
+}
+
+func (f *flushBuffer) Sync() error {
+	return nil
+}
+
+// swap sets the log writers and returns the old array.
+func (l *loggingT) swap(writers [numSeverity]flushSyncWriter) (old [numSeverity]flushSyncWriter) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	old = l.file
+	for i, w := range writers {
+		logging.file[i] = w
+	}
+	return
+}
+
+// newBuffers sets the log writers to all new byte buffers and returns the old array.
+func (l *loggingT) newBuffers() [numSeverity]flushSyncWriter {
+	return l.swap([numSeverity]flushSyncWriter{new(flushBuffer), new(flushBuffer), new(flushBuffer), new(flushBuffer)})
+}
+
+// contents returns the specified log value as a string.
+func contents(s severity) string {
+	return logging.file[s].(*flushBuffer).String()
+}
+
+// contains reports whether the string is contained in the log.
+func contains(s severity, str string, t *testing.T) bool {
+	return strings.Contains(contents(s), str)
+}
+
+// setFlags configures the logging flags how the test expects them.
+func setFlags() {
+	logging.toStderr = false
+}
+
+// Test that Info works as advertised.
+func TestInfo(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	Info("test")
+	if !contains(infoLog, "I", t) {
+		t.Errorf("Info has wrong character: %q", contents(infoLog))
+	}
+	if !contains(infoLog, "test", t) {
+		t.Error("Info failed")
+	}
+}
+
+func TestInfoDepth(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+
+	f := func() { InfoDepth(1, "depth-test1") }
+
+	// The next three lines must stay together
+	_, _, wantLine, _ := runtime.Caller(0)
+	InfoDepth(0, "depth-test0")
+	f()
+
+	msgs := strings.Split(strings.TrimSuffix(contents(infoLog), "\n"), "\n")
+	if len(msgs) != 2 {
+		t.Fatalf("Got %d lines, expected 2", len(msgs))
+	}
+
+	for i, m := range msgs {
+		if !strings.HasPrefix(m, "I") {
+			t.Errorf("InfoDepth[%d] has wrong character: %q", i, m)
+		}
+		w := fmt.Sprintf("depth-test%d", i)
+		if !strings.Contains(m, w) {
+			t.Errorf("InfoDepth[%d] missing %q: %q", i, w, m)
+		}
+
+		// pull out the line number (between : and ])
+		msg := m[strings.LastIndex(m, ":")+1:]
+		x := strings.Index(msg, "]")
+		if x < 0 {
+			t.Errorf("InfoDepth[%d]: missing ']': %q", i, m)
+			continue
+		}
+		line, err := strconv.Atoi(msg[:x])
+		if err != nil {
+			t.Errorf("InfoDepth[%d]: bad line number: %q", i, m)
+			continue
+		}
+		wantLine++
+		if wantLine != line {
+			t.Errorf("InfoDepth[%d]: got line %d, want %d", i, line, wantLine)
+		}
+	}
+}
+
+func init() {
+	CopyStandardLogTo("INFO")
+}
+
+// Test that CopyStandardLogTo panics on bad input.
+func TestCopyStandardLogToPanic(t *testing.T) {
+	defer func() {
+		if s, ok := recover().(string); !ok || !strings.Contains(s, "LOG") {
+			t.Errorf(`CopyStandardLogTo("LOG") should have panicked: %v`, s)
+		}
+	}()
+	CopyStandardLogTo("LOG")
+}
+
+// Test that using the standard log package logs to INFO.
+func TestStandardLog(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	stdLog.Print("test")
+	if !contains(infoLog, "I", t) {
+		t.Errorf("Info has wrong character: %q", contents(infoLog))
+	}
+	if !contains(infoLog, "test", t) {
+		t.Error("Info failed")
+	}
+}
+
+// Test that the header has the correct format.
+func TestHeader(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	defer func(previous func() time.Time) { timeNow = previous }(timeNow)
+	timeNow = func() time.Time {
+		return time.Date(2006, 1, 2, 15, 4, 5, .067890e9, time.Local)
+	}
+	pid = 1234
+	Info("test")
+	var line int
+	format := "I0102 15:04:05.067890    1234 glog_test.go:%d] test\n"
+	n, err := fmt.Sscanf(contents(infoLog), format, &line)
+	if n != 1 || err != nil {
+		t.Errorf("log format error: %d elements, error %s:\n%s", n, err, contents(infoLog))
+	}
+	// Scanf treats multiple spaces as equivalent to a single space,
+	// so check for correct space-padding also.
+	want := fmt.Sprintf(format, line)
+	if contents(infoLog) != want {
+		t.Errorf("log format error: got:\n\t%q\nwant:\t%q", contents(infoLog), want)
+	}
+}
+
+// Test that an Error log goes to Warning and Info.
+// Even in the Info log, the source character will be E, so the data should
+// all be identical.
+func TestError(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	Error("test")
+	if !contains(errorLog, "E", t) {
+		t.Errorf("Error has wrong character: %q", contents(errorLog))
+	}
+	if !contains(errorLog, "test", t) {
+		t.Error("Error failed")
+	}
+	str := contents(errorLog)
+	if !contains(warningLog, str, t) {
+		t.Error("Warning failed")
+	}
+	if !contains(infoLog, str, t) {
+		t.Error("Info failed")
+	}
+}
+
+// Test that a Warning log goes to Info.
+// Even in the Info log, the source character will be W, so the data should
+// all be identical.
+func TestWarning(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	Warning("test")
+	if !contains(warningLog, "W", t) {
+		t.Errorf("Warning has wrong character: %q", contents(warningLog))
+	}
+	if !contains(warningLog, "test", t) {
+		t.Error("Warning failed")
+	}
+	str := contents(warningLog)
+	if !contains(infoLog, str, t) {
+		t.Error("Info failed")
+	}
+}
+
+// Test that a V log goes to Info.
+func TestV(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	logging.verbosity.Set("2")
+	defer logging.verbosity.Set("0")
+	V(2).Info("test")
+	if !contains(infoLog, "I", t) {
+		t.Errorf("Info has wrong character: %q", contents(infoLog))
+	}
+	if !contains(infoLog, "test", t) {
+		t.Error("Info failed")
+	}
+}
+
+// Test that a vmodule enables a log in this file.
+func TestVmoduleOn(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	logging.vmodule.Set("glog_test=2")
+	defer logging.vmodule.Set("")
+	if !V(1) {
+		t.Error("V not enabled for 1")
+	}
+	if !V(2) {
+		t.Error("V not enabled for 2")
+	}
+	if V(3) {
+		t.Error("V enabled for 3")
+	}
+	V(2).Info("test")
+	if !contains(infoLog, "I", t) {
+		t.Errorf("Info has wrong character: %q", contents(infoLog))
+	}
+	if !contains(infoLog, "test", t) {
+		t.Error("Info failed")
+	}
+}
+
+// Test that a vmodule of another file does not enable a log in this file.
+func TestVmoduleOff(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	logging.vmodule.Set("notthisfile=2")
+	defer logging.vmodule.Set("")
+	for i := 1; i <= 3; i++ {
+		if V(Level(i)) {
+			t.Errorf("V enabled for %d", i)
+		}
+	}
+	V(2).Info("test")
+	if contents(infoLog) != "" {
+		t.Error("V logged incorrectly")
+	}
+}
+
+// vGlobs are patterns that match/don't match this file at V=2.
+var vGlobs = map[string]bool{
+	// Easy to test the numeric match here.
+	"glog_test=1": false, // If -vmodule sets V to 1, V(2) will fail.
+	"glog_test=2": true,
+	"glog_test=3": true, // If -vmodule sets V to 1, V(3) will succeed.
+	// These all use 2 and check the patterns. All are true.
+	"*=2":           true,
+	"?l*=2":         true,
+	"????_*=2":      true,
+	"??[mno]?_*t=2": true,
+	// These all use 2 and check the patterns. All are false.
+	"*x=2":         false,
+	"m*=2":         false,
+	"??_*=2":       false,
+	"?[abc]?_*t=2": false,
+}
+
+// Test that vmodule globbing works as advertised.
+func testVmoduleGlob(pat string, match bool, t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	defer logging.vmodule.Set("")
+	logging.vmodule.Set(pat)
+	if V(2) != Verbose(match) {
+		t.Errorf("incorrect match for %q: got %t expected %t", pat, V(2), match)
+	}
+}
+
+// Test that a vmodule globbing works as advertised.
+func TestVmoduleGlob(t *testing.T) {
+	for glob, match := range vGlobs {
+		testVmoduleGlob(glob, match, t)
+	}
+}
+
+func TestRollover(t *testing.T) {
+	setFlags()
+	var err error
+	defer func(previous func(error)) { logExitFunc = previous }(logExitFunc)
+	logExitFunc = func(e error) {
+		err = e
+	}
+	defer func(previous uint64) { MaxSize = previous }(MaxSize)
+	MaxSize = 512
+
+	Info("x") // Be sure we have a file.
+	info, ok := logging.file[infoLog].(*syncBuffer)
+	if !ok {
+		t.Fatal("info wasn't created")
+	}
+	if err != nil {
+		t.Fatalf("info has initial error: %v", err)
+	}
+	fname0 := info.file.Name()
+	Info(strings.Repeat("x", int(MaxSize))) // force a rollover
+	if err != nil {
+		t.Fatalf("info has error after big write: %v", err)
+	}
+
+	// Make sure the next log file gets a file name with a different
+	// time stamp.
+	//
+	// TODO: determine whether we need to support subsecond log
+	// rotation.  C++ does not appear to handle this case (nor does it
+	// handle Daylight Savings Time properly).
+	time.Sleep(1 * time.Second)
+
+	Info("x") // create a new file
+	if err != nil {
+		t.Fatalf("error after rotation: %v", err)
+	}
+	fname1 := info.file.Name()
+	if fname0 == fname1 {
+		t.Errorf("info.f.Name did not change: %v", fname0)
+	}
+	if info.nbytes >= MaxSize {
+		t.Errorf("file size was not reset: %d", info.nbytes)
+	}
+}
+
+func TestLogBacktraceAt(t *testing.T) {
+	setFlags()
+	defer logging.swap(logging.newBuffers())
+	// The peculiar style of this code simplifies line counting and maintenance of the
+	// tracing block below.
+	var infoLine string
+	setTraceLocation := func(file string, line int, ok bool, delta int) {
+		if !ok {
+			t.Fatal("could not get file:line")
+		}
+		_, file = filepath.Split(file)
+		infoLine = fmt.Sprintf("%s:%d", file, line+delta)
+		err := logging.traceLocation.Set(infoLine)
+		if err != nil {
+			t.Fatal("error setting log_backtrace_at: ", err)
+		}
+	}
+	{
+		// Start of tracing block. These lines know about each other's relative position.
+		_, file, line, ok := runtime.Caller(0)
+		setTraceLocation(file, line, ok, +2) // Two lines between Caller and Info calls.
+		Info("we want a stack trace here")
+	}
+	numAppearances := strings.Count(contents(infoLog), infoLine)
+	if numAppearances < 2 {
+		// Need 2 appearances, one in the log header and one in the trace:
+		//   log_test.go:281: I0511 16:36:06.952398 02238 log_test.go:280] we want a stack trace here
+		//   ...
+		//   github.com/glog/glog_test.go:280 (0x41ba91)
+		//   ...
+		// We could be more precise but that would require knowing the details
+		// of the traceback format, which may not be dependable.
+		t.Fatal("got no trace back; log is ", contents(infoLog))
+	}
+}
+
+func BenchmarkHeader(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		buf, _, _ := logging.header(infoLog, 0)
+		logging.putBuffer(buf)
+	}
+}

--- a/vendor/src/github.com/kurin/blazer/.gitignore
+++ b/vendor/src/github.com/kurin/blazer/.gitignore
@@ -1,0 +1,26 @@
+bonfire
+
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/src/github.com/kurin/blazer/.travis.yml
+++ b/vendor/src/github.com/kurin/blazer/.travis.yml
@@ -1,0 +1,6 @@
+language: go
+
+go:
+  - tip
+ 
+script: go test ./base ./b2

--- a/vendor/src/github.com/kurin/blazer/CONTRIBUTING.md
+++ b/vendor/src/github.com/kurin/blazer/CONTRIBUTING.md
@@ -1,0 +1,27 @@
+Want to contribute? Great! First, read this page (including the small print at the end).
+
+### Before you contribute
+Before we can use your code, you must sign the
+[Google Individual Contributor License Agreement]
+(https://cla.developers.google.com/about/google-individual)
+(CLA), which you can do online. The CLA is necessary mainly because you own the
+copyright to your changes, even after your contribution becomes part of our
+codebase, so we need your permission to use and distribute your code. We also
+need to be sure of various other things—for instance that you'll tell us if you
+know that your code infringes on other people's patents. You don't have to sign
+the CLA until after you've submitted your code for review and a member has
+approved it, but you must do it before we can put your code into our codebase.
+Before you start working on a larger contribution, you should get in touch with
+us first through the issue tracker with your idea so that we can help out and
+possibly guide you. Coordinating up front makes it much easier to avoid
+frustration later on.
+
+### Code reviews
+All submissions, including submissions by project members, require review. We
+use Github pull requests for this purpose.
+
+### The small print
+Contributions made by corporations are covered by a different agreement than
+the one above, the
+[Software Grant and Corporate Contributor License Agreement]
+(https://cla.developers.google.com/about/google-corporate).

--- a/vendor/src/github.com/kurin/blazer/LICENSE
+++ b/vendor/src/github.com/kurin/blazer/LICENSE
@@ -1,0 +1,13 @@
+Copyright 2016, Google
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/vendor/src/github.com/kurin/blazer/README.md
+++ b/vendor/src/github.com/kurin/blazer/README.md
@@ -1,0 +1,141 @@
+Blazer
+====
+
+[![GoDoc](https://godoc.org/github.com/kurin/blazer/b2?status.svg)](https://godoc.org/github.com/kurin/blazer/b2)
+[![Build Status](https://travis-ci.org/kurin/blazer.svg)](https://travis-ci.org/kurin/blazer)
+
+Blazer is a Golang client library for Backblaze's B2 object storage service.
+It is designed for simple integration with existing applications that may
+already be using S3 and Google Cloud Storage, by exporting only a few standard
+Go types.
+
+It implements and satisfies the [B2 integration
+checklist](https://www.backblaze.com/b2/docs/integration_checklist.html),
+automatically handling error recovery, reauthentication, and other low-level
+aspects, making it suitable to upload very large files, or over multi-day time
+scales.
+
+```go
+import "github.com/kurin/blazer/b2"
+```
+
+## Examples
+
+### Copy a file into B2
+
+```go
+func copyFile(ctx context.Context, bucket *b2.Bucket, src, dst string) error {
+	f, err := file.Open(src)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	obj := bucket.Object(dst)
+	w := obj.NewWriter(ctx)
+	if _, err := io.Copy(w, f); err != nil {
+		w.Close()
+		return err
+	}
+	return w.Close()
+}
+```
+
+If the file is less than 100MB, Blazer will simply buffer the file and use the
+`b2_upload_file` API to send the file to Backblaze.  If the file is greater
+than 100MB, Blazer will use B2's large file support to upload the file in 100MB
+chunks.
+
+### Copy a file into B2, with multiple concurrent uploads
+
+Uploading a large file with multiple HTTP connections is simple:
+
+```go
+func copyFile(ctx context.Context, bucket *b2.Bucket, writers int, src, dst string) error {
+	f, err := file.Open(src)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	w := bucket.Object(dst).NewWriter(ctx)
+	w.ConcurrentUploads = writers
+	if _, err := io.Copy(w, f); err != nil {
+		w.Close()
+		return err
+	}
+	return w.Close()
+}
+```
+
+This will automatically split the file into `writers` chunks of 100MB uploads.
+Note that 100MB is the smallest chunk size that B2 supports.
+
+### Download a file from B2
+
+Downloading is as simple as uploading:
+
+```go
+func downloadFile(ctx context.Context, bucket *b2.Bucket, downloads int, src, dst string) error {
+	r, err := bucket.Object(src).NewReader(ctx)
+	if err != nil {
+		return err
+	}
+	defer r.Close()
+
+	f, err := file.Create(dst)
+	if err != nil {
+		return err
+	}
+	r.ConcurrentDownloads = downloads
+	if _, err := io.Copy(f, r); err != nil {
+		f.Close()
+		return err
+	}
+	return f.Close()
+}
+```
+
+### List all objects in a bucket
+
+```go
+func printObjects(ctx context.Context, bucket *b2.Bucket) error {
+	var cur *b2.Cursor
+	for {
+		objs, c, err := bucket.ListObjects(ctx, 1000, cur)
+		if err != nil && err != io.EOF {
+			return err
+		}
+		for _, obj := range objs {
+			fmt.Println(obj)
+		}
+		if err == io.EOF {
+			return
+		}
+		cur = c
+	}
+}
+```
+
+### Grant temporary auth to a file
+
+Say you have a number of files in a private bucket, and you want to allow other
+people to download some files.  This is possible to do by issuing a temporary
+authorization token for the prefix of the files you want to share.
+
+```go
+token, err := bucket.AuthToken(ctx, "photos", time.Hour)
+```
+
+If successful, `token` is then an authorization token valid for one hour, which
+can be set in HTTP GET requests.
+
+The hostname to use when downloading files via HTTP is account-specific and can
+be found via the BaseURL method:
+
+```go
+base := bucket.BaseURL()
+```
+
+====
+This is not an official Google product.

--- a/vendor/src/github.com/kurin/blazer/b2/b2.go
+++ b/vendor/src/github.com/kurin/blazer/b2/b2.go
@@ -155,6 +155,11 @@ type Attrs struct {
 	Info            map[string]string // Save arbitrary metadata on upload, but limited to 10 keys.
 }
 
+// Name returns an object's name
+func (o *Object) Name() string {
+	return o.name
+}
+
 // Attrs returns an object's attributes.
 func (o *Object) Attrs(ctx context.Context) (*Attrs, error) {
 	if err := o.ensure(ctx); err != nil {

--- a/vendor/src/github.com/kurin/blazer/b2/b2.go
+++ b/vendor/src/github.com/kurin/blazer/b2/b2.go
@@ -1,0 +1,411 @@
+// Copyright 2016, Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package b2 provides a high-level interface to Backblaze's B2 cloud storage
+// service.
+//
+// It is specifically designed to abstract away the Backblaze API details by
+// providing familiar Go interfaces, specifically an io.Writer for object
+// storage, and an io.Reader for object download.  Handling of transient
+// errors, including network and authentication timeouts, is transparent.
+//
+// Methods that perform network requests accept a context.Context argument.
+// Callers should use the context's cancellation abilities to end requests
+// early, or to provide timeout or deadline guarantees.
+//
+// This package is in development and may make API changes.
+package b2
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"strconv"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// Client is a Backblaze B2 client.
+type Client struct {
+	backend beRootInterface
+}
+
+// NewClient creates and returns a new Client with valid B2 service account
+// tokens.
+func NewClient(ctx context.Context, account, key string) (*Client, error) {
+	c := &Client{
+		backend: &beRoot{
+			b2i: &b2Root{},
+		},
+	}
+	if err := c.backend.authorizeAccount(ctx, account, key); err != nil {
+		return nil, err
+	}
+	return c, nil
+}
+
+// Bucket is a reference to a B2 bucket.
+type Bucket struct {
+	b beBucketInterface
+	r beRootInterface
+}
+
+type BucketType string
+
+const (
+	UnknownType BucketType = ""
+	Private                = "allPrivate"
+	Public                 = "allPublic"
+)
+
+// Bucket returns the named bucket.  If the bucket already exists (and belongs
+// to this account), it is reused.  Otherwise a new private bucket is created.
+//
+// Deprecated; use NewBucket instead.
+func (c *Client) Bucket(ctx context.Context, name string) (*Bucket, error) {
+	return c.NewBucket(ctx, name, Private)
+}
+
+// NewBucket returns a bucket.  The bucket is created if it does not already
+// exist.
+func (c *Client) NewBucket(ctx context.Context, name string, btype BucketType) (*Bucket, error) {
+	buckets, err := c.backend.listBuckets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, bucket := range buckets {
+		if bucket.name() == name && bucket.btype() == btype {
+			return &Bucket{
+				b: bucket,
+				r: c.backend,
+			}, nil
+		}
+	}
+	b, err := c.backend.createBucket(ctx, name, string(btype))
+	if err != nil {
+		return nil, err
+	}
+	return &Bucket{
+		b: b,
+		r: c.backend,
+	}, err
+}
+
+// ListBucket returns all the available buckets.
+func (c *Client) ListBuckets(ctx context.Context) ([]*Bucket, error) {
+	bs, err := c.backend.listBuckets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var buckets []*Bucket
+	for _, b := range bs {
+		buckets = append(buckets, &Bucket{
+			b: b,
+			r: c.backend,
+		})
+	}
+	return buckets, nil
+}
+
+// Delete removes a bucket.  The bucket must be empty.
+func (b *Bucket) Delete(ctx context.Context) error {
+	return b.b.deleteBucket(ctx)
+}
+
+// BaseURL returns the base URL to use for all files uploaded to this bucket.
+func (b *Bucket) BaseURL() string {
+	return b.b.baseURL()
+}
+
+// Name returns the bucket's name.
+func (b *Bucket) Name() string {
+	return b.b.name()
+}
+
+// Object represents a B2 object.
+type Object struct {
+	attrs *Attrs
+	name  string
+	f     beFileInterface
+	b     *Bucket
+}
+
+// Attrs holds an object's metadata.
+type Attrs struct {
+	Name            string            // Not used on upload.
+	Size            int64             // Not used on upload.
+	ContentType     string            // Used on upload, default is "application/octet-stream".
+	Status          ObjectState       // Not used on upload.
+	UploadTimestamp time.Time         // Not used on upload.
+	SHA1            string            // Not used on upload. Can be "none" for large files.
+	LastModified    time.Time         // If present, and there are fewer than 10 keys in the Info field, this is saved on upload.
+	Info            map[string]string // Save arbitrary metadata on upload, but limited to 10 keys.
+}
+
+// Attrs returns an object's attributes.
+func (o *Object) Attrs(ctx context.Context) (*Attrs, error) {
+	if err := o.ensure(ctx); err != nil {
+		return nil, err
+	}
+	fi, err := o.f.getFileInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	name, sha, size, ct, info, st, stamp := fi.stats()
+	var state ObjectState
+	switch st {
+	case "upload":
+		state = Uploaded
+	case "start":
+		state = Started
+	case "hide":
+		state = Hider
+	}
+	var mtime time.Time
+	if v, ok := info["src_last_modified_millis"]; ok {
+		ms, err := strconv.ParseInt(v, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+		mtime = time.Unix(ms/1e3, (ms%1e3)*1e6)
+		delete(info, "src_last_modified_millis")
+	}
+	return &Attrs{
+		Name:            name,
+		Size:            size,
+		ContentType:     ct,
+		UploadTimestamp: stamp,
+		SHA1:            sha,
+		Info:            info,
+		Status:          state,
+		LastModified:    mtime,
+	}, nil
+}
+
+// ObjectState represents the various states an object can be in.
+type ObjectState int
+
+const (
+	Unknown ObjectState = iota
+	// Started represents a large upload that has been started but not finished
+	// or canceled.
+	Started
+	// Uploaded represents an object that has finished uploading and is complete.
+	Uploaded
+	// Hider represents an object that exists only to hide another object.  It
+	// cannot in itself be downloaded and, in particular, is not a hidden object.
+	Hider
+)
+
+// Object returns a reference to the named object in the bucket.  Hidden
+// objects cannot be referenced in this manner; they can only be found by
+// finding the appropriate reference in ListObjects.
+func (b *Bucket) Object(name string) *Object {
+	return &Object{
+		name: name,
+		b:    b,
+	}
+}
+
+// URL returns the full URL to the given object.
+func (o *Object) URL() string {
+	return fmt.Sprintf("%s/file/%s/%s", o.b.BaseURL(), o.b.Name(), o.name)
+}
+
+// NewWriter returns a new writer for the given object.  Objects that are
+// overwritten are not deleted, but are "hidden".
+//
+// Callers must close the writer when finished and check the error status.
+func (o *Object) NewWriter(ctx context.Context) *Writer {
+	ctx, cancel := context.WithCancel(ctx)
+	bw := &Writer{
+		o:      o,
+		name:   o.name,
+		chsh:   sha1.New(),
+		cbuf:   &bytes.Buffer{},
+		ctx:    ctx,
+		cancel: cancel,
+	}
+	bw.w = io.MultiWriter(bw.chsh, bw.cbuf)
+	return bw
+}
+
+// NewRangeReader returns a reader for the given object, reading up to length
+// bytes.  If length is negative, the rest of the object is read.
+func (o *Object) NewRangeReader(ctx context.Context, offset, length int64) *Reader {
+	ctx, cancel := context.WithCancel(ctx)
+	return &Reader{
+		ctx:    ctx,
+		cancel: cancel,
+		o:      o,
+		name:   o.name,
+		chunks: make(map[int]*bytes.Buffer),
+		length: length,
+		offset: offset,
+	}
+}
+
+// NewReader returns a reader for the given object.
+func (o *Object) NewReader(ctx context.Context) *Reader {
+	return o.NewRangeReader(ctx, 0, -1)
+}
+
+func (o *Object) ensure(ctx context.Context) error {
+	if o.f == nil {
+		f, err := o.b.getObject(ctx, o.name)
+		if err != nil {
+			return err
+		}
+		o.f = f.f
+	}
+	return nil
+}
+
+// Delete removes the given object.
+func (o *Object) Delete(ctx context.Context) error {
+	if err := o.ensure(ctx); err != nil {
+		return err
+	}
+	return o.f.deleteFileVersion(ctx)
+}
+
+// Cursor is passed to ListObjects to return subsequent pages.
+type Cursor struct {
+	Name string
+	id   string
+}
+
+// ListObjects returns all objects in the bucket, including multiple versions
+// of the same object.  Cursor may be nil; when passed to a subsequent query,
+// it will continue the listing.
+//
+// ListObjects will return io.EOF when there are no objects left in the bucket,
+// however it may do so concurrently with the last objects.
+func (b *Bucket) ListObjects(ctx context.Context, count int, c *Cursor) ([]*Object, *Cursor, error) {
+	if c == nil {
+		c = &Cursor{}
+	}
+	fs, name, id, err := b.b.listFileVersions(ctx, count, c.Name, c.id)
+	if err != nil {
+		return nil, nil, err
+	}
+	var next *Cursor
+	if name != "" && id != "" {
+		next = &Cursor{
+			Name: name,
+			id:   id,
+		}
+	}
+	var objects []*Object
+	for _, f := range fs {
+		objects = append(objects, &Object{
+			name: f.name(),
+			f:    f,
+			b:    b,
+		})
+	}
+	var rtnErr error
+	if len(objects) == 0 || next == nil {
+		rtnErr = io.EOF
+	}
+	return objects, next, rtnErr
+}
+
+// ListCurrentObjects is similar to ListObjects, except that it returns only
+// current, unhidden objects in the bucket.
+func (b *Bucket) ListCurrentObjects(ctx context.Context, count int, c *Cursor) ([]*Object, *Cursor, error) {
+	if c == nil {
+		c = &Cursor{}
+	}
+	fs, name, err := b.b.listFileNames(ctx, count, c.Name)
+	if err != nil {
+		return nil, nil, err
+	}
+	var next *Cursor
+	if name != "" {
+		next = &Cursor{
+			Name: name,
+		}
+	}
+	var objects []*Object
+	for _, f := range fs {
+		objects = append(objects, &Object{
+			name: f.name(),
+			f:    f,
+			b:    b,
+		})
+	}
+	var rtnErr error
+	if len(objects) == 0 || next == nil {
+		rtnErr = io.EOF
+	}
+	return objects, next, rtnErr
+}
+
+// Hide hides the object from name-based listing.
+func (o *Object) Hide(ctx context.Context) error {
+	if err := o.ensure(ctx); err != nil {
+		return err
+	}
+	_, err := o.b.b.hideFile(ctx, o.name)
+	return err
+}
+
+// Reveal unhides (if hidden) the named object.  If there are multiple objects
+// of a given name, it will reveal the most recent.
+func (b *Bucket) Reveal(ctx context.Context, name string) error {
+	cur := &Cursor{
+		Name: name,
+	}
+	objs, _, err := b.ListObjects(ctx, 1, cur)
+	if err != nil && err != io.EOF {
+		return err
+	}
+	if len(objs) < 1 || objs[0].name != name {
+		return fmt.Errorf("%s: not found", name)
+	}
+	obj := objs[0]
+	if obj.f.status() != "hide" {
+		return nil
+	}
+	return obj.Delete(ctx)
+}
+
+func (b *Bucket) getObject(ctx context.Context, name string) (*Object, error) {
+	fs, _, err := b.b.listFileNames(ctx, 1, name)
+	if err != nil {
+		return nil, err
+	}
+	if len(fs) < 1 {
+		return nil, fmt.Errorf("%s: not found", name)
+	}
+	f := fs[0]
+	if f.name() != name {
+		return nil, fmt.Errorf("%s: not found", name)
+	}
+	return &Object{
+		name: name,
+		f:    f,
+		b:    b,
+	}, nil
+}
+
+// AuthToken returns an authorization token that can be used to access objects
+// in a private bucket.  Only objects that begin with prefix can be accessed.
+// The token expires after the given duration.
+func (b *Bucket) AuthToken(ctx context.Context, prefix string, valid time.Duration) (string, error) {
+	return b.b.getDownloadAuthorization(ctx, prefix, valid)
+}

--- a/vendor/src/github.com/kurin/blazer/b2/b2_test.go
+++ b/vendor/src/github.com/kurin/blazer/b2/b2_test.go
@@ -1,0 +1,586 @@
+// Copyright 2016, Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package b2
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	bucketName    = "MahBucket"
+	smallFileName = "TeenyTiny"
+	largeFileName = "BigBytes"
+)
+
+type testError struct {
+	retry    bool
+	backoff  time.Duration
+	reauth   bool
+	reupload bool
+}
+
+func (t testError) Error() string {
+	return fmt.Sprintf("retry %v; backoff %v; reauth %v; reupload %v", t.retry, t.backoff, t.reauth, t.reupload)
+}
+
+type errCont struct {
+	errMap map[string]map[int]error
+	opMap  map[string]int
+}
+
+func (e *errCont) getError(name string) error {
+	if e.errMap == nil {
+		return nil
+	}
+	if e.opMap == nil {
+		e.opMap = make(map[string]int)
+	}
+	i := e.opMap[name]
+	e.opMap[name]++
+	return e.errMap[name][i]
+}
+
+type testRoot struct {
+	errs      *errCont
+	auths     int
+	bucketMap map[string]map[string]string
+}
+
+func (t *testRoot) authorizeAccount(context.Context, string, string) error {
+	t.auths++
+	return nil
+}
+
+func (t *testRoot) backoff(err error) time.Duration {
+	e, ok := err.(testError)
+	if !ok {
+		return 0
+	}
+	return e.backoff
+}
+
+func (t *testRoot) reauth(err error) bool {
+	e, ok := err.(testError)
+	if !ok {
+		return false
+	}
+	return e.reauth
+}
+
+func (t *testRoot) reupload(err error) bool {
+	e, ok := err.(testError)
+	if !ok {
+		return false
+	}
+	return e.reupload
+}
+
+func (t *testRoot) transient(err error) bool {
+	e, ok := err.(testError)
+	if !ok {
+		return false
+	}
+	return e.retry || e.reupload || e.backoff > 0
+}
+
+func (t *testRoot) createBucket(_ context.Context, name, _ string) (b2BucketInterface, error) {
+	if err := t.errs.getError("createBucket"); err != nil {
+		return nil, err
+	}
+	if _, ok := t.bucketMap[name]; ok {
+		return nil, fmt.Errorf("%s: bucket exists", name)
+	}
+	m := make(map[string]string)
+	t.bucketMap[name] = m
+	return &testBucket{
+		n:     name,
+		errs:  t.errs,
+		files: m,
+	}, nil
+}
+
+func (t *testRoot) listBuckets(context.Context) ([]b2BucketInterface, error) {
+	var b []b2BucketInterface
+	for k, v := range t.bucketMap {
+		b = append(b, &testBucket{
+			n:     k,
+			errs:  t.errs,
+			files: v,
+		})
+	}
+	return b, nil
+}
+
+type testBucket struct {
+	n     string
+	errs  *errCont
+	files map[string]string
+}
+
+func (t *testBucket) name() string                       { return t.n }
+func (t *testBucket) btype() string                      { return "allPrivate" }
+func (t *testBucket) deleteBucket(context.Context) error { return nil }
+
+func (t *testBucket) getUploadURL(context.Context) (b2URLInterface, error) {
+	if err := t.errs.getError("getUploadURL"); err != nil {
+		return nil, err
+	}
+	return &testURL{
+		files: t.files,
+	}, nil
+}
+
+func (t *testBucket) startLargeFile(_ context.Context, name, _ string, _ map[string]string) (b2LargeFileInterface, error) {
+	return &testLargeFile{
+		name:  name,
+		parts: make(map[int][]byte),
+		files: t.files,
+		errs:  t.errs,
+	}, nil
+}
+
+func (t *testBucket) listFileNames(ctx context.Context, count int, cont string) ([]b2FileInterface, string, error) {
+	var f []string
+	for name := range t.files {
+		f = append(f, name)
+	}
+	sort.Strings(f)
+	idx := sort.SearchStrings(f, cont)
+	var b []b2FileInterface
+	var next string
+	for i := idx; i < len(f) && i-idx < count; i++ {
+		b = append(b, &testFile{
+			n:     f[i],
+			s:     int64(len(t.files[f[i]])),
+			files: t.files,
+		})
+		if i+1 < len(f) {
+			next = f[i+1]
+		}
+		if i+1 == len(f) {
+			next = ""
+		}
+	}
+	return b, next, nil
+}
+
+func (t *testBucket) listFileVersions(ctx context.Context, count int, a, b string) ([]b2FileInterface, string, string, error) {
+	x, y, z := t.listFileNames(ctx, count, a)
+	return x, y, "", z
+}
+
+func (t *testBucket) downloadFileByName(_ context.Context, name string, offset, size int64) (b2FileReaderInterface, error) {
+	return &testFileReader{
+		b: ioutil.NopCloser(bytes.NewBufferString(t.files[name][offset : offset+size])),
+	}, nil
+}
+
+func (t *testBucket) hideFile(context.Context, string) (b2FileInterface, error) { return nil, nil }
+func (t *testBucket) getDownloadAuthorization(context.Context, string, time.Duration) (string, error) {
+	return "", nil
+}
+func (t *testBucket) baseURL() string { return "" }
+
+type testURL struct {
+	files map[string]string
+}
+
+func (t *testURL) reload(context.Context) error { return nil }
+
+func (t *testURL) uploadFile(_ context.Context, r io.Reader, _ int, name, _, _ string, _ map[string]string) (b2FileInterface, error) {
+	buf := &bytes.Buffer{}
+	if _, err := io.Copy(buf, r); err != nil {
+		return nil, err
+	}
+	t.files[name] = buf.String()
+	return &testFile{
+		n:     name,
+		s:     int64(len(t.files[name])),
+		files: t.files,
+	}, nil
+}
+
+type testLargeFile struct {
+	name  string
+	mux   sync.Mutex
+	parts map[int][]byte
+	files map[string]string
+	errs  *errCont
+}
+
+func (t *testLargeFile) finishLargeFile(context.Context) (b2FileInterface, error) {
+	var total []byte
+	for i := 1; i <= len(t.parts); i++ {
+		total = append(total, t.parts[i]...)
+	}
+	t.files[t.name] = string(total)
+	return &testFile{
+		n:     t.name,
+		s:     int64(len(total)),
+		files: t.files,
+	}, nil
+}
+
+func (t *testLargeFile) getUploadPartURL(context.Context) (b2FileChunkInterface, error) {
+	return &testFileChunk{
+		parts: t.parts,
+		mux:   &t.mux,
+		errs:  t.errs,
+	}, nil
+}
+
+type testFileChunk struct {
+	mux   *sync.Mutex
+	parts map[int][]byte
+	errs  *errCont
+}
+
+func (t *testFileChunk) reload(context.Context) error { return nil }
+
+func (t *testFileChunk) uploadPart(_ context.Context, r io.Reader, _ string, _, index int) (int, error) {
+	if err := t.errs.getError("uploadPart"); err != nil {
+		return 0, err
+	}
+	buf := &bytes.Buffer{}
+	i, err := io.Copy(buf, r)
+	if err != nil {
+		return int(i), err
+	}
+	t.mux.Lock()
+	t.parts[index] = buf.Bytes()
+	t.mux.Unlock()
+	return int(i), nil
+}
+
+type testFile struct {
+	n     string
+	s     int64
+	t     time.Time
+	a     string
+	files map[string]string
+}
+
+func (t *testFile) name() string         { return t.n }
+func (t *testFile) size() int64          { return t.s }
+func (t *testFile) timestamp() time.Time { return t.t }
+func (t *testFile) status() string       { return t.a }
+
+func (t *testFile) compileParts(int64, map[int]string) b2LargeFileInterface {
+	panic("not implemented")
+}
+
+func (t *testFile) getFileInfo(context.Context) (b2FileInfoInterface, error) {
+	return nil, nil
+}
+
+func (t *testFile) listParts(context.Context, int, int) ([]b2FilePartInterface, int, error) {
+	return nil, 0, nil
+}
+
+func (t *testFile) deleteFileVersion(context.Context) error {
+	delete(t.files, t.n)
+	return nil
+}
+
+type testFileReader struct {
+	b io.ReadCloser
+	s int64
+}
+
+func (t *testFileReader) Read(p []byte) (int, error)                      { return t.b.Read(p) }
+func (t *testFileReader) Close() error                                    { return nil }
+func (t *testFileReader) stats() (int, string, string, map[string]string) { return 0, "", "", nil }
+
+type zReader struct{}
+
+var pattern = []byte{0x02, 0x80, 0xff, 0x1a, 0xcc, 0x63, 0x22}
+
+func (zReader) Read(p []byte) (int, error) {
+	copy(p, pattern)
+	return len(p), nil
+}
+
+func TestReauth(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+	root := &testRoot{
+		bucketMap: make(map[string]map[string]string),
+		errs: &errCont{
+			errMap: map[string]map[int]error{
+				"createBucket": {0: testError{reauth: true}},
+			},
+		},
+	}
+	client := &Client{
+		backend: &beRoot{
+			b2i: root,
+		},
+	}
+	auths := root.auths
+	if _, err := client.NewBucket(ctx, "fun", Private); err != nil {
+		t.Errorf("bucket should not err, got %v", err)
+	}
+	if root.auths != auths+1 {
+		t.Errorf("client should have re-authenticated; did not")
+	}
+}
+
+func TestBackoff(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	var calls []time.Duration
+	ch := make(chan time.Time)
+	close(ch)
+	after = func(d time.Duration) <-chan time.Time {
+		calls = append(calls, d)
+		return ch
+	}
+
+	table := []struct {
+		root *testRoot
+		want int
+	}{
+		{
+			root: &testRoot{
+				bucketMap: make(map[string]map[string]string),
+				errs: &errCont{
+					errMap: map[string]map[int]error{
+						"createBucket": {
+							0: testError{backoff: time.Second},
+							1: testError{backoff: 2 * time.Second},
+						},
+					},
+				},
+			},
+			want: 2,
+		},
+		{
+			root: &testRoot{
+				bucketMap: make(map[string]map[string]string),
+				errs: &errCont{
+					errMap: map[string]map[int]error{
+						"getUploadURL": {
+							0: testError{retry: true},
+						},
+					},
+				},
+			},
+			want: 1,
+		},
+	}
+
+	var total int
+	for _, ent := range table {
+		client := &Client{
+			backend: &beRoot{
+				b2i: ent.root,
+			},
+		}
+		b, err := client.NewBucket(ctx, "fun", Private)
+		if err != nil {
+			t.Fatal(err)
+		}
+		o := b.Object("foo")
+		w := o.NewWriter(ctx)
+		if _, err := io.Copy(w, bytes.NewBufferString("foo")); err != nil {
+			t.Fatal(err)
+		}
+		if err := w.Close(); err != nil {
+			t.Fatal(err)
+		}
+		total += ent.want
+	}
+	if len(calls) != total {
+		t.Errorf("got %d calls, wanted %d", len(calls), total)
+	}
+}
+
+func TestBackoffWithoutRetryAfter(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	var calls []time.Duration
+	ch := make(chan time.Time)
+	close(ch)
+	after = func(d time.Duration) <-chan time.Time {
+		calls = append(calls, d)
+		return ch
+	}
+
+	root := &testRoot{
+		bucketMap: make(map[string]map[string]string),
+		errs: &errCont{
+			errMap: map[string]map[int]error{
+				"createBucket": {
+					0: testError{retry: true},
+					1: testError{retry: true},
+				},
+			},
+		},
+	}
+	client := &Client{
+		backend: &beRoot{
+			b2i: root,
+		},
+	}
+	if _, err := client.NewBucket(ctx, "fun", Private); err != nil {
+		t.Errorf("bucket should not err, got %v", err)
+	}
+	if len(calls) != 2 {
+		t.Errorf("wrong number of backoff calls; got %d, want 2", len(calls))
+	}
+}
+
+func TestReadWrite(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	client := &Client{
+		backend: &beRoot{
+			b2i: &testRoot{
+				bucketMap: make(map[string]map[string]string),
+				errs:      &errCont{},
+			},
+		},
+	}
+
+	bucket, err := client.NewBucket(ctx, bucketName, Private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := bucket.Delete(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	sobj, wsha, err := writeFile(ctx, bucket, smallFileName, 1e6+42, 1e8)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		if err := sobj.Delete(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	if err := readFile(ctx, sobj, wsha, 1e5, 10); err != nil {
+		t.Error(err)
+	}
+
+	lobj, wshaL, err := writeFile(ctx, bucket, largeFileName, 1e6-1e5, 1e4)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := lobj.Delete(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	if err := readFile(ctx, lobj, wshaL, 1e7, 10); err != nil {
+		t.Error(err)
+	}
+}
+
+func TestWriterReturnsError(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	client := &Client{
+		backend: &beRoot{
+			b2i: &testRoot{
+				bucketMap: make(map[string]map[string]string),
+				errs: &errCont{
+					errMap: map[string]map[int]error{
+						"uploadPart": {
+							0: testError{},
+							1: testError{},
+							2: testError{},
+							3: testError{},
+							4: testError{},
+							5: testError{},
+							6: testError{},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	bucket, err := client.NewBucket(ctx, bucketName, Private)
+	if err != nil {
+		t.Fatal(err)
+	}
+	w := bucket.Object("test").NewWriter(ctx)
+	r := io.LimitReader(zReader{}, 1e7)
+	w.ChunkSize = 1e4
+	w.ConcurrentUploads = 4
+	if _, err := io.Copy(w, r); err == nil {
+		t.Fatalf("io.Copy: should have returned an error")
+	}
+}
+
+func writeFile(ctx context.Context, bucket *Bucket, name string, size int64, csize int) (*Object, string, error) {
+	r := io.LimitReader(zReader{}, size)
+	o := bucket.Object(name)
+	f := o.NewWriter(ctx)
+	h := sha1.New()
+	w := io.MultiWriter(f, h)
+	f.ConcurrentUploads = 5
+	f.csize = csize
+	if _, err := io.Copy(w, r); err != nil {
+		return nil, "", err
+	}
+	if err := f.Close(); err != nil {
+		return nil, "", err
+	}
+	return o, fmt.Sprintf("%x", h.Sum(nil)), nil
+}
+
+func readFile(ctx context.Context, obj *Object, sha string, chunk, concur int) error {
+	r := obj.NewReader(ctx)
+	r.ChunkSize = chunk
+	r.ConcurrentDownloads = concur
+	h := sha1.New()
+	if _, err := io.Copy(h, r); err != nil {
+		return err
+	}
+	if err := r.Close(); err != nil {
+		return err
+	}
+	rsha := fmt.Sprintf("%x", h.Sum(nil))
+	if sha != rsha {
+		return fmt.Errorf("bad hash: got %s, want %s", rsha, sha)
+	}
+	return nil
+}

--- a/vendor/src/github.com/kurin/blazer/b2/backend.go
+++ b/vendor/src/github.com/kurin/blazer/b2/backend.go
@@ -1,0 +1,643 @@
+// Copyright 2016, Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package b2
+
+import (
+	"io"
+	"math/rand"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+// This file wraps the baseline interfaces with backoff and retry semantics.
+
+type beRootInterface interface {
+	backoff(error) time.Duration
+	reauth(error) bool
+	transient(error) bool
+	reupload(error) bool
+	authorizeAccount(context.Context, string, string) error
+	reauthorizeAccount(context.Context) error
+	createBucket(ctx context.Context, name, btype string) (beBucketInterface, error)
+	listBuckets(context.Context) ([]beBucketInterface, error)
+}
+
+type beRoot struct {
+	account, key string
+	b2i          b2RootInterface
+}
+
+type beBucketInterface interface {
+	name() string
+	btype() BucketType
+	deleteBucket(context.Context) error
+	getUploadURL(context.Context) (beURLInterface, error)
+	startLargeFile(ctx context.Context, name, contentType string, info map[string]string) (beLargeFileInterface, error)
+	listFileNames(context.Context, int, string) ([]beFileInterface, string, error)
+	listFileVersions(context.Context, int, string, string) ([]beFileInterface, string, string, error)
+	downloadFileByName(context.Context, string, int64, int64) (beFileReaderInterface, error)
+	hideFile(context.Context, string) (beFileInterface, error)
+	getDownloadAuthorization(context.Context, string, time.Duration) (string, error)
+	baseURL() string
+}
+
+type beBucket struct {
+	b2bucket b2BucketInterface
+	ri       beRootInterface
+}
+
+type beURLInterface interface {
+	uploadFile(context.Context, io.ReadSeeker, int, string, string, string, map[string]string) (beFileInterface, error)
+}
+
+type beURL struct {
+	b2url b2URLInterface
+	ri    beRootInterface
+}
+
+type beFileInterface interface {
+	name() string
+	size() int64
+	timestamp() time.Time
+	status() string
+	deleteFileVersion(context.Context) error
+	getFileInfo(context.Context) (beFileInfoInterface, error)
+	listParts(context.Context, int, int) ([]beFilePartInterface, int, error)
+	compileParts(int64, map[int]string) beLargeFileInterface
+}
+
+type beFile struct {
+	b2file b2FileInterface
+	url    beURLInterface
+	ri     beRootInterface
+}
+
+type beLargeFileInterface interface {
+	finishLargeFile(context.Context) (beFileInterface, error)
+	getUploadPartURL(context.Context) (beFileChunkInterface, error)
+}
+
+type beLargeFile struct {
+	b2largeFile b2LargeFileInterface
+	ri          beRootInterface
+}
+
+type beFileChunkInterface interface {
+	reload(context.Context) error
+	uploadPart(context.Context, io.ReadSeeker, string, int, int) (int, error)
+}
+
+type beFileChunk struct {
+	b2fileChunk b2FileChunkInterface
+	ri          beRootInterface
+}
+
+type beFileReaderInterface interface {
+	io.ReadCloser
+	stats() (int, string, string, map[string]string)
+}
+
+type beFileReader struct {
+	b2fileReader b2FileReaderInterface
+	ri           beRootInterface
+}
+
+type beFileInfoInterface interface {
+	stats() (string, string, int64, string, map[string]string, string, time.Time)
+}
+
+type beFilePartInterface interface {
+	number() int
+	sha1() string
+	size() int64
+}
+
+type beFilePart struct {
+	b2filePart b2FilePartInterface
+	ri         beRootInterface
+}
+
+type beFileInfo struct {
+	name   string
+	sha    string
+	size   int64
+	ct     string
+	info   map[string]string
+	status string
+	stamp  time.Time
+}
+
+func (r *beRoot) backoff(err error) time.Duration { return r.b2i.backoff(err) }
+func (r *beRoot) reauth(err error) bool           { return r.b2i.reauth(err) }
+func (r *beRoot) reupload(err error) bool         { return r.b2i.reupload(err) }
+func (r *beRoot) transient(err error) bool        { return r.b2i.transient(err) }
+
+func (r *beRoot) authorizeAccount(ctx context.Context, account, key string) error {
+	f := func() error {
+		if err := r.b2i.authorizeAccount(ctx, account, key); err != nil {
+			return err
+		}
+		r.account = account
+		r.key = key
+		return nil
+	}
+	return withBackoff(ctx, r, f)
+}
+
+func (r *beRoot) reauthorizeAccount(ctx context.Context) error {
+	return r.authorizeAccount(ctx, r.account, r.key)
+}
+
+func (r *beRoot) createBucket(ctx context.Context, name, btype string) (beBucketInterface, error) {
+	var bi beBucketInterface
+	f := func() error {
+		g := func() error {
+			bucket, err := r.b2i.createBucket(ctx, name, btype)
+			if err != nil {
+				return err
+			}
+			bi = &beBucket{
+				b2bucket: bucket,
+				ri:       r,
+			}
+			return nil
+		}
+		return withReauth(ctx, r, g)
+	}
+	if err := withBackoff(ctx, r, f); err != nil {
+		return nil, err
+	}
+	return bi, nil
+}
+
+func (r *beRoot) listBuckets(ctx context.Context) ([]beBucketInterface, error) {
+	var buckets []beBucketInterface
+	f := func() error {
+		g := func() error {
+			bs, err := r.b2i.listBuckets(ctx)
+			if err != nil {
+				return err
+			}
+			for _, b := range bs {
+				buckets = append(buckets, &beBucket{
+					b2bucket: b,
+					ri:       r,
+				})
+			}
+			return nil
+		}
+		return withReauth(ctx, r, g)
+	}
+	if err := withBackoff(ctx, r, f); err != nil {
+		return nil, err
+	}
+	return buckets, nil
+}
+
+func (b *beBucket) name() string {
+	return b.b2bucket.name()
+}
+
+func (b *beBucket) btype() BucketType {
+	return BucketType(b.b2bucket.btype())
+}
+
+func (b *beBucket) deleteBucket(ctx context.Context) error {
+	f := func() error {
+		g := func() error {
+			return b.b2bucket.deleteBucket(ctx)
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	return withBackoff(ctx, b.ri, f)
+}
+
+func (b *beBucket) getUploadURL(ctx context.Context) (beURLInterface, error) {
+	var url beURLInterface
+	f := func() error {
+		g := func() error {
+			u, err := b.b2bucket.getUploadURL(ctx)
+			if err != nil {
+				return err
+			}
+			url = &beURL{
+				b2url: u,
+				ri:    b.ri,
+			}
+			return nil
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return nil, err
+	}
+	return url, nil
+}
+
+func (b *beBucket) startLargeFile(ctx context.Context, name, ct string, info map[string]string) (beLargeFileInterface, error) {
+	var file beLargeFileInterface
+	f := func() error {
+		g := func() error {
+			f, err := b.b2bucket.startLargeFile(ctx, name, ct, info)
+			if err != nil {
+				return err
+			}
+			file = &beLargeFile{
+				b2largeFile: f,
+				ri:          b.ri,
+			}
+			return nil
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func (b *beBucket) listFileNames(ctx context.Context, count int, continuation string) ([]beFileInterface, string, error) {
+	var cont string
+	var files []beFileInterface
+	f := func() error {
+		g := func() error {
+			fs, c, err := b.b2bucket.listFileNames(ctx, count, continuation)
+			if err != nil {
+				return err
+			}
+			cont = c
+			for _, f := range fs {
+				files = append(files, &beFile{
+					b2file: f,
+					ri:     b.ri,
+				})
+			}
+			return nil
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return nil, "", err
+	}
+	return files, cont, nil
+}
+
+func (b *beBucket) listFileVersions(ctx context.Context, count int, nextName, nextID string) ([]beFileInterface, string, string, error) {
+	var name, id string
+	var files []beFileInterface
+	f := func() error {
+		g := func() error {
+			fs, n, d, err := b.b2bucket.listFileVersions(ctx, count, nextName, nextID)
+			if err != nil {
+				return err
+			}
+			name = n
+			id = d
+			for _, f := range fs {
+				files = append(files, &beFile{
+					b2file: f,
+					ri:     b.ri,
+				})
+			}
+			return nil
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return nil, "", "", err
+	}
+	return files, name, id, nil
+}
+
+func (b *beBucket) downloadFileByName(ctx context.Context, name string, offset, size int64) (beFileReaderInterface, error) {
+	var reader beFileReaderInterface
+	f := func() error {
+		g := func() error {
+			fr, err := b.b2bucket.downloadFileByName(ctx, name, offset, size)
+			if err != nil {
+				return err
+			}
+			reader = &beFileReader{
+				b2fileReader: fr,
+				ri:           b.ri,
+			}
+			return nil
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return nil, err
+	}
+	return reader, nil
+}
+
+func (b *beBucket) hideFile(ctx context.Context, name string) (beFileInterface, error) {
+	var file beFileInterface
+	f := func() error {
+		g := func() error {
+			f, err := b.b2bucket.hideFile(ctx, name)
+			if err != nil {
+				return err
+			}
+			file = &beFile{
+				b2file: f,
+				ri:     b.ri,
+			}
+			return nil
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func (b *beBucket) getDownloadAuthorization(ctx context.Context, p string, v time.Duration) (string, error) {
+	var tok string
+	f := func() error {
+		g := func() error {
+			t, err := b.b2bucket.getDownloadAuthorization(ctx, p, v)
+			if err != nil {
+				return err
+			}
+			tok = t
+			return nil
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return "", err
+	}
+	return tok, nil
+}
+
+func (b *beBucket) baseURL() string {
+	return b.b2bucket.baseURL()
+}
+
+func (b *beURL) uploadFile(ctx context.Context, r io.ReadSeeker, size int, name, ct, sha1 string, info map[string]string) (beFileInterface, error) {
+	var file beFileInterface
+	f := func() error {
+		if _, err := r.Seek(0, 0); err != nil {
+			return err
+		}
+		f, err := b.b2url.uploadFile(ctx, r, size, name, ct, sha1, info)
+		if err != nil {
+			return err
+		}
+		file = &beFile{
+			b2file: f,
+			url:    b,
+			ri:     b.ri,
+		}
+		return nil
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func (b *beFile) deleteFileVersion(ctx context.Context) error {
+	f := func() error {
+		g := func() error {
+			return b.b2file.deleteFileVersion(ctx)
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	return withBackoff(ctx, b.ri, f)
+}
+
+func (b *beFile) size() int64 {
+	return b.b2file.size()
+}
+
+func (b *beFile) name() string {
+	return b.b2file.name()
+}
+
+func (b *beFile) timestamp() time.Time {
+	return b.b2file.timestamp()
+}
+
+func (b *beFile) status() string {
+	return b.b2file.status()
+}
+
+func (b *beFile) getFileInfo(ctx context.Context) (beFileInfoInterface, error) {
+	var fileInfo beFileInfoInterface
+	f := func() error {
+		g := func() error {
+			fi, err := b.b2file.getFileInfo(ctx)
+			if err != nil {
+				return err
+			}
+			name, sha, size, ct, info, status, stamp := fi.stats()
+			fileInfo = &beFileInfo{
+				name:   name,
+				sha:    sha,
+				size:   size,
+				ct:     ct,
+				info:   info,
+				status: status,
+				stamp:  stamp,
+			}
+			return nil
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return nil, err
+	}
+	return fileInfo, nil
+}
+
+func (b *beFile) listParts(ctx context.Context, next, count int) ([]beFilePartInterface, int, error) {
+	var fpi []beFilePartInterface
+	var rnxt int
+	f := func() error {
+		g := func() error {
+			ps, n, err := b.b2file.listParts(ctx, next, count)
+			if err != nil {
+				return err
+			}
+			rnxt = n
+			for _, p := range ps {
+				fpi = append(fpi, &beFilePart{
+					b2filePart: p,
+					ri:         b.ri,
+				})
+			}
+			return nil
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return nil, 0, err
+	}
+	return fpi, rnxt, nil
+}
+
+func (b *beFile) compileParts(size int64, seen map[int]string) beLargeFileInterface {
+	return &beLargeFile{
+		b2largeFile: b.b2file.compileParts(size, seen),
+		ri:          b.ri,
+	}
+}
+
+func (b *beLargeFile) getUploadPartURL(ctx context.Context) (beFileChunkInterface, error) {
+	var chunk beFileChunkInterface
+	f := func() error {
+		g := func() error {
+			fc, err := b.b2largeFile.getUploadPartURL(ctx)
+			if err != nil {
+				return err
+			}
+			chunk = &beFileChunk{
+				b2fileChunk: fc,
+				ri:          b.ri,
+			}
+			return nil
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return nil, err
+	}
+	return chunk, nil
+}
+
+func (b *beLargeFile) finishLargeFile(ctx context.Context) (beFileInterface, error) {
+	var file beFileInterface
+	f := func() error {
+		g := func() error {
+			f, err := b.b2largeFile.finishLargeFile(ctx)
+			if err != nil {
+				return err
+			}
+			file = &beFile{
+				b2file: f,
+				ri:     b.ri,
+			}
+			return nil
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return nil, err
+	}
+	return file, nil
+}
+
+func (b *beFileChunk) reload(ctx context.Context) error {
+	f := func() error {
+		g := func() error {
+			return b.b2fileChunk.reload(ctx)
+		}
+		return withReauth(ctx, b.ri, g)
+	}
+	return withBackoff(ctx, b.ri, f)
+}
+
+func (b *beFileChunk) uploadPart(ctx context.Context, r io.ReadSeeker, sha1 string, size, index int) (int, error) {
+	// no re-auth; pass it back up to the caller so they can get an new upload URI and token
+	// TODO: we should handle that here probably
+	var i int
+	f := func() error {
+		if _, err := r.Seek(0, 0); err != nil {
+			return err
+		}
+		j, err := b.b2fileChunk.uploadPart(ctx, r, sha1, size, index)
+		if err != nil {
+			return err
+		}
+		i = j
+		return nil
+	}
+	if err := withBackoff(ctx, b.ri, f); err != nil {
+		return 0, err
+	}
+	return i, nil
+}
+
+func (b *beFileReader) Read(p []byte) (int, error) {
+	return b.b2fileReader.Read(p)
+}
+
+func (b *beFileReader) Close() error {
+	return b.b2fileReader.Close()
+}
+
+func (b *beFileReader) stats() (int, string, string, map[string]string) {
+	return b.b2fileReader.stats()
+}
+
+func (b *beFileInfo) stats() (string, string, int64, string, map[string]string, string, time.Time) {
+	return b.name, b.sha, b.size, b.ct, b.info, b.status, b.stamp
+}
+
+func (b *beFilePart) number() int  { return b.b2filePart.number() }
+func (b *beFilePart) sha1() string { return b.b2filePart.sha1() }
+func (b *beFilePart) size() int64  { return b.b2filePart.size() }
+
+func jitter(d time.Duration) time.Duration {
+	f := float64(d)
+	f /= 50
+	f += f * (rand.Float64() - 0.5)
+	return time.Duration(f)
+}
+
+func getBackoff(d time.Duration) time.Duration {
+	if d > 15*time.Second {
+		return d + jitter(d)
+	}
+	return d*2 + jitter(d*2)
+}
+
+var after = time.After
+
+func withBackoff(ctx context.Context, ri beRootInterface, f func() error) error {
+	backoff := 500 * time.Millisecond
+	for {
+		err := f()
+		if !ri.transient(err) {
+			return err
+		}
+		bo := ri.backoff(err)
+		if bo > 0 {
+			backoff = bo
+		} else {
+			backoff = getBackoff(backoff)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-after(backoff):
+		}
+	}
+}
+
+func withReauth(ctx context.Context, ri beRootInterface, f func() error) error {
+	err := f()
+	if ri.reauth(err) {
+		if err := ri.reauthorizeAccount(ctx); err != nil {
+			return err
+		}
+		err = f()
+	}
+	return err
+}

--- a/vendor/src/github.com/kurin/blazer/b2/baseline.go
+++ b/vendor/src/github.com/kurin/blazer/b2/baseline.go
@@ -1,0 +1,356 @@
+// Copyright 2016, Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package b2
+
+import (
+	"io"
+	"time"
+
+	"github.com/kurin/blazer/base"
+
+	"golang.org/x/net/context"
+)
+
+// This file wraps the base package in a thin layer, for testing.  It should be
+// the only file in b2 that imports base.
+
+type b2RootInterface interface {
+	authorizeAccount(context.Context, string, string) error
+	transient(error) bool
+	backoff(error) time.Duration
+	reauth(error) bool
+	reupload(error) bool
+	createBucket(context.Context, string, string) (b2BucketInterface, error)
+	listBuckets(context.Context) ([]b2BucketInterface, error)
+}
+
+type b2BucketInterface interface {
+	name() string
+	btype() string
+	deleteBucket(context.Context) error
+	getUploadURL(context.Context) (b2URLInterface, error)
+	startLargeFile(ctx context.Context, name, contentType string, info map[string]string) (b2LargeFileInterface, error)
+	listFileNames(context.Context, int, string) ([]b2FileInterface, string, error)
+	listFileVersions(context.Context, int, string, string) ([]b2FileInterface, string, string, error)
+	downloadFileByName(context.Context, string, int64, int64) (b2FileReaderInterface, error)
+	hideFile(context.Context, string) (b2FileInterface, error)
+	getDownloadAuthorization(context.Context, string, time.Duration) (string, error)
+	baseURL() string
+}
+
+type b2URLInterface interface {
+	reload(context.Context) error
+	uploadFile(context.Context, io.Reader, int, string, string, string, map[string]string) (b2FileInterface, error)
+}
+
+type b2FileInterface interface {
+	name() string
+	size() int64
+	timestamp() time.Time
+	status() string
+	deleteFileVersion(context.Context) error
+	getFileInfo(context.Context) (b2FileInfoInterface, error)
+	listParts(context.Context, int, int) ([]b2FilePartInterface, int, error)
+	compileParts(int64, map[int]string) b2LargeFileInterface
+}
+
+type b2LargeFileInterface interface {
+	finishLargeFile(context.Context) (b2FileInterface, error)
+	getUploadPartURL(context.Context) (b2FileChunkInterface, error)
+}
+
+type b2FileChunkInterface interface {
+	reload(context.Context) error
+	uploadPart(context.Context, io.Reader, string, int, int) (int, error)
+}
+
+type b2FileReaderInterface interface {
+	io.ReadCloser
+	stats() (int, string, string, map[string]string)
+}
+
+type b2FileInfoInterface interface {
+	stats() (string, string, int64, string, map[string]string, string, time.Time) // bleck
+}
+
+type b2FilePartInterface interface {
+	number() int
+	sha1() string
+	size() int64
+}
+
+type b2Root struct {
+	b *base.B2
+}
+
+type b2Bucket struct {
+	b *base.Bucket
+}
+
+type b2URL struct {
+	b *base.URL
+}
+
+type b2File struct {
+	b *base.File
+}
+
+type b2LargeFile struct {
+	b *base.LargeFile
+}
+
+type b2FileChunk struct {
+	b *base.FileChunk
+}
+
+type b2FileReader struct {
+	b *base.FileReader
+}
+
+type b2FileInfo struct {
+	b *base.FileInfo
+}
+
+type b2FilePart struct {
+	b *base.FilePart
+}
+
+func (b *b2Root) authorizeAccount(ctx context.Context, account, key string) error {
+	nb, err := base.AuthorizeAccount(ctx, account, key)
+	if err != nil {
+		return err
+	}
+	if b.b == nil {
+		b.b = nb
+		return nil
+	}
+	b.b.Update(nb)
+	return nil
+}
+
+func (*b2Root) backoff(err error) time.Duration {
+	if base.Action(err) != base.Retry {
+		return 0
+	}
+	return base.Backoff(err)
+}
+
+func (*b2Root) reauth(err error) bool {
+	return base.Action(err) == base.ReAuthenticate
+}
+
+func (*b2Root) reupload(err error) bool {
+	return base.Action(err) == base.AttemptNewUpload
+}
+
+func (*b2Root) transient(err error) bool {
+	return base.Action(err) == base.Retry
+}
+
+func (b *b2Root) createBucket(ctx context.Context, name, btype string) (b2BucketInterface, error) {
+	bucket, err := b.b.CreateBucket(ctx, name, btype)
+	if err != nil {
+		return nil, err
+	}
+	return &b2Bucket{bucket}, nil
+}
+
+func (b *b2Root) listBuckets(ctx context.Context) ([]b2BucketInterface, error) {
+	buckets, err := b.b.ListBuckets(ctx)
+	if err != nil {
+		return nil, err
+	}
+	var rtn []b2BucketInterface
+	for _, bucket := range buckets {
+		rtn = append(rtn, &b2Bucket{bucket})
+	}
+	return rtn, err
+}
+
+func (b *b2Bucket) deleteBucket(ctx context.Context) error {
+	return b.b.DeleteBucket(ctx)
+}
+
+func (b *b2Bucket) name() string {
+	return b.b.Name
+}
+
+func (b *b2Bucket) btype() string {
+	return b.b.Type
+}
+
+func (b *b2Bucket) getUploadURL(ctx context.Context) (b2URLInterface, error) {
+	url, err := b.b.GetUploadURL(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &b2URL{url}, nil
+}
+
+func (b *b2Bucket) startLargeFile(ctx context.Context, name, ct string, info map[string]string) (b2LargeFileInterface, error) {
+	lf, err := b.b.StartLargeFile(ctx, name, ct, info)
+	if err != nil {
+		return nil, err
+	}
+	return &b2LargeFile{lf}, nil
+}
+
+func (b *b2Bucket) listFileNames(ctx context.Context, count int, continuation string) ([]b2FileInterface, string, error) {
+	fs, c, err := b.b.ListFileNames(ctx, count, continuation)
+	if err != nil {
+		return nil, "", err
+	}
+	var files []b2FileInterface
+	for _, f := range fs {
+		files = append(files, &b2File{f})
+	}
+	return files, c, nil
+}
+
+func (b *b2Bucket) listFileVersions(ctx context.Context, count int, nextName, nextID string) ([]b2FileInterface, string, string, error) {
+	fs, name, id, err := b.b.ListFileVersions(ctx, count, nextName, nextID)
+	if err != nil {
+		return nil, "", "", err
+	}
+	var files []b2FileInterface
+	for _, f := range fs {
+		files = append(files, &b2File{f})
+	}
+	return files, name, id, nil
+}
+
+func (b *b2Bucket) downloadFileByName(ctx context.Context, name string, offset, size int64) (b2FileReaderInterface, error) {
+	fr, err := b.b.DownloadFileByName(ctx, name, offset, size)
+	if err != nil {
+		return nil, err
+	}
+	return &b2FileReader{fr}, nil
+}
+
+func (b *b2Bucket) hideFile(ctx context.Context, name string) (b2FileInterface, error) {
+	f, err := b.b.HideFile(ctx, name)
+	if err != nil {
+		return nil, err
+	}
+	return &b2File{f}, nil
+}
+
+func (b *b2Bucket) getDownloadAuthorization(ctx context.Context, p string, v time.Duration) (string, error) {
+	return b.b.GetDownloadAuthorization(ctx, p, v)
+}
+
+func (b *b2Bucket) baseURL() string {
+	return b.b.BaseURL()
+}
+
+func (b *b2URL) uploadFile(ctx context.Context, r io.Reader, size int, name, contentType, sha1 string, info map[string]string) (b2FileInterface, error) {
+	file, err := b.b.UploadFile(ctx, r, size, name, contentType, sha1, info)
+	if err != nil {
+		return nil, err
+	}
+	return &b2File{file}, nil
+}
+
+func (b *b2URL) reload(ctx context.Context) error {
+	return b.b.Reload(ctx)
+}
+
+func (b *b2File) deleteFileVersion(ctx context.Context) error {
+	return b.b.DeleteFileVersion(ctx)
+}
+
+func (b *b2File) name() string {
+	return b.b.Name
+}
+
+func (b *b2File) size() int64 {
+	return b.b.Size
+}
+
+func (b *b2File) timestamp() time.Time {
+	return b.b.Timestamp
+}
+
+func (b *b2File) status() string {
+	return b.b.Status
+}
+
+func (b *b2File) getFileInfo(ctx context.Context) (b2FileInfoInterface, error) {
+	fi, err := b.b.GetFileInfo(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &b2FileInfo{fi}, nil
+}
+
+func (b *b2File) listParts(ctx context.Context, next, count int) ([]b2FilePartInterface, int, error) {
+	parts, n, err := b.b.ListParts(ctx, next, count)
+	if err != nil {
+		return nil, 0, err
+	}
+	var rtn []b2FilePartInterface
+	for _, part := range parts {
+		rtn = append(rtn, &b2FilePart{part})
+	}
+	return rtn, n, nil
+}
+
+func (b *b2File) compileParts(size int64, seen map[int]string) b2LargeFileInterface {
+	return &b2LargeFile{b.b.CompileParts(size, seen)}
+}
+
+func (b *b2LargeFile) finishLargeFile(ctx context.Context) (b2FileInterface, error) {
+	f, err := b.b.FinishLargeFile(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &b2File{f}, nil
+}
+
+func (b *b2LargeFile) getUploadPartURL(ctx context.Context) (b2FileChunkInterface, error) {
+	c, err := b.b.GetUploadPartURL(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return &b2FileChunk{c}, nil
+}
+
+func (b *b2FileChunk) reload(ctx context.Context) error {
+	return b.b.Reload(ctx)
+}
+
+func (b *b2FileChunk) uploadPart(ctx context.Context, r io.Reader, sha1 string, size, index int) (int, error) {
+	return b.b.UploadPart(ctx, r, sha1, size, index)
+}
+
+func (b *b2FileReader) Read(p []byte) (int, error) {
+	return b.b.Read(p)
+}
+
+func (b *b2FileReader) Close() error {
+	return b.b.Close()
+}
+
+func (b *b2FileReader) stats() (int, string, string, map[string]string) {
+	return b.b.ContentLength, b.b.ContentType, b.b.SHA1, b.b.Info
+}
+
+func (b *b2FileInfo) stats() (string, string, int64, string, map[string]string, string, time.Time) {
+	return b.b.Name, b.b.SHA1, b.b.Size, b.b.ContentType, b.b.Info, b.b.Status, b.b.Timestamp
+}
+
+func (b *b2FilePart) number() int  { return b.b.Number }
+func (b *b2FilePart) sha1() string { return b.b.SHA1 }
+func (b *b2FilePart) size() int64  { return b.b.Size }

--- a/vendor/src/github.com/kurin/blazer/b2/integration_test.go
+++ b/vendor/src/github.com/kurin/blazer/b2/integration_test.go
@@ -1,0 +1,501 @@
+// Copyright 2016, Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package b2
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	apiID  = "B2_ACCOUNT_ID"
+	apiKey = "B2_SECRET_KEY"
+)
+
+func TestReadWriteLive(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	bucket, done := startLiveTest(ctx, t)
+	defer done()
+
+	sobj, wsha, err := writeFile(ctx, bucket, smallFileName, 1e6-42, 1e8)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lobj, wshaL, err := writeFile(ctx, bucket, largeFileName, 1e8+5e7, 1e8)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := readFile(ctx, lobj, wshaL, 1e7, 10); err != nil {
+		t.Error(err)
+	}
+
+	if err := readFile(ctx, sobj, wsha, 1e5, 10); err != nil {
+		t.Error(err)
+	}
+
+	var cur *Cursor
+	for {
+		objs, c, err := bucket.ListObjects(ctx, 100, cur)
+		if err != nil && err != io.EOF {
+			t.Fatal(err)
+		}
+		for _, o := range objs {
+			if err := o.Delete(ctx); err != nil {
+				t.Error(err)
+			}
+		}
+		if err == io.EOF {
+			break
+		}
+		cur = c
+	}
+}
+
+func TestHideShowLive(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	bucket, done := startLiveTest(ctx, t)
+	defer done()
+
+	// write a file
+	obj, _, err := writeFile(ctx, bucket, smallFileName, 1e6+42, 1e8)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := countObjects(ctx, bucket.ListCurrentObjects)
+	if err != nil {
+		t.Error(err)
+	}
+	if got != 1 {
+		t.Fatalf("got %d objects, wanted 1", got)
+	}
+
+	// hide the file
+	if err := obj.Hide(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = countObjects(ctx, bucket.ListCurrentObjects)
+	if err != nil {
+		t.Error(err)
+	}
+	if got != 0 {
+		t.Fatalf("got %d objects, wanted 0", got)
+	}
+
+	// unhide the file
+	if err := bucket.Reveal(ctx, smallFileName); err != nil {
+		t.Fatal(err)
+	}
+
+	// count see the object again
+	got, err = countObjects(ctx, bucket.ListCurrentObjects)
+	if err != nil {
+		t.Error(err)
+	}
+	if got != 1 {
+		t.Fatalf("got %d objects, wanted 1", got)
+	}
+}
+
+func TestResumeWriter(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	bucket, _ := startLiveTest(ctx, t)
+
+	w := bucket.Object("foo").NewWriter(ctx)
+	r := io.LimitReader(zReader{}, 3e8)
+	go func() {
+		// Cancel the context after the first chunk has been written.
+		ticker := time.NewTicker(time.Second)
+		defer ticker.Stop()
+		defer cancel()
+		for range ticker.C {
+			if w.cidx > 1 {
+				return
+			}
+		}
+	}()
+	if _, err := io.Copy(w, r); err != context.Canceled {
+		t.Fatalf("io.Copy should have resulted in a canceled context")
+	}
+
+	ctx2 := context.Background()
+	ctx2, cancel2 := context.WithTimeout(ctx2, 10*time.Minute)
+	defer cancel2()
+	bucket2, done := startLiveTest(ctx2, t)
+	defer done()
+	w2 := bucket2.Object("foo").NewWriter(ctx2)
+	r2 := io.LimitReader(zReader{}, 3e8)
+	h1 := sha1.New()
+	tr := io.TeeReader(r2, h1)
+	w2.Resume = true
+	w2.ConcurrentUploads = 2
+	if _, err := io.Copy(w2, tr); err != nil {
+		t.Fatal(err)
+	}
+	if err := w2.Close(); err != nil {
+		t.Fatal(err)
+	}
+	begSHA := fmt.Sprintf("%x", h1.Sum(nil))
+
+	objR := bucket2.Object("foo").NewReader(ctx2)
+	objR.ConcurrentDownloads = 3
+	h2 := sha1.New()
+	if _, err := io.Copy(h2, objR); err != nil {
+		t.Fatal(err)
+	}
+	if err := objR.Close(); err != nil {
+		t.Error(err)
+	}
+	endSHA := fmt.Sprintf("%x", h2.Sum(nil))
+	if endSHA != begSHA {
+		t.Errorf("got conflicting hashes: got %q, want %q", endSHA, begSHA)
+	}
+}
+
+func TestAttrs(t *testing.T) {
+	// TODO: test is flaky
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, 10*time.Minute)
+	defer cancel()
+	bucket, done := startLiveTest(ctx, t)
+	defer done()
+
+	attrlist := []*Attrs{
+		&Attrs{
+			ContentType: "jpeg/stream",
+			Info: map[string]string{
+				"one": "a",
+				"two": "b",
+			},
+		},
+		&Attrs{
+			ContentType:  "application/MAGICFACE",
+			LastModified: time.Unix(1464370149, 142000000),
+			Info:         map[string]string{}, // can't be nil
+		},
+	}
+
+	table := []struct {
+		name string
+		size int64
+	}{
+		{
+			name: "small",
+			size: 1e3,
+		},
+		{
+			name: "large",
+			size: 1e8 + 4,
+		},
+	}
+
+	for _, e := range table {
+		for _, attrs := range attrlist {
+			w := bucket.Object(e.name).NewWriter(ctx).WithAttrs(attrs)
+			if _, err := io.Copy(w, io.LimitReader(zReader{}, e.size)); err != nil {
+				t.Error(err)
+				continue
+			}
+			if err := w.Close(); err != nil {
+				t.Error(err)
+				continue
+			}
+			gotAttrs, err := bucket.Object(e.name).Attrs(ctx)
+			if err != nil {
+				t.Error(err)
+				continue
+			}
+			if gotAttrs.ContentType != attrs.ContentType {
+				t.Errorf("bad content-type for %s: got %q, want %q", e.name, gotAttrs.ContentType, attrs.ContentType)
+			}
+			if !reflect.DeepEqual(gotAttrs.Info, attrs.Info) {
+				t.Errorf("bad info for %s: got %#v, want %#v", e.name, gotAttrs.Info, attrs.Info)
+			}
+			if !gotAttrs.LastModified.Equal(attrs.LastModified) {
+				t.Errorf("bad lastmodified time for %s: got %v, want %v", e.name, gotAttrs.LastModified, attrs.LastModified)
+			}
+		}
+	}
+}
+
+func TestAuthTokLive(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	bucket, done := startLiveTest(ctx, t)
+	defer done()
+
+	foo := "foo/bar"
+	baz := "baz/bar"
+
+	fw := bucket.Object(foo).NewWriter(ctx)
+	io.Copy(fw, io.LimitReader(zReader{}, 1e5))
+	if err := fw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	bw := bucket.Object(baz).NewWriter(ctx)
+	io.Copy(bw, io.LimitReader(zReader{}, 1e5))
+	if err := bw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	tok, err := bucket.AuthToken(ctx, "foo", time.Hour)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	furl := fmt.Sprintf("%s?Authorization=%s", bucket.Object(foo).URL(), tok)
+	frsp, err := http.Get(furl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if frsp.StatusCode != 200 {
+		t.Fatalf("%s: got %s, want 200", furl, frsp.Status)
+	}
+	burl := fmt.Sprintf("%s?Authorization=%s", bucket.Object(baz).URL(), tok)
+	brsp, err := http.Get(burl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if brsp.StatusCode != 401 {
+		t.Fatalf("%s: got %s, want 401", burl, brsp.Status)
+	}
+}
+
+func TestRangeReaderLive(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	bucket, done := startLiveTest(ctx, t)
+	defer done()
+
+	buf := &bytes.Buffer{}
+	io.Copy(buf, io.LimitReader(zReader{}, 3e6))
+	rs := bytes.NewReader(buf.Bytes())
+
+	w := bucket.Object("foobar").NewWriter(ctx)
+	if _, err := io.Copy(w, rs); err != nil {
+		t.Fatal(err)
+	}
+	if err := w.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	table := []struct {
+		offset, length int64
+		size           int64 // expected actual size
+	}{
+		{
+			offset: 1e6 - 50,
+			length: 1e6 + 50,
+			size:   1e6 + 50,
+		},
+		{
+			offset: 0,
+			length: -1,
+			size:   3e6,
+		},
+		{
+			offset: 2e6,
+			length: -1,
+			size:   1e6,
+		},
+		{
+			offset: 2e6,
+			length: 2e6,
+			size:   1e6,
+		},
+	}
+
+	for _, e := range table {
+		if _, err := rs.Seek(e.offset, 0); err != nil {
+			t.Error(err)
+			continue
+		}
+		hw := sha1.New()
+		var lr io.Reader
+		lr = rs
+		if e.length >= 0 {
+			lr = io.LimitReader(rs, e.length)
+		}
+		if _, err := io.Copy(hw, lr); err != nil {
+			t.Error(err)
+			continue
+		}
+		r := bucket.Object("foobar").NewRangeReader(ctx, e.offset, e.length)
+		defer r.Close()
+		hr := sha1.New()
+		read, err := io.Copy(hr, r)
+		if err != nil {
+			t.Error(err)
+			continue
+		}
+		if read != e.size {
+			t.Errorf("read %d bytes, wanted %d bytes", read, e.size)
+		}
+		got := fmt.Sprintf("%x", hr.Sum(nil))
+		want := fmt.Sprintf("%x", hw.Sum(nil))
+		if got != want {
+			t.Errorf("bad hash, got %q, want %q", got, want)
+		}
+	}
+}
+
+func TestListObjectsWithPrefix(t *testing.T) {
+	ctx := context.Background()
+	ctx, cancel := context.WithTimeout(ctx, time.Minute)
+	defer cancel()
+	bucket, done := startLiveTest(ctx, t)
+	defer done()
+
+	foo := "foo/bar"
+	baz := "baz/bar"
+
+	fw := bucket.Object(foo).NewWriter(ctx)
+	io.Copy(fw, io.LimitReader(zReader{}, 1e5))
+	if err := fw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	bw := bucket.Object(baz).NewWriter(ctx)
+	io.Copy(bw, io.LimitReader(zReader{}, 1e5))
+	if err := bw.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	// This is kind of a hack, but
+	type lfun func(context.Context, int, *Cursor) ([]*Object, *Cursor, error)
+
+	for _, f := range []lfun{bucket.ListObjects, bucket.ListCurrentObjects} {
+		c := &Cursor{
+			Name: "foo/",
+		}
+		var res []string
+		for {
+			objs, cur, err := f(ctx, 10, c)
+			if err != nil && err != io.EOF {
+				t.Fatalf("bucket.ListObjects: %v", err)
+			}
+			for _, o := range objs {
+				attrs, err := o.Attrs(ctx)
+				if err != nil {
+					t.Errorf("(%v).Attrs: %v", o, err)
+					continue
+				}
+				res = append(res, attrs.Name)
+			}
+			if err == io.EOF {
+				break
+			}
+			c = cur
+		}
+
+		want := []string{"foo/bar"}
+		if !reflect.DeepEqual(res, want) {
+			t.Errorf("got %v, want %v", res, want)
+		}
+	}
+}
+
+type object struct {
+	o   *Object
+	err error
+}
+
+func countObjects(ctx context.Context, f func(context.Context, int, *Cursor) ([]*Object, *Cursor, error)) (int, error) {
+	var got int
+	ch := listObjects(ctx, f)
+	for c := range ch {
+		if c.err != nil {
+			return 0, c.err
+		}
+		got++
+	}
+	return got, nil
+}
+
+func listObjects(ctx context.Context, f func(context.Context, int, *Cursor) ([]*Object, *Cursor, error)) <-chan object {
+	ch := make(chan object)
+	go func() {
+		defer close(ch)
+		var cur *Cursor
+		for {
+			objs, c, err := f(ctx, 100, cur)
+			if err != nil && err != io.EOF {
+				ch <- object{err: err}
+				return
+			}
+			for _, o := range objs {
+				ch <- object{o: o}
+			}
+			if err == io.EOF {
+				return
+			}
+			cur = c
+		}
+	}()
+	return ch
+}
+
+func startLiveTest(ctx context.Context, t *testing.T) (*Bucket, func()) {
+	id := os.Getenv(apiID)
+	key := os.Getenv(apiKey)
+	if id == "" || key == "" {
+		t.Skipf("B2_ACCOUNT_ID or B2_SECRET_KEY unset; skipping integration tests")
+		return nil, nil
+	}
+	client, err := NewClient(ctx, id, key)
+	if err != nil {
+		t.Fatal(err)
+		return nil, nil
+	}
+	bucket, err := client.NewBucket(ctx, id+bucketName, Private)
+	if err != nil {
+		t.Fatal(err)
+		return nil, nil
+	}
+	f := func() {
+		for c := range listObjects(ctx, bucket.ListObjects) {
+			if c.err != nil {
+				continue
+			}
+			if err := c.o.Delete(ctx); err != nil {
+				t.Error(err)
+			}
+		}
+		if err := bucket.Delete(ctx); err != nil {
+			t.Error(err)
+		}
+	}
+	return bucket, f
+}

--- a/vendor/src/github.com/kurin/blazer/b2/reader.go
+++ b/vendor/src/github.com/kurin/blazer/b2/reader.go
@@ -1,0 +1,240 @@
+// Copyright 2016, Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package b2
+
+import (
+	"bytes"
+	"io"
+	"sync"
+
+	"github.com/golang/glog"
+
+	"golang.org/x/net/context"
+)
+
+// Reader reads files from B2.
+type Reader struct {
+	// ConcurrentDownloads is the number of simultaneous downloads to pull from
+	// B2.  Values greater than one will cause B2 to make multiple HTTP requests
+	// for a given file, increasing available bandwidth at the cost of buffering
+	// the downloads in memory.
+	ConcurrentDownloads int
+
+	// ChunkSize is the size to fetch per ConcurrentDownload.  The default is
+	// 10MB.
+	ChunkSize int
+
+	ctx    context.Context
+	cancel context.CancelFunc // cancels ctx
+	o      *Object
+	name   string
+	offset int64 // the start of the file
+	length int64 // the length to read, or -1
+	size   int64 // the end of the file, in absolute terms
+	csize  int   // chunk size
+	read   int   // amount read
+	chwid  int   // chunks written
+	chrid  int   // chunks read
+	chbuf  chan *bytes.Buffer
+	init   sync.Once
+	rmux   sync.Mutex // guards rcond
+	rcond  *sync.Cond
+	chunks map[int]*bytes.Buffer
+
+	emux sync.RWMutex // guards err, believe it or not
+	err  error
+}
+
+// Close frees resources associated with the download.
+func (r *Reader) Close() error {
+	r.cancel()
+	return nil
+}
+
+func (r *Reader) setErr(err error) {
+	r.emux.Lock()
+	defer r.emux.Unlock()
+	if r.err == nil {
+		r.err = err
+		r.cancel()
+	}
+}
+
+func (r *Reader) getErr() error {
+	r.emux.RLock()
+	defer r.emux.RUnlock()
+	return r.err
+}
+
+func (r *Reader) thread() {
+	go func() {
+		for {
+			var buf *bytes.Buffer
+			select {
+			case b, ok := <-r.chbuf:
+				if !ok {
+					return
+				}
+				buf = b
+			case <-r.ctx.Done():
+				return
+			}
+			r.rmux.Lock()
+			chunkID := r.chwid
+			r.chwid++
+			r.rmux.Unlock()
+			offset := int64(chunkID*r.csize) + r.offset
+			size := int64(r.csize)
+			if offset >= r.size {
+				return
+			}
+			if offset+size > r.size {
+				size = r.size - offset
+			}
+		redo:
+			fr, err := r.o.b.b.downloadFileByName(r.ctx, r.name, offset, size)
+			if err != nil {
+				r.setErr(err)
+				r.rcond.Broadcast()
+				return
+			}
+			i, err := copyContext(r.ctx, buf, fr)
+			if i < size || err == io.ErrUnexpectedEOF {
+				// Probably the network connection was closed early.  Retry.
+				glog.Infof("b2 reader %d: got %dB of %dB; retrying", chunkID, i, size)
+				buf.Reset()
+				goto redo
+			}
+			if err != nil {
+				r.setErr(err)
+				r.rcond.Broadcast()
+				return
+			}
+			r.rmux.Lock()
+			r.chunks[chunkID] = buf
+			r.rmux.Unlock()
+			r.rcond.Broadcast()
+		}
+	}()
+}
+
+func (r *Reader) curChunk() (*bytes.Buffer, error) {
+	ch := make(chan *bytes.Buffer)
+	go func() {
+		r.rmux.Lock()
+		defer r.rmux.Unlock()
+		for r.chunks[r.chrid] == nil && r.getErr() == nil && r.ctx.Err() == nil {
+			r.rcond.Wait()
+		}
+		select {
+		case ch <- r.chunks[r.chrid]:
+		case <-r.ctx.Done():
+			return
+		}
+	}()
+	select {
+	case buf := <-ch:
+		return buf, r.getErr()
+	case <-r.ctx.Done():
+		if r.getErr() != nil {
+			return nil, r.getErr()
+		}
+		return nil, r.ctx.Err()
+	}
+}
+
+func (r *Reader) initFunc() {
+	if err := r.o.ensure(r.ctx); err != nil {
+		r.setErr(err)
+		return
+	}
+	r.size = r.o.f.size()
+	if r.length >= 0 && r.offset+r.length < r.size {
+		r.size = r.offset + r.length
+	}
+	if r.offset > r.size {
+		r.offset = r.size
+	}
+	r.rcond = sync.NewCond(&r.rmux)
+	cr := r.ConcurrentDownloads
+	if cr < 1 {
+		cr = 1
+	}
+	if r.ChunkSize < 1 {
+		r.ChunkSize = 1e7
+	}
+	r.csize = r.ChunkSize
+	r.chbuf = make(chan *bytes.Buffer, cr)
+	for i := 0; i < cr; i++ {
+		r.thread()
+		r.chbuf <- &bytes.Buffer{}
+	}
+}
+
+func (r *Reader) Read(p []byte) (int, error) {
+	// TODO: check the SHA1 hash here and verify it on Close.
+	r.init.Do(r.initFunc)
+	chunk, err := r.curChunk()
+	if err != nil {
+		return 0, err
+	}
+	n, err := chunk.Read(p)
+	r.read += n
+	if err == io.EOF {
+		if int64(r.read) >= r.size-r.offset {
+			close(r.chbuf)
+			return n, err
+		}
+		r.chrid++
+		chunk.Reset()
+		r.chbuf <- chunk
+		err = nil
+	}
+	return n, err
+}
+
+// copied from io.Copy, basically.
+func copyContext(ctx context.Context, dst io.Writer, src io.Reader) (written int64, err error) {
+	buf := make([]byte, 32*1024)
+	for {
+		if ctx.Err() != nil {
+			err = ctx.Err()
+			return
+		}
+		nr, er := src.Read(buf)
+		if nr > 0 {
+			nw, ew := dst.Write(buf[0:nr])
+			if nw > 0 {
+				written += int64(nw)
+			}
+			if ew != nil {
+				err = ew
+				break
+			}
+			if nr != nw {
+				err = io.ErrShortWrite
+				break
+			}
+		}
+		if er == io.EOF {
+			break
+		}
+		if er != nil {
+			err = er
+			break
+		}
+	}
+	return written, err
+}

--- a/vendor/src/github.com/kurin/blazer/b2/writer.go
+++ b/vendor/src/github.com/kurin/blazer/b2/writer.go
@@ -1,0 +1,335 @@
+// Copyright 2016, Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package b2
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"errors"
+	"fmt"
+	"hash"
+	"io"
+	"sync"
+	"sync/atomic"
+
+	"github.com/golang/glog"
+
+	"golang.org/x/net/context"
+)
+
+type chunk struct {
+	id   int
+	size int
+	sha1 string
+	buf  *bytes.Buffer
+}
+
+// Writer writes data into Backblaze.  It automatically switches to the large
+// file API if the file exceeds ChunkSize bytes.  Due to that and other
+// Backblaze API details, there is a large buffer.
+//
+// Changes to public Writer attributes must be made before the first call to
+// Write.
+type Writer struct {
+	// ConcurrentUploads is number of different threads sending data concurrently
+	// to Backblaze for large files.  This can increase performance greatly, as
+	// each thread will hit a different endpoint.  However, there is a ChunkSize
+	// buffer for each thread.  Values less than 1 are equivalent to 1.
+	ConcurrentUploads int
+
+	// Resume an upload.  If true, and the upload is a large file, and a file of
+	// the same name was started but not finished, then assume that we are
+	// resuming that file, and don't upload duplicate chunks.
+	Resume bool
+
+	// ChunkSize is the size, in bytes, of each individual part, when writing
+	// large files, and also when determining whether to upload a file normally
+	// or when to split it into parts.  The default is 100M (1e8) (which is also
+	// the minimum).  Values less than 100M are not an error, but will fail.  The
+	// maximum is 5GB (5e9).
+	ChunkSize int
+
+	contentType string
+	info        map[string]string
+
+	csize  int
+	ctx    context.Context
+	cancel context.CancelFunc
+	ready  chan chunk
+	wg     sync.WaitGroup
+	once   sync.Once
+	done   sync.Once
+	file   beLargeFileInterface
+	seen   map[int]string
+
+	o    *Object
+	name string
+
+	cbuf *bytes.Buffer
+	cidx int
+	chsh hash.Hash
+	w    io.Writer
+
+	emux sync.RWMutex
+	err  error
+}
+
+func (w *Writer) setErr(err error) {
+	if err == nil {
+		return
+	}
+	w.emux.Lock()
+	defer w.emux.Unlock()
+	if w.err == nil {
+		glog.Errorf("error writing %s: %v", w.name, err)
+		w.err = err
+		w.cancel()
+	}
+}
+
+func (w *Writer) getErr() error {
+	w.emux.RLock()
+	defer w.emux.RUnlock()
+	return w.err
+}
+
+var gid int32
+
+func (w *Writer) thread() {
+	go func() {
+		id := atomic.AddInt32(&gid, 1)
+		fc, err := w.file.getUploadPartURL(w.ctx)
+		if err != nil {
+			w.setErr(err)
+			return
+		}
+		w.wg.Add(1)
+		defer w.wg.Done()
+		for {
+			chunk, ok := <-w.ready
+			if !ok {
+				return
+			}
+			if sha, ok := w.seen[chunk.id]; ok {
+				if sha != chunk.sha1 {
+					w.setErr(errors.New("resumable upload was requested, but chunks don't match!"))
+					return
+				}
+				glog.V(2).Infof("skipping chunk %d", chunk.id)
+				continue
+			}
+			glog.V(2).Infof("thread %d handling chunk %d", id, chunk.id)
+			r := bytes.NewReader(chunk.buf.Bytes())
+		redo:
+			n, err := fc.uploadPart(w.ctx, r, chunk.sha1, chunk.size, chunk.id)
+			if n != chunk.size || err != nil {
+				if w.o.b.r.reupload(err) {
+					glog.Infof("b2 writer: wrote %d of %d: error: %v; retrying", n, chunk.size, err)
+					f, err := w.file.getUploadPartURL(w.ctx)
+					if err != nil {
+						w.setErr(err)
+						return
+					}
+					fc = f
+					goto redo
+				}
+				w.setErr(err)
+				return
+			}
+			glog.V(2).Infof("chunk %d handled", chunk.id)
+		}
+	}()
+}
+
+// Write satisfies the io.Writer interface.
+func (w *Writer) Write(p []byte) (int, error) {
+	if err := w.getErr(); err != nil {
+		return 0, err
+	}
+	w.csize = w.ChunkSize
+	if w.csize == 0 {
+		w.csize = 1e8
+	}
+	left := w.csize - w.cbuf.Len()
+	if len(p) < left {
+		return w.w.Write(p)
+	}
+	i, err := w.w.Write(p[:left])
+	if err != nil {
+		w.setErr(err)
+		return i, err
+	}
+	if err := w.sendChunk(); err != nil {
+		w.setErr(err)
+		return i, w.getErr()
+	}
+	k, err := w.Write(p[left:])
+	if err != nil {
+		w.setErr(err)
+	}
+	return i + k, err
+}
+
+func (w *Writer) simpleWriteFile() error {
+	ue, err := w.o.b.b.getUploadURL(w.ctx)
+	if err != nil {
+		return err
+	}
+	sha1 := fmt.Sprintf("%x", w.chsh.Sum(nil))
+	ctype := w.contentType
+	if ctype == "" {
+		ctype = "application/octet-stream"
+	}
+	r := bytes.NewReader(w.cbuf.Bytes())
+redo:
+	f, err := ue.uploadFile(w.ctx, r, int(r.Size()), w.name, ctype, sha1, w.info)
+	if err != nil {
+		if w.o.b.r.reupload(err) {
+			glog.Infof("b2 writer: %v; retrying", err)
+			u, err := w.o.b.b.getUploadURL(w.ctx)
+			if err != nil {
+				return err
+			}
+			ue = u
+			goto redo
+		}
+		return err
+	}
+	w.o.f = f
+	return nil
+}
+
+func (w *Writer) getLargeFile() (beLargeFileInterface, error) {
+	if !w.Resume {
+		ctype := w.contentType
+		if ctype == "" {
+			ctype = "application/octet-stream"
+		}
+		return w.o.b.b.startLargeFile(w.ctx, w.name, ctype, w.info)
+	}
+	next := 1
+	seen := make(map[int]string)
+	var size int64
+	var fi beFileInterface
+	for {
+		cur := &Cursor{Name: w.name}
+		objs, _, err := w.o.b.ListObjects(w.ctx, 1, cur)
+		if err != nil {
+			return nil, err
+		}
+		if len(objs) < 1 || objs[0].name != w.name {
+			w.Resume = false
+			return w.getLargeFile()
+		}
+		fi = objs[0].f
+		parts, n, err := fi.listParts(w.ctx, next, 100)
+		if err != nil {
+			return nil, err
+		}
+		next = n
+		for _, p := range parts {
+			seen[p.number()] = p.sha1()
+			size += p.size()
+		}
+		if len(parts) == 0 {
+			break
+		}
+		if next == 0 {
+			break
+		}
+	}
+	w.seen = make(map[int]string) // copy the map
+	for id, sha := range seen {
+		w.seen[id] = sha
+	}
+	return fi.compileParts(size, seen), nil
+}
+
+func (w *Writer) sendChunk() error {
+	var err error
+	w.once.Do(func() {
+		lf, e := w.getLargeFile()
+		if e != nil {
+			err = e
+			return
+		}
+		w.file = lf
+		w.ready = make(chan chunk)
+		if w.ConcurrentUploads < 1 {
+			w.ConcurrentUploads = 1
+		}
+		for i := 0; i < w.ConcurrentUploads; i++ {
+			w.thread()
+		}
+	})
+	if err != nil {
+		return err
+	}
+	select {
+	case w.ready <- chunk{
+		id:   w.cidx + 1,
+		size: w.cbuf.Len(),
+		sha1: fmt.Sprintf("%x", w.chsh.Sum(nil)),
+		buf:  w.cbuf,
+	}:
+	case <-w.ctx.Done():
+		return w.ctx.Err()
+	}
+	w.cidx++
+	w.chsh = sha1.New()
+	w.cbuf = &bytes.Buffer{}
+	w.w = io.MultiWriter(w.chsh, w.cbuf)
+	return nil
+}
+
+// Close satisfies the io.Closer interface.  It is critical to check the return
+// value of Close on all writers.
+func (w *Writer) Close() error {
+	w.done.Do(func() {
+		if w.cidx == 0 {
+			w.setErr(w.simpleWriteFile())
+			return
+		}
+		if w.cbuf.Len() > 0 {
+			if err := w.sendChunk(); err != nil {
+				w.setErr(err)
+				return
+			}
+		}
+		close(w.ready)
+		w.wg.Wait()
+		f, err := w.file.finishLargeFile(w.ctx)
+		if err != nil {
+			w.setErr(err)
+			return
+		}
+		w.o.f = f
+	})
+	return w.getErr()
+}
+
+// WithAttrs sets the writable attributes of the resulting file to given
+// values.  WithAttrs must be called before the first call to Write.
+func (w *Writer) WithAttrs(attrs *Attrs) *Writer {
+	w.contentType = attrs.ContentType
+	w.info = make(map[string]string)
+	for k, v := range attrs.Info {
+		w.info[k] = v
+	}
+	if len(w.info) < 10 && !attrs.LastModified.IsZero() {
+		w.info["src_last_modified_millis"] = fmt.Sprintf("%d", attrs.LastModified.UnixNano()/1e6)
+	}
+	return w
+}

--- a/vendor/src/github.com/kurin/blazer/base/base.go
+++ b/vendor/src/github.com/kurin/blazer/base/base.go
@@ -1,0 +1,867 @@
+// Copyright 2016, Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package base provides a very low-level interface on top of the B2 v1 API.
+// It is not intended to be used directly.
+//
+// It currently lacks support for the following APIs:
+//
+// b2_download_file_by_id
+// b2_list_unfinished_large_files
+// b2_update_bucket
+package base
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/golang/glog"
+	"github.com/kurin/blazer/internal/b2types"
+
+	"golang.org/x/net/context"
+)
+
+var (
+	APIBase = "https://api.backblazeb2.com"
+)
+
+type b2err struct {
+	msg    string
+	method string
+	retry  int
+	code   int
+}
+
+func (e b2err) Error() string {
+	if e.method == "" {
+		return fmt.Sprintf("b2 error: %s", e.msg)
+	}
+	return fmt.Sprintf("%s: %d: %s", e.method, e.code, e.msg)
+}
+
+// Action checks an error and returns a recommended course of action.
+func Action(err error) ErrAction {
+	e, ok := err.(b2err)
+	if !ok {
+		return Punt
+	}
+	if e.retry > 0 {
+		return Retry
+	}
+	if e.code >= 500 && e.code < 600 {
+		if e.method == "b2_upload_file" || e.method == "b2_upload_part" {
+			return AttemptNewUpload
+		}
+	}
+	switch e.code {
+	case 401:
+		if e.method == "b2_authorize_account" {
+			return Punt
+		}
+		if e.method == "b2_upload_file" || e.method == "b2_upload_part" {
+			return AttemptNewUpload
+		}
+		return ReAuthenticate
+	case 429, 500, 503:
+		return Retry
+	}
+	return Punt
+}
+
+// ErrAction is an action that a caller can take when any function returns an
+// error.
+type ErrAction int
+
+const (
+	// ReAuthenticate indicates that the B2 account authentication tokens have
+	// expired, and should be refreshed with a new call to AuthorizeAccount.
+	ReAuthenticate ErrAction = iota
+
+	// AttemptNewUpload indicates that an upload's authentication token (or URL
+	// endpoint) has expored, and that users should request new ones with a call
+	// to GetUploadURL or GetUploadPartURL.
+	AttemptNewUpload
+
+	// Retry indicates that the caller should wait an appropriate amount of time,
+	// and then reattempt the RPC.
+	Retry
+
+	// Punt means that there is no useful action to be taken on this error, and
+	// that it should be displayed to the user.
+	Punt
+)
+
+func mkErr(resp *http.Response) error {
+	data, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	logResponse(resp, data)
+	msg := &b2types.ErrorMessage{}
+	if err := json.Unmarshal(data, msg); err != nil {
+		return err
+	}
+	var retryAfter int
+	retry := resp.Header.Get("Retry-After")
+	if retry != "" {
+		r, err := strconv.ParseInt(retry, 10, 64)
+		if err != nil {
+			return err
+		}
+		retryAfter = int(r)
+	}
+	return b2err{
+		msg:    msg.Msg,
+		retry:  retryAfter,
+		code:   resp.StatusCode,
+		method: resp.Request.Header.Get("X-Blazer-Method"),
+	}
+}
+
+// Backoff returns an appropriate amount of time to wait, given an error, if
+// any was returned by the server.  If the return value is 0, but Action
+// indicates Retry, the user should implement their own exponential backoff,
+// beginning with one second.
+func Backoff(err error) time.Duration {
+	e, ok := err.(b2err)
+	if !ok {
+		return 0
+	}
+	return time.Duration(e.retry) * time.Second
+}
+
+func logRequest(req *http.Request, args []byte) {
+	if !glog.V(2) {
+		return
+	}
+	var headers []string
+	for k, v := range req.Header {
+		if k == "Authorization" || k == "X-Blazer-Method" {
+			continue
+		}
+		headers = append(headers, fmt.Sprintf("%s: %s", k, strings.Join(v, ",")))
+	}
+	hstr := strings.Join(headers, ";")
+	method := req.Header.Get("X-Blazer-Method")
+	if args != nil {
+		glog.V(2).Infof(">> %s uri: %v headers: {%s} args: (%s)", method, req.URL, hstr, string(args))
+		return
+	}
+	glog.V(2).Infof(">> %s uri: %v {%s} (no args)", method, req.URL, hstr)
+}
+
+func logResponse(resp *http.Response, reply []byte) {
+	if !glog.V(2) {
+		return
+	}
+	var headers []string
+	for k, v := range resp.Header {
+		headers = append(headers, fmt.Sprintf("%s: %s", k, strings.Join(v, ",")))
+	}
+	hstr := strings.Join(headers, "; ")
+	method := resp.Request.Header.Get("X-Blazer-Method")
+	id := resp.Request.Header.Get("X-Blazer-Request-ID")
+	if reply != nil {
+		glog.V(2).Infof("<< %s (%s) %s {%s} (%s)", method, id, resp.Status, hstr, string(reply))
+		return
+	}
+	glog.V(2).Infof("<< %s (%s) %s {%s} (no reply)", method, id, resp.Status, hstr)
+}
+
+func millitime(t int64) time.Time {
+	return time.Unix(t/1000, t%1000*1e6)
+}
+
+// B2 holds account information for Backblaze.
+type B2 struct {
+	accountID   string
+	authToken   string
+	apiURI      string
+	downloadURI string
+	minPartSize int
+}
+
+// Update replaces the B2 object with a new one, in-place.
+func (b *B2) Update(n *B2) {
+	b.accountID = n.accountID
+	b.authToken = n.authToken
+	b.apiURI = n.apiURI
+	b.downloadURI = n.downloadURI
+	b.minPartSize = n.minPartSize
+}
+
+type httpReply struct {
+	resp *http.Response
+	err  error
+}
+
+func makeNetRequest(req *http.Request) <-chan httpReply {
+	ch := make(chan httpReply)
+	go func() {
+		resp, err := http.DefaultClient.Do(req)
+		ch <- httpReply{resp, err}
+		close(ch)
+	}()
+	return ch
+}
+
+// FailSomeUploads causes B2 to return errors, randomly, to some RPCs.  It is
+// intended to be used for integration testing.
+var FailSomeUploads = false
+
+var reqID int64
+
+func makeRequest(ctx context.Context, method, verb, url string, b2req, b2resp interface{}, headers map[string]string, body io.Reader) error {
+	var args []byte
+	if b2req != nil {
+		enc, err := json.Marshal(b2req)
+		if err != nil {
+			return err
+		}
+		args = enc
+		body = bytes.NewBuffer(enc)
+	}
+	req, err := http.NewRequest(verb, url, body)
+	if err != nil {
+		return err
+	}
+	for k, v := range headers {
+		req.Header.Set(k, v)
+	}
+	req.Header.Set("X-Blazer-Request-ID", fmt.Sprintf("%d", atomic.AddInt64(&reqID, 1)))
+	req.Header.Set("X-Blazer-Method", method)
+	if FailSomeUploads {
+		req.Header.Set("X-Bz-Test-Mode", "fail_some_uploads")
+	}
+	cancel := make(chan struct{})
+	req.Cancel = cancel
+	logRequest(req, args)
+	ch := makeNetRequest(req)
+	var reply httpReply
+	select {
+	case reply = <-ch:
+	case <-ctx.Done():
+		close(cancel)
+		return ctx.Err()
+	}
+	if reply.err != nil {
+		// Connection errors are retryable.
+		return b2err{
+			msg:   reply.err.Error(),
+			retry: 1,
+		}
+	}
+	resp := reply.resp
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		return mkErr(resp)
+	}
+	var replyArgs []byte
+	if b2resp != nil {
+		rbuf := &bytes.Buffer{}
+		r := io.TeeReader(resp.Body, rbuf)
+		decoder := json.NewDecoder(r)
+		if err := decoder.Decode(b2resp); err != nil {
+			return err
+		}
+		replyArgs = rbuf.Bytes()
+	} else {
+		replyArgs, err = ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+	}
+	logResponse(resp, replyArgs)
+	return nil
+}
+
+// AuthorizeAccount wraps b2_authorize_account.
+func AuthorizeAccount(ctx context.Context, account, key string) (*B2, error) {
+	auth := base64.StdEncoding.EncodeToString([]byte(fmt.Sprintf("%s:%s", account, key)))
+	b2resp := &b2types.AuthorizeAccountResponse{}
+	headers := map[string]string{
+		"Authorization": fmt.Sprintf("Basic %s", auth),
+	}
+	if err := makeRequest(ctx, "b2_authorize_account", "GET", APIBase+b2types.V1api+"b2_authorize_account", nil, b2resp, headers, nil); err != nil {
+		return nil, err
+	}
+	return &B2{
+		accountID:   b2resp.AccountID,
+		authToken:   b2resp.AuthToken,
+		apiURI:      b2resp.URI,
+		downloadURI: b2resp.DownloadURI,
+		minPartSize: b2resp.MinPartSize,
+	}, nil
+}
+
+// CreateBucket wraps b2_create_bucket.
+func (b *B2) CreateBucket(ctx context.Context, name, btype string) (*Bucket, error) {
+	if btype != "allPublic" {
+		btype = "allPrivate"
+	}
+	b2req := &b2types.CreateBucketRequest{
+		AccountID: b.accountID,
+		Name:      name,
+		Type:      btype,
+	}
+	b2resp := &b2types.CreateBucketResponse{}
+	headers := map[string]string{
+		"Authorization": b.authToken,
+	}
+	if err := makeRequest(ctx, "b2_create_bucket", "POST", b.apiURI+b2types.V1api+"b2_create_bucket", b2req, b2resp, headers, nil); err != nil {
+		return nil, err
+	}
+	return &Bucket{
+		Name: name,
+		id:   b2resp.BucketID,
+		b2:   b,
+	}, nil
+}
+
+// DeleteBucket wraps b2_delete_bucket.
+func (b *Bucket) DeleteBucket(ctx context.Context) error {
+	b2req := &b2types.DeleteBucketRequest{
+		AccountID: b.b2.accountID,
+		BucketID:  b.id,
+	}
+	headers := map[string]string{
+		"Authorization": b.b2.authToken,
+	}
+	return makeRequest(ctx, "b2_delete_bucket", "POST", b.b2.apiURI+b2types.V1api+"b2_delete_bucket", b2req, nil, headers, nil)
+}
+
+// Bucket holds B2 bucket details.
+type Bucket struct {
+	Name string
+	Type string
+	id   string
+	b2   *B2
+}
+
+// BaseURL returns the base part of the download URLs.
+func (b *Bucket) BaseURL() string {
+	return b.b2.downloadURI
+}
+
+// ListBuckets wraps b2_list_buckets.
+func (b *B2) ListBuckets(ctx context.Context) ([]*Bucket, error) {
+	b2req := &b2types.ListBucketsRequest{
+		AccountID: b.accountID,
+	}
+	b2resp := &b2types.ListBucketsResponse{}
+	headers := map[string]string{
+		"Authorization": b.authToken,
+	}
+	if err := makeRequest(ctx, "b2_list_buckets", "POST", b.apiURI+b2types.V1api+"b2_list_buckets", b2req, b2resp, headers, nil); err != nil {
+		return nil, err
+	}
+	var buckets []*Bucket
+	for _, bucket := range b2resp.Buckets {
+		buckets = append(buckets, &Bucket{
+			Name: bucket.BucketName,
+			Type: bucket.BucketType,
+			id:   bucket.BucketID,
+			b2:   b,
+		})
+	}
+	return buckets, nil
+}
+
+// URL holds information from the b2_get_upload_url API.
+type URL struct {
+	uri    string
+	token  string
+	b2     *B2
+	bucket *Bucket
+}
+
+// Reload reloads URL in-place, by reissuing a b2_get_upload_url and
+// overwriting the previous values.
+func (url *URL) Reload(ctx context.Context) error {
+	n, err := url.bucket.GetUploadURL(ctx)
+	if err != nil {
+		return err
+	}
+	url.uri = n.uri
+	url.token = n.token
+	return nil
+}
+
+// GetUploadURL wraps b2_get_upload_url.
+func (b *Bucket) GetUploadURL(ctx context.Context) (*URL, error) {
+	b2req := &b2types.GetUploadURLRequest{
+		BucketID: b.id,
+	}
+	b2resp := &b2types.GetUploadURLResponse{}
+	headers := map[string]string{
+		"Authorization": b.b2.authToken,
+	}
+	if err := makeRequest(ctx, "b2_get_upload_url", "POST", b.b2.apiURI+b2types.V1api+"b2_get_upload_url", b2req, b2resp, headers, nil); err != nil {
+		return nil, err
+	}
+	return &URL{
+		uri:    b2resp.URI,
+		token:  b2resp.Token,
+		b2:     b.b2,
+		bucket: b,
+	}, nil
+}
+
+// File represents a B2 file.
+type File struct {
+	Name      string
+	Size      int64
+	Status    string
+	Timestamp time.Time
+	id        string
+	b2        *B2
+}
+
+// UploadFile wraps b2_upload_file.
+func (url *URL) UploadFile(ctx context.Context, r io.Reader, size int, name, contentType, sha1 string, info map[string]string) (*File, error) {
+	headers := map[string]string{
+		"Authorization":     url.token,
+		"X-Bz-File-Name":    name,
+		"Content-Type":      contentType,
+		"Content-Length":    fmt.Sprintf("%d", size),
+		"X-Bz-Content-Sha1": sha1,
+	}
+	for k, v := range info {
+		headers[fmt.Sprintf("X-Bz-Info-%s", k)] = v
+	}
+	b2resp := &b2types.UploadFileResponse{}
+	if err := makeRequest(ctx, "b2_upload_file", "POST", url.uri, nil, b2resp, headers, r); err != nil {
+		return nil, err
+	}
+	return &File{
+		Name:      name,
+		Size:      int64(size),
+		Timestamp: millitime(b2resp.Timestamp),
+		Status:    b2resp.Action,
+		id:        b2resp.FileID,
+		b2:        url.b2,
+	}, nil
+}
+
+// DeleteFileVersion wraps b2_delete_file_version.
+func (f *File) DeleteFileVersion(ctx context.Context) error {
+	b2req := &b2types.DeleteFileVersionRequest{
+		Name:   f.Name,
+		FileID: f.id,
+	}
+	headers := map[string]string{
+		"Authorization": f.b2.authToken,
+	}
+	return makeRequest(ctx, "b2_delete_file_version", "POST", f.b2.apiURI+b2types.V1api+"b2_delete_file_version", b2req, nil, headers, nil)
+}
+
+// LargeFile holds information necessary to implement B2 large file support.
+type LargeFile struct {
+	id string
+	b2 *B2
+
+	mu     sync.Mutex
+	size   int64
+	hashes map[int]string
+}
+
+// StartLargeFile wraps b2_start_large_file.
+func (b *Bucket) StartLargeFile(ctx context.Context, name, contentType string, info map[string]string) (*LargeFile, error) {
+	b2req := &b2types.StartLargeFileRequest{
+		BucketID:    b.id,
+		Name:        name,
+		ContentType: contentType,
+		Info:        info,
+	}
+	b2resp := &b2types.StartLargeFileResponse{}
+	headers := map[string]string{
+		"Authorization": b.b2.authToken,
+	}
+	if err := makeRequest(ctx, "b2_start_large_file", "POST", b.b2.apiURI+b2types.V1api+"b2_start_large_file", b2req, b2resp, headers, nil); err != nil {
+		return nil, err
+	}
+	return &LargeFile{
+		id:     b2resp.ID,
+		b2:     b.b2,
+		hashes: make(map[int]string),
+	}, nil
+}
+
+// CancelLargeFile wraps b2_cancel_large_file.
+func (l *LargeFile) CancelLargeFile(ctx context.Context) error {
+	b2req := &b2types.CancelLargeFileRequest{
+		ID: l.id,
+	}
+	headers := map[string]string{
+		"Authorization": l.b2.authToken,
+	}
+	return makeRequest(ctx, "b2_cancel_large_file", "POST", l.b2.apiURI+b2types.V1api+"b2_cancel_large_file", b2req, nil, headers, nil)
+}
+
+// FilePart is a piece of a started, but not finished, large file upload.
+type FilePart struct {
+	Number int
+	SHA1   string
+	Size   int64
+}
+
+// ListParts wraps b2_list_parts.
+func (f *File) ListParts(ctx context.Context, next, count int) ([]*FilePart, int, error) {
+	b2req := &b2types.ListPartsRequest{
+		ID:    f.id,
+		Start: next,
+		Count: count,
+	}
+	b2resp := &b2types.ListPartsResponse{}
+	headers := map[string]string{
+		"Authorization": f.b2.authToken,
+	}
+	if err := makeRequest(ctx, "b2_list_parts", "POST", f.b2.apiURI+b2types.V1api+"b2_list_parts", b2req, b2resp, headers, nil); err != nil {
+		return nil, 0, err
+	}
+	var parts []*FilePart
+	for _, part := range b2resp.Parts {
+		parts = append(parts, &FilePart{
+			Number: part.Number,
+			SHA1:   part.SHA1,
+			Size:   part.Size,
+		})
+	}
+	return parts, b2resp.Next, nil
+}
+
+// CompileParts returns a LargeFile that can accept new data.  Seen is a
+// mapping of completed part numbers to SHA1 strings; size is the total size of
+// all the completed parts to this point.
+func (f *File) CompileParts(size int64, seen map[int]string) *LargeFile {
+	s := make(map[int]string)
+	for k, v := range seen {
+		s[k] = v
+	}
+	return &LargeFile{
+		id:     f.id,
+		b2:     f.b2,
+		size:   size,
+		hashes: s,
+	}
+}
+
+// FileChunk holds information necessary for uploading file chunks.
+type FileChunk struct {
+	url   string
+	token string
+	file  *LargeFile
+}
+
+type getUploadPartURLRequest struct {
+	ID string `json:"fileId"`
+}
+
+type getUploadPartURLResponse struct {
+	URL   string `json:"uploadUrl"`
+	Token string `json:"authorizationToken"`
+}
+
+// GetUploadPartURL wraps b2_get_upload_part_url.
+func (l *LargeFile) GetUploadPartURL(ctx context.Context) (*FileChunk, error) {
+	b2req := &getUploadPartURLRequest{
+		ID: l.id,
+	}
+	b2resp := &getUploadPartURLResponse{}
+	headers := map[string]string{
+		"Authorization": l.b2.authToken,
+	}
+	if err := makeRequest(ctx, "b2_get_upload_part_url", "POST", l.b2.apiURI+b2types.V1api+"b2_get_upload_part_url", b2req, b2resp, headers, nil); err != nil {
+		return nil, err
+	}
+	return &FileChunk{
+		url:   b2resp.URL,
+		token: b2resp.Token,
+		file:  l,
+	}, nil
+}
+
+// Reload reloads FileChunk in-place.
+func (fc *FileChunk) Reload(ctx context.Context) error {
+	n, err := fc.file.GetUploadPartURL(ctx)
+	if err != nil {
+		return err
+	}
+	fc.url = n.url
+	fc.token = n.token
+	return nil
+}
+
+// UploadPart wraps b2_upload_part.
+func (fc *FileChunk) UploadPart(ctx context.Context, r io.Reader, sha1 string, size, index int) (int, error) {
+	headers := map[string]string{
+		"Authorization":     fc.token,
+		"X-Bz-Part-Number":  fmt.Sprintf("%d", index),
+		"Content-Length":    fmt.Sprintf("%d", size),
+		"X-Bz-Content-Sha1": sha1,
+	}
+	if err := makeRequest(ctx, "b2_upload_part", "POST", fc.url, nil, nil, headers, r); err != nil {
+		return 0, err
+	}
+	fc.file.mu.Lock()
+	fc.file.hashes[index] = sha1
+	fc.file.size += int64(size)
+	fc.file.mu.Unlock()
+	return size, nil
+}
+
+// FinishLargeFile wraps b2_finish_large_file.
+func (l *LargeFile) FinishLargeFile(ctx context.Context) (*File, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	b2req := &b2types.FinishLargeFileRequest{
+		ID:     l.id,
+		Hashes: make([]string, len(l.hashes)),
+	}
+	b2resp := &b2types.FinishLargeFileResponse{}
+	for k, v := range l.hashes {
+		b2req.Hashes[k-1] = v
+	}
+	headers := map[string]string{
+		"Authorization": l.b2.authToken,
+	}
+	if err := makeRequest(ctx, "b2_finish_large_file", "POST", l.b2.apiURI+b2types.V1api+"b2_finish_large_file", b2req, b2resp, headers, nil); err != nil {
+		return nil, err
+	}
+	return &File{
+		Name:      b2resp.Name,
+		Size:      l.size,
+		Timestamp: millitime(b2resp.Timestamp),
+		Status:    b2resp.Action,
+		id:        b2resp.FileID,
+		b2:        l.b2,
+	}, nil
+}
+
+// ListFileNames wraps b2_list_file_names.
+func (b *Bucket) ListFileNames(ctx context.Context, count int, continuation string) ([]*File, string, error) {
+	b2req := &b2types.ListFileNamesRequest{
+		Count:        count,
+		Continuation: continuation,
+		BucketID:     b.id,
+	}
+	b2resp := &b2types.ListFileNamesResponse{}
+	headers := map[string]string{
+		"Authorization": b.b2.authToken,
+	}
+	if err := makeRequest(ctx, "b2_list_file_names", "POST", b.b2.apiURI+b2types.V1api+"b2_list_file_names", b2req, b2resp, headers, nil); err != nil {
+		return nil, "", err
+	}
+	cont := b2resp.Continuation
+	var files []*File
+	for _, f := range b2resp.Files {
+		files = append(files, &File{
+			Name:      f.Name,
+			Size:      f.Size,
+			Status:    f.Action,
+			Timestamp: millitime(f.Timestamp),
+			id:        f.FileID,
+			b2:        b.b2,
+		})
+	}
+	return files, cont, nil
+}
+
+// ListFileVersions wraps b2_list_file_versions.
+func (b *Bucket) ListFileVersions(ctx context.Context, count int, startName, startID string) ([]*File, string, string, error) {
+	b2req := &b2types.ListFileVersionsRequest{
+		BucketID:  b.id,
+		Count:     count,
+		StartName: startName,
+		StartID:   startID,
+	}
+	b2resp := &b2types.ListFileVersionsResponse{}
+	headers := map[string]string{
+		"Authorization": b.b2.authToken,
+	}
+	if err := makeRequest(ctx, "b2_list_file_versions", "POST", b.b2.apiURI+b2types.V1api+"b2_list_file_versions", b2req, b2resp, headers, nil); err != nil {
+		return nil, "", "", err
+	}
+	var files []*File
+	for _, f := range b2resp.Files {
+		files = append(files, &File{
+			Name:      f.Name,
+			Size:      f.Size,
+			Status:    f.Action,
+			Timestamp: millitime(f.Timestamp),
+			id:        f.FileID,
+			b2:        b.b2,
+		})
+	}
+	return files, b2resp.NextName, b2resp.NextID, nil
+}
+
+// GetDownloadAuthorization wraps b2_get_download_authorization.
+func (b *Bucket) GetDownloadAuthorization(ctx context.Context, prefix string, valid time.Duration) (string, error) {
+	b2req := &b2types.GetDownloadAuthorizationRequest{
+		BucketID: b.id,
+		Prefix:   prefix,
+		Valid:    int(valid.Seconds()),
+	}
+	b2resp := &b2types.GetDownloadAuthorizationResponse{}
+	headers := map[string]string{
+		"Authorization": b.b2.authToken,
+	}
+	if err := makeRequest(ctx, "b2_get_download_authorization", "POST", b.b2.apiURI+b2types.V1api+"b2_get_download_authorization", b2req, b2resp, headers, nil); err != nil {
+		return "", err
+	}
+	return b2resp.Token, nil
+}
+
+// FileReader is an io.ReadCloser that downloads a file from B2.
+type FileReader struct {
+	io.ReadCloser
+	ContentLength int
+	ContentType   string
+	SHA1          string
+	Info          map[string]string
+}
+
+func mkRange(offset, size int64) string {
+	if offset == 0 && size == 0 {
+		return ""
+	}
+	if size == 0 {
+		return fmt.Sprintf("bytes=%d-", offset)
+	}
+	return fmt.Sprintf("bytes=%d-%d", offset, offset+size-1)
+}
+
+// DownloadFileByName wraps b2_download_file_by_name.
+func (b *Bucket) DownloadFileByName(ctx context.Context, name string, offset, size int64) (*FileReader, error) {
+	url := fmt.Sprintf("%s/file/%s/%s", b.b2.downloadURI, b.Name, name)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Authorization", b.b2.authToken)
+	req.Header.Set("X-Blazer-Request-ID", fmt.Sprintf("%d", atomic.AddInt64(&reqID, 1)))
+	req.Header.Set("X-Blazer-Method", "b2_download_file_by_name")
+	rng := mkRange(offset, size)
+	if rng != "" {
+		req.Header.Set("Range", rng)
+	}
+	cancel := make(chan struct{})
+	req.Cancel = cancel
+	logRequest(req, nil)
+	ch := makeNetRequest(req)
+	var reply httpReply
+	select {
+	case reply = <-ch:
+	case <-ctx.Done():
+		close(cancel)
+		return nil, ctx.Err()
+	}
+	if reply.err != nil {
+		return nil, reply.err
+	}
+	resp := reply.resp
+	logResponse(resp, nil)
+	if resp.StatusCode != 200 && resp.StatusCode != 206 {
+		return nil, mkErr(resp)
+	}
+	clen, err := strconv.ParseInt(reply.resp.Header.Get("Content-Length"), 10, 64)
+	if err != nil {
+		return nil, err
+	}
+	info := make(map[string]string)
+	for key := range reply.resp.Header {
+		if !strings.HasPrefix(key, "X-Bz-Info-") {
+			continue
+		}
+		name := strings.TrimPrefix(key, "X-Bz-Info-")
+		info[name] = reply.resp.Header.Get(key)
+	}
+	return &FileReader{
+		ReadCloser:    reply.resp.Body,
+		SHA1:          reply.resp.Header.Get("X-Bz-Content-Sha1"),
+		ContentType:   reply.resp.Header.Get("Content-Type"),
+		ContentLength: int(clen),
+		Info:          info,
+	}, nil
+}
+
+// HideFile wraps b2_hide_file.
+func (b *Bucket) HideFile(ctx context.Context, name string) (*File, error) {
+	b2req := &b2types.HideFileRequest{
+		BucketID: b.id,
+		File:     name,
+	}
+	b2resp := &b2types.HideFileResponse{}
+	headers := map[string]string{
+		"Authorization": b.b2.authToken,
+	}
+	if err := makeRequest(ctx, "b2_hide_file", "POST", b.b2.apiURI+b2types.V1api+"b2_hide_file", b2req, b2resp, headers, nil); err != nil {
+		return nil, err
+	}
+	return &File{
+		Status:    b2resp.Action,
+		Name:      name,
+		Timestamp: millitime(b2resp.Timestamp),
+		b2:        b.b2,
+		id:        b2resp.ID,
+	}, nil
+}
+
+// FileInfo holds information about a specific file.
+type FileInfo struct {
+	Name        string
+	SHA1        string
+	Size        int64
+	ContentType string
+	Info        map[string]string
+	Status      string
+	Timestamp   time.Time
+}
+
+// GetFileInfo wraps b2_get_file_info.
+func (f *File) GetFileInfo(ctx context.Context) (*FileInfo, error) {
+	b2req := &b2types.GetFileInfoRequest{
+		ID: f.id,
+	}
+	b2resp := &b2types.GetFileInfoResponse{}
+	headers := map[string]string{
+		"Authorization": f.b2.authToken,
+	}
+	if err := makeRequest(ctx, "b2_get_file_info", "POST", f.b2.apiURI+b2types.V1api+"b2_get_file_info", b2req, b2resp, headers, nil); err != nil {
+		return nil, err
+	}
+	f.Status = b2resp.Action
+	f.Name = b2resp.Name
+	f.Timestamp = millitime(b2resp.Timestamp)
+	return &FileInfo{
+		Name:        b2resp.Name,
+		SHA1:        b2resp.SHA1,
+		Size:        b2resp.Size,
+		ContentType: b2resp.ContentType,
+		Info:        b2resp.Info,
+		Status:      b2resp.Action,
+		Timestamp:   millitime(b2resp.Timestamp),
+	}, nil
+}

--- a/vendor/src/github.com/kurin/blazer/base/integration_test.go
+++ b/vendor/src/github.com/kurin/blazer/base/integration_test.go
@@ -1,0 +1,247 @@
+// Copyright 2016, Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package base
+
+import (
+	"bytes"
+	"crypto/sha1"
+	"fmt"
+	"io"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"golang.org/x/net/context"
+)
+
+const (
+	apiID  = "B2_ACCOUNT_ID"
+	apiKey = "B2_SECRET_KEY"
+)
+
+const (
+	bucketName    = "MahBucket"
+	smallFileName = "TeenyTiny"
+	largeFileName = "BigBytes"
+)
+
+type zReader struct{}
+
+func (zReader) Read(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func TestStorage(t *testing.T) {
+	id := os.Getenv(apiID)
+	key := os.Getenv(apiKey)
+	if id == "" || key == "" {
+		t.Skipf("B2_ACCOUNT_ID or B2_SECRET_KEY unset; skipping integration tests")
+	}
+	ctx := context.Background()
+
+	// b2_authorize_account
+	b2, err := AuthorizeAccount(ctx, id, key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// b2_create_bucket
+	bucket, err := b2.CreateBucket(ctx, id+bucketName, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		// b2_delete_bucket
+		if err := bucket.DeleteBucket(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// b2_list_buckets
+	buckets, err := b2.ListBuckets(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, bucket := range buckets {
+		if bucket.Name == id+bucketName {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("%s: new bucket not found", id+bucketName)
+	}
+
+	// b2_get_upload_url
+	ue, err := bucket.GetUploadURL(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// b2_upload_file
+	smallFile := io.LimitReader(zReader{}, 1024*50) // 50k
+	hash := sha1.New()
+	buf := &bytes.Buffer{}
+	w := io.MultiWriter(hash, buf)
+	if _, err := io.Copy(w, smallFile); err != nil {
+		t.Error(err)
+	}
+	smallSHA1 := fmt.Sprintf("%x", hash.Sum(nil))
+	smallInfoMap := map[string]string{
+		"one": "1",
+		"two": "2",
+	}
+	file, err := ue.UploadFile(ctx, buf, buf.Len(), smallFileName, "application/octet-stream", smallSHA1, smallInfoMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		// b2_delete_file_version
+		if err := file.DeleteFileVersion(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// b2_start_large_file
+	largeInfoMap := map[string]string{
+		"one_BILLION":  "1e9",
+		"two_TRILLION": "2eSomething, I guess 2e12",
+	}
+	lf, err := bucket.StartLargeFile(ctx, largeFileName, "application/octet-stream", largeInfoMap)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// b2_get_upload_part_url
+	fc, err := lf.GetUploadPartURL(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// b2_upload_part
+	largeFile := io.LimitReader(zReader{}, 2*1e8) // 200M
+	for i := 0; i < 2; i++ {
+		r := io.LimitReader(largeFile, 1e8) // 100M
+		hash := sha1.New()
+		buf := &bytes.Buffer{}
+		w := io.MultiWriter(hash, buf)
+		if _, err := io.Copy(w, r); err != nil {
+			t.Error(err)
+		}
+		if _, err := fc.UploadPart(ctx, buf, fmt.Sprintf("%x", hash.Sum(nil)), buf.Len(), i+1); err != nil {
+			t.Error(err)
+		}
+	}
+
+	// b2_finish_large_file
+	lfile, err := lf.FinishLargeFile(ctx)
+	if err != nil {
+		t.Error(err)
+	}
+
+	// b2_get_file_info
+	smallInfo, err := file.GetFileInfo(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compareFileAndInfo(t, smallInfo, smallFileName, smallSHA1, smallInfoMap)
+	largeInfo, err := lfile.GetFileInfo(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	compareFileAndInfo(t, largeInfo, largeFileName, "none", largeInfoMap)
+
+	defer func() {
+		if err := lfile.DeleteFileVersion(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	clf, err := bucket.StartLargeFile(ctx, largeFileName, "application/octet-stream", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// b2_cancel_large_file
+	if err := clf.CancelLargeFile(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// b2_list_file_names
+	files, _, err := bucket.ListFileNames(ctx, 100, "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 2 {
+		t.Errorf("expected 2 files, got %d: %v", len(files), files)
+	}
+
+	// b2_download_file_by_name
+	fr, err := bucket.DownloadFileByName(ctx, smallFileName, 0, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if fr.SHA1 != smallSHA1 {
+		t.Errorf("small file SHAs don't match: got %q, want %q", fr.SHA1, smallSHA1)
+	}
+	lbuf := &bytes.Buffer{}
+	if _, err := io.Copy(lbuf, fr); err != nil {
+		t.Fatal(err)
+	}
+	if lbuf.Len() != fr.ContentLength {
+		t.Errorf("small file retreived lengths don't match: got %d, want %d", lbuf.Len(), fr.ContentLength)
+	}
+
+	// b2_hide_file
+	hf, err := bucket.HideFile(ctx, smallFileName)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := hf.DeleteFileVersion(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// b2_list_file_versions
+	files, _, _, err = bucket.ListFileVersions(ctx, 100, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 3 {
+		t.Errorf("expected 3 files, got %d: %v", len(files), files)
+	}
+
+	// b2_get_download_authorization
+	if _, err := bucket.GetDownloadAuthorization(ctx, "foo/", 24*time.Hour); err != nil {
+		t.Errorf("failed to get download auth token: %v", err)
+	}
+}
+
+func compareFileAndInfo(t *testing.T, info *FileInfo, name, sha1 string, imap map[string]string) {
+	if info.Name != name {
+		t.Errorf("got %q, want %q", info.Name, name)
+	}
+	if info.SHA1 != sha1 {
+		t.Errorf("got %q, want %q", info.SHA1, sha1)
+	}
+	if !reflect.DeepEqual(info.Info, imap) {
+		t.Errorf("got %v, want %v", info.Info, imap)
+	}
+}

--- a/vendor/src/github.com/kurin/blazer/internal/b2types/b2types.go
+++ b/vendor/src/github.com/kurin/blazer/internal/b2types/b2types.go
@@ -1,0 +1,206 @@
+// Copyright 2016, Google
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package b2types implements internal types common to the B2 API.
+package b2types
+
+const (
+	V1api = "/b2api/v1/"
+)
+
+type ErrorMessage struct {
+	Status int    `json:"status"`
+	Code   string `json:"code"`
+	Msg    string `json:"message"`
+}
+
+type AuthorizeAccountResponse struct {
+	AccountID   string `json:"accountId"`
+	AuthToken   string `json:"authorizationToken"`
+	URI         string `json:"apiUrl"`
+	DownloadURI string `json:"downloadUrl"`
+	MinPartSize int    `json:"minimumPartSize"`
+}
+
+type CreateBucketRequest struct {
+	AccountID string `json:"accountId"`
+	Name      string `json:"bucketName"`
+	Type      string `json:"bucketType"`
+}
+
+type CreateBucketResponse struct {
+	BucketID string `json:"bucketId"`
+}
+
+type DeleteBucketRequest struct {
+	AccountID string `json:"accountId"`
+	BucketID  string `json:"bucketId"`
+}
+
+type ListBucketsRequest struct {
+	AccountID string `json:"accountId"`
+}
+
+type ListBucketsResponse struct {
+	Buckets []struct {
+		BucketID   string `json:"bucketId"`
+		BucketName string `json:"bucketName"`
+		BucketType string `json:"bucketType"`
+	} `json:"buckets"`
+}
+
+type GetUploadURLRequest struct {
+	BucketID string `json:"bucketId"`
+}
+
+type GetUploadURLResponse struct {
+	URI   string `json:"uploadUrl"`
+	Token string `json:"authorizationToken"`
+}
+
+type UploadFileResponse struct {
+	FileID    string `json:"fileId"`
+	Timestamp int64  `json:"uploadTimestamp"`
+	Action    string `json:"action"`
+}
+
+type DeleteFileVersionRequest struct {
+	Name   string `json:"fileName"`
+	FileID string `json:"fileId"`
+}
+
+type StartLargeFileRequest struct {
+	BucketID    string            `json:"bucketId"`
+	Name        string            `json:"fileName"`
+	ContentType string            `json:"contentType"`
+	Info        map[string]string `json:"fileInfo,omitempty"`
+}
+
+type StartLargeFileResponse struct {
+	ID string `json:"fileId"`
+}
+
+type CancelLargeFileRequest struct {
+	ID string `json:"fileId"`
+}
+
+type ListPartsRequest struct {
+	ID    string `json:"fileId"`
+	Start int    `json:"startPartNumber"`
+	Count int    `json:"maxPartCount"`
+}
+
+type ListPartsResponse struct {
+	Next  int `json:"nextPartNumber"`
+	Parts []struct {
+		ID     string `json:"fileId"`
+		Number int    `json:"partNumber"`
+		SHA1   string `json:"contentSha1"`
+		Size   int64  `json:"contentLength"`
+	} `json:"parts"`
+}
+
+type getUploadPartURLRequest struct {
+	ID string `json:"fileId"`
+}
+
+type getUploadPartURLResponse struct {
+	URL   string `json:"uploadUrl"`
+	Token string `json:"authorizationToken"`
+}
+
+type FinishLargeFileRequest struct {
+	ID     string   `json:"fileId"`
+	Hashes []string `json:"partSha1Array"`
+}
+
+type FinishLargeFileResponse struct {
+	Name      string `json:"fileName"`
+	FileID    string `json:"fileId"`
+	Timestamp int64  `json:"uploadTimestamp"`
+	Action    string `json:"action"`
+}
+
+type ListFileNamesRequest struct {
+	BucketID     string `json:"bucketId"`
+	Count        int    `json:"maxFileCount"`
+	Continuation string `json:"startFileName,omitempty"`
+}
+
+type ListFileNamesResponse struct {
+	Continuation string `json:"nextFileName"`
+	Files        []struct {
+		FileID    string `json:"fileId"`
+		Name      string `json:"fileName"`
+		Size      int64  `json:"size"`
+		Action    string `json:"action"`
+		Timestamp int64  `json:"uploadTimestamp"`
+	} `json:"files"`
+}
+
+type ListFileVersionsRequest struct {
+	BucketID  string `json:"bucketId"`
+	Count     int    `json:"maxFileCount"`
+	StartName string `json:"startFileName,omitempty"`
+	StartID   string `json:"startFileId,omitempty"`
+}
+
+type ListFileVersionsResponse struct {
+	NextName string `json:"nextFileName"`
+	NextID   string `json:"nextFileId"`
+	Files    []struct {
+		FileID    string `json:"fileId"`
+		Name      string `json:"fileName"`
+		Size      int64  `json:"size"`
+		Action    string `json:"action"`
+		Timestamp int64  `json:"uploadTimestamp"`
+	} `json:"files"`
+}
+
+type HideFileRequest struct {
+	BucketID string `json:"bucketId"`
+	File     string `json:"fileName"`
+}
+
+type HideFileResponse struct {
+	ID        string `json:"fileId"`
+	Timestamp int64  `json:"uploadTimestamp"`
+	Action    string `json:"action"`
+}
+
+type GetFileInfoRequest struct {
+	ID string `json:"fileId"`
+}
+
+type GetFileInfoResponse struct {
+	Name        string            `json:"fileName"`
+	SHA1        string            `json:"contentSha1"`
+	Size        int64             `json:"contentLength"`
+	ContentType string            `json:"contentType"`
+	Info        map[string]string `json:"fileInfo"`
+	Action      string            `json:"action"`
+	Timestamp   int64             `json:"uploadTimestamp"`
+}
+
+type GetDownloadAuthorizationRequest struct {
+	BucketID string `json:"bucketId"`
+	Prefix   string `json:"fileNamePrefix"`
+	Valid    int    `json:"validDurationInSeconds"`
+}
+
+type GetDownloadAuthorizationResponse struct {
+	BucketID string `json:"bucketId"`
+	Prefix   string `json:"fileNamePrefix"`
+	Token    string `json:"authorizationToken"`
+}


### PR DESCRIPTION
This PR implements support for Backblaze B2 as a storage backend using kurin's [blazer](https://github.com/kurin/blazer) package. The code is based on the S3 backend.

Like the S3 backend, the B2 account ID and key credentials should be specified by environment variables (`B2_ACCOUNT_ID` and `B2_ACCOUNT_KEY`), while the B2 bucket name and path prefix are specified through the repository URL in the format: `b2:<bucket name>` or `b2:<bucket name>:<prefix path>`.

If you register with Backblaze B2, you should be able to run the full test suite against the B2 API at least once daily and stay within the free limits. By raising the caps to a modest amount (less than $1 total), you would be able to run the full test suite multiple times.

Resolves #512.
