### PR TITLE
Fixed word-o. ("Package", not "packet".)

### DIFF
--- a/doc/installation.rst
+++ b/doc/installation.rst
@@ -8,7 +8,7 @@ Mac OS X
 ~~~~~~~~~
 
 If you are using Mac OS X, you can install restic using the
-`homebrew <http://brew.sh/>`__ packet manager:
+`homebrew <http://brew.sh/>`__ package manager:
 
 .. code-block:: console
 


### PR DESCRIPTION
Fixed a word-o. homebrew is a package manager, not a packet manager. :)