### PR TITLE
Fix inconsistencies in CLI

### DIFF
--- a/src/cmds/restic/cmd_backup.go
+++ b/src/cmds/restic/cmd_backup.go
@@ -68,10 +68,10 @@ func init() {
 
 	f := cmdBackup.Flags()
 	f.StringVar(&backupOptions.Parent, "parent", "", "use this parent snapshot (default: last snapshot in the repo that has the same target files/directories)")
-	f.BoolVarP(&backupOptions.Force, "force", "f", false, `force re-reading the target files/directories. Overrides the "parent" flag`)
+	f.BoolVarP(&backupOptions.Force, "force", "f", false, `force re-reading the target files/directories (overrides the "parent" flag)`)
 	f.StringSliceVarP(&backupOptions.Excludes, "exclude", "e", []string{}, "exclude a `pattern` (can be specified multiple times)")
 	f.StringVar(&backupOptions.ExcludeFile, "exclude-file", "", "read exclude patterns from a file")
-	f.BoolVarP(&backupOptions.ExcludeOtherFS, "one-file-system", "x", false, "Exclude other file systems")
+	f.BoolVarP(&backupOptions.ExcludeOtherFS, "one-file-system", "x", false, "exclude other file systems")
 	f.BoolVar(&backupOptions.Stdin, "stdin", false, "read backup from stdin")
 	f.StringVar(&backupOptions.StdinFilename, "stdin-filename", "stdin", "file name to use when reading from stdin")
 	f.StringSliceVar(&backupOptions.Tags, "tag", []string{}, "add a `tag` for the new snapshot (can be specified multiple times)")

--- a/src/cmds/restic/cmd_check.go
+++ b/src/cmds/restic/cmd_check.go
@@ -38,8 +38,8 @@ func init() {
 	cmdRoot.AddCommand(cmdCheck)
 
 	f := cmdCheck.Flags()
-	f.BoolVar(&checkOptions.ReadData, "read-data", false, "Read all data blobs")
-	f.BoolVar(&checkOptions.CheckUnused, "check-unused", false, "Find unused blobs")
+	f.BoolVar(&checkOptions.ReadData, "read-data", false, "read all data blobs")
+	f.BoolVar(&checkOptions.CheckUnused, "check-unused", false, "find unused blobs")
 }
 
 func newReadProgress(gopts GlobalOptions, todo restic.Stat) *restic.Progress {

--- a/src/cmds/restic/cmd_dump.go
+++ b/src/cmds/restic/cmd_dump.go
@@ -22,7 +22,7 @@ var cmdDump = &cobra.Command{
 	Use:   "dump [indexes|snapshots|trees|all|packs]",
 	Short: "dump data structures",
 	Long: `
-The "dump" command dumps data structures from a repository as JSON objects. It
+The "dump" command dumps data structures from the repository as JSON objects. It
 is used for debugging purposes only.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runDump(globalOptions, args)

--- a/src/cmds/restic/cmd_find.go
+++ b/src/cmds/restic/cmd_find.go
@@ -36,9 +36,9 @@ func init() {
 	cmdRoot.AddCommand(cmdFind)
 
 	f := cmdFind.Flags()
-	f.StringVarP(&findOptions.Oldest, "oldest", "o", "", "Oldest modification date/time")
-	f.StringVarP(&findOptions.Newest, "newest", "n", "", "Newest modification date/time")
-	f.StringVarP(&findOptions.Snapshot, "snapshot", "s", "", "Snapshot ID to search in")
+	f.StringVarP(&findOptions.Oldest, "oldest", "o", "", "oldest modification date/time")
+	f.StringVarP(&findOptions.Newest, "newest", "n", "", "newest modification date/time")
+	f.StringVarP(&findOptions.Snapshot, "snapshot", "s", "", "snapshot ID to search in")
 }
 
 type findPattern struct {

--- a/src/cmds/restic/cmd_key.go
+++ b/src/cmds/restic/cmd_key.go
@@ -14,7 +14,7 @@ var cmdKey = &cobra.Command{
 	Use:   "key [list|add|rm|passwd] [ID]",
 	Short: "manage keys (passwords)",
 	Long: `
-The "key" command manages keys (passwords) for accessing a repository.
+The "key" command manages keys (passwords) for accessing the repository.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runKey(globalOptions, args)

--- a/src/cmds/restic/cmd_key.go
+++ b/src/cmds/restic/cmd_key.go
@@ -120,7 +120,7 @@ func changePassword(gopts GlobalOptions, repo *repository.Repository) error {
 }
 
 func runKey(gopts GlobalOptions, args []string) error {
-	if len(args) < 1 || (args[0] == "rm" && len(args) != 2) {
+	if len(args) < 1 || (args[0] == "rm" && len(args) != 2) || (args[0] != "rm" && len(args) != 1) {
 		return errors.Fatal("wrong number of arguments")
 	}
 

--- a/src/cmds/restic/cmd_list.go
+++ b/src/cmds/restic/cmd_list.go
@@ -13,7 +13,7 @@ var cmdList = &cobra.Command{
 	Use:   "list [blobs|packs|index|snapshots|keys|locks]",
 	Short: "list objects in the repository",
 	Long: `
-
+The "list" command allows listing objects in the repository based on type.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runList(globalOptions, args)

--- a/src/cmds/restic/cmd_list.go
+++ b/src/cmds/restic/cmd_list.go
@@ -11,7 +11,7 @@ import (
 
 var cmdList = &cobra.Command{
 	Use:   "list [blobs|packs|index|snapshots|keys|locks]",
-	Short: "list items in the repository",
+	Short: "list objects in the repository",
 	Long: `
 
 `,

--- a/src/cmds/restic/cmd_rebuild_index.go
+++ b/src/cmds/restic/cmd_rebuild_index.go
@@ -10,8 +10,8 @@ var cmdRebuildIndex = &cobra.Command{
 	Use:   "rebuild-index [flags]",
 	Short: "build a new index file",
 	Long: `
-The "rebuild-index" command creates a new index by combining the index files
-into a new one.
+The "rebuild-index" command creates a new index based on the pack files in the
+repository.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runRebuildIndex(globalOptions)

--- a/src/cmds/restic/cmd_snapshots.go
+++ b/src/cmds/restic/cmd_snapshots.go
@@ -15,7 +15,7 @@ var cmdSnapshots = &cobra.Command{
 	Use:   "snapshots",
 	Short: "list all snapshots",
 	Long: `
-The "snapshots" command lists all snapshots stored in a repository.
+The "snapshots" command lists all snapshots stored in the repository.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runSnapshots(snapshotOptions, globalOptions, args)

--- a/src/cmds/restic/cmd_unlock.go
+++ b/src/cmds/restic/cmd_unlock.go
@@ -27,7 +27,7 @@ var unlockOptions UnlockOptions
 func init() {
 	cmdRoot.AddCommand(unlockCmd)
 
-	unlockCmd.Flags().BoolVar(&unlockOptions.RemoveAll, "remove-all", false, "Remove all locks, even non-stale ones")
+	unlockCmd.Flags().BoolVar(&unlockOptions.RemoveAll, "remove-all", false, "remove all locks, even non-stale ones")
 }
 
 func runUnlock(opts UnlockOptions, gopts GlobalOptions) error {

--- a/src/cmds/restic/cmd_version.go
+++ b/src/cmds/restic/cmd_version.go
@@ -9,7 +9,7 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print version information",
+	Short: "print version information",
 	Long: `
 The "version" command prints detailed information about the build environment
 and the version of this software.


### PR DESCRIPTION
I did a small review of the help text, and also found a bug in the number of arguments accepted for the key command.

The changes are small, so I didn't create a separate issue. Let me know if I should.