### PR TITLE
fix duplicate bytes in prune output

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -122,7 +122,7 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 		stats.bytes += pack.Size
 		blobs += len(pack.Entries)
 	}
-	Verbosef("repository contains %v packs (%v blobs) with %v bytes\n",
+	Verbosef("repository contains %v packs (%v blobs) with %v\n",
 		len(idx.Packs), blobs, formatBytes(uint64(stats.bytes)))
 
 	blobCount := make(map[restic.BlobHandle]int)


### PR DESCRIPTION
prune outputs something along this line:

`repository contains 12 packs (34 blobs) with 45GiB bytes`