### PR TITLE
small cleanup

### DIFF
--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -218,7 +218,7 @@ func (be *b2Backend) Load(ctx context.Context, h restic.Handle, length int, offs
 }
 
 // Save stores data in the backend at the handle.
-func (be *b2Backend) Save(ctx context.Context, h restic.Handle, rd io.Reader) (err error) {
+func (be *b2Backend) Save(ctx context.Context, h restic.Handle, rd io.Reader) (error) {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -233,7 +233,7 @@ func (be *b2Backend) Save(ctx context.Context, h restic.Handle, rd io.Reader) (e
 	debug.Log("Save %v, name %v", h, name)
 	obj := be.bucket.Object(name)
 
-	_, err = obj.Attrs(ctx)
+	_, err := obj.Attrs(ctx)
 	if err == nil {
 		debug.Log("  %v already exists", h)
 		return errors.New("key already exists")

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -218,7 +218,7 @@ func (be *b2Backend) Load(ctx context.Context, h restic.Handle, length int, offs
 }
 
 // Save stores data in the backend at the handle.
-func (be *b2Backend) Save(ctx context.Context, h restic.Handle, rd io.Reader) (error) {
+func (be *b2Backend) Save(ctx context.Context, h restic.Handle, rd io.Reader) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -118,7 +118,7 @@ func (b *Local) IsNotExist(err error) bool {
 }
 
 // Save stores data in the backend at the handle.
-func (b *Local) Save(ctx context.Context, h restic.Handle, rd io.Reader) (err error) {
+func (b *Local) Save(ctx context.Context, h restic.Handle, rd io.Reader) (error) {
 	debug.Log("Save %v", h)
 	if err := h.Valid(); err != nil {
 		return err

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -118,7 +118,7 @@ func (b *Local) IsNotExist(err error) bool {
 }
 
 // Save stores data in the backend at the handle.
-func (b *Local) Save(ctx context.Context, h restic.Handle, rd io.Reader) (error) {
+func (b *Local) Save(ctx context.Context, h restic.Handle, rd io.Reader) error {
 	debug.Log("Save %v", h)
 	if err := h.Valid(); err != nil {
 		return err

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -70,7 +70,7 @@ func writeCachedirTag(dir string) error {
 
 	debug.Log("Create CACHEDIR.TAG at %v", dir)
 	if _, err := f.Write([]byte(cachedirTagSignature)); err != nil {
-		f.Close()
+		_ = f.Close()
 		return errors.Wrap(err, "Write")
 	}
 

--- a/internal/cache/file.go
+++ b/internal/cache/file.go
@@ -65,7 +65,7 @@ func (c *Cache) Load(h restic.Handle, length int, offset int64) (io.ReadCloser, 
 
 	if offset > 0 {
 		if _, err = f.Seek(offset, io.SeekStart); err != nil {
-			f.Close()
+			_ = f.Close()
 			return nil, err
 		}
 	}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -674,8 +674,8 @@ func checkPack(ctx context.Context, r restic.Repository, id restic.ID) error {
 	}
 
 	defer func() {
-		packfile.Close()
-		os.Remove(packfile.Name())
+		_ = packfile.Close()
+		_ = os.Remove(packfile.Name())
 	}()
 
 	hrd := hashing.NewReader(rd, sha256.New())

--- a/internal/pipe/pipe.go
+++ b/internal/pipe/pipe.go
@@ -67,7 +67,7 @@ func readDirNames(dirname string) ([]string, error) {
 		return nil, errors.Wrap(err, "Open")
 	}
 	names, err := f.Readdirnames(-1)
-	f.Close()
+	_ = f.Close()
 	if err != nil {
 		return nil, errors.Wrap(err, "Readdirnames")
 	}

--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -109,7 +109,7 @@ func newLock(ctx context.Context, repo Repository, excl bool) (*Lock, error) {
 	time.Sleep(waitBeforeLockCheck)
 
 	if err = lock.checkForOtherLocks(ctx); err != nil {
-		lock.Unlock()
+		_ = lock.Unlock()
 		return nil, err
 	}
 

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -253,8 +253,26 @@ func (node Node) createFileAt(ctx context.Context, path string, repo Repository,
 	if err != nil {
 		return errors.Wrap(err, "OpenFile")
 	}
-	defer f.Close()
 
+	err = node.writeNodeContent(ctx, repo, f)
+	closeErr := f.Close()
+
+	if err != nil {
+		return err
+	}
+
+	if closeErr != nil {
+		return errors.Wrap(closeErr, "Close")
+	}
+
+	if node.Links > 1 {
+		idx.Add(node.Inode, node.DeviceID, path)
+	}
+
+	return nil
+}
+
+func (node Node) writeNodeContent(ctx context.Context, repo Repository, f *os.File) (error) {
 	var buf []byte
 	for _, id := range node.Content {
 		size, err := repo.LookupBlobSize(id, DataBlob)
@@ -277,10 +295,6 @@ func (node Node) createFileAt(ctx context.Context, path string, repo Repository,
 		if err != nil {
 			return errors.Wrap(err, "Write")
 		}
-	}
-
-	if node.Links > 1 {
-		idx.Add(node.Inode, node.DeviceID, path)
 	}
 
 	return nil

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -272,7 +272,7 @@ func (node Node) createFileAt(ctx context.Context, path string, repo Repository,
 	return nil
 }
 
-func (node Node) writeNodeContent(ctx context.Context, repo Repository, f *os.File) (error) {
+func (node Node) writeNodeContent(ctx context.Context, repo Repository, f *os.File) error {
 	var buf []byte
 	for _, id := range node.Content {
 		size, err := repo.LookupBlobSize(id, DataBlob)

--- a/internal/restic/restorer.go
+++ b/internal/restic/restorer.go
@@ -51,7 +51,7 @@ func (res *Restorer) restoreTo(ctx context.Context, dst string, dir string, tree
 		debug.Log("SelectFilter returned %v %v", selectedForRestore, childMayBeSelected)
 
 		if selectedForRestore {
-			err := res.restoreNodeTo(ctx, node, dir, dst, idx)
+			err = res.restoreNodeTo(ctx, node, dir, dst, idx)
 			if err != nil {
 				return err
 			}
@@ -74,7 +74,8 @@ func (res *Restorer) restoreTo(ctx context.Context, dst string, dir string, tree
 			if selectedForRestore {
 				// Restore directory timestamp at the end. If we would do it earlier, restoring files within
 				// the directory would overwrite the timestamp of the directory they are in.
-				if err := node.RestoreTimestamps(filepath.Join(dst, dir, node.Name)); err != nil {
+				err = node.RestoreTimestamps(filepath.Join(dst, dir, node.Name))
+				if err != nil {
 					return err
 				}
 			}


### PR DESCRIPTION
As discussed in gh-1385.

- be explicit when discarding returned errors from .Close(), etc.
- remove named return values from funcs when naked return not used
- fix some "err" shadowing when redeclaration not needed