### PR TITLE
Improve restore

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -417,7 +417,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 	}
 
 	selectFilter := func(item string, fi os.FileInfo) bool {
-		matched, err := filter.List(opts.Excludes, item)
+		matched, _, err := filter.List(opts.Excludes, item)
 		if err != nil {
 			Warnf("error for exclude pattern: %v", err)
 		}

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -113,22 +113,32 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		return nil
 	}
 
-	selectExcludeFilter := func(item string, dstpath string, node *restic.Node) (bool, bool) {
-		matched, childMayMatch, err := filter.List(opts.Exclude, item)
+	selectExcludeFilter := func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
+		matched, _, err := filter.List(opts.Exclude, item)
 		if err != nil {
 			Warnf("error for exclude pattern: %v", err)
 		}
 
-		return !matched, childMayMatch
+		// An exclude filter is basically a 'wildcard but foo',
+		// so even if a childMayMatch, other children of a dir may not,
+		// therefore childMayMatch does not matter, but we should not go down
+		// unless the dir is selected for restore
+		selectedForRestore = !matched
+		childMayBeSelected = selectedForRestore && node.Type == "dir"
+
+		return selectedForRestore, childMayBeSelected
 	}
 
-	selectIncludeFilter := func(item string, dstpath string, node *restic.Node) (bool, bool) {
+	selectIncludeFilter := func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
 		matched, childMayMatch, err := filter.List(opts.Include, item)
 		if err != nil {
 			Warnf("error for include pattern: %v", err)
 		}
 
-		return matched, childMayMatch
+		selectedForRestore = matched
+		childMayBeSelected = childMayMatch && node.Type == "dir"
+
+		return selectedForRestore, childMayBeSelected
 	}
 
 	if len(opts.Exclude) > 0 {

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -113,22 +113,22 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		return nil
 	}
 
-	selectExcludeFilter := func(item string, dstpath string, node *restic.Node) bool {
-		matched, err := filter.List(opts.Exclude, item)
+	selectExcludeFilter := func(item string, dstpath string, node *restic.Node) (bool, bool) {
+		matched, childMayMatch, err := filter.List(opts.Exclude, item)
 		if err != nil {
 			Warnf("error for exclude pattern: %v", err)
 		}
 
-		return !matched
+		return !matched, childMayMatch
 	}
 
-	selectIncludeFilter := func(item string, dstpath string, node *restic.Node) bool {
-		matched, err := filter.List(opts.Include, item)
+	selectIncludeFilter := func(item string, dstpath string, node *restic.Node) (bool, bool) {
+		matched, childMayMatch, err := filter.List(opts.Include, item)
 		if err != nil {
 			Warnf("error for include pattern: %v", err)
 		}
 
-		return matched
+		return matched, childMayMatch
 	}
 
 	if len(opts.Exclude) > 0 {

--- a/internal/restic/restorer.go
+++ b/internal/restic/restorer.go
@@ -17,7 +17,7 @@ type Restorer struct {
 	sn   *Snapshot
 
 	Error        func(dir string, node *Node, err error) error
-	SelectFilter func(item string, dstpath string, node *Node) (bool, bool)
+	SelectFilter func(item string, dstpath string, node *Node) (selectedForRestore bool, childMayBeSelected bool)
 }
 
 var restorerAbortOnAllErrors = func(str string, node *Node, err error) error { return err }
@@ -46,9 +46,9 @@ func (res *Restorer) restoreTo(ctx context.Context, dst string, dir string, tree
 	}
 
 	for _, node := range tree.Nodes {
-		selectedForRestore, childMayMatch := res.SelectFilter(filepath.Join(dir, node.Name),
+		selectedForRestore, childMayBeSelected := res.SelectFilter(filepath.Join(dir, node.Name),
 			filepath.Join(dst, dir, node.Name), node)
-		debug.Log("SelectFilter returned %v %v", selectedForRestore, childMayMatch)
+		debug.Log("SelectFilter returned %v %v", selectedForRestore, childMayBeSelected)
 
 		if selectedForRestore {
 			err := res.restoreNodeTo(ctx, node, dir, dst, idx)
@@ -57,7 +57,7 @@ func (res *Restorer) restoreTo(ctx context.Context, dst string, dir string, tree
 			}
 		}
 
-		if node.Type == "dir" && childMayMatch {
+		if node.Type == "dir" && childMayBeSelected {
 			if node.Subtree == nil {
 				return errors.Errorf("Dir without subtree in tree %v", treeID.Str())
 			}


### PR DESCRIPTION
This improves restore performance by several orders of magniture by not going through the whole tree recursively when we can anticipate that no match will ever occur.

Here is a sample run restoring one file from a `/` backup of a Debian machine on S3:

```
time (DEBUG_LOG=/tmp/restic-debug.log ./restic restore --include /etc/resolv.conf 1141ffca --target restore)
debug log file /tmp/restic-debug.log
debug enabled
restoring <Snapshot 1141ffca of [/] at 2017-06-15 09:25:24.915676881 +0200 CEST by root@test> to restore
ignoring error for restore/etc/resolv.conf: Lchown: lchown restore/etc/resolv.conf: operation not permitted
There were 1 errors

real	0m5.075s
user	0m0.927s
sys	0m0.183s
```

- time to reach the target file is significantly improved since it doesn't go down every directory before as well as inside `/etc`
- time after having restored the file is very short since it doesn't go down every other directory

(The error about `lchown` is spurious since I'm not running this as root)

I have not included time from the current version since it just takes literally forever.

Timestamps and rights not being restored correctly will be the next unit of work once this is dealt with.

Fixes #982