### PR TITLE
support SIGINFO on Darwin

### DIFF
--- a/src/restic/progress_unix_with_siginfo.go
+++ b/src/restic/progress_unix_with_siginfo.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin
+// +build darwin
 
 package restic
 
@@ -13,6 +13,7 @@ import (
 func init() {
 	c := make(chan os.Signal)
 	signal.Notify(c, syscall.SIGUSR1)
+	signal.Notify(c, syscall.SIGINFO)
 	go func() {
 		for s := range c {
 			debug.Log("Signal received: %v\n", s)


### PR DESCRIPTION
Some OSes, like Darwin and FreeBSD, support a keyboard shortcut (usually ^T, configured via `stty`) that sends `SIGINFO` to the running process. Tools like `dd`, which on Linux give stats when sent `SIGUSR1`, will give out those stats on receipt of `SIGINFO` on Darwin and FreeBSD.

This PR adds support for `SIGINFO` on Darwin to restic. I hope it is correct - it appears the `updateProgress` channel is not at all reliable in causing a progress update to appear.

This is the first Go I've typed in years, so it is possible I went at this the wrong way. I checked with the #go-nuts IRC channel and I got the impression that build tags are the only way to accomplish this. I do not actually like the way this turned out, so please let me know if I've missed something.