### PR TITLE
Fix a typo

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -333,7 +333,7 @@ root path like this:
     created restic backend a934bac191 at azure:foo:/
     [...]
 
-The number of concurrent connections to the B2 service can be set with the
+The number of concurrent connections to the Azure Blob Storage service can be set with the
 `-o azure.connections=10`. By default, at most five parallel connections are
 established.
 


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Fix a documentation typo in the Azure Blob Storage section.

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's an entry in the `CHANGELOG.md` file that describe the changes for our users
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review