### PR TITLE
fuse: Correct behavior for reading after EOF, add snapshot template string

### DIFF
--- a/changelog/0.8.2/pull-1554
+++ b/changelog/0.8.2/pull-1554
@@ -1,0 +1,7 @@
+Enhancement: fuse/mount: Correctly handle EOF, add template option
+
+We've added the `--snapshot-template` string, which can be used to specify a
+template for a snapshot directory. In addition, accessing data after the end of
+a file via the fuse mount is now handled correctly.
+
+https://github.com/restic/restic/pull/1554

--- a/cmd/restic/integration_fuse_test.go
+++ b/cmd/restic/integration_fuse_test.go
@@ -55,7 +55,9 @@ func waitForMount(t testing.TB, dir string) {
 }
 
 func testRunMount(t testing.TB, gopts GlobalOptions, dir string) {
-	opts := MountOptions{}
+	opts := MountOptions{
+		SnapshotTemplate: time.RFC3339,
+	}
 	rtest.OK(t, runMount(opts, gopts, []string{dir}))
 }
 

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -182,7 +182,6 @@ func (d *dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	node, ok := d.items[name]
 	if !ok {
 		debug.Log("  Lookup(%v) -> not found", name)
-		debug.Log("     items: %v\n", d.items)
 		return nil, fuse.ENOENT
 	}
 	switch node.Type {

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -4,7 +4,6 @@
 package fuse
 
 import (
-	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 
 	"github.com/restic/restic/internal/debug"
@@ -111,7 +110,10 @@ func (f *file) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadR
 	if uint64(offset) > f.node.Size {
 		debug.Log("Read(%v): offset is greater than file size: %v > %v",
 			f.node.Name, req.Offset, f.node.Size)
-		return errors.New("offset greater than files size")
+
+		// return no data
+		resp.Data = resp.Data[:0]
+		return nil
 	}
 
 	// handle special case: file is empty

--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -16,10 +16,11 @@ import (
 
 // Config holds settings for the fuse mount.
 type Config struct {
-	OwnerIsRoot bool
-	Host        string
-	Tags        []restic.TagList
-	Paths       []string
+	OwnerIsRoot      bool
+	Host             string
+	Tags             []restic.TagList
+	Paths            []string
+	SnapshotTemplate string
 }
 
 // Root is the root node of the fuse mount of a repository.


### PR DESCRIPTION
This PR corrects the behavior when data is read after the end of a file, and adds a CLI option to specify the template for the snapshot directories.