### PR TITLE
backup should use latest parent regardless of tags

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -416,7 +416,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 
 	// Find last snapshot to set it as parent, if not already set
 	if !opts.Force && parentSnapshotID == nil {
-		id, err := restic.FindLatestSnapshot(context.TODO(), repo, target, []restic.TagList{opts.Tags}, opts.Hostname)
+		id, err := restic.FindLatestSnapshot(context.TODO(), repo, target, []restic.TagList{}, opts.Hostname)
 		if err == nil {
 			parentSnapshotID = &id
 		} else if err != restic.ErrNoSnapshotFound {

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -656,6 +656,7 @@ func TestBackupTags(t *testing.T) {
 	rtest.Assert(t, newest != nil, "expected a new backup, got nil")
 	rtest.Assert(t, len(newest.Tags) == 0,
 		"expected no tags, got %v", newest.Tags)
+	parent := newest
 
 	opts.Tags = []string{"NL"}
 	testRunBackup(t, []string{env.testdata}, opts, env.gopts)
@@ -664,6 +665,9 @@ func TestBackupTags(t *testing.T) {
 	rtest.Assert(t, newest != nil, "expected a new backup, got nil")
 	rtest.Assert(t, len(newest.Tags) == 1 && newest.Tags[0] == "NL",
 		"expected one NL tag, got %v", newest.Tags)
+	// Tagged backup should have untagged backup as parent.
+	rtest.Assert(t, parent.ID.Equal(*newest.Parent),
+		"expected parent to be %v, got %v", parent.ID, newest.Parent)
 }
 
 func testRunTag(t testing.TB, opts TagOptions, gopts GlobalOptions) {


### PR DESCRIPTION
Backup was choosing a parent snapshot that had the same tags, which
makes backup unnecessarily slow when there are newer snapshots with
different tags.

There's no reason parent has to have the same tags.

This change makes backup choose the newest snapshot instead.

Fixes #1143