### PR TITLE
Fix the links in the readme to render in RST

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -72,10 +72,10 @@ Reproducible Builds
 -------------------
 
 The binaries released with each restic version starting at 0.6.1 are
-[reproducible](https://reproducible-builds.org/), which means that you can
+`reproducible <https://reproducible-builds.org/>`__, which means that you can
 easily reproduce a byte identical version from the source code for that
 release. Instructions on how to do that are contained in the
-[build repository](https://github.com/restic/build).
+`build repository <https://github.com/restic/build>`__.
 
 News
 ----


### PR DESCRIPTION
Someone added markdown links in RST, went ahead and fixed that. 