### PR TITLE
fuse: Improve memory usage

### DIFF
--- a/src/restic/fuse/file.go
+++ b/src/restic/fuse/file.go
@@ -91,6 +91,11 @@ func (f *file) getBlobAt(i int) (blob []byte, err error) {
 		return f.blobs[i], nil
 	}
 
+	// release earlier blobs
+	for j := 0; j < i; j++ {
+		f.blobs[j] = nil
+	}
+
 	buf := restic.NewBlobBuffer(f.sizes[i])
 	n, err := f.repo.LoadBlob(restic.DataBlob, f.node.Content[i], buf)
 	if err != nil {


### PR DESCRIPTION
Discard blobs that aren't in use any more. This greatly reduces memory
usage and will probably only trigger on sequential read (e.g. for
restore via fuse).

Closes #480