### PR TITLE
prune: Fix newly created index

### DIFF
--- a/src/cmds/restic/integration_test.go
+++ b/src/cmds/restic/integration_test.go
@@ -1175,15 +1175,19 @@ func TestPrune(t *testing.T) {
 		SetupTarTestFixture(t, env.testdata, datafile)
 		opts := BackupOptions{}
 
-		testRunBackup(t, []string{filepath.Join(env.testdata, "0", "0", "1")}, opts, gopts)
+		testRunBackup(t, []string{filepath.Join(env.testdata, "0", "0")}, opts, gopts)
+		firstSnapshot := testRunList(t, "snapshots", gopts)
+		Assert(t, len(firstSnapshot) == 1,
+			"expected one snapshot, got %v", firstSnapshot)
+
 		testRunBackup(t, []string{filepath.Join(env.testdata, "0", "0", "2")}, opts, gopts)
 		testRunBackup(t, []string{filepath.Join(env.testdata, "0", "0", "3")}, opts, gopts)
 
 		snapshotIDs := testRunList(t, "snapshots", gopts)
 		Assert(t, len(snapshotIDs) == 3,
-			"expected one snapshot, got %v", snapshotIDs)
+			"expected 3 snapshot, got %v", snapshotIDs)
 
-		testRunForget(t, gopts, snapshotIDs[0].String())
+		testRunForget(t, gopts, firstSnapshot[0].String())
 		testRunPrune(t, gopts)
 		testRunCheck(t, gopts)
 	})


### PR DESCRIPTION
This fixes a bug introduced in c79fb6fcdd254382705753957bd299472696a2c6 where the index file after a prune contains pack files that do not exist any more. Restic will detect this during backup and abort with an error message until the user runs `prune` or `rebuild-index` again.