### PR TITLE
s3: Split Create() from Open()

### DIFF
--- a/src/cmds/restic/global.go
+++ b/src/cmds/restic/global.go
@@ -471,7 +471,7 @@ func create(s string, opts options.Options) (restic.Backend, error) {
 	case "sftp":
 		return sftp.Create(cfg.(sftp.Config))
 	case "s3":
-		return s3.Open(cfg.(s3.Config))
+		return s3.Create(cfg.(s3.Config))
 	case "swift":
 		return swift.Open(cfg.(swift.Config))
 	case "b2":

--- a/src/restic/backend/s3/s3_test.go
+++ b/src/restic/backend/s3/s3_test.go
@@ -103,9 +103,9 @@ type MinioTestConfig struct {
 	stopServer    func()
 }
 
-func openS3(t testing.TB, cfg MinioTestConfig) (be restic.Backend, err error) {
+func createS3(t testing.TB, cfg MinioTestConfig) (be restic.Backend, err error) {
 	for i := 0; i < 10; i++ {
-		be, err = s3.Open(cfg.Config)
+		be, err = s3.Create(cfg.Config)
 		if err != nil {
 			t.Logf("s3 open: try %d: error %v", i, err)
 			time.Sleep(500 * time.Millisecond)
@@ -142,7 +142,7 @@ func newMinioTestSuite(ctx context.Context, t testing.TB) *test.Suite {
 		Create: func(config interface{}) (restic.Backend, error) {
 			cfg := config.(MinioTestConfig)
 
-			be, err := openS3(t, cfg)
+			be, err := createS3(t, cfg)
 			if err != nil {
 				return nil, err
 			}
@@ -236,7 +236,7 @@ func newS3TestSuite(t testing.TB) *test.Suite {
 		Create: func(config interface{}) (restic.Backend, error) {
 			cfg := config.(s3.Config)
 
-			be, err := s3.Open(cfg)
+			be, err := s3.Create(cfg)
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
Just a little cleanup, splitting the Open() function into two separate functions.