### PR TITLE
Improve find

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ Important Changes in 0.X.Y
    https://github.com/restic/restic/issues/512
    https://github.com/restic/restic/pull/978
 
+ * Improved performance for the `find` command: Restic recognizes paths it has
+   already checked for the files in question, so the number of backend requests
+   is reduced a lot.
+   https://github.com/restic/restic/issues/989
+   https://github.com/restic/restic/pull/993
+
 Important Changes in 0.6.1
 ==========================
 

--- a/src/cmds/restic/cmd_find.go
+++ b/src/cmds/restic/cmd_find.go
@@ -173,7 +173,7 @@ func (s *statefulOutput) Finish() {
 }
 
 func findInTree(repo *repository.Repository, pat *findPattern, id restic.ID, prefix string, state *statefulOutput) error {
-	debug.Log("checking tree %v\n", id)
+	debug.Log("%v checking tree %v\n", prefix, id)
 
 	tree, err := repo.LoadTree(id)
 	if err != nil {


### PR DESCRIPTION
The commits in this PR prune the trees to traverse in order to find a file/dir. The reduction in the number of requests to the backend is significant e.g. when many empty directories have been saved.

Closes #989