### PR TITLE
Enable build on Solaris

### DIFF
--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package main

--- a/cmd/restic/integration_fuse_test.go
+++ b/cmd/restic/integration_fuse_test.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package main

--- a/internal/fuse/blob_size_cache.go
+++ b/internal/fuse/blob_size_cache.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/file_test.go
+++ b/internal/fuse/file_test.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/link.go
+++ b/internal/fuse/link.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/meta_dir.go
+++ b/internal/fuse/meta_dir.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/restic/node_solaris.go
+++ b/internal/restic/node_solaris.go
@@ -1,0 +1,27 @@
+package restic
+
+import "syscall"
+
+func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
+	return nil
+}
+
+func (s statUnix) atim() syscall.Timespec { return s.Atim }
+func (s statUnix) mtim() syscall.Timespec { return s.Mtim }
+func (s statUnix) ctim() syscall.Timespec { return s.Ctim }
+
+// Getxattr retrieves extended attribute data associated with path.
+func Getxattr(path, name string) ([]byte, error) {
+	return nil, nil
+}
+
+// Listxattr retrieves a list of names of extended attributes associated with the
+// given path in the file system.
+func Listxattr(path string) ([]string, error) {
+	return nil, nil
+}
+
+// Setxattr associates name and data together as an attribute of path.
+func Setxattr(path, name string, data []byte) error {
+	return nil
+}

--- a/internal/restic/node_xattr.go
+++ b/internal/restic/node_xattr.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package restic


### PR DESCRIPTION
I've got a Oracle Solaris 11 (amd64) box here that I want to get rid of. In order to do the last backup I wanted to use restic. It did not compile, but the fix turned out to be almost trivial.

Basically this is reapplying the special cases of openbsd to the point that I've simply copied the file `internal/restic/node_openbsd.go` to `internal/restic/node_solaris.go`. Maybe it would be better to rename them to `node_bsd.go` (since both are BSD-ish?) and add build tag comment for openbsd and solaris? 