### PR TITLE
use default brew formula

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -25,7 +25,6 @@ If you are using Mac OS X, you can install restic using the
 
 .. code-block:: console
 
-    $ brew tap restic/restic
     $ brew install restic
 
 Arch Linux


### PR DESCRIPTION
restic has been added as a `homebrew-core` formula, the https://github.com/restic/homebrew-restic repo can also be deleted if necessary