### PR TITLE
Use non-formatting functions of errors for strings

### DIFF
--- a/src/cmds/restic/cmd_backup.go
+++ b/src/cmds/restic/cmd_backup.go
@@ -237,7 +237,7 @@ func gatherDevices(items []string) (deviceMap map[uint64]struct{}, err error) {
 
 func readBackupFromStdin(opts BackupOptions, gopts GlobalOptions, args []string) error {
 	if len(args) != 0 {
-		return errors.Fatalf("when reading from stdin, no additional files can be specified")
+		return errors.Fatal("when reading from stdin, no additional files can be specified")
 	}
 
 	if opts.StdinFilename == "" {
@@ -321,7 +321,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 	// same time
 	args = append(args, fromfile...)
 	if len(args) == 0 {
-		return errors.Fatalf("wrong number of parameters")
+		return errors.Fatal("wrong number of parameters")
 	}
 
 	target := make([]string, 0, len(args))

--- a/src/cmds/restic/cmd_cat.go
+++ b/src/cmds/restic/cmd_cat.go
@@ -30,7 +30,7 @@ func init() {
 
 func runCat(gopts GlobalOptions, args []string) error {
 	if len(args) < 1 || (args[0] != "masterkey" && args[0] != "config" && len(args) != 2) {
-		return errors.Fatalf("type or ID not specified")
+		return errors.Fatal("type or ID not specified")
 	}
 
 	repo, err := OpenRepository(gopts)

--- a/src/cmds/restic/cmd_dump.go
+++ b/src/cmds/restic/cmd_dump.go
@@ -168,7 +168,7 @@ func dumpIndexes(repo restic.Repository) error {
 
 func runDump(gopts GlobalOptions, args []string) error {
 	if len(args) != 1 {
-		return errors.Fatalf("type not specified")
+		return errors.Fatal("type not specified")
 	}
 
 	repo, err := OpenRepository(gopts)

--- a/src/cmds/restic/cmd_find.go
+++ b/src/cmds/restic/cmd_find.go
@@ -148,7 +148,7 @@ func findInSnapshot(repo *repository.Repository, pat findPattern, id restic.ID) 
 
 func runFind(opts FindOptions, gopts GlobalOptions, args []string) error {
 	if len(args) != 1 {
-		return errors.Fatalf("wrong number of arguments")
+		return errors.Fatal("wrong number of arguments")
 	}
 
 	var (

--- a/src/cmds/restic/cmd_key.go
+++ b/src/cmds/restic/cmd_key.go
@@ -121,7 +121,7 @@ func changePassword(gopts GlobalOptions, repo *repository.Repository) error {
 
 func runKey(gopts GlobalOptions, args []string) error {
 	if len(args) < 1 || (args[0] == "rm" && len(args) != 2) {
-		return errors.Fatalf("wrong number of arguments")
+		return errors.Fatal("wrong number of arguments")
 	}
 
 	repo, err := OpenRepository(gopts)

--- a/src/cmds/restic/cmd_list.go
+++ b/src/cmds/restic/cmd_list.go
@@ -26,7 +26,7 @@ func init() {
 
 func runList(opts GlobalOptions, args []string) error {
 	if len(args) != 1 {
-		return errors.Fatalf("type not specified")
+		return errors.Fatal("type not specified")
 	}
 
 	repo, err := OpenRepository(opts)

--- a/src/cmds/restic/cmd_ls.go
+++ b/src/cmds/restic/cmd_ls.go
@@ -86,7 +86,7 @@ func printTree(prefix string, repo *repository.Repository, id restic.ID) error {
 
 func runLs(gopts GlobalOptions, args []string) error {
 	if len(args) < 1 || len(args) > 2 {
-		return errors.Fatalf("no snapshot ID given")
+		return errors.Fatal("no snapshot ID given")
 	}
 
 	repo, err := OpenRepository(gopts)

--- a/src/cmds/restic/cmd_mount.go
+++ b/src/cmds/restic/cmd_mount.go
@@ -95,7 +95,7 @@ func umount(mountpoint string) error {
 
 func runMount(opts MountOptions, gopts GlobalOptions, args []string) error {
 	if len(args) == 0 {
-		return errors.Fatalf("wrong number of parameters")
+		return errors.Fatal("wrong number of parameters")
 	}
 
 	mountpoint := args[0]

--- a/src/cmds/restic/cmd_restore.go
+++ b/src/cmds/restic/cmd_restore.go
@@ -49,7 +49,7 @@ func init() {
 
 func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 	if len(args) != 1 {
-		return errors.Fatalf("no snapshot ID specified")
+		return errors.Fatal("no snapshot ID specified")
 	}
 
 	if opts.Target == "" {

--- a/src/cmds/restic/cmd_snapshots.go
+++ b/src/cmds/restic/cmd_snapshots.go
@@ -40,7 +40,7 @@ func init() {
 
 func runSnapshots(opts SnapshotOptions, gopts GlobalOptions, args []string) error {
 	if len(args) != 0 {
-		return errors.Fatalf("wrong number of arguments")
+		return errors.Fatal("wrong number of arguments")
 	}
 
 	repo, err := OpenRepository(gopts)

--- a/src/restic/backend/s3/s3.go
+++ b/src/restic/backend/s3/s3.go
@@ -157,7 +157,7 @@ func (be *s3) Load(h restic.Handle, length int, offset int64) (io.ReadCloser, er
 
 	if offset > info.Size {
 		_ = obj.Close()
-		return nil, errors.Errorf("offset larger than file size")
+		return nil, errors.New("offset larger than file size")
 	}
 
 	l := int64(length)


### PR DESCRIPTION
Commands used:

    $ gofmt -w -r 'errors.Fatalf(x) -> errors.Fatal(x)' src
    $ gofmt -w -r 'errors.Errorf(x) -> errors.New(x)' src

Closes #789