### PR TITLE
Ignore empty lines in excludes file, allow multiple files

### DIFF
--- a/src/cmds/restic/cmd_backup.go
+++ b/src/cmds/restic/cmd_backup.go
@@ -415,11 +415,20 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 
 		scanner := bufio.NewScanner(file)
 		for scanner.Scan() {
-			line := scanner.Text()
-			if !strings.HasPrefix(line, "#") {
-				line = os.ExpandEnv(line)
-				opts.Excludes = append(opts.Excludes, line)
+			line := strings.TrimSpace(scanner.Text())
+
+			// ignore empty lines
+			if line == "" {
+				continue
 			}
+
+			// strip comments
+			if strings.HasPrefix(line, "#") {
+				continue
+			}
+
+			line = os.ExpandEnv(line)
+			opts.Excludes = append(opts.Excludes, line)
 		}
 	}
 

--- a/src/cmds/restic/cmd_backup.go
+++ b/src/cmds/restic/cmd_backup.go
@@ -44,7 +44,7 @@ type BackupOptions struct {
 	Parent         string
 	Force          bool
 	Excludes       []string
-	ExcludeFile    string
+	ExcludeFiles   []string
 	ExcludeOtherFS bool
 	Stdin          bool
 	StdinFilename  string
@@ -68,7 +68,7 @@ func init() {
 	f.StringVar(&backupOptions.Parent, "parent", "", "use this parent snapshot (default: last snapshot in the repo that has the same target files/directories)")
 	f.BoolVarP(&backupOptions.Force, "force", "f", false, `force re-reading the target files/directories (overrides the "parent" flag)`)
 	f.StringSliceVarP(&backupOptions.Excludes, "exclude", "e", nil, "exclude a `pattern` (can be specified multiple times)")
-	f.StringVar(&backupOptions.ExcludeFile, "exclude-file", "", "read exclude patterns from a file")
+	f.StringSliceVar(&backupOptions.ExcludeFiles, "exclude-file", nil, "read exclude patterns from a `file` (can be specified multiple times)")
 	f.BoolVarP(&backupOptions.ExcludeOtherFS, "one-file-system", "x", false, "exclude other file systems")
 	f.BoolVar(&backupOptions.Stdin, "stdin", false, "read backup from stdin")
 	f.StringVar(&backupOptions.StdinFilename, "stdin-filename", "stdin", "file name to use when reading from stdin")
@@ -406,29 +406,31 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 	Verbosef("scan %v\n", target)
 
 	// add patterns from file
-	if opts.ExcludeFile != "" {
-		file, err := fs.Open(opts.ExcludeFile)
-		if err != nil {
-			Warnf("error reading exclude patterns: %v", err)
-			return nil
-		}
-
-		scanner := bufio.NewScanner(file)
-		for scanner.Scan() {
-			line := strings.TrimSpace(scanner.Text())
-
-			// ignore empty lines
-			if line == "" {
-				continue
+	if len(opts.ExcludeFiles) > 0 {
+		for _, filename := range opts.ExcludeFiles {
+			file, err := fs.Open(filename)
+			if err != nil {
+				Warnf("error reading exclude patterns: %v", err)
+				return nil
 			}
 
-			// strip comments
-			if strings.HasPrefix(line, "#") {
-				continue
-			}
+			scanner := bufio.NewScanner(file)
+			for scanner.Scan() {
+				line := strings.TrimSpace(scanner.Text())
 
-			line = os.ExpandEnv(line)
-			opts.Excludes = append(opts.Excludes, line)
+				// ignore empty lines
+				if line == "" {
+					continue
+				}
+
+				// strip comments
+				if strings.HasPrefix(line, "#") {
+					continue
+				}
+
+				line = os.ExpandEnv(line)
+				opts.Excludes = append(opts.Excludes, line)
+			}
 		}
 	}
 

--- a/src/restic/filter/filter.go
+++ b/src/restic/filter/filter.go
@@ -100,9 +100,14 @@ func match(patterns, strs []string) (matched bool, err error) {
 	return false, nil
 }
 
-// List returns true if str matches one of the patterns.
+// List returns true if str matches one of the patterns. Empty patterns are
+// ignored.
 func List(patterns []string, str string) (matched bool, err error) {
 	for _, pat := range patterns {
+		if pat == "" {
+			continue
+		}
+
 		matched, err = Match(pat, str)
 		if err != nil {
 			return false, err

--- a/src/restic/filter/filter_test.go
+++ b/src/restic/filter/filter_test.go
@@ -152,6 +152,7 @@ var filterListTests = []struct {
 	{[]string{"?", "x"}, "/foo/bar/x", true},
 	{[]string{"/*/*/bar/test.*"}, "/foo/bar/test.go", false},
 	{[]string{"/*/*/bar/test.*", "*.go"}, "/foo/bar/test.go", true},
+	{[]string{"", "*.c"}, "/foo/bar/test.go", false},
 }
 
 func TestMatchList(t *testing.T) {


### PR DESCRIPTION
This PR corrects handling empty lines in exclude files. In addition, users can now specify multiple exclude files, which are merged together for backup.

Closes #915