### PR TITLE
Update style in short help commands

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -133,7 +133,7 @@ down to the following steps:
     texts, the manual pages need to be regenerated and commited to the
     repository. In order to do this, compile restic and save the generated
     updated man pages in the subdir `doc/man` with the following command:
-    `./restic manpages --output-dir doc/man`
+    `./restic manpage --output-dir doc/man`
 
  9. Once your code looks good and passes all the tests, we'll merge it. Thanks
     a lot for your contribution!

--- a/cmd/restic/cmd_autocomplete.go
+++ b/cmd/restic/cmd_autocomplete.go
@@ -8,7 +8,7 @@ var autocompleteTarget string
 
 var cmdAutocomplete = &cobra.Command{
 	Use:   "autocomplete",
-	Short: "generate shell autocompletion script",
+	Short: "Generate shell autocompletion script",
 	Long: `The "autocomplete" command generates a shell autocompletion script.
 
 NOTE: The current version supports Bash only.

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -21,7 +21,7 @@ import (
 
 var cmdBackup = &cobra.Command{
 	Use:   "backup [flags] FILE/DIR [FILE/DIR] ...",
-	Short: "create a new backup of files and/or directories",
+	Short: "Create a new backup of files and/or directories",
 	Long: `
 The "backup" command creates a new snapshot and saves the files and directories
 given as the arguments.

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -16,7 +16,7 @@ import (
 
 var cmdCat = &cobra.Command{
 	Use:   "cat [flags] [pack|blob|snapshot|index|key|masterkey|config|lock] ID",
-	Short: "print internal objects to stdout",
+	Short: "Print internal objects to stdout",
 	Long: `
 The "cat" command is used to print internal objects to stdout.
 `,

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -15,7 +15,7 @@ import (
 
 var cmdCheck = &cobra.Command{
 	Use:   "check [flags]",
-	Short: "check the repository for errors",
+	Short: "Check the repository for errors",
 	Long: `
 The "check" command tests the repository for errors and reports any errors it
 finds. It can also be used to read all data and therefore simulate a restore.

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -21,7 +21,7 @@ import (
 
 var cmdDump = &cobra.Command{
 	Use:   "dump [indexes|snapshots|trees|all|packs]",
-	Short: "dump data structures",
+	Short: "Dump data structures",
 	Long: `
 The "dump" command dumps data structures from the repository as JSON objects. It
 is used for debugging purposes only.`,

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -16,7 +16,7 @@ import (
 
 var cmdFind = &cobra.Command{
 	Use:   "find [flags] PATTERN",
-	Short: "find a file or directory",
+	Short: "Find a file or directory",
 	Long: `
 The "find" command searches for files or directories in snapshots stored in the
 repo. `,

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -13,7 +13,7 @@ import (
 
 var cmdForget = &cobra.Command{
 	Use:   "forget [flags] [snapshot ID] [...]",
-	Short: "remove snapshots from the repository",
+	Short: "Remove snapshots from the repository",
 	Long: `
 The "forget" command removes snapshots according to a policy. Please note that
 this command really only deletes the snapshot object in the repository, which

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -13,7 +13,7 @@ import (
 
 var cmdForget = &cobra.Command{
 	Use:   "forget [flags] [snapshot ID] [...]",
-	Short: "forget removes snapshots from the repository",
+	Short: "remove snapshots from the repository",
 	Long: `
 The "forget" command removes snapshots according to a policy. Please note that
 this command really only deletes the snapshot object in the repository, which

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -11,7 +11,7 @@ import (
 
 var cmdInit = &cobra.Command{
 	Use:   "init",
-	Short: "initialize a new repository",
+	Short: "Initialize a new repository",
 	Long: `
 The "init" command initializes a new repository.
 `,

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -13,7 +13,7 @@ import (
 
 var cmdKey = &cobra.Command{
 	Use:   "key [list|add|remove|passwd] [ID]",
-	Short: "manage keys (passwords)",
+	Short: "Manage keys (passwords)",
 	Long: `
 The "key" command manages keys (passwords) for accessing the repository.
 `,

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -13,7 +13,7 @@ import (
 
 var cmdList = &cobra.Command{
 	Use:   "list [blobs|packs|index|snapshots|keys|locks]",
-	Short: "list objects in the repository",
+	Short: "List objects in the repository",
 	Long: `
 The "list" command allows listing objects in the repository based on type.
 `,

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -13,7 +13,7 @@ import (
 
 var cmdLs = &cobra.Command{
 	Use:   "ls [flags] [snapshot-ID ...]",
-	Short: "list files in a snapshot",
+	Short: "List files in a snapshot",
 	Long: `
 The "ls" command allows listing files and directories in a snapshot.
 

--- a/cmd/restic/cmd_manpage.go
+++ b/cmd/restic/cmd_manpage.go
@@ -11,7 +11,7 @@ import (
 
 var cmdManpage = &cobra.Command{
 	Use:   "manpage [command]",
-	Short: "generate manual pages",
+	Short: "Generate manual pages",
 	Long: `
 The "manpage" command generates a manual page for a single command. It can also
 be used to write all manual pages to a directory. If the output directory is

--- a/cmd/restic/cmd_migrate.go
+++ b/cmd/restic/cmd_migrate.go
@@ -9,7 +9,7 @@ import (
 
 var cmdMigrate = &cobra.Command{
 	Use:   "migrate [name]",
-	Short: "apply migrations",
+	Short: "Apply migrations",
 	Long: `
 The "migrate" command applies migrations to a repository. When no migration
 name is explicitly given, a list of migrations that can be applied is printed.

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -22,7 +22,7 @@ import (
 
 var cmdMount = &cobra.Command{
 	Use:   "mount [flags] mountpoint",
-	Short: "mount the repository",
+	Short: "Mount the repository",
 	Long: `
 The "mount" command mounts the repository via fuse to a directory. This is a
 read-only mount.

--- a/cmd/restic/cmd_options.go
+++ b/cmd/restic/cmd_options.go
@@ -10,7 +10,7 @@ import (
 
 var optionsCmd = &cobra.Command{
 	Use:   "options",
-	Short: "print list of extended options",
+	Short: "Print list of extended options",
 	Long: `
 The "options" command prints a list of extended options.
 `,

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -15,7 +15,7 @@ import (
 
 var cmdPrune = &cobra.Command{
 	Use:   "prune [flags]",
-	Short: "remove unneeded data from the repository",
+	Short: "Remove unneeded data from the repository",
 	Long: `
 The "prune" command checks the repository and removes data that is not
 referenced and therefore not needed any more.

--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -11,7 +11,7 @@ import (
 
 var cmdRebuildIndex = &cobra.Command{
 	Use:   "rebuild-index [flags]",
-	Short: "build a new index file",
+	Short: "Build a new index file",
 	Long: `
 The "rebuild-index" command creates a new index based on the pack files in the
 repository.

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -11,7 +11,7 @@ import (
 
 var cmdRestore = &cobra.Command{
 	Use:   "restore [flags] snapshotID",
-	Short: "extract the data from a snapshot",
+	Short: "Extract the data from a snapshot",
 	Long: `
 The "restore" command extracts the data from a snapshot from the repository to
 a directory.

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -13,7 +13,7 @@ import (
 
 var cmdSnapshots = &cobra.Command{
 	Use:   "snapshots [snapshotID ...]",
-	Short: "list all snapshots",
+	Short: "List all snapshots",
 	Long: `
 The "snapshots" command lists all snapshots stored in the repository.
 `,

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -13,7 +13,7 @@ import (
 
 var cmdTag = &cobra.Command{
 	Use:   "tag [flags] [snapshot-ID ...]",
-	Short: "modifies tags on snapshots",
+	Short: "modify tags on snapshots",
 	Long: `
 The "tag" command allows you to modify tags on exiting snapshots.
 

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -13,7 +13,7 @@ import (
 
 var cmdTag = &cobra.Command{
 	Use:   "tag [flags] [snapshot-ID ...]",
-	Short: "modify tags on snapshots",
+	Short: "Modify tags on snapshots",
 	Long: `
 The "tag" command allows you to modify tags on exiting snapshots.
 

--- a/cmd/restic/cmd_unlock.go
+++ b/cmd/restic/cmd_unlock.go
@@ -9,7 +9,7 @@ import (
 
 var unlockCmd = &cobra.Command{
 	Use:   "unlock",
-	Short: "remove locks other processes created",
+	Short: "Remove locks other processes created",
 	Long: `
 The "unlock" command removes stale locks that have been created by other restic processes.
 `,

--- a/cmd/restic/cmd_version.go
+++ b/cmd/restic/cmd_version.go
@@ -9,7 +9,7 @@ import (
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "print version information",
+	Short: "Print version information",
 	Long: `
 The "version" command prints detailed information about the build environment
 and the version of this software.

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -20,7 +20,7 @@ import (
 // cmdRoot is the base command when no other command has been specified.
 var cmdRoot = &cobra.Command{
 	Use:   "restic",
-	Short: "backup and restore files",
+	Short: "Backup and restore files",
 	Long: `
 restic is a backup program which allows saving multiple revisions of files and
 directories in an encrypted repository stored on different backends.

--- a/doc/man/restic-autocomplete.1
+++ b/doc/man/restic-autocomplete.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-autocomplete \- generate shell autocompletion script
+restic\-autocomplete \- Generate shell autocompletion script
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-backup.1
+++ b/doc/man/restic-backup.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-backup \- create a new backup of files and/or directories
+restic\-backup \- Create a new backup of files and/or directories
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-cat.1
+++ b/doc/man/restic-cat.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-cat \- print internal objects to stdout
+restic\-cat \- Print internal objects to stdout
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-check.1
+++ b/doc/man/restic-check.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-check \- check the repository for errors
+restic\-check \- Check the repository for errors
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-dump.1
+++ b/doc/man/restic-dump.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-dump \- dump data structures
+restic\-dump \- Dump data structures
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-find.1
+++ b/doc/man/restic-find.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-find \- find a file or directory
+restic\-find \- Find a file or directory
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-forget.1
+++ b/doc/man/restic-forget.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-forget \- remove snapshots from the repository
+restic\-forget \- Remove snapshots from the repository
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-forget.1
+++ b/doc/man/restic-forget.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-forget \- forget removes snapshots from the repository
+restic\-forget \- remove snapshots from the repository
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-init.1
+++ b/doc/man/restic-init.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-init \- initialize a new repository
+restic\-init \- Initialize a new repository
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-key.1
+++ b/doc/man/restic-key.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-key \- manage keys (passwords)
+restic\-key \- Manage keys (passwords)
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-list.1
+++ b/doc/man/restic-list.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-list \- list objects in the repository
+restic\-list \- List objects in the repository
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-ls.1
+++ b/doc/man/restic-ls.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-ls \- list files in a snapshot
+restic\-ls \- List files in a snapshot
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-manpage.1
+++ b/doc/man/restic-manpage.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-manpage \- generate manual pages
+restic\-manpage \- Generate manual pages
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-migrate.1
+++ b/doc/man/restic-migrate.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-migrate \- apply migrations
+restic\-migrate \- Apply migrations
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-mount.1
+++ b/doc/man/restic-mount.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-mount \- mount the repository
+restic\-mount \- Mount the repository
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-prune.1
+++ b/doc/man/restic-prune.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-prune \- remove unneeded data from the repository
+restic\-prune \- Remove unneeded data from the repository
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-rebuild-index.1
+++ b/doc/man/restic-rebuild-index.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-rebuild\-index \- build a new index file
+restic\-rebuild\-index \- Build a new index file
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-restore.1
+++ b/doc/man/restic-restore.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-restore \- extract the data from a snapshot
+restic\-restore \- Extract the data from a snapshot
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-snapshots.1
+++ b/doc/man/restic-snapshots.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-snapshots \- list all snapshots
+restic\-snapshots \- List all snapshots
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-tag.1
+++ b/doc/man/restic-tag.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-tag \- modify tags on snapshots
+restic\-tag \- Modify tags on snapshots
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-tag.1
+++ b/doc/man/restic-tag.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-tag \- modifies tags on snapshots
+restic\-tag \- modify tags on snapshots
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-unlock.1
+++ b/doc/man/restic-unlock.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-unlock \- remove locks other processes created
+restic\-unlock \- Remove locks other processes created
 
 
 .SH SYNOPSIS

--- a/doc/man/restic-version.1
+++ b/doc/man/restic-version.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic\-version \- print version information
+restic\-version \- Print version information
 
 
 .SH SYNOPSIS

--- a/doc/man/restic.1
+++ b/doc/man/restic.1
@@ -5,7 +5,7 @@
 
 .SH NAME
 .PP
-restic \- backup and restore files
+restic \- Backup and restore files
 
 
 .SH SYNOPSIS

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -20,8 +20,10 @@ Usage help is available:
       backup        Create a new backup of files and/or directories
       cat           Print internal objects to stdout
       check         Check the repository for errors
+      dump          Dump data structures
       find          Find a file or directory
       forget        Remove snapshots from the repository
+      help          Help about any command
       init          Initialize a new repository
       key           Manage keys (passwords)
       list          List items in the repository

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -21,7 +21,7 @@ Usage help is available:
       cat           print internal objects to stdout
       check         check the repository for errors
       find          find a file or directory
-      forget        forget removes snapshots from the repository
+      forget        remove snapshots from the repository
       init          initialize a new repository
       key           manage keys (passwords)
       list          list items in the repository
@@ -31,7 +31,7 @@ Usage help is available:
       rebuild-index build a new index file
       restore       extract the data from a snapshot
       snapshots     list all snapshots
-      tag           modifies tags on snapshots
+      tag           modify tags on snapshots
       unlock        remove locks other processes created
       version       Print version information
 

--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -16,23 +16,23 @@ Usage help is available:
       restic [command]
 
     Available Commands:
-      autocomplete  generate shell autocompletion script
-      backup        create a new backup of files and/or directories
-      cat           print internal objects to stdout
-      check         check the repository for errors
-      find          find a file or directory
-      forget        remove snapshots from the repository
-      init          initialize a new repository
-      key           manage keys (passwords)
-      list          list items in the repository
-      ls            list files in a snapshot
-      mount         mount the repository
-      prune         remove unneeded data from the repository
-      rebuild-index build a new index file
-      restore       extract the data from a snapshot
-      snapshots     list all snapshots
-      tag           modify tags on snapshots
-      unlock        remove locks other processes created
+      autocomplete  Generate shell autocompletion script
+      backup        Create a new backup of files and/or directories
+      cat           Print internal objects to stdout
+      check         Check the repository for errors
+      find          Find a file or directory
+      forget        Remove snapshots from the repository
+      init          Initialize a new repository
+      key           Manage keys (passwords)
+      list          List items in the repository
+      ls            List files in a snapshot
+      mount         Mount the repository
+      prune         Remove unneeded data from the repository
+      rebuild-index Build a new index file
+      restore       Extract the data from a snapshot
+      snapshots     List all snapshots
+      tag           Modify tags on snapshots
+      unlock        Remove locks other processes created
       version       Print version information
 
     Flags:


### PR DESCRIPTION
Update the cobra commands to homogenize the output of `restic help`:
 * Change all commands' short descriptions to imperative voice
 * Capitalize first character (matches git's style and the Cobra-provided help command)
 * Include `help` and `dump` in manual; this was just out of sync.