### PR TITLE
Allow AWS S3 backend to use temporary and path-scoped credentials

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -428,6 +428,10 @@ func parseConfig(loc location.Location, opts options.Options) (interface{}, erro
 			cfg.Secret = os.Getenv("AWS_SECRET_ACCESS_KEY")
 		}
 
+		if cfg.Token == "" {
+			cfg.Token = os.Getenv("AWS_SESSION_TOKEN")
+		}
+
 		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
 			return nil, err
 		}

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -21,7 +21,7 @@ type Config struct {
 
 	Connections       uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
 	MaxRetries        uint `option:"retries" help:"set the number of retries attempted"`
-	NeverCreateBucket bool `option:"never-create-bucket" help:"prevent the backend from lazily creating buckets (default: false)"`
+	NeverCreateBucket uint `option:"never-create-bucket" help:"prevent the backend from lazily creating buckets (default: false)"`
 }
 
 // NewConfig returns a new Config with the default values filled in.

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -12,12 +12,12 @@ import (
 // Config contains all configuration necessary to connect to an s3 compatible
 // server.
 type Config struct {
-	Endpoint      string
-	UseHTTP       bool
-	KeyID, Secret string
-	Bucket        string
-	Prefix        string
-	Layout        string `option:"layout" help:"use this backend layout (default: auto-detect)"`
+	Endpoint             string
+	UseHTTP              bool
+	KeyID, Secret, Token string
+	Bucket               string
+	Prefix               string
+	Layout               string `option:"layout" help:"use this backend layout (default: auto-detect)"`
 
 	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
 	MaxRetries  uint `option:"retries" help:"set the number of retries attempted"`

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -19,8 +19,9 @@ type Config struct {
 	Prefix               string
 	Layout               string `option:"layout" help:"use this backend layout (default: auto-detect)"`
 
-	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
-	MaxRetries  uint `option:"retries" help:"set the number of retries attempted"`
+	Connections       uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	MaxRetries        uint `option:"retries" help:"set the number of retries attempted"`
+	NeverCreateBucket bool `option:"never-create-bucket" help:"prevent the backend from lazily creating buckets (default: false)"`
 }
 
 // NewConfig returns a new Config with the default values filled in.

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -105,7 +105,7 @@ func Create(cfg Config, rt http.RoundTripper) (restic.Backend, error) {
 		return nil, errors.Wrap(err, "open")
 	}
 
-	if cfg.NeverCreateBucket {
+	if cfg.NeverCreateBucket > 0 {
 		return be, nil
 	}
 

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -52,6 +52,7 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 			Value: credentials.Value{
 				AccessKeyID:     cfg.KeyID,
 				SecretAccessKey: cfg.Secret,
+				SessionToken:    cfg.Token,
 			},
 		},
 		&credentials.IAM{
@@ -226,7 +227,7 @@ func lenForFile(f *os.File) (int64, error) {
 func (be *Backend) Save(ctx context.Context, h restic.Handle, rd io.Reader) (err error) {
 	debug.Log("Save %v", h)
 
-	if err := h.Valid(); err != nil {
+	if err = h.Valid(); err != nil {
 		return err
 	}
 

--- a/internal/backend/s3/s3_test.go
+++ b/internal/backend/s3/s3_test.go
@@ -387,7 +387,7 @@ func TestUnprivilegedS3Credentials(t *testing.T) {
 	cfg.KeyID = os.Getenv("RESTIC_TEST_S3_UNPRIV_KEY")
 	cfg.Secret = os.Getenv("RESTIC_TEST_S3_UNPRIV_SECRET")
 	cfg.Token = os.Getenv("RESTIC_TEST_S3_UNPRIV_TOKEN")
-	cfg.NeverCreateBucket = true
+	cfg.NeverCreateBucket = 1
 
 	newS3TestSuite(t, cfg).RunTests(t)
 }


### PR DESCRIPTION
### What is the purpose of this change? What does it change?
It is currently not possible to use the restic S3 backend with IAM credentials that are temporary and scoped to a subdirectory. The first one requires restic to accept AWS_SESSION_TOKEN credentials, the second requires that the s3 backend doesn't try to create whenever the 'bucket exists' check fails due to permission issues. 

### Was the change discussed in an issue or in the forum before?
This pull request aims to solves the issue as described here #1477 

### Checklist

- [ ] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's an entry in the `CHANGELOG.md` file that describe the changes for our users
- [x] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
