### PR TITLE
Add env variable to force progress interval

### DIFF
--- a/internal/restic/progress.go
+++ b/internal/restic/progress.go
@@ -3,6 +3,7 @@ package restic
 import (
 	"fmt"
 	"os"
+	"strconv"
 	"sync"
 	"time"
 
@@ -52,7 +53,7 @@ type ProgressFunc func(s Stat, runtime time.Duration, ticker bool)
 // OnDone is called when Done() is called. Both functions are called
 // synchronously and can use shared state.
 func NewProgress() *Progress {
-	var d time.Duration
+	d := getProgressIntervalEnv()
 	if isTerminal {
 		d = time.Second
 	}
@@ -216,4 +217,14 @@ func (s Stat) String() string {
 
 	return fmt.Sprintf("Stat(%d files, %d dirs, %v trees, %v blobs, %d errors, %v)",
 		s.Files, s.Dirs, s.Trees, s.Blobs, s.Errors, str)
+}
+
+func getProgressIntervalEnv() time.Duration {
+	if e := os.Getenv("RESTIC_PROGRESS_INTERVAL"); e != "" {
+		i, err := strconv.ParseInt(e, 0, 0)
+		if err == nil {
+			return time.Duration(i) * time.Second
+		}
+	}
+	return 0
 }


### PR DESCRIPTION
Adds optional RESTIC_PROGRESS_INTERVAL environment variable to force interval'ed progress output during non-terminal backups.

----

The use-case for this is a GUI that runs `restic backup` and wants to render the progress. It could send `USR1` signals, unless it runs the backup as root -- then every signal would need to be sent as root as well.