### PR TITLE
implement constrained restore that only walks paths specified in the --include pattern

### DIFF
--- a/internal/restic/restorer.go
+++ b/internal/restic/restorer.go
@@ -7,9 +7,9 @@ import (
 
 	"github.com/restic/restic/internal/errors"
 
+	"fmt"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/fs"
-	"fmt"
 	"strings"
 )
 
@@ -93,11 +93,11 @@ func (res *Restorer) restoreTo(ctx context.Context, dst string, dir string, tree
 	return nil
 }
 
-func (res *Restorer) unconstrained() (bool) {
+func (res *Restorer) unconstrained() bool {
 	return len(res.ConstrainedPaths) == 0
 }
 
-func (res *Restorer) matchesConstrainedPath(subdir string) (bool) {
+func (res *Restorer) matchesConstrainedPath(subdir string) bool {
 	for _, path := range res.ConstrainedPaths {
 		if strings.HasPrefix(path, subdir) {
 			fmt.Printf("%s matches => %s\n", subdir, path)


### PR DESCRIPTION

If the user is doing restore using "--include" paths, and all of the
given paths are absolute (begin with '/'), and no glob match chars are
present, we can prevent walking the entire restore tree, and instead
visit only subdirs that match the given "--include" paths.

This is a huge speedup for large/remote repos. In my testing with s3,
I went 53m18s to 1m17s. Prior to this patch, the restore often failed
to complete at all due to timeouts.