### PR TITLE
Improve s3 backend

### DIFF
--- a/src/restic/backend/s3/s3.go
+++ b/src/restic/backend/s3/s3.go
@@ -81,17 +81,17 @@ func (be *s3) Location() string {
 	return be.bucketname
 }
 
-type Sizer interface {
-	Size() int64
-}
-
-type Lenner interface {
-	Len() int
-}
-
 // getRemainingSize returns number of bytes remaining. If it is not possible to
 // determine the size, panic() is called.
 func getRemainingSize(rd io.Reader) (size int64, err error) {
+	type Sizer interface {
+		Size() int64
+	}
+
+	type Lenner interface {
+		Len() int
+	}
+
 	if r, ok := rd.(Lenner); ok {
 		size = int64(r.Len())
 	} else if r, ok := rd.(Sizer); ok {

--- a/src/restic/backend/s3/s3_internal_test.go
+++ b/src/restic/backend/s3/s3_internal_test.go
@@ -15,10 +15,6 @@ func writeFile(t testing.TB, data []byte, offset int64) *os.File {
 		t.Fatal(err)
 	}
 
-	if err = os.Remove(tempfile.Name()); err != nil {
-		t.Fatal(err)
-	}
-
 	if _, err = tempfile.Write(data); err != nil {
 		t.Fatal(err)
 	}
@@ -41,6 +37,15 @@ func TestGetRemainingSize(t *testing.T) {
 	_, _ = io.ReadFull(partReader, buf)
 
 	partFileReader := writeFile(t, data, int64(partialRead))
+	defer func() {
+		if err := partFileReader.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := os.Remove(partFileReader.Name()); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	var tests = []struct {
 		io.Reader

--- a/src/restic/backend/s3/s3_internal_test.go
+++ b/src/restic/backend/s3/s3_internal_test.go
@@ -1,0 +1,66 @@
+package s3
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"restic/test"
+	"testing"
+)
+
+func writeFile(t testing.TB, data []byte, offset int64) *os.File {
+	tempfile, err := ioutil.TempFile("", "restic-test-")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = os.Remove(tempfile.Name()); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = tempfile.Write(data); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err = tempfile.Seek(offset, io.SeekStart); err != nil {
+		t.Fatal(err)
+	}
+
+	return tempfile
+}
+
+func TestGetRemainingSize(t *testing.T) {
+	length := 18 * 1123
+	partialRead := 1005
+
+	data := test.Random(23, length)
+
+	partReader := bytes.NewReader(data)
+	buf := make([]byte, partialRead)
+	_, _ = io.ReadFull(partReader, buf)
+
+	partFileReader := writeFile(t, data, int64(partialRead))
+
+	var tests = []struct {
+		io.Reader
+		size int64
+	}{
+		{bytes.NewReader([]byte("foobar test")), 11},
+		{partReader, int64(length - partialRead)},
+		{partFileReader, int64(length - partialRead)},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			size, err := getRemainingSize(test.Reader)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if size != test.size {
+				t.Fatalf("invalid size returned, want %v, got %v", test.size, size)
+			}
+		})
+	}
+}

--- a/src/restic/backend/test/tests.go
+++ b/src/restic/backend/test/tests.go
@@ -293,7 +293,7 @@ func (s *Suite) TestSave(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if _, err = tmpfile.Seek(0, 0); err != nil {
+	if _, err = tmpfile.Seek(0, io.SeekStart); err != nil {
 		t.Fatal(err)
 	}
 
@@ -306,17 +306,32 @@ func (s *Suite) TestSave(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err = tmpfile.Close(); err != nil {
+	err = b.Remove(h)
+	if err != nil {
+		t.Fatalf("error removing item: %+v", err)
+	}
+
+	// try again directly with the temp file
+	if _, err = tmpfile.Seek(588, io.SeekStart); err != nil {
 		t.Fatal(err)
 	}
 
-	if err = os.Remove(tmpfile.Name()); err != nil {
+	err = b.Save(h, tmpfile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err = tmpfile.Close(); err != nil {
 		t.Fatal(err)
 	}
 
 	err = b.Remove(h)
 	if err != nil {
 		t.Fatalf("error removing item: %+v", err)
+	}
+
+	if err = os.Remove(tmpfile.Name()); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
This PR changes code to use a more low level API from minio-go to access a S3 server. Most of the high level stuff minio-go does isn't needed for restic anyway. The statistics (made with the new backend benchmarks) look really impressive: For some operations the memory allocations are down 99%!

**Note**: The upload/download bandwith to AWS S3 is limited by my Internet connection at home ;)

Save:

    benchmark                        old ns/op       new ns/op       delta
    BenchmarkBackendMinio/Save-4     184482294       40663344        -77.96%
    BenchmarkBackendS3/Save-4        35030825568     54475455819     +55.51%

    benchmark                        old MB/s     new MB/s     speedup
    BenchmarkBackendMinio/Save-4     90.95        412.64       4.54x
    BenchmarkBackendS3/Save-4        0.48         0.31         0.65x

    benchmark                        old allocs     new allocs     delta
    BenchmarkBackendMinio/Save-4     631            560            -11.25%
    BenchmarkBackendS3/Save-4        646            584            -9.60%

    benchmark                        old bytes     new bytes     delta
    BenchmarkBackendMinio/Save-4     66818060      50735         -99.92%
    BenchmarkBackendS3/Save-4        66834000      73024         -99.89%

Load:

    benchmark                                         old ns/op      new ns/op      delta
    BenchmarkBackendMinio/LoadFile-4                  9213315        11001787       +19.41%
    BenchmarkBackendMinio/LoadPartialFile-4           4176619        3479707        -16.69%
    BenchmarkBackendMinio/LoadPartialFileOffset-4     4391521        3139214        -28.52%
    BenchmarkBackendS3/LoadFile-4                     2886070905     2505907501     -13.17%
    BenchmarkBackendS3/LoadPartialFile-4              762702722      735694398      -3.54%
    BenchmarkBackendS3/LoadPartialFileOffset-4        789724328      1108989142     +40.43%

    benchmark                                         old MB/s     new MB/s     speedup
    BenchmarkBackendMinio/LoadFile-4                  1821.21      1525.15      0.84x
    BenchmarkBackendMinio/LoadPartialFile-4           1004.49      1205.67      1.20x
    BenchmarkBackendMinio/LoadPartialFileOffset-4     955.34       1336.45      1.40x
    BenchmarkBackendS3/LoadFile-4                     5.81         6.70         1.15x
    BenchmarkBackendS3/LoadPartialFile-4              5.50         5.70         1.04x
    BenchmarkBackendS3/LoadPartialFileOffset-4        5.31         3.78         0.71x

    benchmark                                         old allocs     new allocs     delta
    BenchmarkBackendMinio/LoadFile-4                  406            204            -49.75%
    BenchmarkBackendMinio/LoadPartialFile-4           225            206            -8.44%
    BenchmarkBackendMinio/LoadPartialFileOffset-4     227            207            -8.81%
    BenchmarkBackendS3/LoadFile-4                     600            388            -35.33%
    BenchmarkBackendS3/LoadPartialFile-4              416            302            -27.40%
    BenchmarkBackendS3/LoadPartialFileOffset-4        417            303            -27.34%

    benchmark                                         old bytes     new bytes     delta
    BenchmarkBackendMinio/LoadFile-4                  29475         13904         -52.83%
    BenchmarkBackendMinio/LoadPartialFile-4           4218838       13958         -99.67%
    BenchmarkBackendMinio/LoadPartialFileOffset-4     4219175       14332         -99.66%
    BenchmarkBackendS3/LoadFile-4                     114152        97424         -14.65%
    BenchmarkBackendS3/LoadPartialFile-4              4265416       56212         -98.68%
    BenchmarkBackendS3/LoadPartialFileOffset-4        4266520       56308         -98.68%