### PR TITLE
fixed restic-check does not retry backend.Test failures

### DIFF
--- a/internal/backend/backend_retry.go
+++ b/internal/backend/backend_retry.go
@@ -117,3 +117,14 @@ func (be *RetryBackend) Remove(ctx context.Context, h restic.Handle) (err error)
 		return be.Backend.Remove(ctx, h)
 	})
 }
+
+// Test a boolean value whether a File with the name and type exists.
+func (be *RetryBackend) Test(ctx context.Context, h restic.Handle) (exists bool, err error) {
+	err = be.retry(ctx, fmt.Sprintf("Test(%v)", h), func() error {
+		var innerError error
+		exists, innerError = be.Backend.Test(ctx, h)
+
+		return innerError
+	})
+	return exists, err
+}


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Fixes `restic check` fails due to intermittent remote repository access failures, which are fairly common with Google Drive and to a lesser extend with MS OneDrive (and I assume all other cloud storage providers, but don't have first-hand experience).

### Was the change discussed in an issue or in the forum before?

no, didn't see any prior discussions of the issue

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's an entry in the `CHANGELOG.md` file that describe the changes for our users
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
