### PR TITLE
doc: S3 requires ListObjects not ListBucket permission

### DIFF
--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -147,7 +147,7 @@ saved. Now a second statement is created:
 
    Effect: Allow
    Service: Amazon S3
-   Actions: ListBucket
+   Actions: ListObjects
    Resource: arn:aws:s3:::restic-demo
 
 Again, substitute ``restic-demo`` with the actual name of your bucket. Note that,


### PR DESCRIPTION
The S3 example in the documentation erroneously refers to the ListBucket permission, however ListObjects is required instead.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

Fixes a documentation issue.

### Was the change discussed in an issue or in the forum before?

No.

### Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's an entry in the `CHANGELOG.md` file that describe the changes for our users
- [ ] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
