### PR TITLE
Small cleanups

### DIFF
--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -35,8 +35,6 @@ type packerManager struct {
 	key     *crypto.Key
 	pm      sync.Mutex
 	packers []*Packer
-
-	pool sync.Pool
 }
 
 const minPackSize = 4 * 1024 * 1024
@@ -49,11 +47,6 @@ func newPackerManager(be Saver, key *crypto.Key) *packerManager {
 	return &packerManager{
 		be:  be,
 		key: key,
-		pool: sync.Pool{
-			New: func() interface{} {
-				return make([]byte, (minPackSize+maxPackSize)/2)
-			},
-		},
 	}
 }
 

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -53,6 +53,13 @@ type Node struct {
 	Path string `json:"-"`
 }
 
+// Nodes is a slice of nodes that can be sorted.
+type Nodes []*Node
+
+func (n Nodes) Len() int           { return len(n) }
+func (n Nodes) Less(i, j int) bool { return n[i].Name < n[j].Name }
+func (n Nodes) Swap(i, j int)      { n[i], n[j] = n[j], n[i] }
+
 func (node Node) String() string {
 	switch node.Type {
 	case "file":

--- a/internal/restic/tree.go
+++ b/internal/restic/tree.go
@@ -71,6 +71,13 @@ func (t Tree) binarySearch(name string) (int, *Node, error) {
 	return pos, nil, errors.New("named node not found")
 }
 
+// Sort sorts the nodes by name.
+func (t *Tree) Sort() {
+	list := Nodes(t.Nodes)
+	sort.Sort(list)
+	t.Nodes = list
+}
+
 // Subtrees returns a slice of all subtree IDs of the tree.
 func (t Tree) Subtrees() (trees IDs) {
 	for _, node := range t.Nodes {


### PR DESCRIPTION
This PR is a preparation for #1040, in cleans up an unused instance of `sync.Pool` and allows sorting nodes in a tree.