### PR TITLE
Fix SamePaths() and make it into a receiver function

### DIFF
--- a/src/cmds/restic/cmd_snapshots.go
+++ b/src/cmds/restic/cmd_snapshots.go
@@ -68,7 +68,7 @@ func runSnapshots(opts SnapshotOptions, gopts GlobalOptions, args []string) erro
 			continue
 		}
 
-		if restic.SamePaths(sn.Paths, opts.Paths) && (opts.Host == "" || opts.Host == sn.Hostname) {
+		if (opts.Host == "" || opts.Host == sn.Hostname) && sn.HasPaths(opts.Paths) {
 			pos := sort.Search(len(list), func(i int) bool {
 				return list[i].Time.After(sn.Time)
 			})

--- a/src/cmds/restic/cmd_tag.go
+++ b/src/cmds/restic/cmd_tag.go
@@ -57,7 +57,7 @@ func changeTags(repo *repository.Repository, snapshotID restic.ID, setTags, addT
 	if err != nil {
 		return false, err
 	}
-	if (host != "" && host != sn.Hostname) || !sn.HasTags(tags) || !restic.SamePaths(sn.Paths, paths) {
+	if (host != "" && host != sn.Hostname) || !sn.HasTags(tags) || !sn.HasPaths(paths) {
 		return false, nil
 	}
 


### PR DESCRIPTION
Add `HasPath(paths []string) bool` to Snapshot for testing if the
snapshot has at least the paths given to the function.

Reimplemented SamePaths(paths []string) so it does what the name implies,
compare if all given paths are in the snapshot.

Closes #856