### PR TITLE
Fix layout issue in cmd_snapshot "ascii art"

### DIFF
--- a/src/cmds/restic/cmd_snapshots.go
+++ b/src/cmds/restic/cmd_snapshots.go
@@ -127,6 +127,9 @@ func printSnapshotsReadable(stdout io.Writer, list []*restic.Snapshot) {
 		}
 
 		rows := len(sn.Paths)
+		if rows < len(sn.Tags) {
+			rows = len(sn.Tags)
+		}
 
 		treeElement := "   "
 		if rows != 1 {


### PR DESCRIPTION
The layouter does not account for multi tags when determining the need for ascii art.

```console
36fd8178  2017-03-03 21:35:04  abuseio.polyware.nl    NL          /
                                                      A       └──
```
vs

```console
36fd8178  2017-03-03 21:35:04  abuseio.polyware.nl    NL      ┌── /
                                                      A       └──
```