### PR TITLE
s3: Increase MaxIdleConnsPerHost

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,11 +14,11 @@
 #   docker run --rm -v $PWD:/home/travis/restic restic/test gb test -v ./backend
 #
 # build the image for an older version of Go:
-#   docker build --build-arg GOVERSION=1.3.3 -t restic/test:go1.3.3 .
+#   docker build --build-arg GOVERSION=1.6.4 -t restic/test:go1.6.4 .
 
 FROM ubuntu:14.04
 
-ARG GOVERSION=1.7
+ARG GOVERSION=1.7.5
 ARG GOARCH=amd64
 
 # install dependencies

--- a/src/restic/backend/rest/rest.go
+++ b/src/restic/backend/rest/rest.go
@@ -17,7 +17,7 @@ import (
 	"restic/backend"
 )
 
-const connLimit = 10
+const connLimit = 40
 
 // make sure the rest backend implements restic.Backend
 var _ restic.Backend = &restBackend{}

--- a/src/restic/backend/test/tests.go
+++ b/src/restic/backend/test/tests.go
@@ -245,21 +245,25 @@ func TestLoad(t testing.TB) {
 		buf, err := ioutil.ReadAll(rd)
 		if err != nil {
 			t.Errorf("Load(%d, %d) ReadAll() returned unexpected error: %v", l, o, err)
+			rd.Close()
 			continue
 		}
 
 		if l <= len(d) && len(buf) != l {
 			t.Errorf("Load(%d, %d) wrong number of bytes read: want %d, got %d", l, o, l, len(buf))
+			rd.Close()
 			continue
 		}
 
 		if l > len(d) && len(buf) != len(d) {
 			t.Errorf("Load(%d, %d) wrong number of bytes read for overlong read: want %d, got %d", l, o, l, len(buf))
+			rd.Close()
 			continue
 		}
 
 		if !bytes.Equal(buf, d) {
 			t.Errorf("Load(%d, %d) returned wrong bytes", l, o)
+			rd.Close()
 			continue
 		}
 


### PR DESCRIPTION
This increases the maximum number of idle connections to the s3 server. Additionally, a fix is included so that the maximum number of concurrent connections is limited.

Closes #791