### PR TITLE
Add password successful feedback

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -132,20 +132,6 @@ func restoreTerminal() {
 	})
 }
 
-// shouldOutputPasswordSuccessful returns true if the password is supplied
-// interactively and the stdout is a terminal.
-func shouldOutputPasswordSuccessful() bool {
-	if globalOptions.PasswordFile != "" {
-		return false
-	}
-
-	if os.Getenv("RESTIC_PASSWORD") != "" {
-		return false
-	}
-
-	return stdoutIsTerminal()
-}
-
 // ClearLine creates a platform dependent string to clear the current
 // line, so it can be overwritten. ANSI sequences are not supported on
 // current windows cmd shell.
@@ -340,7 +326,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		return nil, err
 	}
 
-	if shouldOutputPasswordSuccessful() {
+	if stdoutIsTerminal() {
 		Verbosef("password is correct\n")
 	}
 

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -132,6 +132,20 @@ func restoreTerminal() {
 	})
 }
 
+// shouldOutputPasswordSuccessful returns true if the password is supplied
+// interactively and the stdout is a terminal.
+func shouldOutputPasswordSuccessful() bool {
+	if globalOptions.PasswordFile != "" {
+		return false
+	}
+
+	if os.Getenv("RESTIC_PASSWORD") != "" {
+		return false
+	}
+
+	return stdoutIsTerminal()
+}
+
 // ClearLine creates a platform dependent string to clear the current
 // line, so it can be overwritten. ANSI sequences are not supported on
 // current windows cmd shell.
@@ -324,6 +338,10 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 	err = s.SearchKey(context.TODO(), opts.password, maxKeys)
 	if err != nil {
 		return nil, err
+	}
+
+	if shouldOutputPasswordSuccessful() {
+		Verbosef("password is correct\n")
 	}
 
 	if opts.NoCache {


### PR DESCRIPTION
This adds some feedback when entering the password on the command line.
When the password is entered and supplied through stdin (and stdout is a
terminal) then the a message saying `password is correct` if correct is
printed.

The pull request aims to fix #438 

I'm not sure if it's the correct place to output in the `OpenRepository` function
or that my assumption is correct in when it should be outputted.

Thanks!