### PR TITLE
Refactor cmd_forget

### DIFF
--- a/src/cmds/restic/cmd_snapshots.go
+++ b/src/cmds/restic/cmd_snapshots.go
@@ -91,13 +91,13 @@ func runSnapshots(opts SnapshotOptions, gopts GlobalOptions, args []string) erro
 		}
 		return nil
 	}
-	printSnapshotsReadable(gopts.stdout, list)
+	PrintSnapshots(gopts.stdout, list)
 
 	return nil
 }
 
-// printSnapshotsReadable prints a text table of the snapshots in list to stdout.
-func printSnapshotsReadable(stdout io.Writer, list []*restic.Snapshot) {
+// PrintSnapshots prints a text table of the snapshots in list to stdout.
+func PrintSnapshots(stdout io.Writer, list []*restic.Snapshot) {
 
 	// Determine the max widths for host and tag.
 	maxHost, maxTag := 10, 6


### PR DESCRIPTION
Add `--path` for snapshot filtering by path.

Add `--groupby-tags` for grouping on host,tags,dirs instead of host,dirs.

Borrow the snapshot printing from cmd_snapshot.

Closes #841