### PR TITLE
Fix S3 panic on Invalid configuration

### DIFF
--- a/src/restic/backend/s3/s3.go
+++ b/src/restic/backend/s3/s3.go
@@ -92,6 +92,9 @@ func Open(cfg Config) (restic.Backend, error) {
 // it does not exist yet.
 func Create(cfg Config) (restic.Backend, error) {
 	be, err := open(cfg)
+	if err != nil {
+		return nil, errors.Wrap(err, "open")
+	}
 	found, err := be.client.BucketExists(cfg.Bucket)
 	if err != nil {
 		debug.Log("BucketExists(%v) returned err %v", cfg.Bucket, err)


### PR DESCRIPTION
Before:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x7d2c60]

goroutine 1 [running]:
restic/backend/s3.Create(0xc42001201d, 0x0, 0x0, 0xc420012042, 0x14, 0xc420014016, 0x28, 0xc42001201e, 0xb, 0x9c2c1b, ...)
	src/restic/backend/s3/s3.go:79 +0x70
```

after:

```
create backend at s3:https:/// failed: open: minio.New: Endpoint:  does not follow ip address or domain name standards.
```