### PR TITLE
Allow filtering absolute paths

### DIFF
--- a/src/restic/restorer.go
+++ b/src/restic/restorer.go
@@ -116,11 +116,11 @@ func (res *Restorer) restoreNodeTo(node *Node, dir string, dst string, idx *Hard
 	return nil
 }
 
-// RestoreTo creates the directories and files in the snapshot below dir.
+// RestoreTo creates the directories and files in the snapshot below dst.
 // Before an item is created, res.Filter is called.
-func (res *Restorer) RestoreTo(dir string) error {
+func (res *Restorer) RestoreTo(dst string) error {
 	idx := NewHardlinkIndex()
-	return res.restoreTo(dir, string(filepath.Separator), *res.sn.Tree, idx)
+	return res.restoreTo(dst, string(filepath.Separator), *res.sn.Tree, idx)
 }
 
 // Snapshot returns the snapshot this restorer is configured to use.

--- a/src/restic/restorer.go
+++ b/src/restic/restorer.go
@@ -120,7 +120,7 @@ func (res *Restorer) restoreNodeTo(node *Node, dir string, dst string, idx *Hard
 // Before an item is created, res.Filter is called.
 func (res *Restorer) RestoreTo(dir string) error {
 	idx := NewHardlinkIndex()
-	return res.restoreTo(dir, "", *res.sn.Tree, idx)
+	return res.restoreTo(dir, string(filepath.Separator), *res.sn.Tree, idx)
 }
 
 // Snapshot returns the snapshot this restorer is configured to use.


### PR DESCRIPTION
Before, the restorer called the filter function with a relative path, this prevented anchoring absolute patterns (which just never matched). Now call the restore function with an absolute virtual path, starting at the filepath separator.

Closes #834 
Closes #374