### PR TITLE
Reenable cache

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -363,6 +363,9 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		return s, nil
 	}
 
+	// start using the cache
+	s.UseCache(c)
+
 	oldCacheDirs, err := cache.Old(c.Base)
 	if err != nil {
 		Warnf("unable to find old cache directories: %v", err)
@@ -389,7 +392,6 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 			len(oldCacheDirs), c.Base)
 	}
 
-	s.UseCache(c)
 	return s, nil
 }
 


### PR DESCRIPTION
In 6341c7d72c8f773d5f14321150207c8b48a68f09, the cache was accidentally disabled due to a bug, this commit reenables the cache.