### PR TITLE
supports mount on windows

### DIFF
--- a/cmd/restic/cmd_cgofuse.go
+++ b/cmd/restic/cmd_cgofuse.go
@@ -1,0 +1,140 @@
+// +build windows
+
+package main
+
+import (
+	"context"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	cgofuse "github.com/billziss-gh/cgofuse/fuse"
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
+	resticfs "github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/fuse"
+	"github.com/restic/restic/internal/restic"
+)
+
+var cmdMount = &cobra.Command{
+	Use:   "mount [flags] mountpoint",
+	Short: "Mount the repository",
+	Long: `
+The "mount" command mounts the repository via fuse to a directory. This is a
+read-only mount.
+`,
+	DisableAutoGenTag: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runMount(mountOptions, globalOptions, args)
+	},
+}
+
+var host *cgofuse.FileSystemHost
+
+// MountOptions collects all options for the mount command.
+type MountOptions struct {
+	OwnerRoot  bool
+	AllowRoot  bool
+	AllowOther bool
+	Host       string
+	Tags       restic.TagLists
+	Paths      []string
+}
+
+var mountOptions MountOptions
+
+func init() {
+	cmdRoot.AddCommand(cmdMount)
+
+	mountFlags := cmdMount.Flags()
+	mountFlags.BoolVar(&mountOptions.OwnerRoot, "owner-root", false, "use 'root' as the owner of files and dirs")
+	mountFlags.BoolVar(&mountOptions.AllowRoot, "allow-root", false, "allow root user to access the data in the mounted directory")
+	mountFlags.BoolVar(&mountOptions.AllowOther, "allow-other", false, "allow other users to access the data in the mounted directory")
+
+	mountFlags.StringVarP(&mountOptions.Host, "host", "H", "", `only consider snapshots for this host`)
+	mountFlags.Var(&mountOptions.Tags, "tag", "only consider snapshots which include this `taglist`")
+	mountFlags.StringArrayVar(&mountOptions.Paths, "path", nil, "only consider snapshots which include this (absolute) `path`")
+}
+
+func mount(opts MountOptions, gopts GlobalOptions, mountpoint string) error {
+	debug.Log("start mount")
+	defer debug.Log("finish mount")
+	if _, err := resticfs.Stat(mountpoint); err == nil {
+		Verbosef("Mountpoint %s already used, please choose a unused volume \n", mountpoint)
+		return os.ErrExist
+	}
+
+	repo, err := OpenRepository(gopts)
+	if err != nil {
+		return err
+	}
+
+	lock, err := lockRepo(repo)
+	defer unlockRepo(lock)
+	if err != nil {
+		return err
+	}
+
+	err = repo.LoadIndex(context.TODO())
+	if err != nil {
+		return err
+	}
+
+	mountOptions := []string{
+		"ro",
+		"fsname=restic",
+	}
+
+	if opts.AllowRoot {
+		mountOptions = append(mountOptions, "allow_root")
+	}
+
+	if opts.AllowOther {
+		mountOptions = append(mountOptions, "allow_other")
+	}
+
+	cfg := fuse.Config{
+		OwnerIsRoot: opts.OwnerRoot,
+		Host:        opts.Host,
+		Tags:        opts.Tags,
+		Paths:       opts.Paths,
+	}
+
+	root, err := fuse.NewRoot(context.TODO(), repo, cfg)
+	if err != nil {
+		return err
+	}
+	fs := fuse.NewCgofs(context.TODO(), root)
+
+	Printf("Now serving the repository at %s\n", mountpoint)
+
+	debug.Log("serving mount at %v", mountpoint)
+
+	host = cgofuse.NewFileSystemHost(fs)
+	host.Mount(mountpoint, nil)
+
+	return nil
+}
+
+func umount(mountpoint string) error {
+	return nil
+}
+
+func runMount(opts MountOptions, gopts GlobalOptions, args []string) error {
+	if len(args) == 0 {
+		return errors.Fatal("wrong number of parameters")
+	}
+
+	mountpoint := args[0]
+
+	AddCleanupHandler(func() error {
+		debug.Log("running umount cleanup handler for mount at %v", mountpoint)
+		err := umount(mountpoint)
+		if err != nil {
+			Warnf("unable to umount (maybe already umounted?): %v\n", err)
+		}
+		return nil
+	})
+
+	return mount(opts, gopts, mountpoint)
+}

--- a/internal/fuse/blob_size_cache.go
+++ b/internal/fuse/blob_size_cache.go
@@ -1,6 +1,4 @@
 // +build !openbsd
