### PR TITLE
Fix code block formatting in FAQs

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -114,4 +114,5 @@ via other protocols.
 The following may work:
 
 ::
+
     $ restic init -r sftp:user@nas:/restic-repo init


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Fixes the formatting of a code block in the FAQs and makes it render properly.

[FAQ](https://restic.readthedocs.io/en/latest/faq.html) prior to fix:
<img width="371" alt="faq" src="https://user-images.githubusercontent.com/302566/34632365-e3156b9e-f26c-11e7-923c-b17a830d9e56.png">


### Was the change discussed in an issue or in the forum before?

No.

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's an entry in the `CHANGELOG.md` file that describe the changes for our users
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
