### PR TITLE
backup: Do not save access time by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,13 @@ Small changes
    cache will be rebuild once a repo is accessed again.
    https://github.com/restic/restic/pull/1436
 
+ * By default, the access time for files and dirs is not saved any more. It is
+   not possible to reliably disable updating the access time during a backup,
+   so for the next backup the access time is different again. This means a lot
+   of metadata is saved. If you want to save the access time anyway, pass
+   `--with-atime` to the `backup` command.
+   https://github.com/restic/restic/pull/1452
+
 Important Changes in 0.8.0
 ==========================
 

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -65,6 +65,7 @@ type BackupOptions struct {
 	Hostname         string
 	FilesFrom        string
 	TimeStamp        string
+	WithAtime        bool
 }
 
 var backupOptions BackupOptions
@@ -86,6 +87,7 @@ func init() {
 	f.StringVar(&backupOptions.Hostname, "hostname", "", "set the `hostname` for the snapshot manually. To prevent an expensive rescan use the \"parent\" flag")
 	f.StringVar(&backupOptions.FilesFrom, "files-from", "", "read the files to backup from file (can be combined with file args)")
 	f.StringVar(&backupOptions.TimeStamp, "time", "", "time of the backup (ex. '2012-11-01 22:08:41') (default: now)")
+	f.BoolVar(&backupOptions.WithAtime, "with-atime", false, "store the atime for all files and directories")
 }
 
 func newScanProgress(gopts GlobalOptions) *restic.Progress {
@@ -452,6 +454,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 	arch := archiver.New(repo)
 	arch.Excludes = opts.Excludes
 	arch.SelectFilter = selectFilter
+	arch.WithAccessTime = opts.WithAtime
 
 	arch.Warn = func(dir string, fi os.FileInfo, err error) {
 		// TODO: make ignoring errors configurable

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -127,8 +127,8 @@ args:
 
     $ restic -r /tmp/backup backup --files-from /tmp/files_to_backup /tmp/some_additional_file
 
-Backing up special items
-************************
+Backing up special items and metadata
+*************************************
 
 **Symlinks** are archived as symlinks, ``restic`` does not follow them.
 When you restore, you get the same symlink again, with the same link target
@@ -140,6 +140,12 @@ If there is a **bind-mount** below a directory that is to be saved, restic desce
 archived as a block device file and restored as such. This also means that the content of the
 corresponding disk is not read, at least not from the device file.
 
+By default, restic does not save the access time (atime) for any files or other
+items, since it is not possible to reliably disable updating the access time by
+restic itself. This means that for each new backup a lot of metadata is
+written, and the next backup needs to write new metadata again. If you really
+want to save the access time for files and directories, you can pass the
+``--with-atime`` option to the ``backup`` command.
 
 Reading data from stdin
 ***********************


### PR DESCRIPTION
It's not possible to not update the access time on all operating systems, which blows up the metadata for each backup. This PR disables saving the metadata by default, and adds a new option `--with-atime` which re-enables saving it.