-// +build !windows
-
 package fuse
 
 import (

--- a/internal/fuse/cgofuse.go
+++ b/internal/fuse/cgofuse.go
@@ -1,0 +1,322 @@
+// +build windows
+
+package fuse
+
+import (
+	"bazil.org/fuse"
+	"bazil.org/fuse/fs"
+	"fmt"
+	"github.com/billziss-gh/cgofuse/examples/shared"
+	cgofuse "github.com/billziss-gh/cgofuse/fuse"
+	"github.com/restic/restic/internal/debug"
+	"golang.org/x/net/context"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+func (self *Cgofs) synchronize() func() {
+	self.lock.Lock()
+	return func() {
+		self.lock.Unlock()
+	}
+}
+
+type DirNode interface {
+	fs.Node
+	fs.HandleReadDirAller
+	fs.NodeStringLookuper
+}
+
+type Cgofs struct {
+	cgofuse.FileSystemBase
+	lock    sync.Mutex
+	root    *Root
+	ctx     context.Context
+	openmap map[uint64]fs.Node
+}
+
+func getInode(n fs.Node, ctx context.Context) uint64 {
+	attr := fuse.Attr{}
+
+	n.Attr(ctx, &attr)
+
+	return attr.Inode
+
+}
+
+func NewCgofs(ctx context.Context, root *Root) *Cgofs {
+	ret := &Cgofs{
+		ctx:     ctx,
+		root:    root,
+		openmap: make(map[uint64]fs.Node),
+	}
+
+	ret.openmap[root.inode] = root
+
+	for _, v := range root.entries {
+		ret.openmap[getInode(v, ctx)] = v
+	}
+
+	return ret
+}
+
+func split(path string) []string {
+	return strings.Split(path, "/")
+}
+
+func (self *Cgofs) lookupNode(ctx context.Context, path string, ancestor fs.Node) (prnt fs.Node, name string, node fs.Node, err error) {
+	fmt.Printf("lookup for %s\n", path)
+	prnt = self.root
+	name = ""
+	node = self.root
+	err = nil
+	for _, c := range split(path) {
+		if "" != c {
+			if 255 < len(c) {
+				panic(cgofuse.Error(-cgofuse.ENAMETOOLONG))
+			}
+			prnt, name = node, c
+
+			dirNode, ok := node.(DirNode)
+			if ok {
+				fmt.Printf("%s is dir\n", name)
+				//this node is a dir
+				node, err = dirNode.Lookup(ctx, c)
+				if nil != ancestor && node == ancestor {
+					name = "" // special case loop condition
+					return
+				}
+			} else {
+				fmt.Printf("%s is file\n", name)
+				//this node is a file
+				return
+			}
+		}
+	}
+	return
+}
+func (self *Cgofs) openNode(path string, dir bool) (int, uint64) {
+	_, _, node, err := self.lookupNode(self.ctx, path, nil)
+	if nil != err {
+		debug.Log("have errror %v", err)
+		return -cgofuse.ENOENT, ^uint64(0)
+	}
+	if nil == node {
+		debug.Log("no node found when openNode")
+		return -cgofuse.ENOENT, ^uint64(0)
+	}
+
+	fmt.Printf("found node %s\n", path)
+
+	return 0, getInode(node, self.ctx)
+}
+
+func (self *Cgofs) Open(path string, flags int) (errc int, fh uint64) {
+	defer trace(path, flags)(&errc, &fh)
+	defer self.synchronize()()
+	return self.openNode(path, false)
+}
+
+func (self *Cgofs) Opendir(path string) (errc int, fh uint64) {
+	defer trace(path)(&errc, &fh)
+	debug.Log("open dir %v", path)
+	return self.openNode(path, true)
+}
+
+func trace(vals ...interface{}) func(vals ...interface{}) {
+	uid, gid, _ := cgofuse.Getcontext()
+	return shared.Trace(1, fmt.Sprintf("[uid=%v,gid=%v]", uid, gid), vals...)
+}
+
+func (self *Cgofs) Releasedir(path string, fh uint64) (errc int) {
+	defer trace(path, fh)(&errc)
+	defer self.synchronize()()
+	return 0
+}
+
+var dt_mode_map = map[fuse.DirentType]uint32{fuse.DT_Unknown: 0, fuse.DT_File: cgofuse.S_IFREG, fuse.DT_Link: cgofuse.S_IFLNK, fuse.DT_Dir: cgofuse.S_IFDIR, fuse.DT_Char: cgofuse.S_IFCHR, fuse.DT_Socket: cgofuse.S_IFSOCK, fuse.DT_Block: cgofuse.S_IFBLK, fuse.DT_FIFO: cgofuse.S_IFIFO}
+
+func direntToStat(ent *fuse.Dirent, mode uint32) *cgofuse.Stat_t {
+
+	return &cgofuse.Stat_t{
+		Ino:  ent.Inode,
+		Mode: dt_mode_map[ent.Type] | mode,
+	}
+
+}
+
+func (self *Cgofs) Readdir(
+	path string,
+	fill func(name string, stat *cgofuse.Stat_t, ofst int64) bool,
+	ofst int64,
+	fh uint64) (errc int) {
+	defer trace(path, fill, ofst, fh)(&errc)
+	defer self.synchronize()()
+	dirNode := self.openmap[fh].(DirNode)
+
+	debug.Log("readdir %s, %d", path, fh)
+
+	ents, err := dirNode.ReadDirAll(self.ctx)
+
+	if err != nil {
+		return -cgofuse.ENOENT
+	}
+
+	_, is_snapshots := dirNode.(*SnapshotsDir)
+
+	for _, ent := range ents {
+
+		orMode := 00777
+
+		//latest dir under snapshots not supported yet
+		if is_snapshots && ent.Name == "latest" {
+			continue
+		}
+
+		fill(ent.Name, direntToStat(&ent, uint32(orMode)), 0)
+	}
+
+	return 0
+
+}
+
+func (self *Cgofs) getNode(path string, fh uint64) (fs.Node, error) {
+	if ^uint64(0) == fh {
+		_, _, node, err := self.lookupNode(self.ctx, path, nil)
+		return node, err
+	} else {
+		return self.openmap[fh], nil
+	}
+}
+
+func timeToSpec(t time.Time) cgofuse.Timespec {
+	return cgofuse.Timespec{
+		Sec:  int64(t.Second()),
+		Nsec: int64(t.Nanosecond()),
+	}
+}
+
+var modeMap = map[os.FileMode]uint32{
+	os.ModeDir:        cgofuse.S_IFDIR,
+	os.ModeSymlink:    cgofuse.S_IFLNK,
+	os.ModeNamedPipe:  cgofuse.S_IFIFO,
+	os.ModeCharDevice: cgofuse.S_IFCHR,
+}
+
+func attrToStat(a *fuse.Attr, t *cgofuse.Stat_t) {
+
+	permission := a.Mode & 0777
+
+	mappedMode, has := modeMap[a.Mode-permission]
+	fmt.Printf("permssion is %d, from mode is %d, convert ot %d\n", permission, a.Mode-permission, mappedMode)
+	if !has {
+		mappedMode = cgofuse.S_IFREG
+	}
+
+	t.Ino = a.Inode
+	t.Gid = a.Gid
+	t.Uid = a.Uid
+	t.Mode = mappedMode | uint32(a.Mode|permission)
+	t.Atim = timeToSpec(a.Atime)
+	t.Ctim = timeToSpec(a.Ctime)
+	t.Mtim = timeToSpec(a.Mtime)
+	t.Nlink = a.Nlink
+	t.Size = int64(a.Size)
+	t.Blksize = int64(a.BlockSize)
+	t.Blocks = int64(a.Blocks)
+
+}
+
+func (self *Cgofs) Getattr(path string, stat *cgofuse.Stat_t, fh uint64) (errc int) {
+	defer trace(path, fh)(&errc, stat)
+	defer self.synchronize()()
+	node, err := self.getNode(path, fh)
+	if nil != err {
+		debug.Log("have error when found for %s , %d", path, fh)
+		return -cgofuse.ENOENT
+	}
+	if nil == node {
+		debug.Log("no node found for %s , %d", path, fh)
+		return -cgofuse.ENOENT
+	}
+
+	debug.Log("node found for %s , %d", path, fh)
+
+	a := fuse.Attr{}
+
+	self.openmap[getInode(node, self.ctx)] = node
+
+	node.Attr(self.ctx, &a)
+
+	attrToStat(&a, stat)
+
+	return 0
+}
+
+func (self *Cgofs) Read(path string, buff []byte, ofst int64, fh uint64) (n int) {
+
+	defer trace(path, buff, ofst, fh)(&n)
+	defer self.synchronize()()
+	node, err := self.getNode(path, fh)
+	if nil != err {
+		return -cgofuse.ENOENT
+	}
+	if nil == node {
+		return -cgofuse.ENOENT
+	}
+
+	f := node.(*file)
+
+	resp := &fuse.ReadResponse{Data: buff}
+	f.read(self.ctx, len(buff), ofst, resp)
+
+	return len(resp.Data)
+}
+
+func (self *Cgofs) Release(path string, fh uint64) (errc int) {
+	defer trace(path, fh)(&errc)
+	defer self.synchronize()()
+	return self.closeNode(fh)
+}
+
+func (self *Cgofs) closeNode(fh uint64) int {
+	node := self.openmap[fh]
+	f, is_file := node.(*file)
+	if !is_file {
+		f.release()
+	}
+	return 0
+}
+
+func (self *Cgofs) Readlink(path string) (errc int, target string) {
+	defer trace(path)(&errc, &target)
+	defer self.synchronize()()
+	_, _, node, err := self.lookupNode(self.ctx, path, nil)
+	if nil == node {
+		return -cgofuse.ENOENT, ""
+	}
+
+	if nil != err {
+		return -cgofuse.ENOENT, ""
+	}
+
+	//TODO construct ReadlinkRequest ?
+	target, err = node.(fs.NodeReadlinker).Readlink(self.ctx, nil)
+
+	if err != nil {
+		return -cgofuse.ENOENT, ""
+	}
+
+	return 0, target
+}
+
+var _ = DirNode(&TagsDir{})
+var _ = DirNode(&dir{})
+var _ = DirNode(&SnapshotsIDSDir{})
+var _ = DirNode(&SnapshotsDir{})
+var _ = DirNode(&HostsDir{})
+var _ = fs.Node(&snapshotLink{})
+var _ = fs.Node(&file{})
+var _ = fs.Node(&other{})

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -1,5 +1,4 @@
 // +build !openbsd
-// +build !windows
 
 package fuse
 

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -1,5 +1,4 @@
 // +build !openbsd
-// +build !windows
 
 package fuse
 

--- a/internal/fuse/link.go
+++ b/internal/fuse/link.go
@@ -1,5 +1,4 @@
 // +build !openbsd
-// +build !windows
 
 package fuse
 

--- a/internal/fuse/meta_dir.go
+++ b/internal/fuse/meta_dir.go
@@ -1,5 +1,4 @@
 // +build !openbsd
-// +build !windows
 
 package fuse
 

--- a/internal/fuse/other.go
+++ b/internal/fuse/other.go
@@ -1,5 +1,4 @@
 // +build !openbsd
-// +build !windows
 
 package fuse
 

--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -1,5 +1,4 @@
 // +build !openbsd
-// +build !windows
 
 package fuse
 

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -1,5 +1,4 @@
 // +build !openbsd
-// +build !windows
 
 package fuse
 

--- a/vendor/bazil.org/fuse/buffer.go
+++ b/vendor/bazil.org/fuse/buffer.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fuse
 
 import "unsafe"

--- a/vendor/bazil.org/fuse/common.go
+++ b/vendor/bazil.org/fuse/common.go
@@ -1,0 +1,254 @@
+package fuse
+
+import (
+	"os"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// An Attr is the metadata for a single file or directory.
+type Attr struct {
+	Valid time.Duration // how long Attr can be cached
+
+	Inode     uint64      // inode number
+	Size      uint64      // size in bytes
+	Blocks    uint64      // size in 512-byte units
+	Atime     time.Time   // time of last access
+	Mtime     time.Time   // time of last modification
+	Ctime     time.Time   // time of last inode change
+	Crtime    time.Time   // time of creation (OS X only)
+	Mode      os.FileMode // file mode
+	Nlink     uint32      // number of links (usually 1)
+	Uid       uint32      // owner uid
+	Gid       uint32      // group gid
+	Rdev      uint32      // device numbers
+	Flags     uint32      // chflags(2) flags (OS X only)
+	BlockSize uint32      // preferred blocksize for filesystem I/O
+}
+
+// An ErrorNumber is an error with a specific error number.
+//
+// Operations may return an error value that implements ErrorNumber to
+// control what specific error number (errno) to return.
+type ErrorNumber interface {
+	// Errno returns the the error number (errno) for this error.
+	Errno() Errno
+}
+
+const (
+	// ENOSYS indicates that the call is not supported.
+	ENOSYS = Errno(syscall.ENOSYS)
+
+	// ESTALE is used by Serve to respond to violations of the FUSE protocol.
+	ESTALE = Errno(syscall.ESTALE)
+
+	ENOENT = Errno(syscall.ENOENT)
+	EIO    = Errno(syscall.EIO)
+	EPERM  = Errno(syscall.EPERM)
+
+	// EINTR indicates request was interrupted by an InterruptRequest.
+	// See also fs.Intr.
+	EINTR = Errno(syscall.EINTR)
+
+	ERANGE  = Errno(syscall.ERANGE)
+	ENOTSUP = Errno(syscall.ENOTSUP)
+	EEXIST  = Errno(syscall.EEXIST)
+)
+
+// Errno implements Error and ErrorNumber using a syscall.Errno.
+type Errno syscall.Errno
+
+// A Dirent represents a single directory entry.
+type Dirent struct {
+	// Inode this entry names.
+	Inode uint64
+
+	// Type of the entry, for example DT_File.
+	//
+	// Setting this is optional. The zero value (DT_Unknown) means
+	// callers will just need to do a Getattr when the type is
+	// needed. Providing a type can speed up operations
+	// significantly.
+	Type DirentType
+
+	// Name of the entry
+	Name string
+}
+
+// Type of an entry in a directory listing.
+type DirentType uint32
+
+const (
+	// These don't quite match os.FileMode; especially there's an
+	// explicit unknown, instead of zero value meaning file. They
+	// are also not quite syscall.DT_*; nothing says the FUSE
+	// protocol follows those, and even if they were, we don't
+	// want each fs to fiddle with syscall.
+
+	// The shift by 12 is hardcoded in the FUSE userspace
+	// low-level C library, so it's safe here.
+
+	DT_Unknown DirentType = 0
+	DT_Socket  DirentType = syscall.S_IFSOCK >> 12
+	DT_Link    DirentType = syscall.S_IFLNK >> 12
+	DT_File    DirentType = syscall.S_IFREG >> 12
+	DT_Block   DirentType = syscall.S_IFBLK >> 12
+	DT_Dir     DirentType = syscall.S_IFDIR >> 12
+	DT_Char    DirentType = syscall.S_IFCHR >> 12
+	DT_FIFO    DirentType = syscall.S_IFIFO >> 12
+)
+
+func (e Errno) Error() string {
+	return syscall.Errno(e).Error()
+}
+
+// A ListxattrRequest asks to list the extended attributes associated with r.Node.
+type ListxattrRequest struct {
+	Header   `json:"-"`
+	Size     uint32 // maximum size to return
+	Position uint32 // offset within attribute list
+}
+
+// A GetxattrRequest asks for the extended attributes associated with r.Node.
+type GetxattrRequest struct {
+	Header `json:"-"`
+
+	// Maximum size to return.
+	Size uint32
+
+	// Name of the attribute requested.
+	Name string
+
+	// Offset within extended attributes.
+	//
+	// Only valid for OS X, and then only with the resource fork
+	// attribute.
+	Position uint32
+}
+
+// A Conn represents a connection to a mounted FUSE file system.
+type Conn struct {
+	// Ready is closed when the mount is complete or has failed.
+	Ready <-chan struct{}
+
+	// MountError stores any error from the mount process. Only valid
+	// after Ready is closed.
+	MountError error
+
+	// File handle for kernel communication. Only safe to access if
+	// rio or wio is held.
+	dev *os.File
+	wio sync.RWMutex
+	rio sync.RWMutex
+
+	// Protocol version negotiated with InitRequest/InitResponse.
+	proto Protocol
+}
+
+// A Header describes the basic information sent in every request.
+type Header struct {
+	Conn *Conn     `json:"-"` // connection this request was received on
+	ID   RequestID // unique ID for request
+	Node NodeID    // file or directory the request is about
+	Uid  uint32    // user ID of process making request
+	Gid  uint32    // group ID of process making request
+	Pid  uint32    // process ID of process making request
+
+	// for returning to reqPool
+	msg *message
+}
+
+// A RequestID identifies an active FUSE request.
+type RequestID uint64
+
+// A NodeID is a number identifying a directory or file.
+// It must be unique among IDs returned in LookupResponses
+// that have not yet been forgotten by ForgetRequests.
+type NodeID uint64
+
+// a message represents the bytes of a single FUSE message
+type message struct {
+	conn *Conn
+	buf  []byte    // all bytes
+	hdr  *inHeader // header
+	off  int       // offset for reading additional fields
+}
+type inHeader struct {
+	Len    uint32
+	Opcode uint32
+	Unique uint64
+	Nodeid uint64
+	Uid    uint32
+	Gid    uint32
+	Pid    uint32
+	_      uint32
+}
+
+// A ListxattrResponse is the response to a ListxattrRequest.
+type ListxattrResponse struct {
+	Xattr []byte
+}
+
+// A GetxattrResponse is the response to a GetxattrRequest.
+type GetxattrResponse struct {
+	Xattr []byte
+}
+
+// A ReadRequest asks to read from an open file.
+type ReadRequest struct {
+	Header    `json:"-"`
+	Dir       bool // is this Readdir?
+	Handle    HandleID
+	Offset    int64
+	Size      int
+	Flags     ReadFlags
+	LockOwner uint64
+	FileFlags OpenFlags
+}
+
+// The ReadFlags are passed in ReadRequest.
+type ReadFlags uint32
+
+// A HandleID is a number identifying an open directory or file.
+// It only needs to be unique while the directory or file is open.
+type HandleID uint64
+
+// OpenFlags are the O_FOO flags passed to open/create/etc calls. For
+// example, os.O_WRONLY | os.O_APPEND.
+type OpenFlags uint32
+
+// A ReadResponse is the response to a ReadRequest.
+type ReadResponse struct {
+	Data []byte
+}
+
+// A ReleaseRequest asks to release (close) an open file handle.
+type ReleaseRequest struct {
+	Header       `json:"-"`
+	Dir          bool // is this Releasedir?
+	Handle       HandleID
+	Flags        OpenFlags // flags from OpenRequest
+	ReleaseFlags ReleaseFlags
+	LockOwner    uint32
+}
+
+// A ReadlinkRequest is a request to read a symlink's target.
+type ReadlinkRequest struct {
+	Header `json:"-"`
+}
+
+// The ReleaseFlags are used in the Release exchange.
+type ReleaseFlags uint32
+
+// Append adds an extended attribute name to the response.
+func (r *ListxattrResponse) Append(names ...string) {
+	for _, name := range names {
+		r.Xattr = append(r.Xattr, name...)
+		r.Xattr = append(r.Xattr, '\x00')
+	}
+}
+
+func (e Errno) Errno() Errno {
+	return e
+}

--- a/vendor/bazil.org/fuse/error_windows.go
+++ b/vendor/bazil.org/fuse/error_windows.go
@@ -1,0 +1,13 @@
+package fuse
+
+import (
+	"syscall"
+)
+
+const (
+	ENODATA = Errno(syscall.ENODATA)
+)
+
+const (
+	errNoXattr = ENODATA
+)

--- a/vendor/bazil.org/fuse/fs/common.go
+++ b/vendor/bazil.org/fuse/fs/common.go
@@ -1,0 +1,99 @@
+package fs
+
+import (
+	"bazil.org/fuse"
+	"context"
+	"encoding/binary"
+	"hash/fnv"
+)
+
+// A Node is the interface required of a file or directory.
+// See the documentation for type FS for general information
+// pertaining to all methods.
+//
+// A Node must be usable as a map key, that is, it cannot be a
+// function, map or slice.
+//
+// Other FUSE requests can be handled by implementing methods from the
+// Node* interfaces, for example NodeOpener.
+//
+// Methods returning Node should take care to return the same Node
+// when the result is logically the same instance. Without this, each
+// Node will get a new NodeID, causing spurious cache invalidations,
+// extra lookups and aliasing anomalies. This may not matter for a
+// simple, read-only filesystem.
+type Node interface {
+	// Attr fills attr with the standard metadata for the node.
+	//
+	// Fields with reasonable defaults are prepopulated. For example,
+	// all times are set to a fixed moment when the program started.
+	//
+	// If Inode is left as 0, a dynamic inode number is chosen.
+	//
+	// The result may be cached for the duration set in Valid.
+	Attr(ctx context.Context, attr *fuse.Attr) error
+}
+
+type HandleReadDirAller interface {
+	ReadDirAll(ctx context.Context) ([]fuse.Dirent, error)
+}
+type HandleReadAller interface {
+	ReadAll(ctx context.Context) ([]byte, error)
+}
+
+type NodeStringLookuper interface {
+	// Lookup looks up a specific entry in the receiver,
+	// which must be a directory.  Lookup should return a Node
+	// corresponding to the entry.  If the name does not exist in
+	// the directory, Lookup should return ENOENT.
+	//
+	// Lookup need not to handle the names "." and "..".
+	Lookup(ctx context.Context, name string) (Node, error)
+}
+
+type HandleReader interface {
+	// Read requests to read data from the handle.
+	//
+	// There is a page cache in the kernel that normally submits only
+	// page-aligned reads spanning one or more pages. However, you
+	// should not rely on this. To see individual requests as
+	// submitted by the file system clients, set OpenDirectIO.
+	//
+	// Note that reads beyond the size of the file as reported by Attr
+	// are not even attempted (except in OpenDirectIO mode).
+
+	Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error
+}
+type HandleReleaser interface {
+	Release(ctx context.Context, req *fuse.ReleaseRequest) error
+}
+
+// This optional request will be called only for symbolic link nodes.
+type NodeReadlinker interface {
+	// Readlink reads a symbolic link.
+	Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (string, error)
+}
+
+// GenerateDynamicInode returns a dynamic inode.
+//
+// The parent inode and current entry name are used as the criteria
+// for choosing a pseudorandom inode. This makes it likely the same
+// entry will get the same inode on multiple runs.
+func GenerateDynamicInode(parent uint64, name string) uint64 {
+	h := fnv.New64a()
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], parent)
+	_, _ = h.Write(buf[:])
+	_, _ = h.Write([]byte(name))
+	var inode uint64
+	for {
+		inode = h.Sum64()
+		if inode != 0 {
+			break
+		}
+		// there's a tiny probability that result is zero; change the
+		// input a little and try again
+		_, _ = h.Write([]byte{'x'})
+	}
+	return inode
+}

--- a/vendor/bazil.org/fuse/fs/serve.go
+++ b/vendor/bazil.org/fuse/fs/serve.go
@@ -1,3 +1,4 @@
+// +build !windows
 // FUSE service loop, for servers that wish to use it.
 
 package fs // import "bazil.org/fuse/fs"
@@ -74,33 +75,6 @@ type FSInodeGenerator interface {
 	GenerateInode(parentInode uint64, name string) uint64
 }
 
-// A Node is the interface required of a file or directory.
-// See the documentation for type FS for general information
-// pertaining to all methods.
-//
-// A Node must be usable as a map key, that is, it cannot be a
-// function, map or slice.
-//
-// Other FUSE requests can be handled by implementing methods from the
-// Node* interfaces, for example NodeOpener.
-//
-// Methods returning Node should take care to return the same Node
-// when the result is logically the same instance. Without this, each
-// Node will get a new NodeID, causing spurious cache invalidations,
-// extra lookups and aliasing anomalies. This may not matter for a
-// simple, read-only filesystem.
-type Node interface {
-	// Attr fills attr with the standard metadata for the node.
-	//
-	// Fields with reasonable defaults are prepopulated. For example,
-	// all times are set to a fixed moment when the program started.
-	//
-	// If Inode is left as 0, a dynamic inode number is chosen.
-	//
-	// The result may be cached for the duration set in Valid.
-	Attr(ctx context.Context, attr *fuse.Attr) error
-}
-
 type NodeGetattrer interface {
 	// Getattr obtains the standard metadata for the receiver.
 	// It should store that metadata in resp.
@@ -129,12 +103,6 @@ type NodeSymlinker interface {
 	Symlink(ctx context.Context, req *fuse.SymlinkRequest) (Node, error)
 }
 
-// This optional request will be called only for symbolic link nodes.
-type NodeReadlinker interface {
-	// Readlink reads a symbolic link.
-	Readlink(ctx context.Context, req *fuse.ReadlinkRequest) (string, error)
-}
-
 type NodeLinker interface {
 	// Link creates a new directory entry in the receiver based on an
 	// existing Node. Receiver must be a directory.
@@ -158,16 +126,6 @@ type NodeAccesser interface {
 	// implemented, the Node behaves as if it always returns nil
 	// (permission granted), relying on checks in Open instead.
 	Access(ctx context.Context, req *fuse.AccessRequest) error
-}
-
-type NodeStringLookuper interface {
-	// Lookup looks up a specific entry in the receiver,
-	// which must be a directory.  Lookup should return a Node
-	// corresponding to the entry.  If the name does not exist in
-	// the directory, Lookup should return ENOENT.
-	//
-	// Lookup need not to handle the names "." and "..".
-	Lookup(ctx context.Context, name string) (Node, error)
 }
 
 type NodeRequestLookuper interface {
@@ -282,27 +240,6 @@ type HandleFlusher interface {
 	Flush(ctx context.Context, req *fuse.FlushRequest) error
 }
 
-type HandleReadAller interface {
-	ReadAll(ctx context.Context) ([]byte, error)
-}
-
-type HandleReadDirAller interface {
-	ReadDirAll(ctx context.Context) ([]fuse.Dirent, error)
-}
-
-type HandleReader interface {
-	// Read requests to read data from the handle.
-	//
-	// There is a page cache in the kernel that normally submits only
-	// page-aligned reads spanning one or more pages. However, you
-	// should not rely on this. To see individual requests as
-	// submitted by the file system clients, set OpenDirectIO.
-	//
-	// Note that reads beyond the size of the file as reported by Attr
-	// are not even attempted (except in OpenDirectIO mode).
-	Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error
-}
-
 type HandleWriter interface {
 	// Write requests to write data into the handle at the given offset.
 	// Store the amount of data written in resp.Size.
@@ -316,10 +253,6 @@ type HandleWriter interface {
 	// (as seen through Attr). Note that file size changes are
 	// communicated also through Setattr.
 	Write(ctx context.Context, req *fuse.WriteRequest, resp *fuse.WriteResponse) error
-}
-
-type HandleReleaser interface {
-	Release(ctx context.Context, req *fuse.ReleaseRequest) error
 }
 
 type Config struct {
@@ -1541,28 +1474,4 @@ type dataHandle struct {
 
 func (d *dataHandle) ReadAll(ctx context.Context) ([]byte, error) {
 	return d.data, nil
-}
-
-// GenerateDynamicInode returns a dynamic inode.
-//
-// The parent inode and current entry name are used as the criteria
-// for choosing a pseudorandom inode. This makes it likely the same
-// entry will get the same inode on multiple runs.
-func GenerateDynamicInode(parent uint64, name string) uint64 {
-	h := fnv.New64a()
-	var buf [8]byte
-	binary.LittleEndian.PutUint64(buf[:], parent)
-	_, _ = h.Write(buf[:])
-	_, _ = h.Write([]byte(name))
-	var inode uint64
-	for {
-		inode = h.Sum64()
-		if inode != 0 {
-			break
-		}
-		// there's a tiny probability that result is zero; change the
-		// input a little and try again
-		_, _ = h.Write([]byte{'x'})
-	}
-	return inode
 }

--- a/vendor/bazil.org/fuse/fuse_kernel.go
+++ b/vendor/bazil.org/fuse/fuse_kernel.go
@@ -1,3 +1,4 @@
+// +build !windows
 // See the file LICENSE for copyright and licensing information.
 
 // Derived from FUSE's fuse_kernel.h, which carries this notice:
@@ -174,10 +175,6 @@ const (
 // from the other flags in OpenFlags.
 const OpenAccessModeMask OpenFlags = syscall.O_ACCMODE
 
-// OpenFlags are the O_FOO flags passed to open/create/etc calls. For
-// example, os.O_WRONLY | os.O_APPEND.
-type OpenFlags uint32
-
 func (fl OpenFlags) String() string {
 	// O_RDONLY, O_RWONLY, O_RDWR are not flags
 	s := accModeName(fl & OpenAccessModeMask)
@@ -331,9 +328,6 @@ func flagString(f uint32, names []flagName) string {
 	}
 	return s[1:]
 }
-
-// The ReleaseFlags are used in the Release exchange.
-type ReleaseFlags uint32
 
 const (
 	ReleaseFlush ReleaseFlags = 1 << 0
@@ -575,9 +569,6 @@ func readInSize(p Protocol) uintptr {
 	}
 }
 
-// The ReadFlags are passed in ReadRequest.
-type ReadFlags uint32
-
 const (
 	// LockOwner field is valid.
 	ReadLockOwner ReadFlags = 1 << 1
@@ -724,17 +715,6 @@ type bmapIn struct {
 
 type bmapOut struct {
 	Block uint64
-}
-
-type inHeader struct {
-	Len    uint32
-	Opcode uint32
-	Unique uint64
-	Nodeid uint64
-	Uid    uint32
-	Gid    uint32
-	Pid    uint32
-	_      uint32
 }
 
 const inHeaderSize = int(unsafe.Sizeof(inHeader{}))

--- a/vendor/bazil.org/fuse/fuseutil/fuseutil.go
+++ b/vendor/bazil.org/fuse/fuseutil/fuseutil.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fuseutil // import "bazil.org/fuse/fuseutil"
 
 import (

--- a/vendor/bazil.org/fuse/options.go
+++ b/vendor/bazil.org/fuse/options.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fuse
 
 import (

--- a/vendor/bazil.org/fuse/unmount.go
+++ b/vendor/bazil.org/fuse/unmount.go
@@ -1,3 +1,5 @@
+// +build !windows
+
 package fuse
 
 // Unmount tries to unmount the filesystem mounted at dir.

--- a/vendor/bazil.org/fuse/unmount_std.go
+++ b/vendor/bazil.org/fuse/unmount_std.go
@@ -1,4 +1,5 @@
 // +build !linux
+// +build !windows
 
 package fuse
 


### PR DESCRIPTION
these patches support mount on windows through winfsp

#361 have some discuss on dokan , but I prefer [winfsp](http://www.secfs.net/winfsp/) instead, reasons:

* its official go bind [cgofuse](https://godoc.org/github.com/billziss-gh/cgofuse/fuse) have similar interface to bazil fuse,  and it also targets linux/osx,  makes port easily
* it's used by [rclone](https://rclone.org/commands/rclone_mount/) mount on windows
* winfsp's author takes [test](http://www.secfs.net/winfsp/develop/tests/) heavily
* winfsp suggests better [performance](http://www.secfs.net/winfsp/develop/perf-tests/) 
* in my test environment (with antivirus and data leak prevention software), dokan based encfs4win cause BSOD , but winfsp works without problem (with it's memfs example). and winfsp never crash during my restic development (even with my incorrect code)

this implementation is not a "native" port , it's an adapter layer which reuses current implementation .for that  I've moved minimal set codes to separate file in bazil fuse to make it built on windows.   it should not change behavior for other OS , and we can evaluate this on windows. 


- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's an entry in the `CHANGELOG.md` file that describe the changes for our users
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
