### PR TITLE
Add option to exclude contents of cache directories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -72,6 +72,14 @@ Small changes
    run. This is now corrected.
    https://github.com/restic/restic/pull/1191
 
+ * A new option `--exclude-caches` was added that allows excluding cache
+   directories (that are tagged as such). This is a special case of a more
+   generic option `--exclude-if-present` which excludes a directory if a file
+   with a specific name (and contents) is present.
+   https://github.com/restic/restic/issues/317
+   https://github.com/restic/restic/pull/1170
+
+
 Important Changes in 0.7.1
 ==========================
 

--- a/cmd/restic/exclude_test.go
+++ b/cmd/restic/exclude_test.go
@@ -1,0 +1,58 @@
+package main
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsExcludedByFile(t *testing.T) {
+	const (
+		tagFilename = "CACHEDIR.TAG"
+		header      = "Signature: 8a477f597d28d172789f06886806bc55"
+	)
+	tests := []struct {
+		name    string
+		tagFile string
+		content string
+		want    bool
+	}{
+		{"NoTagfile", "", "", false},
+		{"EmptyTagfile", tagFilename, "", true},
+		{"UnnamedTagFile", "", header, false},
+		{"WrongTagFile", "notatagfile", header, false},
+		{"IncorrectSig", tagFilename, header[1:], false},
+		{"ValidSig", tagFilename, header, true},
+		{"ValidPlusStuff", tagFilename, header + "foo", true},
+		{"ValidPlusNewlineAndStuff", tagFilename, header + "\nbar", true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			tempDir, err := ioutil.TempDir("", "restic-test-")
+			if err != nil {
+				t.Fatalf("could not create temp dir: %v", err)
+			}
+			defer os.RemoveAll(tempDir)
+			foo := filepath.Join(tempDir, "foo")
+			err = ioutil.WriteFile(foo, []byte("foo"), 0666)
+			if err != nil {
+				t.Fatalf("could not write file: %v", err)
+			}
+			if tc.tagFile != "" {
+				tagFile := filepath.Join(tempDir, tc.tagFile)
+				err = ioutil.WriteFile(tagFile, []byte(tc.content), 0666)
+				if err != nil {
+					t.Fatalf("could not write tagfile: %v", err)
+				}
+			}
+			h := header
+			if tc.content == "" {
+				h = ""
+			}
+			if got := isExcludedByFile(foo, tagFilename, h); tc.want != got {
+				t.Fatalf("expected %v, got %v", tc.want, got)
+			}
+		})
+	}
+}

--- a/doc/man/restic-backup.1
+++ b/doc/man/restic-backup.1
@@ -25,8 +25,16 @@ given as the arguments.
     exclude a \fB\fCpattern\fR (can be specified multiple times)
 
 .PP
+\fB\-\-exclude\-caches\fP[=false]
+    excludes cache directories that are marked with a CACHEDIR.TAG file
+
+.PP
 \fB\-\-exclude\-file\fP=[]
     read exclude patterns from a \fB\fCfile\fR (can be specified multiple times)
+
+.PP
+\fB\-\-exclude\-if\-present\fP=""
+    takes filename[:header], exclude contents of directories containing filename (except filename itself) if header of that file is as provided
 
 .PP
 \fB\-\-files\-from\fP=""


### PR DESCRIPTION
The option is named --exclude-caches and behaves as the likewise-named
option of tar(1): Directories are recognized as cache if they contain a
file named "CACHEDIR.TAG. The contents of the cache directories are not
to be backed up, except for CACHEDIR.TAG itself.

Closes #317.