### PR TITLE
Align path names generated for file and S3 backend

### DIFF
--- a/src/cmds/restic/global.go
+++ b/src/cmds/restic/global.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"restic"
 	"runtime"
+	"strconv"
 	"strings"
 	"syscall"
 
@@ -326,6 +327,7 @@ func open(s string) (restic.Backend, error) {
 		if cfg.Secret == "" {
 			cfg.Secret = os.Getenv("AWS_SECRET_ACCESS_KEY")
 		}
+		cfg.LegacyPaths, _ = strconv.ParseBool(os.Getenv("AWS_LEGACY_PATHS"))
 
 		debug.Log("opening s3 repository at %#v", cfg)
 		be, err = s3.Open(cfg)

--- a/src/restic/backend/paths.go
+++ b/src/restic/backend/paths.go
@@ -30,7 +30,7 @@ var Paths = struct {
 // backends.
 var Modes = struct{ Dir, File os.FileMode }{0700, 0600}
 
-// Construct default directory for given FileType.
+// Dirname constructs the default directory for given FileType.
 func Dirname(base string, t restic.FileType, name string) string {
 	var n string
 	switch t {
@@ -51,7 +51,7 @@ func Dirname(base string, t restic.FileType, name string) string {
 	return filepath.Join(base, n)
 }
 
-// Construct default path for given FileType and name.
+// Filename constructs the default path for given FileType and name.
 func Filename(base string, t restic.FileType, name string) string {
 	if t == restic.ConfigFile {
 		return filepath.Join(base, "config")

--- a/src/restic/backend/paths.go
+++ b/src/restic/backend/paths.go
@@ -1,6 +1,11 @@
 package backend
 
-import "os"
+import (
+	"os"
+	"path/filepath"
+
+	"restic"
+)
 
 // Paths contains the default paths for file-based backends (e.g. local).
 var Paths = struct {
@@ -24,3 +29,33 @@ var Paths = struct {
 // Modes holds the default modes for directories and files for file-based
 // backends.
 var Modes = struct{ Dir, File os.FileMode }{0700, 0600}
+
+// Construct default directory for given FileType.
+func Dirname(base string, t restic.FileType, name string) string {
+	var n string
+	switch t {
+	case restic.DataFile:
+		n = Paths.Data
+		if len(name) > 2 {
+			n = filepath.Join(n, name[:2])
+		}
+	case restic.SnapshotFile:
+		n = Paths.Snapshots
+	case restic.IndexFile:
+		n = Paths.Index
+	case restic.LockFile:
+		n = Paths.Locks
+	case restic.KeyFile:
+		n = Paths.Keys
+	}
+	return filepath.Join(base, n)
+}
+
+// Construct default path for given FileType and name.
+func Filename(base string, t restic.FileType, name string) string {
+	if t == restic.ConfigFile {
+		return filepath.Join(base, "config")
+	}
+
+	return filepath.Join(Dirname(base, t, name), name)
+}

--- a/src/restic/backend/s3/config.go
+++ b/src/restic/backend/s3/config.go
@@ -13,6 +13,7 @@ import (
 type Config struct {
 	Endpoint      string
 	UseHTTP       bool
+	LegacyPaths   bool
 	KeyID, Secret string
 	Bucket        string
 	Prefix        string

--- a/src/restic/backend/s3/s3.go
+++ b/src/restic/backend/s3/s3.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/minio/minio-go"
 
+	"restic/backend"
 	"restic/debug"
 )
 
@@ -18,10 +19,11 @@ const connLimit = 10
 
 // s3 is a backend which stores the data on an S3 endpoint.
 type s3 struct {
-	client     *minio.Client
-	connChan   chan struct{}
-	bucketname string
-	prefix     string
+	client      *minio.Client
+	connChan    chan struct{}
+	bucketname  string
+	prefix      string
+	legacyPaths bool
 }
 
 // Open opens the S3 backend at bucket and region. The bucket is created if it
@@ -34,7 +36,7 @@ func Open(cfg Config) (restic.Backend, error) {
 		return nil, errors.Wrap(err, "minio.New")
 	}
 
-	be := &s3{client: client, bucketname: cfg.Bucket, prefix: cfg.Prefix}
+	be := &s3{client: client, bucketname: cfg.Bucket, prefix: cfg.Prefix, legacyPaths: cfg.LegacyPaths}
 	be.createConnections()
 
 	found, err := client.BucketExists(cfg.Bucket)
@@ -55,10 +57,14 @@ func Open(cfg Config) (restic.Backend, error) {
 }
 
 func (be *s3) s3path(t restic.FileType, name string) string {
-	if t == restic.ConfigFile {
-		return path.Join(be.prefix, string(t))
+	// Use legacy paths if requested
+	if be.legacyPaths {
+		if t == restic.ConfigFile {
+			return path.Join(be.prefix, string(t))
+		}
+		return path.Join(be.prefix, string(t), name)
 	}
-	return path.Join(be.prefix, string(t), name)
+	return backend.Filename(be.prefix, t, name)
 }
 
 func (be *s3) createConnections() {

--- a/src/restic/backend/s3/s3.go
+++ b/src/restic/backend/s3/s3.go
@@ -247,7 +247,8 @@ func (be *s3) List(t restic.FileType, done <-chan struct{}) <-chan string {
 	go func() {
 		defer close(ch)
 		for obj := range listresp {
-			m := strings.TrimPrefix(obj.Key, prefix)
+			s := strings.Split(obj.Key, "/")
+			m := s[len(s)-1]
 			if m == "" {
 				continue
 			}


### PR DESCRIPTION
This aligns the path names generated for S3 backend to the ones used by
the file backend allowing S3 objects to be used as file backend and
vice versa.

Dirname and Filename generation logic have moved from file backend to
tha backend package.

Added a environment variable (AWS_LEGACY_PATHS) to S3 backend which
cat be set to true to switch to legacy pathnames (to be used with
existing repositories).

See #654 for a discussion about this.
I decided to step in with a very simple proposal on how to solve this. Especially because there are some pull requests for new backend that will use the same path names as S3.
This is probably not the best (or even wanted) solution as it requires S3 users to set a additional environment variable to be able to use their repository but I think it's the easiest one and I wanted to push the discussion forward.

We could provide an additional tool for "one-shot" migrations from "legacy S3" to "new style S3" backend paths so that restic does not have to maintain two different path styles forever.

(Please be lenient with me as I'm in no way familiar with go :smiley: )