### PR TITLE
Update links to design.md to design.rst

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -986,7 +986,7 @@ Under the hood: Browse repository objects
 
 Internally, a repository stores data of several different types
 described in the `design
-documentation <https://github.com/restic/restic/blob/master/doc/Design.md>`__.
+documentation <https://github.com/restic/restic/blob/master/doc/Design.rst>`__.
 You can ``list`` objects such as blobs, packs, index, snapshots, keys or
 locks with the following command:
 

--- a/src/restic/index/index_test.go
+++ b/src/restic/index/index_test.go
@@ -328,7 +328,7 @@ func TestIndexAddRemovePack(t *testing.T) {
 	}
 }
 
-// example index serialization from doc/Design.md
+// example index serialization from doc/Design.rst
 var docExample = []byte(`
 {
   "supersedes": [

--- a/src/restic/repository/index_test.go
+++ b/src/restic/repository/index_test.go
@@ -195,7 +195,7 @@ func TestIndexSize(t *testing.T) {
 	t.Logf("Index file size for %d blobs in %d packs is %d", blobs*packs, packs, wr.Len())
 }
 
-// example index serialization from doc/Design.md
+// example index serialization from doc/Design.rst
 var docExample = []byte(`
 {
   "supersedes": [


### PR DESCRIPTION
Only really one place in docs/manual.rst but also comments in two other test files which I updated for completeness.   

This follows on from #1101 