### PR TITLE
replace ad-hoc context.TODO() with gopts.ctx

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"bufio"
-	"context"
 	"fmt"
 	"io"
 	"os"
@@ -256,7 +255,7 @@ func readBackupFromStdin(opts BackupOptions, gopts GlobalOptions, args []string)
 		return err
 	}
 
-	err = repo.LoadIndex(context.TODO())
+	err = repo.LoadIndex(gopts.ctx)
 	if err != nil {
 		return err
 	}
@@ -267,7 +266,7 @@ func readBackupFromStdin(opts BackupOptions, gopts GlobalOptions, args []string)
 		Hostname:   opts.Hostname,
 	}
 
-	_, id, err := r.Archive(context.TODO(), opts.StdinFilename, os.Stdin, newArchiveStdinProgress(gopts))
+	_, id, err := r.Archive(gopts.ctx, opts.StdinFilename, os.Stdin, newArchiveStdinProgress(gopts))
 	if err != nil {
 		return err
 	}
@@ -404,7 +403,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 		rejectFuncs = append(rejectFuncs, f)
 	}
 
-	err = repo.LoadIndex(context.TODO())
+	err = repo.LoadIndex(gopts.ctx)
 	if err != nil {
 		return err
 	}
@@ -423,7 +422,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 
 	// Find last snapshot to set it as parent, if not already set
 	if !opts.Force && parentSnapshotID == nil {
-		id, err := restic.FindLatestSnapshot(context.TODO(), repo, target, []restic.TagList{}, opts.Hostname)
+		id, err := restic.FindLatestSnapshot(gopts.ctx, repo, target, []restic.TagList{}, opts.Hostname)
 		if err == nil {
 			parentSnapshotID = &id
 		} else if err != restic.ErrNoSnapshotFound {
@@ -469,7 +468,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	_, id, err := arch.Snapshot(context.TODO(), newArchiveProgress(gopts, stat), target, opts.Tags, opts.Hostname, parentSnapshotID, timeStamp)
+	_, id, err := arch.Snapshot(gopts.ctx, newArchiveProgress(gopts, stat), target, opts.Tags, opts.Hostname, parentSnapshotID, timeStamp)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -75,7 +74,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 		fmt.Println(string(buf))
 		return nil
 	case "index":
-		buf, err := repo.LoadAndDecrypt(context.TODO(), restic.IndexFile, id)
+		buf, err := repo.LoadAndDecrypt(gopts.ctx, restic.IndexFile, id)
 		if err != nil {
 			return err
 		}
@@ -85,7 +84,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 
 	case "snapshot":
 		sn := &restic.Snapshot{}
-		err = repo.LoadJSONUnpacked(context.TODO(), restic.SnapshotFile, id, sn)
+		err = repo.LoadJSONUnpacked(gopts.ctx, restic.SnapshotFile, id, sn)
 		if err != nil {
 			return err
 		}
@@ -100,7 +99,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 		return nil
 	case "key":
 		h := restic.Handle{Type: restic.KeyFile, Name: id.String()}
-		buf, err := backend.LoadAll(context.TODO(), repo.Backend(), h)
+		buf, err := backend.LoadAll(gopts.ctx, repo.Backend(), h)
 		if err != nil {
 			return err
 		}
@@ -127,7 +126,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 		fmt.Println(string(buf))
 		return nil
 	case "lock":
-		lock, err := restic.LoadLock(context.TODO(), repo, id)
+		lock, err := restic.LoadLock(gopts.ctx, repo, id)
 		if err != nil {
 			return err
 		}
@@ -143,7 +142,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 	}
 
 	// load index, handle all the other types
-	err = repo.LoadIndex(context.TODO())
+	err = repo.LoadIndex(gopts.ctx)
 	if err != nil {
 		return err
 	}
@@ -151,7 +150,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 	switch tpe {
 	case "pack":
 		h := restic.Handle{Type: restic.DataFile, Name: id.String()}
-		buf, err := backend.LoadAll(context.TODO(), repo.Backend(), h)
+		buf, err := backend.LoadAll(gopts.ctx, repo.Backend(), h)
 		if err != nil {
 			return err
 		}
@@ -173,7 +172,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 			blob := list[0]
 
 			buf := make([]byte, blob.Length)
-			n, err := repo.LoadBlob(context.TODO(), t, id, buf)
+			n, err := repo.LoadBlob(gopts.ctx, t, id, buf)
 			if err != nil {
 				return err
 			}

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"time"
@@ -104,7 +103,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	chkr := checker.New(repo)
 
 	Verbosef("load indexes\n")
-	hints, errs := chkr.LoadIndex(context.TODO())
+	hints, errs := chkr.LoadIndex(gopts.ctx)
 
 	dupFound := false
 	for _, hint := range hints {
@@ -129,7 +128,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	errChan := make(chan error)
 
 	Verbosef("check all packs\n")
-	go chkr.Packs(context.TODO(), errChan)
+	go chkr.Packs(gopts.ctx, errChan)
 
 	for err := range errChan {
 		errorsFound = true
@@ -138,7 +137,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 
 	Verbosef("check snapshots, trees and blobs\n")
 	errChan = make(chan error)
-	go chkr.Structure(context.TODO(), errChan)
+	go chkr.Structure(gopts.ctx, errChan)
 
 	for err := range errChan {
 		errorsFound = true
@@ -165,7 +164,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 		p := newReadProgress(gopts, restic.Stat{Blobs: chkr.CountPacks()})
 		errChan := make(chan error)
 
-		go chkr.ReadData(context.TODO(), p, errChan)
+		go chkr.ReadData(gopts.ctx, p, errChan)
 
 		for err := range errChan {
 			errorsFound = true

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -183,7 +183,7 @@ func runDebugDump(gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	err = repo.LoadIndex(context.TODO())
+	err = repo.LoadIndex(gopts.ctx)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -162,7 +162,7 @@ func runDump(opts DumpOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	sn, err := restic.LoadSnapshot(context.TODO(), repo, id)
+	sn, err := restic.LoadSnapshot(gopts.ctx, repo, id)
 	if err != nil {
 		Exitf(2, "loading snapshot %q failed: %v", snapshotIDString, err)
 	}

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -125,7 +125,7 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 			// When explicit snapshots args are given, remove them immediately.
 			if !opts.DryRun {
 				h := restic.Handle{Type: restic.SnapshotFile, Name: sn.ID().String()}
-				if err = repo.Backend().Remove(context.TODO(), h); err != nil {
+				if err = repo.Backend().Remove(gopts.ctx, h); err != nil {
 					return err
 				}
 				Verbosef("removed snapshot %v\n", sn.ID().Str())
@@ -223,7 +223,7 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 		if !opts.DryRun {
 			for _, sn := range remove {
 				h := restic.Handle{Type: restic.SnapshotFile, Name: sn.ID().String()}
-				err = repo.Backend().Remove(context.TODO(), h)
+				err = repo.Backend().Remove(gopts.ctx, h)
 				if err != nil {
 					return err
 				}

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
 
@@ -44,7 +42,7 @@ func runInit(gopts GlobalOptions, args []string) error {
 
 	s := repository.New(be)
 
-	err = s.Init(context.TODO(), gopts.password)
+	err = s.Init(gopts.ctx, gopts.password)
 	if err != nil {
 		return errors.Fatalf("create key in backend at %s failed: %v\n", gopts.Repo, err)
 	}

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -76,7 +76,7 @@ func addKey(gopts GlobalOptions, repo *repository.Repository) error {
 		return err
 	}
 
-	id, err := repository.AddKey(context.TODO(), repo, pw, repo.Key())
+	id, err := repository.AddKey(gopts.ctx, repo, pw, repo.Key())
 	if err != nil {
 		return errors.Fatalf("creating new key failed: %v\n", err)
 	}
@@ -86,13 +86,13 @@ func addKey(gopts GlobalOptions, repo *repository.Repository) error {
 	return nil
 }
 
-func deleteKey(repo *repository.Repository, name string) error {
+func deleteKey(ctx context.Context, repo *repository.Repository, name string) error {
 	if name == repo.KeyName() {
 		return errors.Fatal("refusing to remove key currently used to access repository")
 	}
 
 	h := restic.Handle{Type: restic.KeyFile, Name: name}
-	err := repo.Backend().Remove(context.TODO(), h)
+	err := repo.Backend().Remove(ctx, h)
 	if err != nil {
 		return err
 	}
@@ -107,13 +107,13 @@ func changePassword(gopts GlobalOptions, repo *repository.Repository) error {
 		return err
 	}
 
-	id, err := repository.AddKey(context.TODO(), repo, pw, repo.Key())
+	id, err := repository.AddKey(gopts.ctx, repo, pw, repo.Key())
 	if err != nil {
 		return errors.Fatalf("creating new key failed: %v\n", err)
 	}
 
 	h := restic.Handle{Type: restic.KeyFile, Name: repo.KeyName()}
-	err = repo.Backend().Remove(context.TODO(), h)
+	err = repo.Backend().Remove(gopts.ctx, h)
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func runKey(gopts GlobalOptions, args []string) error {
 			return err
 		}
 
-		return deleteKey(repo, id)
+		return deleteKey(gopts.ctx, repo, id)
 	case "passwd":
 		lock, err := lockRepoExclusive(repo)
 		defer unlockRepo(lock)

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	"github.com/restic/restic/internal/errors"
@@ -58,7 +57,7 @@ func runList(opts GlobalOptions, args []string) error {
 	case "locks":
 		t = restic.LockFile
 	case "blobs":
-		idx, err := index.Load(context.TODO(), repo, nil)
+		idx, err := index.Load(opts.ctx, repo, nil)
 		if err != nil {
 			return err
 		}
@@ -74,7 +73,7 @@ func runList(opts GlobalOptions, args []string) error {
 		return errors.Fatal("invalid type")
 	}
 
-	for id := range repo.List(context.TODO(), t) {
+	for id := range repo.List(opts.ctx, t) {
 		Printf("%s\n", id)
 	}
 

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -4,7 +4,6 @@
 package main
 
 import (
-	"context"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -73,7 +72,7 @@ func mount(opts MountOptions, gopts GlobalOptions, mountpoint string) error {
 		return err
 	}
 
-	err = repo.LoadIndex(context.TODO())
+	err = repo.LoadIndex(gopts.ctx)
 	if err != nil {
 		return err
 	}
@@ -114,7 +113,7 @@ func mount(opts MountOptions, gopts GlobalOptions, mountpoint string) error {
 		Tags:        opts.Tags,
 		Paths:       opts.Paths,
 	}
-	root, err := fuse.NewRoot(context.TODO(), repo, cfg)
+	root, err := fuse.NewRoot(gopts.ctx, repo, cfg)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -77,14 +77,14 @@ func changeTags(repo *repository.Repository, sn *restic.Snapshot, setTags, addTa
 		}
 
 		// Save the new snapshot.
-		id, err := repo.SaveJSONUnpacked(context.TODO(), restic.SnapshotFile, sn)
+		id, err := repo.SaveJSONUnpacked(globalOptions.ctx, restic.SnapshotFile, sn)
 		if err != nil {
 			return false, err
 		}
 
 		debug.Log("new snapshot saved as %v", id.Str())
 
-		if err = repo.Flush(); err != nil {
+		if err = repo.Flush(globalOptions.ctx); err != nil {
 			return false, err
 		}
 

--- a/cmd/restic/cmd_unlock.go
+++ b/cmd/restic/cmd_unlock.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/restic/restic/internal/restic"
 	"github.com/spf13/cobra"
 )
@@ -43,7 +41,7 @@ func runUnlock(opts UnlockOptions, gopts GlobalOptions) error {
 		fn = restic.RemoveAllLocks
 	}
 
-	err = fn(context.TODO(), repo)
+	err = fn(gopts.ctx, repo)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -344,7 +344,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		return nil, err
 	}
 
-	err = s.SearchKey(context.TODO(), opts.password, maxKeys)
+	err = s.SearchKey(opts.ctx, opts.password, maxKeys)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -553,7 +553,7 @@ func open(s string, opts options.Options) (restic.Backend, error) {
 	case "swift":
 		be, err = swift.Open(cfg.(swift.Config), rt)
 	case "b2":
-		be, err = b2.Open(cfg.(b2.Config), rt)
+		be, err = b2.Open(globalOptions.ctx, cfg.(b2.Config), rt)
 	case "rest":
 		be, err = rest.Open(cfg.(rest.Config), rt)
 
@@ -566,7 +566,7 @@ func open(s string, opts options.Options) (restic.Backend, error) {
 	}
 
 	// check if config is there
-	fi, err := be.Stat(context.TODO(), restic.Handle{Type: restic.ConfigFile})
+	fi, err := be.Stat(globalOptions.ctx, restic.Handle{Type: restic.ConfigFile})
 	if err != nil {
 		return nil, errors.Fatalf("unable to open config file: %v\nIs there a repository at the following location?\n%v", err, s)
 	}
@@ -610,7 +610,7 @@ func create(s string, opts options.Options) (restic.Backend, error) {
 	case "swift":
 		return swift.Open(cfg.(swift.Config), rt)
 	case "b2":
-		return b2.Create(cfg.(b2.Config), rt)
+		return b2.Create(globalOptions.ctx, cfg.(b2.Config), rt)
 	case "rest":
 		return rest.Create(cfg.(rest.Config), rt)
 	}

--- a/internal/archiver/archive_reader.go
+++ b/internal/archiver/archive_reader.go
@@ -103,7 +103,7 @@ func (r *Reader) Archive(ctx context.Context, name string, rd io.Reader, p *rest
 
 	debug.Log("snapshot saved as %v", id.Str())
 
-	err = repo.Flush()
+	err = repo.Flush(ctx)
 	if err != nil {
 		return nil, restic.ID{}, err
 	}

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -764,7 +764,7 @@ func (arch *Archiver) Snapshot(ctx context.Context, p *restic.Progress, paths, t
 	debug.Log("workers terminated")
 
 	// flush repository
-	err = arch.repo.Flush()
+	err = arch.repo.Flush(ctx)
 	if err != nil {
 		return nil, restic.ID{}, err
 	}

--- a/internal/archiver/archiver_duplication_test.go
+++ b/internal/archiver/archiver_duplication_test.go
@@ -144,7 +144,7 @@ func testArchiverDuplication(t *testing.T) {
 
 	wg.Wait()
 
-	err = repo.Flush()
+	err = repo.Flush(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -248,7 +248,7 @@ func testParallelSaveWithDuplication(t *testing.T, seed int) {
 		rtest.OK(t, <-errChan)
 	}
 
-	rtest.OK(t, repo.Flush())
+	rtest.OK(t, repo.Flush(context.Background()))
 	rtest.OK(t, repo.SaveIndex(context.TODO()))
 
 	chkr := createAndInitChecker(t, repo)

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -115,7 +115,7 @@ func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (restic.Backe
 		sem:          sem,
 	}
 
-	present, err := be.Test(context.TODO(), restic.Handle{Type: restic.ConfigFile})
+	present, err := be.Test(ctx, restic.Handle{Type: restic.ConfigFile})
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -41,10 +41,10 @@ func newClient(ctx context.Context, cfg Config, rt http.RoundTripper) (*b2.Clien
 }
 
 // Open opens a connection to the B2 service.
-func Open(cfg Config, rt http.RoundTripper) (restic.Backend, error) {
+func Open(ctx context.Context, cfg Config, rt http.RoundTripper) (restic.Backend, error) {
 	debug.Log("cfg %#v", cfg)
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	client, err := newClient(ctx, cfg, rt)
@@ -79,10 +79,10 @@ func Open(cfg Config, rt http.RoundTripper) (restic.Backend, error) {
 
 // Create opens a connection to the B2 service. If the bucket does not exist yet,
 // it is created.
-func Create(cfg Config, rt http.RoundTripper) (restic.Backend, error) {
+func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (restic.Backend, error) {
 	debug.Log("cfg %#v", cfg)
 
-	ctx, cancel := context.WithCancel(context.TODO())
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
 	client, err := newClient(ctx, cfg, rt)

--- a/internal/backend/b2/b2_test.go
+++ b/internal/backend/b2/b2_test.go
@@ -45,19 +45,19 @@ func newB2TestSuite(t testing.TB) *test.Suite {
 		// CreateFn is a function that creates a temporary repository for the tests.
 		Create: func(config interface{}) (restic.Backend, error) {
 			cfg := config.(b2.Config)
-			return b2.Create(cfg, tr)
+			return b2.Create(context.Background(), cfg, tr)
 		},
 
 		// OpenFn is a function that opens a previously created temporary repository.
 		Open: func(config interface{}) (restic.Backend, error) {
 			cfg := config.(b2.Config)
-			return b2.Open(cfg, tr)
+			return b2.Open(context.Background(), cfg, tr)
 		},
 
 		// CleanupFn removes data created during the tests.
 		Cleanup: func(config interface{}) error {
 			cfg := config.(b2.Config)
-			be, err := b2.Open(cfg, tr)
+			be, err := b2.Open(context.Background(), cfg, tr)
 			if err != nil {
 				return err
 			}

--- a/internal/backend/backend_retry.go
+++ b/internal/backend/backend_retry.go
@@ -43,10 +43,6 @@ func (be *RetryBackend) retry(ctx context.Context, msg string, f func() error) e
 		},
 	)
 
-	if errors.Cause(err) == context.Canceled {
-		return nil
-	}
-
 	return err
 }
 

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -89,7 +89,7 @@ func (r *packerManager) insertPacker(p *Packer) {
 }
 
 // savePacker stores p in the backend.
-func (r *Repository) savePacker(t restic.BlobType, p *Packer) error {
+func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packer) error {
 	debug.Log("save packer for %v with %d blobs (%d bytes)\n", t, p.Packer.Count(), p.Packer.Size())
 	_, err := p.Packer.Finalize()
 	if err != nil {
@@ -104,7 +104,7 @@ func (r *Repository) savePacker(t restic.BlobType, p *Packer) error {
 	id := restic.IDFromHash(p.hw.Sum(nil))
 	h := restic.Handle{Type: restic.DataFile, Name: id.String()}
 
-	err = r.be.Save(context.TODO(), h, p.tmpfile)
+	err = r.be.Save(ctx, h, p.tmpfile)
 	if err != nil {
 		debug.Log("Save(%v) error: %v", h, err)
 		return err

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -126,7 +126,7 @@ func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, kee
 		}
 	}
 
-	if err := repo.Flush(); err != nil {
+	if err := repo.Flush(ctx); err != nil {
 		return nil, err
 	}
 

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -55,13 +55,13 @@ func createRandomBlobs(t testing.TB, repo restic.Repository, blobs int, pData fl
 		}
 
 		if rand.Float32() < 0.2 {
-			if err = repo.Flush(); err != nil {
+			if err = repo.Flush(context.Background()); err != nil {
 				t.Fatalf("repo.Flush() returned error %v", err)
 			}
 		}
 	}
 
-	if err := repo.Flush(); err != nil {
+	if err := repo.Flush(context.Background()); err != nil {
 		t.Fatalf("repo.Flush() returned error %v", err)
 	}
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -250,7 +250,7 @@ func (r *Repository) SaveAndEncrypt(ctx context.Context, t restic.BlobType, data
 	}
 
 	// else write the pack to the backend
-	return *id, r.savePacker(t, packer)
+	return *id, r.savePacker(ctx, t, packer)
 }
 
 // SaveJSONUnpacked serialises item as JSON and encrypts and saves it in the
@@ -289,7 +289,7 @@ func (r *Repository) SaveUnpacked(ctx context.Context, t restic.FileType, p []by
 }
 
 // Flush saves all remaining packs.
-func (r *Repository) Flush() error {
+func (r *Repository) Flush(ctx context.Context) error {
 	pms := []struct {
 		t  restic.BlobType
 		pm *packerManager
@@ -303,7 +303,7 @@ func (r *Repository) Flush() error {
 
 		debug.Log("manually flushing %d packs", len(p.pm.packers))
 		for _, packer := range p.pm.packers {
-			err := r.savePacker(p.t, packer)
+			err := r.savePacker(ctx, p.t, packer)
 			if err != nil {
 				p.pm.pm.Unlock()
 				return err

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -37,7 +37,7 @@ func TestSave(t *testing.T) {
 
 		rtest.Equals(t, id, sid)
 
-		rtest.OK(t, repo.Flush())
+		rtest.OK(t, repo.Flush(context.Background()))
 		// rtest.OK(t, repo.SaveIndex())
 
 		// read back
@@ -72,7 +72,7 @@ func TestSaveFrom(t *testing.T) {
 		rtest.OK(t, err)
 		rtest.Equals(t, id, id2)
 
-		rtest.OK(t, repo.Flush())
+		rtest.OK(t, repo.Flush(context.Background()))
 
 		// read back
 		buf := restic.NewBlobBuffer(size)
@@ -122,7 +122,7 @@ func TestLoadTree(t *testing.T) {
 
 	// archive a few files
 	sn := archiver.TestSnapshot(t, repo, rtest.BenchArchiveDirectory, nil)
-	rtest.OK(t, repo.Flush())
+	rtest.OK(t, repo.Flush(context.Background()))
 
 	_, err := repo.LoadTree(context.TODO(), *sn.Tree)
 	rtest.OK(t, err)
@@ -138,7 +138,7 @@ func BenchmarkLoadTree(t *testing.B) {
 
 	// archive a few files
 	sn := archiver.TestSnapshot(t, repo, rtest.BenchArchiveDirectory, nil)
-	rtest.OK(t, repo.Flush())
+	rtest.OK(t, repo.Flush(context.Background()))
 
 	t.ResetTimer()
 
@@ -159,7 +159,7 @@ func TestLoadBlob(t *testing.T) {
 
 	id, err := repo.SaveBlob(context.TODO(), restic.DataBlob, buf, restic.ID{})
 	rtest.OK(t, err)
-	rtest.OK(t, repo.Flush())
+	rtest.OK(t, repo.Flush(context.Background()))
 
 	// first, test with buffers that are too small
 	for _, testlength := range []int{length - 20, length, restic.CiphertextLength(length) - 1} {
@@ -204,7 +204,7 @@ func BenchmarkLoadBlob(b *testing.B) {
 
 	id, err := repo.SaveBlob(context.TODO(), restic.DataBlob, buf, restic.ID{})
 	rtest.OK(b, err)
-	rtest.OK(b, repo.Flush())
+	rtest.OK(b, repo.Flush(context.Background()))
 
 	b.ResetTimer()
 	b.SetBytes(int64(length))
@@ -352,7 +352,7 @@ func TestRepositoryIncrementalIndex(t *testing.T) {
 		// add 3 packs, write intermediate index
 		for i := 0; i < 3; i++ {
 			saveRandomDataBlobs(t, repo, 5, 1<<15)
-			rtest.OK(t, repo.Flush())
+			rtest.OK(t, repo.Flush(context.Background()))
 		}
 
 		rtest.OK(t, repo.SaveFullIndex(context.TODO()))
@@ -361,7 +361,7 @@ func TestRepositoryIncrementalIndex(t *testing.T) {
 	// add another 5 packs
 	for i := 0; i < 5; i++ {
 		saveRandomDataBlobs(t, repo, 5, 1<<15)
-		rtest.OK(t, repo.Flush())
+		rtest.OK(t, repo.Flush(context.Background()))
 	}
 
 	// save final index

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -29,7 +29,7 @@ type Repository interface {
 	List(context.Context, FileType) <-chan ID
 	ListPack(context.Context, ID) ([]Blob, int64, error)
 
-	Flush() error
+	Flush(context.Context) error
 
 	SaveUnpacked(context.Context, FileType, []byte) (ID, error)
 	SaveJSONUnpacked(context.Context, FileType, interface{}) (ID, error)

--- a/internal/restic/restorer_test.go
+++ b/internal/restic/restorer_test.go
@@ -90,7 +90,7 @@ func saveSnapshot(t testing.TB, repo restic.Repository, snapshot Snapshot) (rest
 
 	treeID := saveDir(t, repo, snapshot.Nodes)
 
-	err := repo.Flush()
+	err := repo.Flush(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/restic/testing.go
+++ b/internal/restic/testing.go
@@ -189,7 +189,7 @@ func TestCreateSnapshot(t testing.TB, repo Repository, at time.Time, depth int, 
 
 	t.Logf("saved snapshot %v", id.Str())
 
-	err = repo.Flush()
+	err = repo.Flush(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/restic/tree_test.go
+++ b/internal/restic/tree_test.go
@@ -103,7 +103,7 @@ func TestLoadTree(t *testing.T) {
 	rtest.OK(t, err)
 
 	// save packs
-	rtest.OK(t, repo.Flush())
+	rtest.OK(t, repo.Flush(context.Background()))
 
 	// load tree again
 	tree2, err := repo.LoadTree(context.TODO(), id)

--- a/internal/walk/walk_test.go
+++ b/internal/walk/walk_test.go
@@ -29,7 +29,7 @@ func TestWalkTree(t *testing.T) {
 	rtest.OK(t, err)
 
 	// flush repo, write all packs
-	rtest.OK(t, repo.Flush())
+	rtest.OK(t, repo.Flush(context.Background()))
 
 	// start tree walker
 	treeJobs := make(chan walk.TreeJob)


### PR DESCRIPTION
replace ad-hoc context.TODO() with gopts.ctx, so that cancellation can properly trickle down from cmd_backup & cmd_tag.

This commit fixes the main issue in gh-1434. There are more cmd_* files that need work, but I wanted to give @fd0 a chance to eyeball the pattern of this change before I go further.