### PR TITLE
cache: OS-specific cache directories

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -84,7 +84,7 @@ func writeCachedirTag(dir string) error {
 // performReadahead returns true.
 func New(id string, basedir string) (c *Cache, err error) {
 	if basedir == "" {
-		basedir, err = getXDGCacheDir()
+		basedir, err = defaultCacheDir()
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Note: I haven't had a chance to test this on Windows yet, and I don't have an OS X machine.

Windows, and to a lesser extent OS X, don't conform to XDG and have
their own preferred locations for caches.

On Windows, use %LOCALAPPDATA%/restic (i.e., ~/AppData/Local/restic). I
can't find authoritative documentation from Microsoft recommending
specifically which of %APPDATA%, %LOCALAPPDATA%, and %TEMP% should be
used for caches, but %LOCALAPPDATA% is where browsers store their
caches, so it seems like a good fit.

On OS X, use ~/Library/Caches/restic, which is recommended by the Apple
documentation. They do suggest using the application "bundle identifier"
as the base folder name, but restic doesn't have one, so I just used
"restic".