### PR TITLE
Remove timestamp from `version` command

### DIFF
--- a/build.go
+++ b/build.go
@@ -12,7 +12,6 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 )
 
 var (
@@ -32,8 +31,6 @@ var config = struct {
 	Main:      "cmds/restic",                      // package name for the main package
 	Tests:     []string{"restic/...", "cmds/..."}, // tests to run
 }
-
-const timeFormat = "2006-01-02 15:04:05"
 
 // specialDir returns true if the file begins with a special character ('.' or '_').
 func specialDir(name string) bool {
@@ -392,8 +389,7 @@ func main() {
 	output := filepath.Join(cwd, outputFilename)
 
 	version := getVersion()
-	compileTime := time.Now().Format(timeFormat)
-	constants := Constants{`main.compiledAt`: compileTime}
+	constants := Constants{}
 	if version != "" {
 		constants["main.version"] = version
 	}

--- a/src/cmds/restic/cmd_version.go
+++ b/src/cmds/restic/cmd_version.go
@@ -15,8 +15,8 @@ The "version" command prints detailed information about the build environment
 and the version of this software.
 `,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("restic %s\ncompiled at %s with %v on %v/%v\n",
-			version, compiledAt, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		fmt.Printf("restic %s\ncompiled with %v on %v/%v\n",
+			version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	},
 }
 

--- a/src/cmds/restic/global.go
+++ b/src/cmds/restic/global.go
@@ -26,7 +26,6 @@ import (
 )
 
 var version = "compiled manually"
-var compiledAt = "unknown time"
 
 func parseEnvironment(cmd *cobra.Command, args []string) {
 	repo := os.Getenv("RESTIC_REPOSITORY")


### PR DESCRIPTION
This enables reproducible builds, for details see
https://reproducible-builds.org/docs/timestamps/