### PR TITLE
Skip subdirs on local backends for keys

### DIFF
--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -257,6 +257,12 @@ func (b *Local) List(ctx context.Context, t restic.FileType) <-chan string {
 				return err
 			}
 
+			// Skip subdirs in keys directory
+			if ((t == restic.KeyFile) && b.Basedir(t) != path) && fi.IsDir() {
+				debug.Log("Skipping dir %s", path)
+				return filepath.SkipDir
+			}
+
 			if !isFile(fi) {
 				return nil
 			}


### PR DESCRIPTION
In cases where there are subdirectories present in the keys/ dir the
path returned is stripped off the component.

Keys should reside only in the top level of keys/ so skip the
subdirectories for now.

The use case causing this patch is a local storage mounted via cifs on
some webdav server that litters .DAV subdirectories everywhere.


