### PR TITLE
Use lowercase in messages from check/tag commands, too

### DIFF
--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -93,7 +93,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	}
 
 	if !gopts.NoLock {
-		Verbosef("Create exclusive lock for repository\n")
+		Verbosef("create exclusive lock for repository\n")
 		lock, err := lockRepoExclusive(repo)
 		defer unlockRepo(lock)
 		if err != nil {
@@ -103,7 +103,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 
 	chkr := checker.New(repo)
 
-	Verbosef("Load indexes\n")
+	Verbosef("load indexes\n")
 	hints, errs := chkr.LoadIndex(context.TODO())
 
 	dupFound := false
@@ -128,7 +128,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	errorsFound := false
 	errChan := make(chan error)
 
-	Verbosef("Check all packs\n")
+	Verbosef("check all packs\n")
 	go chkr.Packs(context.TODO(), errChan)
 
 	for err := range errChan {
@@ -136,7 +136,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 	}
 
-	Verbosef("Check snapshots, trees and blobs\n")
+	Verbosef("check snapshots, trees and blobs\n")
 	errChan = make(chan error)
 	go chkr.Structure(context.TODO(), errChan)
 
@@ -160,7 +160,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	}
 
 	if opts.ReadData {
-		Verbosef("Read all data\n")
+		Verbosef("read all data\n")
 
 		p := newReadProgress(gopts, restic.Stat{Blobs: chkr.CountPacks()})
 		errChan := make(chan error)
@@ -177,7 +177,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 		return errors.Fatal("repository contains errors")
 	}
 
-	Verbosef("No errors were found\n")
+	Verbosef("no errors were found\n")
 
 	return nil
 }

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -113,7 +113,7 @@ func runTag(opts TagOptions, gopts GlobalOptions, args []string) error {
 	}
 
 	if !gopts.NoLock {
-		Verbosef("Create exclusive lock for repository\n")
+		Verbosef("create exclusive lock for repository\n")
 		lock, err := lockRepoExclusive(repo)
 		defer unlockRepo(lock)
 		if err != nil {
@@ -135,9 +135,9 @@ func runTag(opts TagOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 	if changeCnt == 0 {
-		Verbosef("No snapshots were modified\n")
+		Verbosef("no snapshots were modified\n")
 	} else {
-		Verbosef("Modified tags on %v snapshots\n", changeCnt)
+		Verbosef("modified tags on %v snapshots\n", changeCnt)
 	}
 	return nil
 }

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -104,8 +104,8 @@ command does that:
 .. code-block:: console
 
     $ restic -r /tmp/backup tag --set NL --set CH 590c8fc8
-    Create exclusive lock for repository
-    Modified tags on 1 snapshots
+    create exclusive lock for repository
+    modified tags on 1 snapshots
 
 Note the snapshot ID has changed, so between each change we need to look
 up the new ID of the snapshot. But there is an even better way, the
@@ -117,19 +117,19 @@ So we can add and remove tags incrementally like this:
 .. code-block:: console
 
     $ restic -r /tmp/backup tag --tag NL --remove CH
-    Create exclusive lock for repository
-    Modified tags on 1 snapshots
+    create exclusive lock for repository
+    modified tags on 1 snapshots
 
     $ restic -r /tmp/backup tag --tag NL --add UK
-    Create exclusive lock for repository
-    Modified tags on 1 snapshots
+    create exclusive lock for repository
+    modified tags on 1 snapshots
 
     $ restic -r /tmp/backup tag --tag NL --remove NL
-    Create exclusive lock for repository
-    Modified tags on 1 snapshots
+    create exclusive lock for repository
+    modified tags on 1 snapshots
 
     $ restic -r /tmp/backup tag --tag NL --add SOMETHING
-    No snapshots were modified
+    no snapshots were modified
 
 Under the hood
 --------------


### PR DESCRIPTION
Almost all commands output in lowercase. Let's bring check & tag commands to that standard, too.