### PR TITLE
Clarify cache location documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ Important Changes in 0.X.Y
  * We've added a local cache for metadata so that restic doesn't need to load
    all metadata (snapshots, indexes, ...) from the repo each time it starts. By
    default the cache is active, but there's a new global option `--no-cache`
-   that can be used to disable the cache. The cache location is
-   `~/.cache/restic` by default, which can be overridden with `--cache-dir` or
-   the environment variable `XDG_CACHE_HOME`. The cache will automatically
-   populate, indexes and snapshots are saved as they are loaded.
+   that can be used to disable the cache. By deafult, the cache a standard
+   cache folder for the OS, which can be overridden with `--cache-dir`.  The
+   cache will automatically populate, indexes and snapshots are saved as they
+   are loaded.
    https://github.com/restic/restic/pull/1040
    https://github.com/restic/restic/issues/29
    https://github.com/restic/restic/issues/738

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -267,12 +267,16 @@ Caching
 
 Restic keeps a cache with some files from the repository on the local machine.
 This allows faster operations, since meta data does not need to be loaded from
-a remote repository. The cache is automatically created, usually in the
-directory ``.cache/restic`` in the user's home directory. The environment
-variable ``XDG_CACHE_DIR`` or the command line parameter ``--cache-dir`` can
-each be used to specify where the cache is located. The parameter
-``--no-cache`` disables the cache entirely. In this case, all data is loaded
-from the repo.
+a remote repository. The cache is automatically created, usually in an
+OS-specific cache folder:
+
+ * Linux/other: ``~/.cache/restic`` (or ``$XDG_CACHE_HOME/restic``)
+ * macOS: ``~/Library/Caches/restic``
+ * Windows: ``%LOCALAPPDATA%/restic``
+
+The command line parameter ``--cache-dir`` can each be used to override the
+default cache location. The parameter ``--no-cache`` disables the cache
+entirely. In this case, all data is loaded from the repo.
 
 The cache is ephemeral: When a file cannot be read from the cache, it is loaded
 from the repository.


### PR DESCRIPTION
PR #1287 changed the default cache location on darwin and windows.
Update the changelog and manual to reflect the new behavior.

Since the cache hasn't been included in an official release yet, I've
just changed the main cache changelog entry.

Fixes #1309