### PR TITLE
Fix cache dir detection

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -86,6 +86,9 @@ func writeCachedirTag(dir string) error {
 func New(id string, basedir string) (c *Cache, err error) {
 	if basedir == "" {
 		basedir, err = DefaultDir()
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	err = mkdirCacheDir(basedir)

--- a/internal/cache/dir.go
+++ b/internal/cache/dir.go
@@ -56,10 +56,16 @@ func DefaultDir() (cachedir string, err error) {
 		cachedir, err = darwinCacheDir()
 	case "windows":
 		cachedir, err = windowsCacheDir()
+	default:
+		// Default to XDG for Linux and any other OSes.
+		cachedir, err = xdgCacheDir()
 	}
 
-	// Default to XDG for Linux and any other OSes.
-	return xdgCacheDir()
+	if err != nil {
+		return "", err
+	}
+
+	return cachedir, nil
 }
 
 func mkdirCacheDir(cachedir string) error {


### PR DESCRIPTION
This PR corrects a bug introduced just recently in the default cache dir detection for Darwin and Windows. It'll put the cache dir to `~/.cache` instead of the correct location.
