### PR TITLE
Force restic to ask the password when adding a key.

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -249,7 +249,7 @@ func readBackupFromStdin(opts BackupOptions, gopts GlobalOptions, args []string)
 		return errors.Fatal("filename for backup from stdin must not be empty")
 	}
 
-	if gopts.password == "" && gopts.PasswordFile == "" {
+	if gopts.password == "" {
 		return errors.Fatal("unable to read password from stdin when data is to be read from stdin, use --password-file or $RESTIC_PASSWORD")
 	}
 
@@ -322,8 +322,8 @@ func readLinesFromFile(filename string) ([]string, error) {
 }
 
 func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
-	if opts.FilesFrom == "-" && gopts.password == "" && gopts.PasswordFile == "" {
-		return errors.Fatal("no password; either use `--password-file` option or put the password into the RESTIC_PASSWORD environment variable")
+	if opts.FilesFrom == "-" && gopts.password == "" {
+		return errors.Fatal("unable to read password from stdin when data is to be read from stdin, use --password-file or $RESTIC_PASSWORD")
 	}
 
 	fromfile, err := readLinesFromFile(opts.FilesFrom)

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -34,13 +34,11 @@ func runInit(gopts GlobalOptions, args []string) error {
 		return errors.Fatalf("create backend at %s failed: %v\n", gopts.Repo, err)
 	}
 
-	if gopts.password == "" {
-		gopts.password, err = ReadPasswordTwice(gopts,
-			"enter password for new backend: ",
-			"enter password again: ")
-		if err != nil {
-			return err
-		}
+	gopts.password, err = ReadPasswordTwice(gopts,
+		"enter password for new backend: ",
+		"enter password again: ")
+	if err != nil {
+		return err
 	}
 
 	s := repository.New(be)

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
 
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
@@ -59,7 +60,16 @@ func getNewPassword(gopts GlobalOptions) (string, error) {
 		return testKeyNewPassword, nil
 	}
 
-	return ReadPasswordTwice(gopts,
+	// Since we already have an open repository, temporary remove the overrides
+	// to prompt the user for their passwd
+	oldPasswd := os.Getenv("RESTIC_PASSWORD")
+	defer func() { os.Setenv("RESTIC_PASSWORD", oldPasswd) }()
+	os.Unsetenv("RESTIC_PASSWORD")
+	newopts := gopts
+	newopts.password = ""
+	newopts.PasswordFile = ""
+
+	return ReadPasswordTwice(newopts,
 		"enter password for new key: ",
 		"enter password again: ")
 }

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
 
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
@@ -60,14 +59,10 @@ func getNewPassword(gopts GlobalOptions) (string, error) {
 		return testKeyNewPassword, nil
 	}
 
-	// Since we already have an open repository, temporary remove the overrides
-	// to prompt the user for their passwd
-	oldPasswd := os.Getenv("RESTIC_PASSWORD")
-	defer func() { os.Setenv("RESTIC_PASSWORD", oldPasswd) }()
-	os.Unsetenv("RESTIC_PASSWORD")
+	// Since we already have an open repository, temporary remove the password
+	// to prompt the user for the passwd.
 	newopts := gopts
 	newopts.password = ""
-	newopts.PasswordFile = ""
 
 	return ReadPasswordTwice(newopts,
 		"enter password for new key: ",

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -307,11 +307,9 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 
 	s := repository.New(be)
 
-	if opts.password == "" {
-		opts.password, err = ReadPassword(opts, "enter password for repository: ")
-		if err != nil {
-			return nil, err
-		}
+	opts.password, err = ReadPassword(opts, "enter password for repository: ")
+	if err != nil {
+		return nil, err
 	}
 
 	err = s.SearchKey(context.TODO(), opts.password, maxKeys)

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -36,6 +36,13 @@ directories in an encrypted repository stored on different backends.
 		}
 		globalOptions.extended = opts
 
+		pwd, err := resolvePassword(globalOptions, "RESTIC_PASSWORD")
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Resolving password failed: %v\n", err)
+			Exit(1)
+		}
+		globalOptions.password = pwd
+
 		// run the debug functions for all subcommands (if build tag "debug" is
 		// enabled)
 		if err := runDebug(); err != nil {


### PR DESCRIPTION
As `restic key add` uses the same `ReadPasswordTwice()` as the
rest of restic, it is sensitive to the environment variable
RESTIC_PASSWORD or --password-file= override.

When asking for the new key, temporary remove these 2 overrides, forcing
the password to be asked.

Closes #1132