### PR TITLE
also handle SIGPIPE in cleanup routines

### DIFF
--- a/cmd/restic/cleanup.go
+++ b/cmd/restic/cleanup.go
@@ -73,8 +73,14 @@ func RunCleanupHandlers() {
 func CleanupHandler(c <-chan os.Signal) {
 	for s := range c {
 		debug.Log("signal %v received, cleaning up", s)
-		fmt.Printf("%sInterrupt received, cleaning up\n", ClearLine())
-		Exit(0)
+		fmt.Fprintf(stderr, "%ssignal %v received, cleaning up\n", ClearLine(), s)
+
+		code := 0
+		if s != syscall.SIGINT {
+			code = 1
+		}
+
+		Exit(code)
 	}
 }
 


### PR DESCRIPTION
fixes gh-1413: restic fails to cleanup locks when bash pipeline fails.

Something else to consider: is it still appropriate to exit(0) when a SIGPIPE is received, as we currently do for SIGINT?

If the bash pipeline fails, even if it's not the fault of restic, perhaps restic should maybe exit(1)? I think it would be bad for restic to give the false impression of success (0) when in fact it had a problem. I don't really know what standard practice is. 