### PR TITLE
Add support for IAM instance profile

### DIFF
--- a/src/restic/backend/s3/s3.go
+++ b/src/restic/backend/s3/s3.go
@@ -43,7 +43,7 @@ func open(cfg Config) (*Backend, error) {
 	var err error
 
 	if cfg.KeyID == "" || cfg.Secret == "" {
-		debug.Log("iam")
+		debug.Log("key/secret not found, trying to get them from IAM")
 		creds := credentials.NewIAM("")
 		client, err = minio.NewWithCredentials(cfg.Endpoint, creds, !cfg.UseHTTP, "")
 
@@ -51,7 +51,7 @@ func open(cfg Config) (*Backend, error) {
 			return nil, errors.Wrap(err, "minio.NewWithCredentials")
 		}
 	} else {
-		debug.Log("key, secret")
+		debug.Log("key/secret found")
 		client, err = minio.New(cfg.Endpoint, cfg.KeyID, cfg.Secret, !cfg.UseHTTP)
 
 		if err != nil {

--- a/src/restic/backend/s3/s3.go
+++ b/src/restic/backend/s3/s3.go
@@ -14,6 +14,7 @@ import (
 	"restic/errors"
 
 	"github.com/minio/minio-go"
+	"github.com/minio/minio-go/pkg/credentials"
 
 	"restic/debug"
 )
@@ -38,9 +39,24 @@ func open(cfg Config) (*Backend, error) {
 		minio.MaxRetry = int(cfg.MaxRetries)
 	}
 
-	client, err := minio.New(cfg.Endpoint, cfg.KeyID, cfg.Secret, !cfg.UseHTTP)
-	if err != nil {
-		return nil, errors.Wrap(err, "minio.New")
+	var client *minio.Client
+	var err error
+
+	if cfg.KeyID == "" || cfg.Secret == "" {
+		debug.Log("iam")
+		creds := credentials.NewIAM("")
+		client, err = minio.NewWithCredentials(cfg.Endpoint, creds, !cfg.UseHTTP, "")
+
+		if err != nil {
+			return nil, errors.Wrap(err, "minio.NewWithCredentials")
+		}
+	} else {
+		debug.Log("key, secret")
+		client, err = minio.New(cfg.Endpoint, cfg.KeyID, cfg.Secret, !cfg.UseHTTP)
+
+		if err != nil {
+			return nil, errors.Wrap(err, "minio.New")
+		}
 	}
 
 	sem, err := backend.NewSemaphore(cfg.Connections)


### PR DESCRIPTION
This is probably a very ugly way to do it, but I'm not experienced in Golang. I've tested it with IAM instance profile attached and with regular environment variables/credential file.

Closes #1067