### PR TITLE
Support for TLS client certificate authentication

### DIFF
--- a/changelog/0.8.2/issue-1522
+++ b/changelog/0.8.2/issue-1522
@@ -1,9 +1,8 @@
-Enhancement: Add support for TLS client certificate authentication.
+Enhancement: Add support for TLS client certificate authentication
 
-Support has been added to the http backend for providing a TLS client
-certificate/key pair using `--tls-client-cert` and `--tls-client-key` when
-connecting to https resources that perform TLS client certificate
-authentication.
+Support has been added for using a TLS client certificate for authentication to
+HTTP based backend. A file containing the PEM encoded private key and
+certificate can be set using the `--tls-client-cert` option.
 
 https://github.com/restic/restic/issues/1522
 https://github.com/restic/restic/pull/1524

--- a/changelog/0.8.2/issue-1522
+++ b/changelog/0.8.2/issue-1522
@@ -1,0 +1,9 @@
+Enhancement: Add support for TLS client certificate authentication.
+
+Support has been added to the http backend for providing a TLS client
+certificate/key pair using `--tls-client-cert` and `--tls-client-key` when
+connecting to https resources that perform TLS client certificate
+authentication.
+
+https://github.com/restic/restic/issues/1522
+https://github.com/restic/restic/pull/1524

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -48,7 +48,6 @@ type GlobalOptions struct {
 	NoCache       bool
 	CACerts       []string
 	TLSClientCert string
-	TLSClientKey  string
 	CleanupCache  bool
 
 	LimitUploadKb   int
@@ -86,8 +85,7 @@ func init() {
 	f.StringVar(&globalOptions.CacheDir, "cache-dir", "", "set the cache directory")
 	f.BoolVar(&globalOptions.NoCache, "no-cache", false, "do not use a local cache")
 	f.StringSliceVar(&globalOptions.CACerts, "cacert", nil, "path to load root certificates from (default: use system certificates)")
-	f.StringVar(&globalOptions.TLSClientCert, "tls-client-cert", "", "path to a TLS client certificate")
-	f.StringVar(&globalOptions.TLSClientKey, "tls-client-key", "", "path to a TLS client certificate key")
+	f.StringVar(&globalOptions.TLSClientCert, "tls-client-cert", "", "path to a file containing PEM encoded TLS client certificate and private key")
 	f.BoolVar(&globalOptions.CleanupCache, "cleanup-cache", false, "auto remove old cache directories")
 	f.IntVar(&globalOptions.LimitUploadKb, "limit-upload", 0, "limits uploads to a maximum rate in KiB/s. (default: unlimited)")
 	f.IntVar(&globalOptions.LimitDownloadKb, "limit-download", 0, "limits downloads to a maximum rate in KiB/s. (default: unlimited)")
@@ -545,7 +543,11 @@ func open(s string, gopts GlobalOptions, opts options.Options) (restic.Backend, 
 		return nil, err
 	}
 
-	rt, err := backend.Transport(globalOptions.CACerts, globalOptions.TLSClientCert, globalOptions.TLSClientKey)
+	tropts := backend.TransportOptions{
+		RootCertFilenames:        globalOptions.CACerts,
+		TLSClientCertKeyFilename: globalOptions.TLSClientCert,
+	}
+	rt, err := backend.Transport(tropts)
 	if err != nil {
 		return nil, err
 	}
@@ -609,7 +611,11 @@ func create(s string, opts options.Options) (restic.Backend, error) {
 		return nil, err
 	}
 
-	rt, err := backend.Transport(globalOptions.CACerts, globalOptions.TLSClientCert, globalOptions.TLSClientKey)
+	tropts := backend.TransportOptions{
+		RootCertFilenames:        globalOptions.CACerts,
+		TLSClientCertKeyFilename: globalOptions.TLSClientCert,
+	}
+	rt, err := backend.Transport(tropts)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -39,15 +39,17 @@ var version = "compiled manually"
 
 // GlobalOptions hold all global options for restic.
 type GlobalOptions struct {
-	Repo         string
-	PasswordFile string
-	Quiet        bool
-	NoLock       bool
-	JSON         bool
-	CacheDir     string
-	NoCache      bool
-	CACerts      []string
-	CleanupCache bool
+	Repo          string
+	PasswordFile  string
+	Quiet         bool
+	NoLock        bool
+	JSON          bool
+	CacheDir      string
+	NoCache       bool
+	CACerts       []string
+	TLSClientCert string
+	TLSClientKey  string
+	CleanupCache  bool
 
 	LimitUploadKb   int
 	LimitDownloadKb int
@@ -84,6 +86,8 @@ func init() {
 	f.StringVar(&globalOptions.CacheDir, "cache-dir", "", "set the cache directory")
 	f.BoolVar(&globalOptions.NoCache, "no-cache", false, "do not use a local cache")
 	f.StringSliceVar(&globalOptions.CACerts, "cacert", nil, "path to load root certificates from (default: use system certificates)")
+	f.StringVar(&globalOptions.TLSClientCert, "tls-client-cert", "", "path to a TLS client certificate")
+	f.StringVar(&globalOptions.TLSClientKey, "tls-client-key", "", "path to a TLS client certificate key")
 	f.BoolVar(&globalOptions.CleanupCache, "cleanup-cache", false, "auto remove old cache directories")
 	f.IntVar(&globalOptions.LimitUploadKb, "limit-upload", 0, "limits uploads to a maximum rate in KiB/s. (default: unlimited)")
 	f.IntVar(&globalOptions.LimitDownloadKb, "limit-download", 0, "limits downloads to a maximum rate in KiB/s. (default: unlimited)")
@@ -541,7 +545,7 @@ func open(s string, gopts GlobalOptions, opts options.Options) (restic.Backend, 
 		return nil, err
 	}
 
-	rt, err := backend.Transport(globalOptions.CACerts)
+	rt, err := backend.Transport(globalOptions.CACerts, globalOptions.TLSClientCert, globalOptions.TLSClientKey)
 	if err != nil {
 		return nil, err
 	}
@@ -605,7 +609,7 @@ func create(s string, opts options.Options) (restic.Backend, error) {
 		return nil, err
 	}
 
-	rt, err := backend.Transport(globalOptions.CACerts)
+	rt, err := backend.Transport(globalOptions.CACerts, globalOptions.TLSClientCert, globalOptions.TLSClientKey)
 	if err != nil {
 		return nil, err
 	}

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -51,8 +51,8 @@ Usage help is available:
       -p, --password-file string    read the repository password from a file (default: $RESTIC_PASSWORD_FILE)
       -q, --quiet                   do not output comprehensive progress report
       -r, --repo string             repository to backup to or restore from (default: $RESTIC_REPOSITORY)
-          --tls-client-cert string  path to a TLS client certificate
-          --tls-client-key string   path to a TLS client certificate key
+          --tls-client-cert string   path to a file containing PEM encoded TLS client certificate and private key
+
 
     Use "restic [command] --help" for more information about a command.
 

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -39,18 +39,20 @@ Usage help is available:
       version       Print version information
 
     Flags:
-          --cacert stringSlice     path to load root certificates from (default: use system certificates)
-          --cache-dir string       set the cache directory
-      -h, --help                   help for restic
-          --json                   set output mode to JSON for commands that support it
-          --limit-download int     limits downloads to a maximum rate in KiB/s. (default: unlimited)
-          --limit-upload int       limits uploads to a maximum rate in KiB/s. (default: unlimited)
-          --no-cache               do not use a local cache
-          --no-lock                do not lock the repo, this allows some operations on read-only repos
-      -o, --option key=value       set extended option (key=value, can be specified multiple times)
-      -p, --password-file string   read the repository password from a file (default: $RESTIC_PASSWORD_FILE)
-      -q, --quiet                  do not output comprehensive progress report
-      -r, --repo string            repository to backup to or restore from (default: $RESTIC_REPOSITORY)
+          --cacert stringSlice      path to load root certificates from (default: use system certificates)
+          --cache-dir string        set the cache directory
+      -h, --help                    help for restic
+          --json                    set output mode to JSON for commands that support it
+          --limit-download int      limits downloads to a maximum rate in KiB/s. (default: unlimited)
+          --limit-upload int        limits uploads to a maximum rate in KiB/s. (default: unlimited)
+          --no-cache                do not use a local cache
+          --no-lock                 do not lock the repo, this allows some operations on read-only repos
+      -o, --option key=value        set extended option (key=value, can be specified multiple times)
+      -p, --password-file string    read the repository password from a file (default: $RESTIC_PASSWORD_FILE)
+      -q, --quiet                   do not output comprehensive progress report
+      -r, --repo string             repository to backup to or restore from (default: $RESTIC_REPOSITORY)
+          --tls-client-cert string  path to a TLS client certificate
+          --tls-client-key string   path to a TLS client certificate key
 
     Use "restic [command] --help" for more information about a command.
 
@@ -87,17 +89,19 @@ command:
           --time string                      time of the backup (ex. '2012-11-01 22:08:41') (default: now)
 
     Global Flags:
-          --cacert stringSlice     path to load root certificates from (default: use system certificates)
-          --cache-dir string       set the cache directory
-          --json                   set output mode to JSON for commands that support it
-          --limit-download int     limits downloads to a maximum rate in KiB/s. (default: unlimited)
-          --limit-upload int       limits uploads to a maximum rate in KiB/s. (default: unlimited)
-          --no-cache               do not use a local cache
-          --no-lock                do not lock the repo, this allows some operations on read-only repos
-      -o, --option key=value       set extended option (key=value, can be specified multiple times)
-      -p, --password-file string   read the repository password from a file (default: $RESTIC_PASSWORD_FILE)
-      -q, --quiet                  do not output comprehensive progress report
-      -r, --repo string            repository to backup to or restore from (default: $RESTIC_REPOSITORY)
+          --cacert stringSlice      path to load root certificates from (default: use system certificates)
+          --cache-dir string        set the cache directory
+          --json                    set output mode to JSON for commands that support it
+          --limit-download int      limits downloads to a maximum rate in KiB/s. (default: unlimited)
+          --limit-upload int        limits uploads to a maximum rate in KiB/s. (default: unlimited)
+          --no-cache                do not use a local cache
+          --no-lock                 do not lock the repo, this allows some operations on read-only repos
+      -o, --option key=value        set extended option (key=value, can be specified multiple times)
+      -p, --password-file string    read the repository password from a file (default: $RESTIC_PASSWORD_FILE)
+      -q, --quiet                   do not output comprehensive progress report
+      -r, --repo string             repository to backup to or restore from (default: $RESTIC_REPOSITORY)
+          --tls-client-cert string  path to a TLS client certificate
+          --tls-client-key string   path to a TLS client certificate key
 
 Subcommand that support showing progress information such as ``backup``,
 ``check`` and ``prune`` will do so unless the quiet flag ``-q`` or

--- a/internal/backend/azure/azure_test.go
+++ b/internal/backend/azure/azure_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newAzureTestSuite(t testing.TB) *test.Suite {
-	tr, err := backend.Transport(nil, "", "")
+	tr, err := backend.Transport(backend.TransportOptions{})
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}

--- a/internal/backend/azure/azure_test.go
+++ b/internal/backend/azure/azure_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newAzureTestSuite(t testing.TB) *test.Suite {
-	tr, err := backend.Transport(nil)
+	tr, err := backend.Transport(nil, "", "")
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}

--- a/internal/backend/b2/b2_test.go
+++ b/internal/backend/b2/b2_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newB2TestSuite(t testing.TB) *test.Suite {
-	tr, err := backend.Transport(nil, "", "")
+	tr, err := backend.Transport(backend.TransportOptions{})
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}

--- a/internal/backend/b2/b2_test.go
+++ b/internal/backend/b2/b2_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newB2TestSuite(t testing.TB) *test.Suite {
-	tr, err := backend.Transport(nil)
+	tr, err := backend.Transport(nil, "", "")
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}

--- a/internal/backend/http_transport.go
+++ b/internal/backend/http_transport.go
@@ -3,19 +3,66 @@ package backend
 import (
 	"crypto/tls"
 	"crypto/x509"
-	"fmt"
+	"encoding/pem"
 	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
+	"strings"
 	"time"
 
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 )
+
+// TransportOptions collects various options which can be set for an HTTP based
+// transport.
+type TransportOptions struct {
+	// contains filenames of PEM encoded root certificates to trust
+	RootCertFilenames []string
+
+	// contains the name of a file containing the TLS client certificate and private key in PEM format
+	TLSClientCertKeyFilename string
+}
+
+// readPEMCertKey reads a file and returns the PEM encoded certificate and key
+// blocks.
+func readPEMCertKey(filename string) (certs []byte, key []byte, err error) {
+	data, err := ioutil.ReadFile(os.Args[1])
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "ReadFile")
+	}
+
+	var block *pem.Block
+	for {
+		if len(data) == 0 {
+			break
+		}
+		block, data = pem.Decode(data)
+		if block == nil {
+			break
+		}
+
+		switch {
+		case strings.HasSuffix(block.Type, "CERTIFICATE"):
+			certs = append(certs, pem.EncodeToMemory(block)...)
+		case strings.HasSuffix(block.Type, "PRIVATE KEY"):
+			if key != nil {
+				return nil, nil, errors.Errorf("error loading TLS cert and key from %v: more than one private key found", filename)
+			}
+			key = pem.EncodeToMemory(block)
+		default:
+			return nil, nil, errors.Errorf("error loading TLS cert and key from %v: unknown block type %v found", filename, block.Type)
+		}
+	}
+
+	return certs, key, nil
+}
 
 // Transport returns a new http.RoundTripper with default settings applied. If
 // a custom rootCertFilename is non-empty, it must point to a valid PEM file,
 // otherwise the function will return an error.
-func Transport(rootCertFilenames []string, tlsClientCert string, tlsClientKey string) (http.RoundTripper, error) {
+func Transport(opts TransportOptions) (http.RoundTripper, error) {
 	// copied from net/http
 	tr := &http.Transport{
 		Proxy: http.ProxyFromEnvironment,
@@ -32,34 +79,36 @@ func Transport(rootCertFilenames []string, tlsClientCert string, tlsClientKey st
 		TLSClientConfig:       &tls.Config{},
 	}
 
-	if tlsClientCert != "" && tlsClientKey != "" {
-		c, err := tls.LoadX509KeyPair(tlsClientCert, tlsClientKey)
+	if opts.TLSClientCertKeyFilename != "" {
+		certs, key, err := readPEMCertKey(opts.TLSClientCertKeyFilename)
 		if err != nil {
-			return nil, fmt.Errorf("unable to read client certificate/key pair: %v", err)
+			return nil, err
 		}
-		tr.TLSClientConfig.Certificates = []tls.Certificate{c}
-	}
 
-	if rootCertFilenames == nil {
-		return debug.RoundTripper(tr), nil
-	}
-
-	p := x509.NewCertPool()
-	for _, filename := range rootCertFilenames {
-		if filename == "" {
-			return nil, fmt.Errorf("empty filename for root certificate supplied")
-		}
-		b, err := ioutil.ReadFile(filename)
+		crt, err := tls.X509KeyPair(certs, key)
 		if err != nil {
-			return nil, fmt.Errorf("unable to read root certificate: %v", err)
+			return nil, errors.Errorf("parse TLS client cert or key: %v", err)
 		}
-		if ok := p.AppendCertsFromPEM(b); !ok {
-			return nil, fmt.Errorf("cannot parse root certificate from %q", filename)
-		}
+		tr.TLSClientConfig.Certificates = []tls.Certificate{crt}
 	}
 
-	tr.TLSClientConfig.RootCAs = p
+	if opts.RootCertFilenames != nil {
+		pool := x509.NewCertPool()
+		for _, filename := range opts.RootCertFilenames {
+			if filename == "" {
+				return nil, errors.Errorf("empty filename for root certificate supplied")
+			}
+			b, err := ioutil.ReadFile(filename)
+			if err != nil {
+				return nil, errors.Errorf("unable to read root certificate: %v", err)
+			}
+			if ok := pool.AppendCertsFromPEM(b); !ok {
+				return nil, errors.Errorf("cannot parse root certificate from %q", filename)
+			}
+		}
+		tr.TLSClientConfig.RootCAs = pool
+	}
 
-	// wrap in the debug round tripper
+	// wrap in the debug round tripper (if active)
 	return debug.RoundTripper(tr), nil
 }

--- a/internal/backend/rest/rest_test.go
+++ b/internal/backend/rest/rest_test.go
@@ -68,7 +68,7 @@ func runRESTServer(ctx context.Context, t testing.TB, dir string) (*url.URL, fun
 }
 
 func newTestSuite(ctx context.Context, t testing.TB, url *url.URL, minimalData bool) *test.Suite {
-	tr, err := backend.Transport(nil, "", "")
+	tr, err := backend.Transport(backend.TransportOptions{})
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}

--- a/internal/backend/rest/rest_test.go
+++ b/internal/backend/rest/rest_test.go
@@ -68,7 +68,7 @@ func runRESTServer(ctx context.Context, t testing.TB, dir string) (*url.URL, fun
 }
 
 func newTestSuite(ctx context.Context, t testing.TB, url *url.URL, minimalData bool) *test.Suite {
-	tr, err := backend.Transport(nil)
+	tr, err := backend.Transport(nil, "", "")
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}

--- a/internal/backend/s3/s3_test.go
+++ b/internal/backend/s3/s3_test.go
@@ -121,7 +121,7 @@ func createS3(t testing.TB, cfg MinioTestConfig, tr http.RoundTripper) (be resti
 }
 
 func newMinioTestSuite(ctx context.Context, t testing.TB) *test.Suite {
-	tr, err := backend.Transport(nil, "", "")
+	tr, err := backend.Transport(backend.TransportOptions{})
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}
@@ -221,7 +221,7 @@ func BenchmarkBackendMinio(t *testing.B) {
 }
 
 func newS3TestSuite(t testing.TB) *test.Suite {
-	tr, err := backend.Transport(nil, "", "")
+	tr, err := backend.Transport(backend.TransportOptions{})
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}

--- a/internal/backend/s3/s3_test.go
+++ b/internal/backend/s3/s3_test.go
@@ -121,7 +121,7 @@ func createS3(t testing.TB, cfg MinioTestConfig, tr http.RoundTripper) (be resti
 }
 
 func newMinioTestSuite(ctx context.Context, t testing.TB) *test.Suite {
-	tr, err := backend.Transport(nil)
+	tr, err := backend.Transport(nil, "", "")
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}
@@ -221,7 +221,7 @@ func BenchmarkBackendMinio(t *testing.B) {
 }
 
 func newS3TestSuite(t testing.TB) *test.Suite {
-	tr, err := backend.Transport(nil)
+	tr, err := backend.Transport(nil, "", "")
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}

--- a/internal/backend/swift/swift_test.go
+++ b/internal/backend/swift/swift_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newSwiftTestSuite(t testing.TB) *test.Suite {
-	tr, err := backend.Transport(nil)
+	tr, err := backend.Transport(nil, "", "")
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}

--- a/internal/backend/swift/swift_test.go
+++ b/internal/backend/swift/swift_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func newSwiftTestSuite(t testing.TB) *test.Suite {
-	tr, err := backend.Transport(nil, "", "")
+	tr, err := backend.Transport(backend.TransportOptions{})
 	if err != nil {
 		t.Fatalf("cannot create transport for tests: %v", err)
 	}


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

This adds `--tls-client-cert` and `--tls-client-key` parameters and enables use
of that certificate/key pair when connecting to https servers.

First, I must apologize if this isn't adhering to Go conventions. I don't write Go, I only pieced this together from the Restic source, [an example](https://gist.github.com/michaljemala/d6f4e01c4834bf47a9c4) I found Googling, and Go's [pkg/crypto/tls documentation](https://golang.org/pkg/crypto/tls/). I welcome any and all feedback.

### Was the change discussed in an issue or in the forum before?

Feature request: #1522

### Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [X] I have added documentation for the changes (in the manual)
- [X] There's an entry in the `CHANGELOG.md` file that describe the changes for our users
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
