### PR TITLE
Add box-drawing character to the snapshots command

### DIFF
--- a/src/cmds/restic/cmd_snapshots.go
+++ b/src/cmds/restic/cmd_snapshots.go
@@ -57,8 +57,8 @@ func runSnapshots(opts SnapshotOptions, gopts GlobalOptions, args []string) erro
 	}
 
 	tab := NewTable()
-	tab.Header = fmt.Sprintf("%-8s  %-19s  %-10s  %-10s  %s", "ID", "Date", "Host", "Tags", "Directory")
-	tab.RowFormat = "%-8s  %-19s  %-10s  %-10s  %s"
+	tab.Header = fmt.Sprintf("%-8s  %-19s  %-10s  %-10s  %-3s %s", "ID", "Date", "Host", "Tags", "", "Directory")
+	tab.RowFormat = "%-8s  %-19s  %-10s  %-10s  %-3s %s"
 
 	done := make(chan struct{})
 	defer close(done)
@@ -97,9 +97,15 @@ func runSnapshots(opts SnapshotOptions, gopts GlobalOptions, args []string) erro
 			firstTag = sn.Tags[0]
 		}
 
-		tab.Rows = append(tab.Rows, []interface{}{sn.ID().Str(), sn.Time.Format(TimeFormat), sn.Hostname, firstTag, sn.Paths[0]})
-
 		rows := len(sn.Paths)
+
+		treeElement := "   "
+		if rows != 1 {
+			treeElement = "┌──"
+		}
+
+		tab.Rows = append(tab.Rows, []interface{}{sn.ID().Str(), sn.Time.Format(TimeFormat), sn.Hostname, firstTag, treeElement, sn.Paths[0]})
+
 		if len(sn.Tags) > rows {
 			rows = len(sn.Tags)
 		}
@@ -115,7 +121,12 @@ func runSnapshots(opts SnapshotOptions, gopts GlobalOptions, args []string) erro
 				tag = sn.Tags[i]
 			}
 
-			tab.Rows = append(tab.Rows, []interface{}{"", "", "", tag, path})
+			treeElement := "│"
+			if i == (rows - 1) {
+				treeElement = "└──"
+			}
+
+			tab.Rows = append(tab.Rows, []interface{}{"", "", "", tag, treeElement, path})
 		}
 	}
 


### PR DESCRIPTION
The following pull request adds box-drawing characters to the output of the snapshot command to visualize which directory belongs to which snapshot. It looks like the following:

```
   ID           Date                 Host        Tags        Directory
----------------------------------------------------------------------
├──97d80712     2017-01-17 12:47:26  voyager                 /home/cit/Videos
├──6def47be     2017-01-17 14:03:07  voyager                 /home/cit/Dokumente
│  └──                                                       /home/cit/Videos
├──2a74e4fa     2017-01-17 14:12:37  voyager                 /home/cit/Backup
│  ├──                                                       /home/cit/Dokumente
│  └──                                                       /home/cit/Videos
├──f02dd44d     2017-01-17 20:37:23  voyager                 /home/cit/Backup
│  ├──                                                       /home/cit/Dokumente
│  ├──                                                       /home/cit/Sync
│  └──                                                       /home/cit/Videos
```