### PR TITLE
Fix test failing on OpenBSD #1307

### DIFF
--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -72,7 +72,7 @@ func sameModTime(fi1, fi2 os.FileInfo) bool {
 	}
 
 	same := fi1.ModTime().Equal(fi2.ModTime())
-	if !same && runtime.GOOS == "darwin" {
+	if !same && (runtime.GOOS == "darwin" || runtime.GOOS == "openbsd") {
 		// Allow up to 1μs difference, because macOS <10.13 cannot restore
 		// with nanosecond precision and the current version of Go (1.9.2)
 		// does not yet support the new syscall. (#1087)


### PR DESCRIPTION
Is seems that #1307 is similar to #1087, which describes a comparable
observation on Apple's new filesystem. #1389 Has been committed and
fixes the problem on Darwin.

Although I'm not sure if the root cause of the issue is the same the
solution is similar for OpenBSD, and leverages #1389.