### PR TITLE
detect errors from fs.Walk() in local backend List()

### DIFF
--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -252,23 +252,27 @@ func (b *Local) List(ctx context.Context, t restic.FileType) <-chan string {
 	go func() {
 		defer close(ch)
 
-		fs.Walk(b.Basedir(t), func(path string, fi os.FileInfo, err error) error {
+		err := fs.Walk(b.Basedir(t), func(path string, fi os.FileInfo, err error) error {
 			if err != nil {
 				return err
 			}
 
 			if !isFile(fi) {
-				return err
+				return nil
 			}
 
 			select {
 			case ch <- filepath.Base(path):
 			case <-ctx.Done():
-				return err
+				return nil
 			}
 
-			return err
+			return nil
 		})
+
+		if err != nil {
+			debug.Log("Walk %v", err)
+		}
 	}()
 
 	return ch


### PR DESCRIPTION
I found another place where failing to check an error might hide a bug, or at least a problematic repo. 

The scenario where this matters is when there is a problem in a local repo, e.g. permissions setting on a data/FOO directory. This will cause "list packs" and similar code paths to silently stop listing data when it encounters the problematic dir. 

My solution here isn't really satisfactory, as it merely logs it, and only to the debug log (not really user-visible). What do you think?

Related to gh-1385.