### PR TITLE
CLI options now override env vars

### DIFF
--- a/src/cmds/restic/global.go
+++ b/src/cmds/restic/global.go
@@ -25,18 +25,6 @@ import (
 
 var version = "compiled manually"
 
-func parseEnvironment() {
-	repo := os.Getenv("RESTIC_REPOSITORY")
-	if repo != "" {
-		globalOptions.Repo = repo
-	}
-
-	pw := os.Getenv("RESTIC_PASSWORD")
-	if pw != "" {
-		globalOptions.password = pw
-	}
-}
-
 // GlobalOptions hold all global options for restic.
 type GlobalOptions struct {
 	Repo         string
@@ -55,9 +43,13 @@ var globalOptions = GlobalOptions{
 }
 
 func init() {
-	parseEnvironment()
+	pw := os.Getenv("RESTIC_PASSWORD")
+	if pw != "" {
+		globalOptions.password = pw
+	}
+
 	f := cmdRoot.PersistentFlags()
-	f.StringVarP(&globalOptions.Repo, "repo", "r", "", "repository to backup to or restore from (default: $RESTIC_REPOSITORY)")
+	f.StringVarP(&globalOptions.Repo, "repo", "r", os.Getenv("RESTIC_REPOSITORY"), "repository to backup to or restore from (default: $RESTIC_REPOSITORY)")
 	f.StringVarP(&globalOptions.PasswordFile, "password-file", "p", "", "read the repository password from a file")
 	f.BoolVarP(&globalOptions.Quiet, "quiet", "q", false, "do not outputcomprehensive progress report")
 	f.BoolVar(&globalOptions.NoLock, "no-lock", false, "do not lock the repo, this allows some operations on read-only repos")

--- a/src/cmds/restic/global.go
+++ b/src/cmds/restic/global.go
@@ -10,8 +10,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/spf13/cobra"
-
 	"restic/backend/local"
 	"restic/backend/rest"
 	"restic/backend/s3"
@@ -27,7 +25,7 @@ import (
 
 var version = "compiled manually"
 
-func parseEnvironment(cmd *cobra.Command, args []string) {
+func parseEnvironment() {
 	repo := os.Getenv("RESTIC_REPOSITORY")
 	if repo != "" {
 		globalOptions.Repo = repo
@@ -57,6 +55,7 @@ var globalOptions = GlobalOptions{
 }
 
 func init() {
+	parseEnvironment()
 	f := cmdRoot.PersistentFlags()
 	f.StringVarP(&globalOptions.Repo, "repo", "r", "", "repository to backup to or restore from (default: $RESTIC_REPOSITORY)")
 	f.StringVarP(&globalOptions.PasswordFile, "password-file", "p", "", "read the repository password from a file")

--- a/src/cmds/restic/main.go
+++ b/src/cmds/restic/main.go
@@ -20,9 +20,8 @@ var cmdRoot = &cobra.Command{
 restic is a backup program which allows saving multiple revisions of files and
 directories in an encrypted repository stored on different backends.
 `,
-	SilenceErrors:    true,
-	SilenceUsage:     true,
-	PersistentPreRun: parseEnvironment,
+	SilenceErrors: true,
+	SilenceUsage:  true,
 }
 
 func init() {


### PR DESCRIPTION
In testing restic, I had an env variable RESTIC_REPOSITORY that was my "main" or "real" backup location, but then I ran `restic --repo /other/repo/for/testing init` and it still tried to use the value in RESTIC_REPOSITORY. This change re-prioritizes CLI flags over env vars, which in my opinion, is more intuitive.

I hope it's on the right track, I noticed that the `parseEnvironment()` function didn't use any of its parameters and I didn't see why it needed to happen outside of the `init()`.

Let me know if you need anything in the way of testing this.