### PR TITLE
Fix manual.rst to use key remove instead of key rm

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -678,7 +678,7 @@ Manage repository keys
 ----------------------
 
 The ``key`` command allows you to set multiple access keys or passwords
-per repository. In fact, you can use the ``list``, ``add``, ``rm``
+per repository. In fact, you can use the ``list``, ``add``, ``remove``
 and ``passwd`` sub-commands to manage these keys very precisely:
 
 .. code-block:: console


### PR DESCRIPTION
Since  #1164 the command to remove a key is ``key remove`` instead of ``key rm``