### PR TITLE
Add --read-data-subset flag to check command

### DIFF
--- a/changelog/0.8.3/issue-1497
+++ b/changelog/0.8.3/issue-1497
@@ -1,0 +1,7 @@
+Enhancement: Add --read-data-subset flag to check command
+
+This change introduces ability to check integrity of a subset of repository 
+data packs. This can be used to spread integrity check of larger repositories
+over period of time.
+
+https://github.com/restic/restic/issues/1497

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -87,3 +87,29 @@ yield the same error:
     Load indexes
     ciphertext verification failed
 
+By default, ``check`` command does not check that repository data files 
+are unmodified. Use ``--read-data`` parameter to check all repository
+data files:
+
+.. code-block:: console
+
+    $ restic -r /tmp/backup check --read-data
+    load indexes
+    check all packs
+    check snapshots, trees and blobs
+    read all data
+
+Use ``--read-data-subset=n/t`` parameter to check subset of repository data
+files. The parameter takes two values, ``n`` and ``t``. All repository data 
+files are logically devided in ``t`` roughly equal groups and only files that
+belong to the group number ``n`` are checked. For example, the following 
+commands check all repository data files over 5 separate invocations:
+
+.. code-block:: console
+
+    $ restic -r /tmp/backup check --read-data-subset=1/5
+    $ restic -r /tmp/backup check --read-data-subset=2/5
+    $ restic -r /tmp/backup check --read-data-subset=3/5
+    $ restic -r /tmp/backup check --read-data-subset=4/5
+    $ restic -r /tmp/backup check --read-data-subset=5/5
+


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

This change introduces ability to check integrity of a subset of repository 
data packs. This can be used to spread integrity check of larger repositories
over period of time.

### Was the change discussed in an issue or in the forum before?

See #1497

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
