### PR TITLE
build.go: Strip temporary path, allow reproducible builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ Small changes:
    reporting the current status by sending a `USR1` signal to the process.
    https://github.com/restic/restic/pull/974
 
+ * The `build.go` now strips the temporary directory used for compilation from
+   the binary. This is the first step in enabling reproducible builds.
+   https://github.com/restic/restic/pull/981
+
 Important Changes in 0.6.0
 ==========================
 

--- a/build.go
+++ b/build.go
@@ -195,8 +195,11 @@ func cleanEnv() (env []string) {
 
 // build runs "go build args..." with GOPATH set to gopath.
 func build(cwd, goos, goarch, gopath string, args ...string) error {
-	args = append([]string{"build"}, args...)
-	cmd := exec.Command("go", args...)
+	a := []string{"build"}
+	a = append(a, "-asmflags", fmt.Sprintf("-trimpath=%s", gopath))
+	a = append(a, "-gcflags", fmt.Sprintf("-trimpath=%s", gopath))
+	a = append(a, args...)
+	cmd := exec.Command("go", a...)
 	cmd.Env = append(cleanEnv(), "GOPATH="+gopath, "GOARCH="+goarch, "GOOS="+goos)
 	if !enableCGO {
 		cmd.Env = append(cmd.Env, "CGO_ENABLED=0")


### PR DESCRIPTION
This is the first step in enabling reproducible builds.