### PR TITLE
restore: Improve error message for more than one ID

### DIFF
--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -53,8 +53,11 @@ func init() {
 func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 	ctx := gopts.ctx
 
-	if len(args) != 1 {
+	switch {
+	case len(args) == 0:
 		return errors.Fatal("no snapshot ID specified")
+	case len(args) > 1:
+		return errors.Fatalf("more than one snapshot ID specified: %v", args)
 	}
 
 	if opts.Target == "" {

--- a/internal/errors/fatal.go
+++ b/internal/errors/fatal.go
@@ -34,5 +34,5 @@ func Fatal(s string) error {
 
 // Fatalf returns an error which implements the Fataler interface.
 func Fatalf(s string, data ...interface{}) error {
-	return fatalError(fmt.Sprintf(s, data...))
+	return Wrap(fatalError(fmt.Sprintf(s, data...)), "Fatal")
 }

--- a/internal/options/options_test.go
+++ b/internal/options/options_test.go
@@ -65,11 +65,11 @@ var invalidOptsTests = []struct {
 }{
 	{
 		[]string{"=bar", "bar=baz", "k="},
-		"empty key is not a valid option",
+		"Fatal: empty key is not a valid option",
 	},
 	{
 		[]string{"x=1", "foo=bar", "y=2", "foo=baz"},
-		`key "foo" present more than once`,
+		`Fatal: key "foo" present more than once`,
 	},
 }
 
@@ -185,7 +185,7 @@ var invalidSetTests = []struct {
 			"first_name": "foobar",
 		},
 		"ns",
-		"option ns.first_name is not known",
+		"Fatal: option ns.first_name is not known",
 	},
 	{
 		Options{


### PR DESCRIPTION
This PR improves the error message in case the `restore` command gets passed more than one snapshot ID. It was accidentally discovered by a user, described in the forum here: https://forum.restic.net/t/restic-restore-latest-gives-no-snapshot-id-specified/372/18?u=fd0  