### PR TITLE
Dynamic host,tag columns widths in snapshots command

### DIFF
--- a/src/cmds/restic/cmd_snapshots.go
+++ b/src/cmds/restic/cmd_snapshots.go
@@ -99,9 +99,22 @@ func runSnapshots(opts SnapshotOptions, gopts GlobalOptions, args []string) erro
 // printSnapshotsReadable prints a text table of the snapshots in list to stdout.
 func printSnapshotsReadable(stdout io.Writer, list []*restic.Snapshot) {
 
+	// Determine the max widths for host and tag.
+	maxHost, maxTag := 10, 6
+	for _, sn := range list {
+		if len(sn.Hostname) > maxHost {
+			maxHost = len(sn.Hostname)
+		}
+		for _, tag := range sn.Tags {
+			if len(tag) > maxTag {
+				maxTag = len(tag)
+			}
+		}
+	}
+
 	tab := NewTable()
-	tab.Header = fmt.Sprintf("%-8s  %-19s  %-10s  %-10s  %-3s %s", "ID", "Date", "Host", "Tags", "", "Directory")
-	tab.RowFormat = "%-8s  %-19s  %-10s  %-10s  %-3s %s"
+	tab.Header = fmt.Sprintf("%-8s  %-19s  %-*s  %-*s  %-3s %s", "ID", "Date", -maxHost, "Host", -maxTag, "Tags", "", "Directory")
+	tab.RowFormat = fmt.Sprintf("%%-8s  %%-19s  %%%ds  %%%ds  %%-3s %%s", -maxHost, -maxTag)
 
 	for _, sn := range list {
 		if len(sn.Paths) == 0 {


### PR DESCRIPTION
Ok, this irritated me now long enough. Columns widths are now dynamic, with reasonable minimums.
Example output. Note how my FQDN hostname are way longer than 10 chars.

```
$ ../../../bin/restic -r rest:http://qnap.******:8000 snapshots
ID        Date                 Host                   Tags        Directory
----------------------------------------------------------------------
15ec968d  2017-03-02 01:18:03  bigbox.**.********.**  CH      ┌── /
                                                              │   /boot
                                                              │   /boot/efi
                                                              └── /home
9e860414  2017-03-02 03:49:02  rp1.**.********.**     CH      ┌── /
                                                              └── /boot
af61db20  2017-03-03 12:26:20  bigbox.**.********.**  CH      ┌── /
                                                              │   /boot
                                                              │   /boot/efi
                                                              └── /home
167a5e40  2017-03-03 21:35:04  abuseio.********.**    NL          /
bc407177  2017-03-04 00:30:22  bigbox.**.********.**  CH      ┌── /
                                                              │   /boot
                                                              │   /boot/efi
                                                              └── /home
d09476f9  2017-03-05 00:30:22  bigbox.**.********.**  CH      ┌── /
                                                              │   /boot
                                                              │   /boot/efi
                                                              └── /home
```
(excuse the ascii art, the program created it :P)