### PR TITLE
Add 'migrate' command, change s3 layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,12 @@ Important Changes in 0.X.Y
    https://github.com/restic/restic/issues/989
    https://github.com/restic/restic/pull/993
 
+ * The default layout for the s3 backend is now `default` (instead of
+   `s3legacy`). Also, there's a new `migrate` command to convert an existing
+   repo, it can be run like this: `restic migrate s3_layout`
+   https://github.com/restic/restic/issues/965
+   https://github.com/restic/restic/pull/1004
+
 Important Changes in 0.6.1
 ==========================
 

--- a/src/cmds/restic/cmd_migrate.go
+++ b/src/cmds/restic/cmd_migrate.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"restic"
+	"restic/migrations"
+
+	"github.com/spf13/cobra"
+)
+
+var cmdMigrate = &cobra.Command{
+	Use:   "migrate [name]",
+	Short: "apply migrations",
+	Long: `
+The "migrate" command applies migrations to a repository. When no migration
+name is explicitely given, a list of migrations that can be applied is printed.
+`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runMigrate(migrateOptions, globalOptions, args)
+	},
+}
+
+// MigrateOptions bundles all options for the 'check' command.
+type MigrateOptions struct {
+}
+
+var migrateOptions MigrateOptions
+
+func init() {
+	cmdRoot.AddCommand(cmdMigrate)
+}
+
+func checkMigrations(opts MigrateOptions, gopts GlobalOptions, repo restic.Repository) error {
+	ctx := gopts.ctx
+	Printf("available migrations:\n")
+	for _, m := range migrations.All {
+		ok, err := m.Check(ctx, repo)
+		if err != nil {
+			return err
+		}
+
+		if ok {
+			Printf("  %v\n", m.Name())
+		}
+	}
+
+	return nil
+}
+
+func applyMigrations(opts MigrateOptions, gopts GlobalOptions, repo restic.Repository, args []string) error {
+	ctx := gopts.ctx
+
+	var firsterr error
+	for _, name := range args {
+		for _, m := range migrations.All {
+			if m.Name() == name {
+				ok, err := m.Check(ctx, repo)
+				if err != nil {
+					return err
+				}
+
+				if !ok {
+					Warnf("migration %v cannot be applied: check failed\n")
+					continue
+				}
+
+				if err = m.Apply(ctx, repo); err != nil {
+					Warnf("migration %v failed: %v\n", m.Name(), err)
+					if firsterr == nil {
+						firsterr = err
+					}
+					continue
+				}
+
+				Printf("migration %v: success\n", m.Name())
+			}
+		}
+	}
+
+	return firsterr
+}
+
+func runMigrate(opts MigrateOptions, gopts GlobalOptions, args []string) error {
+	repo, err := OpenRepository(gopts)
+	if err != nil {
+		return err
+	}
+
+	lock, err := lockRepoExclusive(repo)
+	defer unlockRepo(lock)
+	if err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return checkMigrations(opts, gopts, repo)
+	}
+
+	return applyMigrations(opts, gopts, repo, args)
+}

--- a/src/cmds/restic/cmd_migrate.go
+++ b/src/cmds/restic/cmd_migrate.go
@@ -39,7 +39,7 @@ func checkMigrations(opts MigrateOptions, gopts GlobalOptions, repo restic.Repos
 		}
 
 		if ok {
-			Printf("  %v\n", m.Name())
+			Printf("  %v: %v\n", m.Name(), m.Desc())
 		}
 	}
 
@@ -59,10 +59,11 @@ func applyMigrations(opts MigrateOptions, gopts GlobalOptions, repo restic.Repos
 				}
 
 				if !ok {
-					Warnf("migration %v cannot be applied: check failed\n")
+					Warnf("migration %v cannot be applied: check failed\n", m.Name())
 					continue
 				}
 
