### PR TITLE
internal: check error before deferring file Close()

### DIFF
--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -210,10 +210,10 @@ func updateNodeContent(node *restic.Node, results []saveResult) error {
 // Save for each chunk.
 func (arch *Archiver) SaveFile(ctx context.Context, p *restic.Progress, node *restic.Node) (*restic.Node, error) {
 	file, err := fs.Open(node.Path)
-	defer file.Close()
 	if err != nil {
 		return node, errors.Wrap(err, "Open")
 	}
+	defer file.Close()
 
 	debug.RunHook("archiver.SaveFile", node.Path)
 

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -243,11 +243,10 @@ func (node Node) createFileAt(ctx context.Context, path string, repo Repository,
 	}
 
 	f, err := fs.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
-	defer f.Close()
-
 	if err != nil {
 		return errors.Wrap(err, "OpenFile")
 	}
+	defer f.Close()
 
 	var buf []byte
 	for _, id := range node.Content {

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -94,8 +94,8 @@ func Random(seed, count int) []byte {
 // SetupTarTestFixture extracts the tarFile to outputDir.
 func SetupTarTestFixture(t testing.TB, outputDir, tarFile string) {
 	input, err := os.Open(tarFile)
-	defer input.Close()
 	OK(t, err)
+	defer input.Close()
 
 	var rd io.Reader
 	switch filepath.Ext(tarFile) {


### PR DESCRIPTION
If there is an error, file will be `nil`. We should check the returned error before deferring file `Close()`.