### PR TITLE
backup command: output of written bytes

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -136,12 +136,13 @@ func newArchiveProgress(gopts GlobalOptions, todo restic.Stat) *restic.Progress 
 
 		itemsDone := s.Files + s.Dirs
 
-		status1 := fmt.Sprintf("[%s] %s  %s/s  %s / %s  %d / %d items  %d errors  ",
+		status1 := fmt.Sprintf("[%s] %s  %s/s  %s / %s  %d / %d items  %s written  %d errors  ",
 			formatDuration(d),
 			formatPercent(s.Bytes, todo.Bytes),
 			formatBytes(bps),
 			formatBytes(s.Bytes), formatBytes(todo.Bytes),
 			itemsDone, itemsTodo,
+			formatBytes(s.BytesWritten),
 			s.Errors)
 		status2 := fmt.Sprintf("ETA %s ", formatSeconds(eta))
 
@@ -461,12 +462,12 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	_, id, err := arch.Snapshot(context.TODO(), newArchiveProgress(gopts, stat), target, opts.Tags, opts.Hostname, parentSnapshotID, timeStamp)
+	_, id, bytesWritten, err := arch.Snapshot(context.TODO(), newArchiveProgress(gopts, stat), target, opts.Tags, opts.Hostname, parentSnapshotID, timeStamp)
 	if err != nil {
 		return err
 	}
 
-	Verbosef("snapshot %s saved\n", id.Str())
+	Verbosef("snapshot %s saved, %s written\n", id.Str(), formatBytes(bytesWritten))
 
 	return nil
 }

--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -64,7 +64,7 @@ func rebuildIndex(ctx context.Context, repo restic.Repository, ignorePacks resti
 		supersedes = append(supersedes, id)
 	}
 
-	id, err := idx.Save(ctx, repo, supersedes)
+	id, _, err := idx.Save(ctx, repo, supersedes)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -77,14 +77,14 @@ func changeTags(repo *repository.Repository, sn *restic.Snapshot, setTags, addTa
 		}
 
 		// Save the new snapshot.
-		id, err := repo.SaveJSONUnpacked(context.TODO(), restic.SnapshotFile, sn)
+		id, _, err := repo.SaveJSONUnpacked(context.TODO(), restic.SnapshotFile, sn)
 		if err != nil {
 			return false, err
 		}
 
 		debug.Log("new snapshot saved as %v", id.Str())
 
