### PR TITLE
doc: remove broken link

### DIFF
--- a/doc/manual.rst
+++ b/doc/manual.rst
@@ -111,8 +111,8 @@ command and enter the same password twice:
     Please note that knowledge of your password is required to access the repository.
     Losing your password means that your data is irrecoverably lost.
 
-Other backends like sftp and s3 are `described in a later
-section <#create-an-sftp-repository>`__ of this document.
+Other backends like sftp and s3 are described in the following
+sections.
 
 Remembering your password is important! If you lose it, you won't be
 able to access data stored in the repository.


### PR DESCRIPTION
The link to SFTP is broken, remove it.

I don't even bother to put a new link, since SFTP is literally the next section.