### PR TITLE
Fix failure to detect some legacy s3 repos

### DIFF
--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -172,8 +172,9 @@ func (be *Backend) ReadDir(dir string) (list []os.FileInfo, err error) {
 		}
 
 		name := strings.TrimPrefix(obj.Key, dir)
+		// Sometimes s3 returns an entry for the dir itself. Ignore it.
 		if name == "" {
-			return nil, errors.Errorf("invalid key name %v, removing prefix %v yielded empty string", obj.Key, dir)
+			continue
 		}
 		entry := fileInfo{
 			name:    name,


### PR DESCRIPTION
Sometimes s3 listobjects for a directory includes an entry for that
directory. The restic s3 backend doesn't expect that and returns
an error.

Symptom is:
  ReadDir: invalid key name restic/key/, removing prefix
     restic/key/ yielded empty string

I'm not sure when s3 does that; I'm unable to reproduce it myself.

But in any case, it seems correct to ignore that when it happens.

Fixes #1068