### PR TITLE
Add --tag filtering to every command, where applicable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: go
 sudo: false
 
 go:
-  - 1.6.4
   - 1.7.5
   - 1.8
   - tip
@@ -17,8 +16,6 @@ env:
 
 matrix:
   exclude:
-    - os: osx
-      go: 1.6.4
     - os: osx
       go: 1.7.5
     - os: osx

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,7 +77,7 @@ Just clone the repository, `cd` to it and run `gb build` to build the binary:
     [...]
     $ bin/restic version
     restic compiled manually
-    compiled at unknown time with go1.6
+    compiled at unknown time with go1.7
 
 The following commands can be used to run all the tests:
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ You can download the latest pre-compiled binary from the [restic release page](h
 Build restic
 ============
 
-Install Go/Golang (at least version 1.6), then run `go run build.go`,
+Install Go/Golang (at least version 1.7), then run `go run build.go`,
 afterwards you'll find the binary in the current directory:
 
     $ go run build.go

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,7 +1,7 @@
 # -*- mode: ruby -*-
 # vi: set ft=ruby :
 
-GO_VERSION = '1.6'
+GO_VERSION = '1.7'
 
 def packages_freebsd
   return <<-EOF

--- a/doc/Manual.md
+++ b/doc/Manual.md
@@ -27,7 +27,7 @@ $ pacaur -S restic-git
 
 # Building restic
 
-restic is written in the Go programming language and you need at least Go version 1.6.
+restic is written in the Go programming language and you need at least Go version 1.7.
 Building restic may also work with older versions of Go, but that's not supported.
 See the [Getting started](https://golang.org/doc/install) guide of the Go project for
 instructions how to install Go.

--- a/src/cmds/restic/cmd_backup.go
+++ b/src/cmds/restic/cmd_backup.go
@@ -67,12 +67,12 @@ func init() {
 	f := cmdBackup.Flags()
 	f.StringVar(&backupOptions.Parent, "parent", "", "use this parent snapshot (default: last snapshot in the repo that has the same target files/directories)")
 	f.BoolVarP(&backupOptions.Force, "force", "f", false, `force re-reading the target files/directories (overrides the "parent" flag)`)
-	f.StringSliceVarP(&backupOptions.Excludes, "exclude", "e", []string{}, "exclude a `pattern` (can be specified multiple times)")
+	f.StringSliceVarP(&backupOptions.Excludes, "exclude", "e", nil, "exclude a `pattern` (can be specified multiple times)")
 	f.StringVar(&backupOptions.ExcludeFile, "exclude-file", "", "read exclude patterns from a file")
 	f.BoolVarP(&backupOptions.ExcludeOtherFS, "one-file-system", "x", false, "exclude other file systems")
 	f.BoolVar(&backupOptions.Stdin, "stdin", false, "read backup from stdin")
 	f.StringVar(&backupOptions.StdinFilename, "stdin-filename", "stdin", "file name to use when reading from stdin")
-	f.StringSliceVar(&backupOptions.Tags, "tag", []string{}, "add a `tag` for the new snapshot (can be specified multiple times)")
+	f.StringSliceVar(&backupOptions.Tags, "tag", nil, "add a `tag` for the new snapshot (can be specified multiple times)")
 	f.StringVar(&backupOptions.Hostname, "hostname", hostname, "set the `hostname` for the snapshot manually")
 	f.StringVar(&backupOptions.FilesFrom, "files-from", "", "read the files to backup from file (can be combined with file args)")
 }
@@ -391,7 +391,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 
 	// Find last snapshot to set it as parent, if not already set
 	if !opts.Force && parentSnapshotID == nil {
-		id, err := restic.FindLatestSnapshot(repo, target, opts.Hostname)
+		id, err := restic.FindLatestSnapshot(repo, target, opts.Tags, opts.Hostname)
 		if err == nil {
 			parentSnapshotID = &id
 		} else if err != restic.ErrNoSnapshotFound {

--- a/src/cmds/restic/cmd_check.go
+++ b/src/cmds/restic/cmd_check.go
@@ -24,7 +24,7 @@ finds. It can also be used to read all data and therefore simulate a restore.
 	},
 }
 
-// CheckOptions bundle all options for the 'check' command.
+// CheckOptions bundles all options for the 'check' command.
 type CheckOptions struct {
 	ReadData    bool
 	CheckUnused bool

--- a/src/cmds/restic/cmd_find.go
+++ b/src/cmds/restic/cmd_find.go
@@ -24,7 +24,7 @@ repo. `,
 	},
 }
 
-// FindOptions bundle all options for the find command.
+// FindOptions bundles all options for the find command.
 type FindOptions struct {
 	Oldest          string
 	Newest          string

--- a/src/cmds/restic/cmd_restore.go
+++ b/src/cmds/restic/cmd_restore.go
@@ -31,6 +31,7 @@ type RestoreOptions struct {
 	Target  string
 	Host    string
 	Paths   []string
+	Tags    []string
 }
 
 var restoreOptions RestoreOptions
@@ -44,6 +45,7 @@ func init() {
 	flags.StringVarP(&restoreOptions.Target, "target", "t", "", "directory to extract data to")
 
 	flags.StringVarP(&restoreOptions.Host, "host", "H", "", `only consider snapshots for this host when the snapshot ID is "latest"`)
+	flags.StringSliceVar(&restoreOptions.Tags, "tag", nil, "only consider snapshots which include this `tag` for snapshot ID \"latest\"")
 	flags.StringSliceVar(&restoreOptions.Paths, "path", nil, "only consider snapshots which include this (absolute) `path` for snapshot ID \"latest\"")
 }
 
@@ -85,7 +87,7 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 	var id restic.ID
 
 	if snapshotIDString == "latest" {
-		id, err = restic.FindLatestSnapshot(repo, opts.Paths, opts.Host)
+		id, err = restic.FindLatestSnapshot(repo, opts.Paths, opts.Tags, opts.Host)
 		if err != nil {
 			Exitf(1, "latest snapshot for criteria not found: %v Paths:%v Host:%v", err, opts.Paths, opts.Host)
 		}

--- a/src/cmds/restic/cmd_snapshots.go
+++ b/src/cmds/restic/cmd_snapshots.go
@@ -23,7 +23,7 @@ The "snapshots" command lists all snapshots stored in the repository.
 	},
 }
 
-// SnapshotOptions bundle all options for the snapshots command.
+// SnapshotOptions bundles all options for the snapshots command.
 type SnapshotOptions struct {
 	Host  string
 	Paths []string

--- a/src/cmds/restic/find.go
+++ b/src/cmds/restic/find.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"context"
+
+	"restic"
+	"restic/repository"
+)
+
+// FindFilteredSnapshots yields Snapshots, either given explicitly by `snapshotIDs` or filtered from the list of all snapshots.
+func FindFilteredSnapshots(ctx context.Context, repo *repository.Repository, host string, tags []string, paths []string, snapshotIDs []string) <-chan *restic.Snapshot {
+	out := make(chan *restic.Snapshot)
+	go func() {
+		defer close(out)
+		if len(snapshotIDs) != 0 {
+			var (
+				id         restic.ID
+				usedFilter bool
+				err        error
+			)
+			ids := make(restic.IDs, 0, len(snapshotIDs))
+			// Process all snapshot IDs given as arguments.
+			for _, s := range snapshotIDs {
+				if s == "latest" {
+					id, err = restic.FindLatestSnapshot(repo, paths, tags, host)
+					if err != nil {
+						Warnf("Ignoring %q, no snapshot matched given filter (Paths:%v Tags:%v Host:%v)\n", s, paths, tags, host)
+						usedFilter = true
+						continue
+					}
+				} else {
+					id, err = restic.FindSnapshot(repo, s)
+					if err != nil {
+						Warnf("Ignoring %q, it is not a snapshot id\n", s)
+						continue
+					}
+				}
+				ids = append(ids, id)
+			}
+
+			// Give the user some indication their filters are not used.
+			if !usedFilter && (host != "" || len(tags) != 0 || len(paths) != 0) {
+				Warnf("Ignoring filters as there are explicit snapshot ids given\n")
+			}
+
+			for _, id := range ids.Uniq() {
+				sn, err := restic.LoadSnapshot(repo, id)
+				if err != nil {
+					Warnf("Ignoring %q, could not load snapshot: %v\n", id, err)
+					continue
+				}
+				select {
+				case <-ctx.Done():
+					return
+				case out <- sn:
+				}
+			}
+			return
+		}
+
+		for id := range repo.List(restic.SnapshotFile, ctx.Done()) {
+			sn, err := restic.LoadSnapshot(repo, id)
+			if err != nil {
+				Warnf("Ignoring %q, could not load snapshot: %v\n", id, err)
+				continue
+			}
+			if (host != "" && host != sn.Hostname) || !sn.HasTags(tags) || !sn.HasPaths(paths) {
+				continue
+			}
+			select {
+			case <-ctx.Done():
+				return
+			case out <- sn:
+			}
+		}
+	}()
+	return out
+}

--- a/src/cmds/restic/format.go
+++ b/src/cmds/restic/format.go
@@ -2,7 +2,11 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
+
+	"restic"
 )
 
 func formatBytes(c uint64) string {
@@ -57,4 +61,24 @@ func formatRate(bytes uint64, duration time.Duration) string {
 func formatDuration(d time.Duration) string {
 	sec := uint64(d / time.Second)
 	return formatSeconds(sec)
+}
+
+func formatNode(prefix string, n *restic.Node, long bool) string {
+	if !long {
+		return filepath.Join(prefix, n.Name)
+	}
+
+	switch n.Type {
+	case "file":
+		return fmt.Sprintf("%s %5d %5d %6d %s %s",
+			n.Mode, n.UID, n.GID, n.Size, n.ModTime.Format(TimeFormat), filepath.Join(prefix, n.Name))
+	case "dir":
+		return fmt.Sprintf("%s %5d %5d %6d %s %s",
+			n.Mode|os.ModeDir, n.UID, n.GID, n.Size, n.ModTime.Format(TimeFormat), filepath.Join(prefix, n.Name))
+	case "symlink":
+		return fmt.Sprintf("%s %5d %5d %6d %s %s -> %s",
+			n.Mode|os.ModeSymlink, n.UID, n.GID, n.Size, n.ModTime.Format(TimeFormat), filepath.Join(prefix, n.Name), n.LinkTarget)
+	default:
+		return fmt.Sprintf("<Node(%s) %s>", n.Type, n.Name)
+	}
 }

--- a/src/cmds/restic/global.go
+++ b/src/cmds/restic/global.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -33,6 +34,7 @@ type GlobalOptions struct {
 	NoLock       bool
 	JSON         bool
 
+	ctx      context.Context
 	password string
 	stdout   io.Writer
 	stderr   io.Writer
@@ -48,6 +50,13 @@ func init() {
 	if pw != "" {
 		globalOptions.password = pw
 	}
+
+	var cancel context.CancelFunc
+	globalOptions.ctx, cancel = context.WithCancel(context.Background())
+	AddCleanupHandler(func() error {
+		cancel()
+		return nil
+	})
 
 	f := cmdRoot.PersistentFlags()
 	f.StringVarP(&globalOptions.Repo, "repo", "r", os.Getenv("RESTIC_REPOSITORY"), "repository to backup to or restore from (default: $RESTIC_REPOSITORY)")

--- a/src/cmds/restic/integration_helpers_test.go
+++ b/src/cmds/restic/integration_helpers_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -194,6 +195,7 @@ func withTestEnvironment(t testing.TB, f func(*testEnvironment, GlobalOptions)) 
 	gopts := GlobalOptions{
 		Repo:     env.repo,
 		Quiet:    true,
+		ctx:      context.Background(),
 		password: TestPassword,
 		stdout:   os.Stdout,
 		stderr:   os.Stderr,

--- a/src/cmds/restic/integration_test.go
+++ b/src/cmds/restic/integration_test.go
@@ -142,7 +142,9 @@ func testRunLs(t testing.TB, gopts GlobalOptions, snapshotID string) []string {
 		globalOptions.Quiet = quiet
 	}()
 
-	OK(t, runLs(gopts, []string{snapshotID}))
+	opts := LsOptions{}
+
+	OK(t, runLs(opts, gopts, []string{snapshotID}))
 
 	return strings.Split(string(buf.Bytes()), "\n")
 }

--- a/src/restic/snapshot.go
+++ b/src/restic/snapshot.go
@@ -177,8 +177,8 @@ func (sn *Snapshot) SamePaths(paths []string) bool {
 // ErrNoSnapshotFound is returned when no snapshot for the given criteria could be found.
 var ErrNoSnapshotFound = errors.New("no snapshot found")
 
-// FindLatestSnapshot finds latest snapshot with optional target/directory and hostname filters.
-func FindLatestSnapshot(repo Repository, targets []string, hostname string) (ID, error) {
+// FindLatestSnapshot finds latest snapshot with optional target/directory, tags and hostname filters.
+func FindLatestSnapshot(repo Repository, targets []string, tags []string, hostname string) (ID, error) {
 	var (
 		latest   time.Time
 		latestID ID
@@ -190,7 +190,7 @@ func FindLatestSnapshot(repo Repository, targets []string, hostname string) (ID,
 		if err != nil {
 			return ID{}, errors.Errorf("Error listing snapshot: %v", err)
 		}
-		if snapshot.Time.After(latest) && snapshot.HasPaths(targets) && (hostname == "" || hostname == snapshot.Hostname) {
+		if snapshot.Time.After(latest) && (hostname == "" || hostname == snapshot.Hostname) && snapshot.HasTags(tags) && snapshot.HasPaths(targets) {
 			latest = snapshot.Time
 			latestID = snapshotID
 			found = true


### PR DESCRIPTION
Add helper function `FindFilteredSnapshots()` to handle the bulk of iterating
over the snapshots and perform filtering.

Started using contexts (which means minimal requirement is now Go 1.7)

Fixed long silent runs of `find` by outputting results as we find them.
(We lost the ability to print how many matches we found however.)

Made `mount` more interesting, it now applies filters when filling the
`snapshots` directory.

Closes #863