### PR TITLE
Improve packers, prepare for cache

### DIFF
--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -50,7 +50,7 @@ func newPackerManager(be Saver, key *crypto.Key) *packerManager {
 
 // findPacker returns a packer for a new blob of size bytes. Either a new one is
 // created or one is returned that already has some blobs.
-func (r *packerManager) findPacker(size uint) (packer *Packer, err error) {
+func (r *packerManager) findPacker() (packer *Packer, err error) {
 	r.pm.Lock()
 	defer r.pm.Unlock()
 
@@ -62,7 +62,7 @@ func (r *packerManager) findPacker(size uint) (packer *Packer, err error) {
 	}
 
 	// no suitable packer found, return new
-	debug.Log("create new pack for %d bytes", size)
+	debug.Log("create new pack")
 	tmpfile, err := fs.TempFile("", "restic-temp-pack-")
 	if err != nil {
 		return nil, errors.Wrap(err, "fs.TempFile")

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -38,8 +38,6 @@ type packerManager struct {
 }
 
 const minPackSize = 4 * 1024 * 1024
-const maxPackSize = 16 * 1024 * 1024
-const maxPackers = 200
 
 // newPackerManager returns an new packer manager which writes temporary files
 // to a temporary directory
@@ -58,15 +56,9 @@ func (r *packerManager) findPacker(size uint) (packer *Packer, err error) {
 
 	// search for a suitable packer
 	if len(r.packers) > 0 {
-		debug.Log("searching packer for %d bytes\n", size)
-		for i, p := range r.packers {
-			if p.Packer.Size()+size < maxPackSize {
-				debug.Log("found packer %v", p)
-				// remove from list
-				r.packers = append(r.packers[:i], r.packers[i+1:]...)
-				return p, nil
-			}
-		}
+		p := r.packers[0]
+		r.packers = r.packers[1:]
+		return p, nil
 	}
 
 	// no suitable packer found, return new

--- a/internal/repository/packer_manager_test.go
+++ b/internal/repository/packer_manager_test.go
@@ -72,7 +72,7 @@ func fillPacks(t testing.TB, rnd *randReader, be Saver, pm *packerManager, buf [
 		l := rnd.rand.Intn(1 << 20)
 		seed := rnd.rand.Int63()
 
-		packer, err := pm.findPacker(uint(l))
+		packer, err := pm.findPacker()
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/repository/packer_manager_test.go
+++ b/internal/repository/packer_manager_test.go
@@ -91,7 +91,7 @@ func fillPacks(t testing.TB, rnd *randReader, be Saver, pm *packerManager, buf [
 		}
 		bytes += l
 
-		if packer.Size() < minPackSize && pm.countPacker() < maxPackers {
+		if packer.Size() < minPackSize {
 			pm.insertPacker(packer)
 			continue
 		}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -191,9 +191,8 @@ func (r *Repository) SaveAndEncrypt(ctx context.Context, t restic.BlobType, data
 		return restic.ID{}, err
 	}
 
-	// if the pack is not full enough and there are less than maxPackers
-	// packers, put back to the list
-	if packer.Size() < minPackSize && r.countPacker() < maxPackers {
+	// if the pack is not full enough, put back to the list
+	if packer.Size() < minPackSize {
 		debug.Log("pack is not full enough (%d bytes)", packer.Size())
 		r.insertPacker(packer)
 		return *id, nil


### PR DESCRIPTION
The code now bundles tree blobs and data blobs into different pack files, so we'll end up with pack files that either only contain data or trees. This is in preparation to adding a cache (#1040), because tree-only pack files can easily be cached later on.

The second commit simplifies finding a packer: The first open packer is taken, and the upper limit for the pack file is removed.