### PR TITLE
Improve GCS support

### DIFF
--- a/src/restic/backend/mem/mem_backend.go
+++ b/src/restic/backend/mem/mem_backend.go
@@ -8,7 +8,6 @@ import (
 	"restic"
 	"sync"
 
-	"restic/backend"
 	"restic/errors"
 
 	"restic/debug"
@@ -114,7 +113,7 @@ func (be *MemoryBackend) Load(ctx context.Context, h restic.Handle, length int, 
 		buf = buf[:length]
 	}
 
-	return backend.Closer{Reader: bytes.NewReader(buf)}, nil
+	return ioutil.NopCloser(bytes.NewReader(buf)), nil
 }
 
 // Stat returns information about a file in the backend.

--- a/src/restic/backend/rest/rest.go
+++ b/src/restic/backend/rest/rest.go
@@ -108,9 +108,8 @@ func (b *restBackend) Save(ctx context.Context, h restic.Handle, rd io.Reader) (
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	// make sure that client.Post() cannot close the reader by wrapping it in
-	// backend.Closer, which has a noop method.
-	rd = backend.Closer{Reader: rd}
+	// make sure that client.Post() cannot close the reader by wrapping it
+	rd = ioutil.NopCloser(rd)
 
 	b.sem.GetToken()
 	resp, err := ctxhttp.Post(ctx, b.client, b.Filename(h), "binary/octet-stream", rd)

--- a/src/restic/backend/s3/s3.go
+++ b/src/restic/backend/s3/s3.go
@@ -291,6 +291,11 @@ func (be *Backend) Remove(ctx context.Context, h restic.Handle) error {
 	objName := be.Filename(h)
 	err := be.client.RemoveObject(be.bucketname, objName)
 	debug.Log("Remove(%v) at %v -> err %v", h, objName, err)
+
+	if be.IsNotExist(err) {
+		err = nil
+	}
+
 	return errors.Wrap(err, "client.RemoveObject")
 }
 

--- a/src/restic/backend/s3/s3_test.go
+++ b/src/restic/backend/s3/s3_test.go
@@ -103,6 +103,21 @@ type MinioTestConfig struct {
 	stopServer    func()
 }
 
+func openS3(t testing.TB, cfg MinioTestConfig) (be restic.Backend, err error) {
+	for i := 0; i < 10; i++ {
+		be, err = s3.Open(cfg.Config)
+		if err != nil {
+			t.Logf("s3 open: try %d: error %v", i, err)
+			time.Sleep(500 * time.Millisecond)
+			continue
+		}
+
+		break
+	}
+
+	return be, err
+}
+
 func newMinioTestSuite(ctx context.Context, t testing.TB) *test.Suite {
 	return &test.Suite{
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
@@ -127,7 +142,7 @@ func newMinioTestSuite(ctx context.Context, t testing.TB) *test.Suite {
 		Create: func(config interface{}) (restic.Backend, error) {
 			cfg := config.(MinioTestConfig)
 
-			be, err := s3.Open(cfg.Config)
+			be, err := openS3(t, cfg)
 			if err != nil {
 				return nil, err
 			}

--- a/src/restic/backend/test/tests.go
+++ b/src/restic/backend/test/tests.go
@@ -446,9 +446,15 @@ func delayedRemove(b restic.Backend, h restic.Handle) error {
 	found, err := b.Test(context.TODO(), h)
 	for i := 0; found && i < 20; i++ {
 		found, err = b.Test(context.TODO(), h)
-		if found {
-			time.Sleep(100 * time.Millisecond)
+		if err != nil {
+			return err
 		}
+
+		if !found {
+			break
+		}
+
+		time.Sleep(100 * time.Millisecond)
 	}
 	return err
 }
@@ -591,7 +597,7 @@ func (s *Suite) TestBackend(t *testing.T) {
 
 				found, err = b.Test(context.TODO(), h)
 				test.OK(t, err)
-				test.Assert(t, !found, fmt.Sprintf("id %q not found after removal", id))
+				test.Assert(t, !found, fmt.Sprintf("id %q found after removal", id))
 			}
 		}
 	}

--- a/src/restic/backend/utils.go
+++ b/src/restic/backend/utils.go
@@ -29,16 +29,6 @@ func LoadAll(ctx context.Context, be restic.Backend, h restic.Handle) (buf []byt
 	return ioutil.ReadAll(rd)
 }
 
-// Closer wraps an io.Reader and adds a Close() method that does nothing.
-type Closer struct {
-	io.Reader
-}
-
-// Close is a no-op.
-func (c Closer) Close() error {
-	return nil
-}
-
 // LimitedReadCloser wraps io.LimitedReader and exposes the Close() method.
 type LimitedReadCloser struct {
 	io.ReadCloser


### PR DESCRIPTION
This is a followup PR for #996. The code prevents that an *os.File is closed by the s3 backend, which seems to happen when used with GCS. In addition, a bit of custom code is removed that was also present in the stdlib, and the backend Remove() method for s3 ignores errors for non-existing files.