### PR TITLE
cache: Synchronize downloading

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -155,10 +155,7 @@ func (c *Cache) IsNotExist(err error) bool {
 
 // Wrap returns a backend with a cache.
 func (c *Cache) Wrap(be restic.Backend) restic.Backend {
-	return &Backend{
-		Backend: be,
-		Cache:   c,
-	}
+	return newBackend(be, c)
 }
 
 // BaseDir returns the base directory.

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -163,7 +163,7 @@ func (sn *Snapshot) HasTagList(l []TagList) bool {
 
 	for _, tags := range l {
 		if sn.HasTags(tags) {
-			debug.Log("  snapshot satisfies %v", tags, l)
+			debug.Log("  snapshot satisfies %v %v", tags, l)
 			return true
 		}
 	}


### PR DESCRIPTION
This commit adds code to synchronize downloading files to the cache. Before, requests that came in for files currently downloading would fail because the file was not completed in the cache. Now, the code waits until the download is completed. 
Closes #1278