### PR TITLE
fix typo: outputcomprehensive

### DIFF
--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -77,7 +77,7 @@ Available Commands:
 Flags:
       --no-lock                do not lock the repo, this allows some operations on read-only repos
   -p, --password-file string   read the repository password from a file
-  -q, --quiet                  do not outputcomprehensive progress report
+  -q, --quiet                  do not output comprehensive progress report
   -r, --repo string            repository to backup to or restore from (default: $RESTIC_REPOSITORY)
 
 Use "restic [command] --help" for more information about a command.
@@ -110,7 +110,7 @@ Flags:
 Global Flags:
       --no-lock                do not lock the repo, this allows some operations on read-only repos
   -p, --password-file string   read the repository password from a file
-  -q, --quiet                  do not outputcomprehensive progress report
+  -q, --quiet                  do not output comprehensive progress report
   -r, --repo string            repository to backup to or restore from (default: $RESTIC_REPOSITORY)
 ```
 

--- a/src/cmds/restic/global.go
+++ b/src/cmds/restic/global.go
@@ -51,7 +51,7 @@ func init() {
 	f := cmdRoot.PersistentFlags()
 	f.StringVarP(&globalOptions.Repo, "repo", "r", os.Getenv("RESTIC_REPOSITORY"), "repository to backup to or restore from (default: $RESTIC_REPOSITORY)")
 	f.StringVarP(&globalOptions.PasswordFile, "password-file", "p", "", "read the repository password from a file")
-	f.BoolVarP(&globalOptions.Quiet, "quiet", "q", false, "do not outputcomprehensive progress report")
+	f.BoolVarP(&globalOptions.Quiet, "quiet", "q", false, "do not output comprehensive progress report")
 	f.BoolVar(&globalOptions.NoLock, "no-lock", false, "do not lock the repo, this allows some operations on read-only repos")
 
 	restoreTerminal()


### PR DESCRIPTION
Just fix a small typo