### PR TITLE
snapshots: Add short ID to JSON output

### DIFF
--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -172,7 +172,8 @@ func PrintSnapshots(stdout io.Writer, list restic.Snapshots, compact bool) {
 type Snapshot struct {
 	*restic.Snapshot
 
-	ID *restic.ID `json:"id"`
+	ID      *restic.ID `json:"id"`
+	ShortID string     `json:"short_id"`
 }
 
 // printSnapshotsJSON writes the JSON representation of list to stdout.
@@ -185,6 +186,7 @@ func printSnapshotsJSON(stdout io.Writer, list restic.Snapshots) error {
 		k := Snapshot{
 			Snapshot: sn,
 			ID:       sn.ID(),
+			ShortID:  sn.ID().Str(),
 		}
 		snapshots = append(snapshots, k)
 	}


### PR DESCRIPTION
We're using the short ID in all output to users, so it should also be included in the JSON output of the `snapshots` command.