### PR TITLE
Add explicit OK output to check command

### DIFF
--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -176,5 +176,8 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	if errorsFound {
 		return errors.Fatal("repository contains errors")
 	}
+
+	Verbosef("No errors were found\n")
+
 	return nil
 }


### PR DESCRIPTION
This adds additional output to the check command when no errors were
found. It means that when all checks have been completed, the following
output is displayed:

	No errors were found

The output is added to make sure that it is easier to understand that no
errors were found.

Full example output:

	Create exclusive lock for repository
	Load indexes
	Check all packs
	Check snapshots, trees and blobs
	No errors were found

Fixes #1303 

Thanks!