### PR TITLE
Add code to autodetect whether backends are read-only or can be written to

### DIFF
--- a/cmd/restic/cmd_writable.go
+++ b/cmd/restic/cmd_writable.go
@@ -1,0 +1,49 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/restic/restic/internal/cache"
+	"github.com/restic/restic/internal/restic"
+	"github.com/spf13/cobra"
+)
+
+var cmdWritable = &cobra.Command{
+	Use:   "writable",
+	Short: "Print whether the repository can be written to.",
+	Long: `
+The "writable" command is used to check whether the repository is writable or read-only".
+`,
+	DisableAutoGenTag: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runWritable(globalOptions, args)
+	},
+}
+
+func init() {
+	cmdRoot.AddCommand(cmdWritable)
+}
+
+func runWritable(gopts GlobalOptions, args []string) error {
+	repo, err := OpenRepository(gopts)
+	if err != nil {
+		return err
+	}
+	defer repo.Close()
+	b := repo.Backend()
+	switch x := b.(type) {
+	case *cache.Backend:
+		b = x.Backend
+	default:
+	}
+	w, ok := b.(restic.Writabler)
+	if !ok {
+		return fmt.Errorf("The repository backend does not provide a definite answer. You just need to try.")
+	}
+	if w.Writable() {
+		fmt.Println("The repository is considered to be writable.")
+	} else {
+		fmt.Println("The repository is read-only.")
+	}
+	return nil
+}

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -30,6 +30,9 @@ const defaultListMaxItems = 1000
 // ensure statically that *b2Backend implements restic.Backend.
 var _ restic.Backend = &b2Backend{}
 
+// ensure statically that *b2Backend implements restic.Writable.
+var _ restic.Writabler = &b2Backend{}
+
 func newClient(ctx context.Context, cfg Config, rt http.RoundTripper) (*b2.Client, error) {
 	opts := []b2.ClientOption{b2.Transport(rt)}
 
@@ -385,3 +388,10 @@ func (be *b2Backend) Delete(ctx context.Context) error {
 
 // Close does nothing
 func (be *b2Backend) Close() error { return nil }
+
+// Writable implements restic.Writabler for b2Backend. It always returns true
+// because without authorized credentials B2 will not even allow to list the
+// objects in the bucket.
+func (be *b2Backend) Writable() bool {
+	return true
+}

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -23,6 +23,9 @@ type Local struct {
 // ensure statically that *Local implements restic.Backend.
 var _ restic.Backend = &Local{}
 
+// ensure statically that *Local implements restic.Writabler.
+var _ restic.Writabler = &Local{}
+
 const defaultLayout = "default"
 
 // dirExists returns true if the name exists and is a directory.
@@ -286,4 +289,15 @@ func (b *Local) Close() error {
 	// this does not need to do anything, all open files are closed within the
 	// same function.
 	return nil
+}
+
+// Writable returns whether the local backend b can be written to.
+func (b *Local) Writable() bool {
+	s, err := fs.Stat(b.Path)
+	if err != nil {
+		// how could the repo be opened in the first place?
+		// better consider it to be read-only
+		return false
+	}
+	return s.Mode()&0200 != 0
 }

--- a/internal/restic/backend.go
+++ b/internal/restic/backend.go
@@ -42,6 +42,17 @@ type Backend interface {
 	IsNotExist(err error) bool
 }
 
+// Writabler is the interface that wraps the basic Writable method.
+//
+// Writable returns true if the receiver of the method can be written to (i.e.
+// is not read-only). It is supposed to be used (and later even embedded) by
+// types that implement the Backend interface. The suggested use is that types
+// that do not implement Writabler are considered to be writeable to remain
+// backwards-compatible.
+type Writabler interface {
+	Writable() bool
+}
+
 // FileInfo is returned by Stat() and contains information about a file in the
 // backend.
 type FileInfo struct{ Size int64 }


### PR DESCRIPTION
This comment is an attempt to address #351.

It adds the `restic.Writabler` interface which wraps the basic `Writable() bool` method, that has been added to some of the backends: local, REST, SFTP, and B2. Once `restic.Writabler` is implemented by all `restic.Backend` implementations, `Writable() bool` can (and should) be added to `restic.Backend`. 
To add the functionality to the missing backends, one would only need to implement `restic.Writabler` for them on a case-by-case basis.

The PR also adds `cmd_writable.go` which serves as a usage example. `restic writable` may not a very useful command (or perhaps it is for scripts?), but it served me well for testing the code and may be of interest for checking things out during reviews. In any case, I am happy to remove it before an eventual merge to upstream.

The name `Ẁritable() bool` was chosen over `ReadOnly() bool` because I prefer the affirmative result to return `true` and because otherwise the interfache name were `type ReadOnlier interface` and I did not like that. :)
