### PR TITLE
debug: properly handle interrupted profiles

### DIFF
--- a/cmd/restic/global_release.go
+++ b/cmd/restic/global_release.go
@@ -4,6 +4,3 @@ package main
 
 // runDebug is a noop without the debug tag.
 func runDebug() error { return nil }
-
-// shutdownDebug is a noop without the debug tag.
-func shutdownDebug() {}

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -52,9 +52,6 @@ directories in an encrypted repository stored on different backends.
 
 		return nil
 	},
-	PersistentPostRun: func(*cobra.Command, []string) {
-		shutdownDebug()
-	},
 }
 
 var logBuffer = bytes.NewBuffer(nil)


### PR DESCRIPTION
By default (i.e., without profile.NoShutdownHook), profile.Start listens
for SIGINT and will stop the profile and call os.Exit(0).

restic already listens for SIGINT and runs its own cleanup handlers
before calling os.Exit(0).

As is, these handlers are racing when an interrupt occurs, and in my
experience, restic tends to win the race, resulting in an unusable
profile.

Eliminate the race and properly stop profiles on interrupt by disabling
package profile's signal handler and instead stop the profile in a
restic cleanup handler.