### PR TITLE
Update minimum Go version

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -35,7 +35,7 @@ From Source
 -----------
 
 restic is written in the Go programming language and you need at least
-Go version 1.7. Building restic may also work with older versions of Go,
+Go version 1.8. Building restic may also work with older versions of Go,
 but that's not supported. See the `Getting
 started <https://golang.org/doc/install>`__ guide of the Go project for
 instructions how to install Go.


### PR DESCRIPTION
Minimum version is now 1.8 according to build.go (from latest master, cloned a few minutes ago):

```
paul@voga:~/third-dev/restic$ go run build.go 
Go version go1.7.4 detected, restic requires at least Go 1.8
exit status 1
```