+				Printf("applying migration %v...\n", m.Name())
 				if err = m.Apply(ctx, repo); err != nil {
 					Warnf("migration %v failed: %v\n", m.Name(), err)
 					if firsterr == nil {

--- a/src/restic/backend/layout.go
+++ b/src/restic/backend/layout.go
@@ -17,6 +17,7 @@ type Layout interface {
 	Dirname(restic.Handle) string
 	Basedir(restic.FileType) string
 	Paths() []string
+	Name() string
 }
 
 // Filesystem is the abstraction of a file system used for a backend.

--- a/src/restic/backend/layout_default.go
+++ b/src/restic/backend/layout_default.go
@@ -19,6 +19,15 @@ var defaultLayoutPaths = map[restic.FileType]string{
 	restic.KeyFile:      "keys",
 }
 
+func (l *DefaultLayout) String() string {
+	return "<DefaultLayout>"
+}
+
+// Name returns the name for this layout.
+func (l *DefaultLayout) Name() string {
+	return "default"
+}
+
 // Dirname returns the directory path for a given file type and name.
 func (l *DefaultLayout) Dirname(h restic.Handle) string {
 	p := defaultLayoutPaths[h.Type]

--- a/src/restic/backend/layout_rest.go
+++ b/src/restic/backend/layout_rest.go
@@ -11,6 +11,15 @@ type RESTLayout struct {
 
 var restLayoutPaths = defaultLayoutPaths
 
+func (l *RESTLayout) String() string {
+	return "<RESTLayout>"
+}
+
+// Name returns the name for this layout.
+func (l *RESTLayout) Name() string {
+	return "rest"
+}
+
 // Dirname returns the directory path for a given file type and name.
 func (l *RESTLayout) Dirname(h restic.Handle) string {
 	if h.Type == restic.ConfigFile {

--- a/src/restic/backend/layout_s3legacy.go
+++ b/src/restic/backend/layout_s3legacy.go
@@ -18,6 +18,15 @@ var s3LayoutPaths = map[restic.FileType]string{
 	restic.KeyFile:      "key",
 }
 
+func (l *S3LegacyLayout) String() string {
+	return "<S3LegacyLayout>"
+}
+
+// Name returns the name for this layout.
+func (l *S3LegacyLayout) Name() string {
+	return "s3legacy"
+}
+
 // join calls Join with the first empty elements removed.
 func (l *S3LegacyLayout) join(url string, items ...string) string {
 	for len(items) > 0 && items[0] == "" {

--- a/src/restic/backend/s3/s3.go
+++ b/src/restic/backend/s3/s3.go
@@ -35,7 +35,7 @@ type Backend struct {
 // make sure that *Backend implements backend.Backend
 var _ restic.Backend = &Backend{}
 
-const defaultLayout = "s3legacy"
+const defaultLayout = "default"
 
 // Open opens the S3 backend at bucket and region. The bucket is created if it
 // does not exist yet.

--- a/src/restic/migrations/doc.go
+++ b/src/restic/migrations/doc.go
@@ -1,0 +1,2 @@
+// Package migrations contains migrations that can be applied to a repository and/or backend.
+package migrations

--- a/src/restic/migrations/interface.go
+++ b/src/restic/migrations/interface.go
@@ -1,0 +1,21 @@
+package migrations
+
+import (
+	"context"
+	"restic"
+)
+
+// Migration implements a data migration.
+type Migration interface {
+	// Check returns true if the migration can be applied to a repo.
+	Check(context.Context, restic.Repository) (bool, error)
+
+	// Apply runs the migration.
+	Apply(context.Context, restic.Repository) error
+
+	// Name returns a short name.
+	Name() string
+
+	// Descr returns a description what the migration does.
+	Desc() string
+}

--- a/src/restic/migrations/list.go
+++ b/src/restic/migrations/list.go
@@ -1,0 +1,8 @@
+package migrations
+
+// All contains all migrations.
+var All []Migration
+
+func register(m Migration) {
+	All = append(All, m)
+}

--- a/src/restic/migrations/s3_layout.go
+++ b/src/restic/migrations/s3_layout.go
@@ -1,0 +1,87 @@
+package migrations
+
+import (
+	"context"
+	"path"
+	"restic"
+	"restic/backend"
+	"restic/backend/s3"
+	"restic/debug"
+	"restic/errors"
+)
+
+func init() {
+	register(&S3Layout{})
+}
+
+// S3Layout migrates a repository on an S3 backend from the "s3legacy" to the
+// "default" layout.
+type S3Layout struct{}
+
+// Check tests whether the migration can be applied.
+func (m *S3Layout) Check(ctx context.Context, repo restic.Repository) (bool, error) {
+	be, ok := repo.Backend().(*s3.Backend)
+	if !ok {
+		debug.Log("backend is not s3")
+		return false, nil
+	}
+
+	if be.Layout.Name() != "s3legacy" {
+		debug.Log("layout is not s3legacy")
+		return false, nil
+	}
+
+	return true, nil
+}
+
+func (m *S3Layout) moveFiles(ctx context.Context, be *s3.Backend, l backend.Layout, t restic.FileType) error {
+	for name := range be.List(ctx, t) {
+		h := restic.Handle{Type: t, Name: name}
+		debug.Log("move %v", h)
+		if err := be.Rename(h, l); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// Apply runs the migration.
+func (m *S3Layout) Apply(ctx context.Context, repo restic.Repository) error {
+	be, ok := repo.Backend().(*s3.Backend)
+	if !ok {
+		debug.Log("backend is not s3")
+		return errors.New("backend is not s3")
+	}
+
+	newLayout := &backend.DefaultLayout{
+		Path: be.Path(),
+		Join: path.Join,
+	}
+
+	for _, t := range []restic.FileType{
+		restic.KeyFile,
+		restic.SnapshotFile,
+		restic.DataFile,
+		restic.LockFile,
+	} {
+		err := m.moveFiles(ctx, be, newLayout, t)
+		if err != nil {
+			return err
+		}
+	}
+
+	be.Layout = newLayout
+
+	return nil
+}
+
+// Name returns the name for this migration.
+func (m *S3Layout) Name() string {
+	return "s3_layout"
+}
+
+// Desc returns a short description what the migration does.
+func (m *S3Layout) Desc() string {
+	return "move files from 's3legacy' to the 'default' repository layout"
+}


### PR DESCRIPTION
This PR adds a `migrate` command and a migration to move s3 repositories from the `s3legacy` to the `default` layout. The default layout for s3 is now `default`.

Closes #965