### PR TITLE
forget: group-by-tags-only

### DIFF
--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -6,8 +6,8 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/restic"
 	"github.com/spf13/cobra"
 )
 
@@ -40,9 +40,9 @@ type ForgetOptions struct {
 	Paths []string
 
 	// Grouping
-	GroupBy		string
-	DryRun          bool
-	Prune           bool
+	GroupBy string
+	DryRun  bool
+	Prune   bool
 }
 
 var forgetOptions ForgetOptions
@@ -93,20 +93,24 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 	}
 	snapshotGroups := make(map[string]restic.Snapshots)
 
-	var GroupByTag      bool
-	var GroupByHost     bool
-	var GroupByPath     bool
+	var GroupByTag bool
+	var GroupByHost bool
+	var GroupByPath bool
 	var GroupOptionList []string
 
-	GroupOptionList = strings.Split( opts.GroupBy, "," )
+	GroupOptionList = strings.Split(opts.GroupBy, ",")
 
 	for _, option := range GroupOptionList {
-		switch( option ) {
-			case "host": GroupByHost = true
-			case "paths": GroupByPath = true
-			case "tags": GroupByTag = true
-			case "":
-			default: return errors.Fatal( "unknown grouping option: '" + option + "'" )
+		switch option {
+		case "host":
+			GroupByHost = true
+		case "paths":
+			GroupByPath = true
+		case "tags":
+			GroupByTag = true
+		case "":
+		default:
+			return errors.Fatal("unknown grouping option: '" + option + "'")
 		}
 	}
 
@@ -180,21 +184,21 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 		}
 
 		// Info
-		Verbosef( "snapshots" )
+		Verbosef("snapshots")
 		var infoStrings []string
 		if GroupByTag {
-			infoStrings = append( infoStrings, "tags [" + strings.Join( key.Tags, ", " ) + "]" )
+			infoStrings = append(infoStrings, "tags ["+strings.Join(key.Tags, ", ")+"]")
 		}
 		if GroupByHost {
-			infoStrings = append( infoStrings, "host [" + key.Hostname + "]" )
+			infoStrings = append(infoStrings, "host ["+key.Hostname+"]")
 		}
 		if GroupByPath {
-			infoStrings = append( infoStrings, "paths [" + strings.Join( key.Paths, ", " ) + "]" )
+			infoStrings = append(infoStrings, "paths ["+strings.Join(key.Paths, ", ")+"]")
 		}
 		if infoStrings != nil {
-			Verbosef( " for ("  + strings.Join( infoStrings, ", " ) + ")" )
+			Verbosef(" for (" + strings.Join(infoStrings, ", ") + ")")
 		}
-		Verbosef( ":\n\n" )
+		Verbosef(":\n\n")
 
 		keep, remove := restic.ApplyPolicy(snapshotGroup, policy)
 

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -95,10 +96,19 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 	var GroupByTag      bool
 	var GroupByHost     bool
 	var GroupByPath     bool
+	var GroupOptionList []string
 
-	GroupByTag = strings.Contains( opts.GroupBy, "tag" )
-	GroupByHost = strings.Contains( opts.GroupBy, "host" )
-	GroupByPath = strings.Contains( opts.GroupBy, "path" )
+	GroupOptionList = strings.Split( opts.GroupBy, "," )
+
+	for _, option := range GroupOptionList {
+		switch( option ) {
+			case "host": GroupByHost = true
+			case "paths": GroupByPath = true
+			case "tags": GroupByTag = true
+			case "":
+			default: return errors.Fatal( "unknown grouping option: '" + option + "'" )
+		}
+	}
 
 	ctx, cancel := context.WithCancel(gopts.ctx)
 	defer cancel()

--- a/doc/man/restic-forget.1
+++ b/doc/man/restic-forget.1
@@ -51,10 +51,6 @@ data after 'forget' was run successfully, see the 'prune' command.
     keep snapshots with this \fB\fCtaglist\fR (can be specified multiple times)
 
 .PP
-\fB\-G\fP, \fB\-\-group\-by\-tags\fP[=false]
-    Group by host,paths,tags instead of just host,paths
-
-.PP
 \fB\-\-host\fP=""
     only consider snapshots with the given \fB\fChost\fR
 
@@ -69,6 +65,10 @@ data after 'forget' was run successfully, see the 'prune' command.
 .PP
 \fB\-\-path\fP=[]
     only consider snapshots which include this (absolute) \fB\fCpath\fR (can be specified multiple times)
+
+.PP
+\fB\-g\fP, \fB\-\-group\-by\fP="host,paths"
+    string for grouping snapshots by host,paths,tags
 
 .PP
 \fB\-n\fP, \fB\-\-dry\-run\fP[=false]


### PR DESCRIPTION
This is not complete - what if "restic forget --group-by-tags --group-by-tags-only" is given?

