### PR TITLE
Fix relative link to CONTRIBUTING.md

### DIFF
--- a/doc/development.rst
+++ b/doc/development.rst
@@ -9,7 +9,7 @@ new feature. This way, duplicate work is prevented and we can discuss
 your ideas and design first.
 
 More information and a description of the development environment can be
-found in `CONTRIBUTING.md <CONTRIBUTING.md>`__.
+found in `CONTRIBUTING.md <https://github.com/restic/restic/blob/master/CONTRIBUTING.md>`__.
 A document describing the design of restic and the data structures stored on the
 back end is contained in `Design <https://restic.readthedocs.io/en/latest/design.html>`__.
 


### PR DESCRIPTION
The link does not work at the moment, not on github and not in the generated docs. This commit makes it work on github, but still the file is not part of the generated docs. Maybe we should just put an absolute link on the file in the repo on `master` branch there?