### PR TITLE
fuse mount: speedup

### DIFF
--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -27,6 +27,7 @@ type Root struct {
 	inode         uint64
 	snapshots     restic.Snapshots
 	blobSizeCache *BlobSizeCache
+	snCount       int
 
 	*MetaDir
 }


### PR DESCRIPTION
Before reading the indexes, restic now checks whether the count of snapshots in the repository changed

A better way would be to have a hash for the whole repository?
