### PR TITLE
Doc: Specify `key passwd` usage

### DIFF
--- a/doc/070_encryption.rst
+++ b/doc/070_encryption.rst
@@ -26,8 +26,8 @@ Manage repository keys
 **********************
 
 The ``key`` command allows you to set multiple access keys or passwords
-per repository. In fact, you can use the ``list``, ``add``, ``remove``
-and ``passwd`` sub-commands to manage these keys very precisely:
+per repository. In fact, you can use the ``list``, ``add``, ``remove``, and
+``passwd`` (changes a password) sub-commands to manage these keys very precisely:
 
 .. code-block:: console
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

Specify that `key passwd` is used to change a password. Helps people searching the web find the right  documentation. With changes will match searches like “change restic backup password”.

### Was the change discussed in an issue or in the forum before?

No.

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] ~~I have added tests for all changes in this PR~~
- [x] I have added documentation for the changes (in the manual)
- [ ] ~~There's an entry in the `CHANGELOG.md` file that describe the changes for our users~~
- [ ] ~~I have run `gofmt` on the code in all commits~~
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