-		if err = repo.Flush(); err != nil {
+		if _, err = repo.Flush(); err != nil {
 			return false, err
 		}
 

--- a/internal/archiver/archive_reader.go
+++ b/internal/archiver/archive_reader.go
@@ -55,7 +55,7 @@ func (r *Reader) Archive(ctx context.Context, name string, rd io.Reader, p *rest
 		id := restic.Hash(chunk.Data)
 
 		if !repo.Index().Has(id, restic.DataBlob) {
-			_, err := repo.SaveBlob(ctx, restic.DataBlob, chunk.Data, id)
+			_, _, err := repo.SaveBlob(ctx, restic.DataBlob, chunk.Data, id)
 			if err != nil {
 				return nil, restic.ID{}, err
 			}
@@ -89,26 +89,26 @@ func (r *Reader) Archive(ctx context.Context, name string, rd io.Reader, p *rest
 		},
 	}
 
-	treeID, err := repo.SaveTree(ctx, tree)
+	treeID, _, err := repo.SaveTree(ctx, tree)
 	if err != nil {
 		return nil, restic.ID{}, err
 	}
 	sn.Tree = &treeID
 	debug.Log("tree saved as %v", treeID.Str())
 
-	id, err := repo.SaveJSONUnpacked(ctx, restic.SnapshotFile, sn)
+	id, _, err := repo.SaveJSONUnpacked(ctx, restic.SnapshotFile, sn)
 	if err != nil {
 		return nil, restic.ID{}, err
 	}
 
 	debug.Log("snapshot saved as %v", id.Str())
 
-	err = repo.Flush()
+	_, err = repo.Flush()
 	if err != nil {
 		return nil, restic.ID{}, err
 	}
 
-	err = repo.SaveIndex(ctx)
+	_, err = repo.SaveIndex(ctx)
 	if err != nil {
 		return nil, restic.ID{}, err
 	}

--- a/internal/archiver/archiver_duplication_test.go
+++ b/internal/archiver/archiver_duplication_test.go
@@ -109,7 +109,7 @@ func testArchiverDuplication(t *testing.T) {
 
 				buf := make([]byte, 50)
 
-				err := arch.Save(context.TODO(), restic.DataBlob, buf, id)
+				_, err := arch.Save(context.TODO(), restic.DataBlob, buf, id)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -128,7 +128,7 @@ func testArchiverDuplication(t *testing.T) {
 			case <-done:
 				return
 			case <-ticker.C:
-				err := repo.SaveFullIndex(context.TODO())
+				_, err := repo.SaveFullIndex(context.TODO())
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -144,7 +144,7 @@ func testArchiverDuplication(t *testing.T) {
 
 	wg.Wait()
 
-	err = repo.Flush()
+	_, err = repo.Flush()
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -108,7 +108,7 @@ func archiveDirectory(b testing.TB) {
 
 	arch := archiver.New(repo)
 
-	_, id, err := arch.Snapshot(context.TODO(), nil, []string{BenchArchiveDirectory}, nil, "localhost", nil, time.Now())
+	_, id, _, err := arch.Snapshot(context.TODO(), nil, []string{BenchArchiveDirectory}, nil, "localhost", nil, time.Now())
 	OK(b, err)
 
 	b.Logf("snapshot archived as %v", id)
@@ -238,7 +238,7 @@ func testParallelSaveWithDuplication(t *testing.T, seed int) {
 
 				id := restic.Hash(c.Data)
 				time.Sleep(time.Duration(id[0]))
-				err := arch.Save(context.TODO(), restic.DataBlob, c.Data, id)
+				_, err := arch.Save(context.TODO(), restic.DataBlob, c.Data, id)
 				<-barrier
 				errChan <- err
 			}(c, errChan)
@@ -249,8 +249,11 @@ func testParallelSaveWithDuplication(t *testing.T, seed int) {
 		OK(t, <-errChan)
 	}
 
-	OK(t, repo.Flush())
-	OK(t, repo.SaveIndex(context.TODO()))
+	_, err := repo.Flush()
+	OK(t, err)
+
+	_, err = repo.SaveIndex(context.TODO())
+	OK(t, err)
 
 	chkr := createAndInitChecker(t, repo)
 	assertNoUnreferencedPacks(t, chkr)
@@ -302,7 +305,7 @@ func TestArchiveEmptySnapshot(t *testing.T) {
 
 	arch := archiver.New(repo)
 
-	sn, id, err := arch.Snapshot(context.TODO(), nil, []string{"file-does-not-exist-123123213123", "file2-does-not-exist-too-123123123"}, nil, "localhost", nil, time.Now())
+	sn, id, _, err := arch.Snapshot(context.TODO(), nil, []string{"file-does-not-exist-123123213123", "file2-does-not-exist-too-123123123"}, nil, "localhost", nil, time.Now())
 	if err == nil {
 		t.Errorf("expected error for empty snapshot, got nil")
 	}
@@ -354,7 +357,7 @@ func TestArchiveNameCollision(t *testing.T) {
 
 	arch := archiver.New(repo)
 
-	sn, id, err := arch.Snapshot(context.TODO(), nil, []string{"testfile", filepath.Join("..", "testfile")}, nil, "localhost", nil, time.Now())
+	sn, id, _, err := arch.Snapshot(context.TODO(), nil, []string{"testfile", filepath.Join("..", "testfile")}, nil, "localhost", nil, time.Now())
 	OK(t, err)
 
 	t.Logf("snapshot archived as %v", id)

--- a/internal/archiver/testing.go
+++ b/internal/archiver/testing.go
@@ -11,7 +11,7 @@ import (
 // TestSnapshot creates a new snapshot of path.
 func TestSnapshot(t testing.TB, repo restic.Repository, path string, parent *restic.ID) *restic.Snapshot {
 	arch := New(repo)
-	sn, _, err := arch.Snapshot(context.TODO(), nil, []string{path}, []string{"test"}, "localhost", parent, time.Now())
+	sn, _, _, err := arch.Snapshot(context.TODO(), nil, []string{path}, []string{"test"}, "localhost", parent, time.Now())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -306,7 +306,7 @@ func TestCheckerModifiedData(t *testing.T) {
 	defer cleanup()
 
 	arch := archiver.New(repo)
-	_, id, err := arch.Snapshot(context.TODO(), nil, []string{"."}, nil, "localhost", nil, time.Now())
+	_, id, _, err := arch.Snapshot(context.TODO(), nil, []string{"."}, nil, "localhost", nil, time.Now())
 	test.OK(t, err)
 	t.Logf("archived as %v", id.Str())
 

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -254,7 +254,7 @@ func (idx *Index) FindBlob(h restic.BlobHandle) (result []Location, err error) {
 }
 
 // Save writes the complete index to the repo.
-func (idx *Index) Save(ctx context.Context, repo restic.Repository, supersedes restic.IDs) (restic.ID, error) {
+func (idx *Index) Save(ctx context.Context, repo restic.Repository, supersedes restic.IDs) (restic.ID, uint64, error) {
 	packs := make(map[restic.ID][]restic.Blob, len(idx.Packs))
 	for id, p := range idx.Packs {
 		packs[id] = p.Entries
@@ -264,7 +264,7 @@ func (idx *Index) Save(ctx context.Context, repo restic.Repository, supersedes r
 }
 
 // Save writes a new index containing the given packs.
-func Save(ctx context.Context, repo restic.Repository, packs map[restic.ID][]restic.Blob, supersedes restic.IDs) (restic.ID, error) {
+func Save(ctx context.Context, repo restic.Repository, packs map[restic.ID][]restic.Blob, supersedes restic.IDs) (restic.ID, uint64, error) {
 	idx := &indexJSON{
 		Supersedes: supersedes,
 		Packs:      make([]*packJSON, 0, len(packs)),

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -172,7 +172,7 @@ func BenchmarkIndexSave(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		id, err := idx.Save(context.TODO(), repo, nil)
+		id, _, err := idx.Save(context.TODO(), repo, nil)
 		if err != nil {
 			b.Fatalf("New() returned error %v", err)
 		}
@@ -227,7 +227,7 @@ func TestSave(t *testing.T) {
 
 	t.Logf("save %d/%d packs in a new index\n", len(packs), len(idx.Packs))
 
-	id, err := Save(context.TODO(), repo, packs, idx.IndexIDs.List())
+	id, _, err := Save(context.TODO(), repo, packs, idx.IndexIDs.List())
 	if err != nil {
 		t.Fatalf("unable to save new index: %v", err)
 	}
@@ -269,7 +269,7 @@ func TestIndexSave(t *testing.T) {
 
 	idx := loadIndex(t, repo)
 
-	id, err := idx.Save(context.TODO(), repo, idx.IndexIDs.List())
+	id, _, err := idx.Save(context.TODO(), repo, idx.IndexIDs.List())
 	if err != nil {
 		t.Fatalf("unable to save new index: %v", err)
 	}
@@ -366,7 +366,7 @@ func TestIndexLoadDocReference(t *testing.T) {
 	repo, cleanup := repository.TestRepository(t)
 	defer cleanup()
 
-	id, err := repo.SaveUnpacked(context.TODO(), restic.IndexFile, docExample)
+	id, _, err := repo.SaveUnpacked(context.TODO(), restic.IndexFile, docExample)
 	if err != nil {
 		t.Fatalf("SaveUnpacked() returned error %v", err)
 	}

--- a/internal/mock/repository.go
+++ b/internal/mock/repository.go
@@ -27,17 +27,17 @@ type Repository struct {
 
 	FlushFn func() error
 
-	SaveUnpackedFn     func(restic.FileType, []byte) (restic.ID, error)
-	SaveJSONUnpackedFn func(restic.FileType, interface{}) (restic.ID, error)
+	SaveUnpackedFn     func(restic.FileType, []byte) (restic.ID, uint64, error)
+	SaveJSONUnpackedFn func(restic.FileType, interface{}) (restic.ID, uint64, error)
 
 	LoadJSONUnpackedFn func(restic.FileType, restic.ID, interface{}) error
 	LoadAndDecryptFn   func(restic.FileType, restic.ID) ([]byte, error)
 
 	LoadBlobFn func(restic.BlobType, restic.ID, []byte) (int, error)
-	SaveBlobFn func(restic.BlobType, []byte, restic.ID) (restic.ID, error)
+	SaveBlobFn func(restic.BlobType, []byte, restic.ID) (restic.ID, uint64, error)
 
 	LoadTreeFn func(restic.ID) (*restic.Tree, error)
-	SaveTreeFn func(t *restic.Tree) (restic.ID, error)
+	SaveTreeFn func(t *restic.Tree) (restic.ID, uint64, error)
 }
 
 // Backend is a stub method.
@@ -101,12 +101,12 @@ func (repo Repository) Flush() error {
 }
 
 // SaveUnpacked is a stub method.
-func (repo Repository) SaveUnpacked(t restic.FileType, buf []byte) (restic.ID, error) {
+func (repo Repository) SaveUnpacked(t restic.FileType, buf []byte) (restic.ID, uint64, error) {
 	return repo.SaveUnpackedFn(t, buf)
 }
 
 // SaveJSONUnpacked is a stub method.
-func (repo Repository) SaveJSONUnpacked(t restic.FileType, item interface{}) (restic.ID, error) {
+func (repo Repository) SaveJSONUnpacked(t restic.FileType, item interface{}) (restic.ID, uint64, error) {
 	return repo.SaveJSONUnpackedFn(t, item)
 }
 
@@ -126,7 +126,7 @@ func (repo Repository) LoadBlob(t restic.BlobType, id restic.ID, buf []byte) (in
 }
 
 // SaveBlob is a stub method.
-func (repo Repository) SaveBlob(t restic.BlobType, buf []byte, id restic.ID) (restic.ID, error) {
+func (repo Repository) SaveBlob(t restic.BlobType, buf []byte, id restic.ID) (restic.ID, uint64, error) {
 	return repo.SaveBlobFn(t, buf, id)
 }
 
@@ -136,6 +136,6 @@ func (repo Repository) LoadTree(id restic.ID) (*restic.Tree, error) {
 }
 
 // SaveTree is a stub method.
-func (repo Repository) SaveTree(t *restic.Tree) (restic.ID, error) {
+func (repo Repository) SaveTree(t *restic.Tree) (restic.ID, uint64, error) {
 	return repo.SaveTreeFn(t)
 }

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -63,11 +63,11 @@ type headerEntry struct {
 // Finalize writes the header for all added blobs and finalizes the pack.
 // Returned are the number of bytes written, including the header. If the
 // underlying writer implements io.Closer, it is closed.
-func (p *Packer) Finalize() (uint, error) {
+func (p *Packer) Finalize() (uint64, error) {
 	p.m.Lock()
 	defer p.m.Unlock()
 
-	bytesWritten := p.bytes
+	bytesWritten := uint64(p.bytes)
 
 	hdrBuf := bytes.NewBuffer(nil)
 	bytesHeader, err := p.writeHeader(hdrBuf)
@@ -91,14 +91,14 @@ func (p *Packer) Finalize() (uint, error) {
 		return 0, errors.New("wrong number of bytes written")
 	}
 
-	bytesWritten += uint(hdrBytes)
+	bytesWritten += uint64(hdrBytes)
 
 	// write length
 	err = binary.Write(p.wr, binary.LittleEndian, uint32(restic.CiphertextLength(len(p.blobs)*int(entrySize))))
 	if err != nil {
 		return 0, errors.Wrap(err, "binary.Write")
 	}
-	bytesWritten += uint(binary.Size(uint32(0)))
+	bytesWritten += uint64(binary.Size(uint32(0)))
 
 	p.bytes = uint(bytesWritten)
 

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -101,7 +101,7 @@ func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, kee
 					h, tempfile.Name(), id)
 			}
 
-			_, err = repo.SaveBlob(ctx, entry.Type, buf, entry.ID)
+			_, _, err = repo.SaveBlob(ctx, entry.Type, buf, entry.ID)
 			if err != nil {
 				return nil, err
 			}
@@ -123,7 +123,7 @@ func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, kee
 		}
 	}
 
-	if err := repo.Flush(); err != nil {
+	if _, err := repo.Flush(); err != nil {
 		return nil, err
 	}
 

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -49,19 +49,19 @@ func createRandomBlobs(t testing.TB, repo restic.Repository, blobs int, pData fl
 			continue
 		}
 
-		_, err := repo.SaveBlob(context.TODO(), tpe, buf, id)
+		_, _, err := repo.SaveBlob(context.TODO(), tpe, buf, id)
 		if err != nil {
 			t.Fatalf("SaveFrom() error %v", err)
 		}
 
 		if rand.Float32() < 0.2 {
-			if err = repo.Flush(); err != nil {
+			if _, err = repo.Flush(); err != nil {
 				t.Fatalf("repo.Flush() returned error %v", err)
 			}
 		}
 	}
 
-	if err := repo.Flush(); err != nil {
+	if _, err := repo.Flush(); err != nil {
 		t.Fatalf("repo.Flush() returned error %v", err)
 	}
 }
@@ -142,7 +142,7 @@ func repack(t *testing.T, repo restic.Repository, packs restic.IDSet, blobs rest
 }
 
 func saveIndex(t *testing.T, repo restic.Repository) {
-	if err := repo.SaveIndex(context.TODO()); err != nil {
+	if _, err := repo.SaveIndex(context.TODO()); err != nil {
 		t.Fatalf("repo.SaveIndex() %v", err)
 	}
 }
@@ -164,7 +164,7 @@ func rebuildIndex(t *testing.T, repo restic.Repository) {
 		}
 	}
 
-	_, err = idx.Save(context.TODO(), repo, nil)
+	_, _, err = idx.Save(context.TODO(), repo, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/restic/config_test.go
+++ b/internal/restic/config_test.go
@@ -8,9 +8,9 @@ import (
 	. "github.com/restic/restic/internal/test"
 )
 
-type saver func(restic.FileType, interface{}) (restic.ID, error)
+type saver func(restic.FileType, interface{}) (restic.ID, uint64, error)
 
-func (s saver) SaveJSONUnpacked(t restic.FileType, arg interface{}) (restic.ID, error) {
+func (s saver) SaveJSONUnpacked(t restic.FileType, arg interface{}) (restic.ID, uint64, error) {
 	return s(t, arg)
 }
 
@@ -22,20 +22,20 @@ func (l loader) LoadJSONUnpacked(ctx context.Context, t restic.FileType, id rest
 
 func TestConfig(t *testing.T) {
 	resultConfig := restic.Config{}
-	save := func(tpe restic.FileType, arg interface{}) (restic.ID, error) {
+	save := func(tpe restic.FileType, arg interface{}) (restic.ID, uint64, error) {
 		Assert(t, tpe == restic.ConfigFile,
 			"wrong backend type: got %v, wanted %v",
 			tpe, restic.ConfigFile)
 
 		cfg := arg.(restic.Config)
 		resultConfig = cfg
-		return restic.ID{}, nil
+		return restic.ID{}, 0, nil
 	}
 
 	cfg1, err := restic.CreateConfig()
 	OK(t, err)
 
-	_, err = saver(save).SaveJSONUnpacked(restic.ConfigFile, cfg1)
+	_, _, err = saver(save).SaveJSONUnpacked(restic.ConfigFile, cfg1)
 
 	load := func(ctx context.Context, tpe restic.FileType, id restic.ID, arg interface{}) error {
 		Assert(t, tpe == restic.ConfigFile,

--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -170,7 +170,7 @@ func eachLock(ctx context.Context, repo Repository, f func(ID, *Lock, error) err
 
 // createLock acquires the lock by creating a file in the repository.
 func (l *Lock) createLock(ctx context.Context) (ID, error) {
-	id, err := l.repo.SaveJSONUnpacked(ctx, LockFile, l)
+	id, _, err := l.repo.SaveJSONUnpacked(ctx, LockFile, l)
 	if err != nil {
 		return ID{}, err
 	}

--- a/internal/restic/lock_test.go
+++ b/internal/restic/lock_test.go
@@ -92,10 +92,10 @@ func TestExclusiveLockOnLockedRepo(t *testing.T) {
 	OK(t, elock.Unlock())
 }
 
-func createFakeLock(repo restic.Repository, t time.Time, pid int) (restic.ID, error) {
+func createFakeLock(repo restic.Repository, t time.Time, pid int) (restic.ID, uint64, error) {
 	hostname, err := os.Hostname()
 	if err != nil {
-		return restic.ID{}, err
+		return restic.ID{}, 0, err
 	}
 
 	newLock := &restic.Lock{Time: t, PID: pid, Hostname: hostname}
@@ -175,13 +175,13 @@ func TestLockWithStaleLock(t *testing.T) {
 	repo, cleanup := repository.TestRepository(t)
 	defer cleanup()
 
-	id1, err := createFakeLock(repo, time.Now().Add(-time.Hour), os.Getpid())
+	id1, _, err := createFakeLock(repo, time.Now().Add(-time.Hour), os.Getpid())
 	OK(t, err)
 
-	id2, err := createFakeLock(repo, time.Now().Add(-time.Minute), os.Getpid())
+	id2, _, err := createFakeLock(repo, time.Now().Add(-time.Minute), os.Getpid())
 	OK(t, err)
 
-	id3, err := createFakeLock(repo, time.Now().Add(-time.Minute), os.Getpid()+500000)
+	id3, _, err := createFakeLock(repo, time.Now().Add(-time.Minute), os.Getpid()+500000)
 	OK(t, err)
 
 	OK(t, restic.RemoveStaleLocks(context.TODO(), repo))
@@ -200,13 +200,13 @@ func TestRemoveAllLocks(t *testing.T) {
 	repo, cleanup := repository.TestRepository(t)
 	defer cleanup()
 
-	id1, err := createFakeLock(repo, time.Now().Add(-time.Hour), os.Getpid())
+	id1, _, err := createFakeLock(repo, time.Now().Add(-time.Hour), os.Getpid())
 	OK(t, err)
 
-	id2, err := createFakeLock(repo, time.Now().Add(-time.Minute), os.Getpid())
+	id2, _, err := createFakeLock(repo, time.Now().Add(-time.Minute), os.Getpid())
 	OK(t, err)
 
-	id3, err := createFakeLock(repo, time.Now().Add(-time.Minute), os.Getpid()+500000)
+	id3, _, err := createFakeLock(repo, time.Now().Add(-time.Minute), os.Getpid()+500000)
 	OK(t, err)
 
 	OK(t, restic.RemoveAllLocks(context.TODO(), repo))

--- a/internal/restic/progress.go
+++ b/internal/restic/progress.go
@@ -35,12 +35,13 @@ type Progress struct {
 
 // Stat captures newly done parts of the operation.
 type Stat struct {
-	Files  uint64
-	Dirs   uint64
-	Bytes  uint64
-	Trees  uint64
-	Blobs  uint64
-	Errors uint64
+	Files        uint64
+	Dirs         uint64
+	Bytes        uint64
+	Trees        uint64
+	Blobs        uint64
+	BytesWritten uint64
+	Errors       uint64
 }
 
 // ProgressFunc is used to report progress back to the user.
@@ -194,6 +195,7 @@ func (s *Stat) Add(other Stat) {
 	s.Files += other.Files
 	s.Trees += other.Trees
 	s.Blobs += other.Blobs
+	s.BytesWritten += other.BytesWritten
 	s.Errors += other.Errors
 }
 
@@ -214,6 +216,15 @@ func (s Stat) String() string {
 		str = fmt.Sprintf("%dB", s.Bytes)
 	}
 
-	return fmt.Sprintf("Stat(%d files, %d dirs, %v trees, %v blobs, %d errors, %v)",
-		s.Files, s.Dirs, s.Trees, s.Blobs, s.Errors, str)
+	return fmt.Sprintf("Stat(%d files, %d dirs, %v trees, %v blobs, %d bytes written, %d errors, %v)",
+		s.Files, s.Dirs, s.Trees, s.Blobs, s.BytesWritten, s.Errors, str)
+}
+
+// BytesWritten returns the bytes written to the backend so far
+func (p *Progress) BytesWritten() uint64 {
+	if p == nil {
+		return 0
+	}
+
+	return p.cur.BytesWritten
 }

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -18,8 +18,8 @@ type Repository interface {
 	SetIndex(Index)
 
 	Index() Index
-	SaveFullIndex(context.Context) error
-	SaveIndex(context.Context) error
+	SaveFullIndex(context.Context) (uint64, error)
+	SaveIndex(context.Context) (uint64, error)
 	LoadIndex(context.Context) error
 
 	Config() Config
@@ -29,19 +29,19 @@ type Repository interface {
 	List(context.Context, FileType) <-chan ID
 	ListPack(context.Context, ID) ([]Blob, int64, error)
 
-	Flush() error
+	Flush() (uint64, error)
 
-	SaveUnpacked(context.Context, FileType, []byte) (ID, error)
-	SaveJSONUnpacked(context.Context, FileType, interface{}) (ID, error)
+	SaveUnpacked(context.Context, FileType, []byte) (ID, uint64, error)
+	SaveJSONUnpacked(context.Context, FileType, interface{}) (ID, uint64, error)
 
 	LoadJSONUnpacked(context.Context, FileType, ID, interface{}) error
 	LoadAndDecrypt(context.Context, FileType, ID) ([]byte, error)
 
 	LoadBlob(context.Context, BlobType, ID, []byte) (int, error)
-	SaveBlob(context.Context, BlobType, []byte, ID) (ID, error)
+	SaveBlob(context.Context, BlobType, []byte, ID) (ID, uint64, error)
 
 	LoadTree(context.Context, ID) (*Tree, error)
-	SaveTree(context.Context, *Tree) (ID, error)
+	SaveTree(context.Context, *Tree) (ID, uint64, error)
 }
 
 // Deleter removes all data stored in a backend/repo.

--- a/internal/restic/testing.go
+++ b/internal/restic/testing.go
@@ -54,7 +54,7 @@ func (fs *fakeFileSystem) saveFile(ctx context.Context, rd io.Reader) (blobs IDs
 
 		id := Hash(chunk.Data)
 		if !fs.blobIsKnown(id, DataBlob) {
-			_, err := fs.repo.SaveBlob(ctx, DataBlob, chunk.Data, id)
+			_, _, err := fs.repo.SaveBlob(ctx, DataBlob, chunk.Data, id)
 			if err != nil {
 				fs.t.Fatalf("error saving chunk: %v", err)
 			}
@@ -146,7 +146,7 @@ func (fs *fakeFileSystem) saveTree(ctx context.Context, seed int64, depth int) I
 		return id
 	}
 
-	_, err := fs.repo.SaveBlob(ctx, TreeBlob, buf, id)
+	_, _, err := fs.repo.SaveBlob(ctx, TreeBlob, buf, id)
 	if err != nil {
 		fs.t.Fatal(err)
 	}
@@ -180,7 +180,7 @@ func TestCreateSnapshot(t testing.TB, repo Repository, at time.Time, depth int, 
 	treeID := fs.saveTree(context.TODO(), seed, depth)
 	snapshot.Tree = &treeID
 
-	id, err := repo.SaveJSONUnpacked(context.TODO(), SnapshotFile, snapshot)
+	id, _, err := repo.SaveJSONUnpacked(context.TODO(), SnapshotFile, snapshot)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -189,12 +189,12 @@ func TestCreateSnapshot(t testing.TB, repo Repository, at time.Time, depth int, 
 
 	t.Logf("saved snapshot %v", id.Str())
 
-	err = repo.Flush()
+	_, err = repo.Flush()
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	err = repo.SaveIndex(context.TODO())
+	_, err = repo.SaveIndex(context.TODO())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/restic/tree_test.go
+++ b/internal/restic/tree_test.go
@@ -99,11 +99,12 @@ func TestLoadTree(t *testing.T) {
 
 	// save tree
 	tree := restic.NewTree()
-	id, err := repo.SaveTree(context.TODO(), tree)
+	id, _, err := repo.SaveTree(context.TODO(), tree)
 	OK(t, err)
 
 	// save packs
-	OK(t, repo.Flush())
+	_, err = repo.Flush()
+	OK(t, err)
 
 	// load tree again
 	tree2, err := repo.LoadTree(context.TODO(), id)

--- a/internal/walk/walk_test.go
+++ b/internal/walk/walk_test.go
@@ -25,11 +25,12 @@ func TestWalkTree(t *testing.T) {
 
 	// archive a few files
 	arch := archiver.New(repo)
-	sn, _, err := arch.Snapshot(context.TODO(), nil, dirs, nil, "localhost", nil, time.Now())
+	sn, _, _, err := arch.Snapshot(context.TODO(), nil, dirs, nil, "localhost", nil, time.Now())
 	OK(t, err)
 
 	// flush repo, write all packs
-	OK(t, repo.Flush())
+	_, err = repo.Flush()
+	OK(t, err)
 
 	// start tree walker
 	treeJobs := make(chan walk.TreeJob)


### PR DESCRIPTION
Output looks like this:
scanned 1 directories, 4 files in 0:00
[0:00] 100.00%  0B/s  20.000 MiB / 20.000 MiB  5 / 5 items  20.001 MiB written  0 errors  ETA 0:00 
duration: 0:00, 124.95MiB/s
snapshot b201fcf1 saved, 20.006 MiB written

Maybe this can be used to make restic stop writing beyond a given size