### PR TITLE
Fix restore/fuse with larger files

### DIFF
--- a/src/restic/checker/checker_test.go
+++ b/src/restic/checker/checker_test.go
@@ -9,7 +9,6 @@ import (
 
 	"restic"
 	"restic/archiver"
-	"restic/backend/mem"
 	"restic/checker"
 	"restic/repository"
 	"restic/test"
@@ -249,19 +248,15 @@ func induceError(data []byte) {
 }
 
 func TestCheckerModifiedData(t *testing.T) {
-	be := mem.New()
-
-	repository.TestUseLowSecurityKDFParameters(t)
-
-	repo := repository.New(be)
-	test.OK(t, repo.Init(test.TestPassword))
+	repo, cleanup := repository.TestRepository(t)
+	defer cleanup()
 
 	arch := archiver.New(repo)
 	_, id, err := arch.Snapshot(nil, []string{"."}, nil, nil)
 	test.OK(t, err)
 	t.Logf("archived as %v", id.Str())
 
-	beError := &errorBackend{Backend: be}
+	beError := &errorBackend{Backend: repo.Backend()}
 	checkRepo := repository.New(beError)
 	test.OK(t, checkRepo.SearchKey(test.TestPassword, 5))
 

--- a/src/restic/readerat.go
+++ b/src/restic/readerat.go
@@ -2,6 +2,7 @@ package restic
 
 import (
 	"io"
+	"restic/debug"
 )
 
 type backendReaderAt struct {
@@ -20,6 +21,7 @@ func ReaderAt(be Backend, h Handle) io.ReaderAt {
 
 // ReadAt reads from the backend handle h at the given position.
 func ReadAt(be Backend, h Handle, offset int64, p []byte) (n int, err error) {
+	debug.Log("ReadAt(%v) at %v, len %v", h, offset, len(p))
 	rd, err := be.Load(h, len(p), offset)
 	if err != nil {
 		return 0, err
@@ -30,6 +32,8 @@ func ReadAt(be Backend, h Handle, offset int64, p []byte) (n int, err error) {
 	if err == nil {
 		err = e
 	}
+
+	debug.Log("ReadAt(%v) ReadFull returned %v bytes", h, n)
 
 	return n, err
 }

--- a/src/restic/repository/repository.go
+++ b/src/restic/repository/repository.go
@@ -520,7 +520,7 @@ func (r *Repository) Close() error {
 // be large enough to hold the encrypted blob, since it is used as scratch
 // space.
 func (r *Repository) LoadBlob(t restic.BlobType, id restic.ID, buf []byte) (int, error) {
-	debug.Log("load blob %v into buf %p", id.Str(), buf)
+	debug.Log("load blob %v into buf (len %v, cap %v)", id.Str(), len(buf), cap(buf))
 	size, err := r.idx.LookupSize(id, t)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
This fixes the bug introduced in 9a5b9253c4bce73a68b08e9f6bd6ac205d8ebc8f. Basically, too much data was read when `repo.LoadBlob()` was passed a too-large buffer.

In addition I've added a few more tests, especially for the fuse package.

Closes #742, #743