### PR TITLE
Small changes to cmd_forget and snapshot_filter

### DIFF
--- a/src/cmds/restic/cmd_forget.go
+++ b/src/cmds/restic/cmd_forget.go
@@ -90,7 +90,7 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 	}
 	snapshotGroups := make(map[string]restic.Snapshots)
 
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(gopts.ctx)
 	defer cancel()
 	for sn := range FindFilteredSnapshots(ctx, repo, opts.Host, opts.Tags, opts.Paths, args) {
 		if len(args) > 0 {

--- a/src/restic/snapshot_filter_test.go
+++ b/src/restic/snapshot_filter_test.go
@@ -91,6 +91,28 @@ func TestFilterSnapshots(t *testing.T) {
 	}
 }
 
+func TestExpireSnapshotOps(t *testing.T) {
+	data := []struct {
+		expectEmpty bool
+		expectSum   int
+		p           *restic.ExpirePolicy
+	}{
+		{true, 0, &restic.ExpirePolicy{}},
+		{true, 0, &restic.ExpirePolicy{Tags: []string{}}},
+		{false, 22, &restic.ExpirePolicy{Daily: 7, Weekly: 2, Monthly: 3, Yearly: 10}},
+	}
+	for i, d := range data {
+		isEmpty := d.p.Empty()
+		if isEmpty != d.expectEmpty {
+			t.Errorf("empty test %v: wrong result, want:\n  %#v\ngot:\n  %#v", i, d.expectEmpty, isEmpty)
+		}
+		hasSum := d.p.Sum()
+		if hasSum != d.expectSum {
+			t.Errorf("sum test %v: wrong result, want:\n  %#v\ngot:\n  %#v", i, d.expectSum, hasSum)
+		}
+	}
+}
+
 var testExpireSnapshots = restic.Snapshots{
 	{Time: parseTimeUTC("2014-09-01 10:20:30")},
 	{Time: parseTimeUTC("2014-09-02 10:20:30")},


### PR DESCRIPTION
Like all other CLI commands, cmd_forget should use the global context.

Update some variable names in snapshot_filter.apply to better show their behavior.