### PR TITLE
Fix modtime tests on APFS: allow 1us difference

### DIFF
--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -71,7 +71,17 @@ func sameModTime(fi1, fi2 os.FileInfo) bool {
 		}
 	}
 
-	return fi1.ModTime().Equal(fi2.ModTime())
+	same := fi1.ModTime().Equal(fi2.ModTime())
+	if !same && runtime.GOOS == "darwin" {
+		// Allow up to 1μs difference, because macOS <10.13 cannot restore
+		// with nanosecond precision and the current version of Go (1.9.2)
+		// does not yet support the new syscall. (#1087)
+		mt1 := fi1.ModTime()
+		mt2 := fi2.ModTime()
+		usecDiff := (mt1.Nanosecond()-mt2.Nanosecond())/1000 + (mt1.Second()-mt2.Second())*1000000
+		same = usecDiff <= 1 && usecDiff >= -1
+	}
+	return same
 }
 
 // directoriesEqualContents checks if both directories contain exactly the same


### PR DESCRIPTION
Fixes #1087.

This fixes the tests failing on APFS as reported in #1087  by allowing a difference in modtime of up to 1 microsecond.

I'm not sure if this is the right approach. Maybe we should increase the precision that we store in backups instead?