### PR TITLE
Retry all repository file download errors

### DIFF
--- a/changelog/0.8.2/pull-1560
+++ b/changelog/0.8.2/pull-1560
@@ -1,0 +1,3 @@
+Enhancement: retry all repository file download errors
+
+https://github.com/restic/restic/pull/1560

--- a/internal/archiver/archiver_duplication_test.go
+++ b/internal/archiver/archiver_duplication_test.go
@@ -38,13 +38,13 @@ func randomID() restic.ID {
 
 // forgetfulBackend returns a backend that forgets everything.
 func forgetfulBackend() restic.Backend {
-	be := &mock.Backend{}
+	be := mock.NewBackend()
 
 	be.TestFn = func(ctx context.Context, h restic.Handle) (bool, error) {
 		return false, nil
 	}
 
-	be.LoadFn = func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+	be.OpenReaderFn = func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 		return nil, errors.New("not found")
 	}
 

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -178,10 +178,13 @@ func (wr wrapReader) Close() error {
 	return err
 }
 
-// Load returns a reader that yields the contents of the file at h at the
-// given offset. If length is nonzero, only a portion of the file is
-// returned. rd must be closed after use.
-func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+// Load runs fn with a reader that yields the contents of the file at h at the
+// given offset.
+func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
+}
+
+func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -142,9 +142,13 @@ func (be *b2Backend) IsNotExist(err error) bool {
 	return b2.IsNotExist(errors.Cause(err))
 }
 
-// Load returns the data stored in the backend for h at the given offset
-// and saves it in p. Load has the same semantics as io.ReaderAt.
-func (be *b2Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+// Load runs fn with a reader that yields the contents of the file at h at the
+// given offset.
+func (be *b2Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
+}
+
+func (be *b2Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/backend_error.go
+++ b/internal/backend/backend_error.go
@@ -66,12 +66,12 @@ func (be *ErrorBackend) Save(ctx context.Context, h restic.Handle, rd io.Reader)
 // given offset. If length is larger than zero, only a portion of the file
 // is returned. rd must be closed after use. If an error is returned, the
 // ReadCloser must be nil.
-func (be *ErrorBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (be *ErrorBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, consumer func(rd io.Reader) error) error {
 	if be.fail(be.FailLoad) {
-		return nil, errors.Errorf("Load(%v, %v, %v) random error induced", h, length, offset)
+		return errors.Errorf("Load(%v, %v, %v) random error induced", h, length, offset)
 	}
 
-	return be.Backend.Load(ctx, h, length, offset)
+	return be.Backend.Load(ctx, h, length, offset, consumer)
 }
 
 // Stat returns information about the File identified by h.

--- a/internal/backend/backend_retry.go
+++ b/internal/backend/backend_retry.go
@@ -88,15 +88,11 @@ func (be *RetryBackend) Save(ctx context.Context, h restic.Handle, rd io.Reader)
 // given offset. If length is larger than zero, only a portion of the file
 // is returned. rd must be closed after use. If an error is returned, the
 // ReadCloser must be nil.
-func (be *RetryBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (rd io.ReadCloser, err error) {
-	err = be.retry(ctx, fmt.Sprintf("Load(%v, %v, %v)", h, length, offset),
+func (be *RetryBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, consumer func(rd io.Reader) error) (err error) {
+	return be.retry(ctx, fmt.Sprintf("Load(%v, %v, %v)", h, length, offset),
 		func() error {
-			var innerError error
-			rd, innerError = be.Backend.Load(ctx, h, length, offset)
-
-			return innerError
+			return be.Backend.Load(ctx, h, length, offset, consumer)
 		})
-	return rd, err
 }
 
 // Stat returns information about the File identified by h.

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -282,10 +282,13 @@ func (wr wrapReader) Close() error {
 	return err
 }
 
-// Load returns a reader that yields the contents of the file at h at the
-// given offset. If length is nonzero, only a portion of the file is
-// returned. rd must be closed after use.
-func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+// Load runs fn with a reader that yields the contents of the file at h at the
+// given offset.
+func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
+}
+
+func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -146,10 +146,13 @@ func (b *Local) Save(ctx context.Context, h restic.Handle, rd io.Reader) error {
 	return setNewFileMode(filename, backend.Modes.File)
 }
 
-// Load returns a reader that yields the contents of the file at h at the
-// given offset. If length is nonzero, only a portion of the file is
-// returned. rd must be closed after use.
-func (b *Local) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+// Load runs fn with a reader that yields the contents of the file at h at the
+// given offset.
+func (b *Local) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+	return backend.DefaultLoad(ctx, h, length, offset, b.openReader, fn)
+}
+
+func (b *Local) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -166,10 +166,13 @@ func (b *restBackend) IsNotExist(err error) bool {
 	return ok
 }
 
-// Load returns a reader that yields the contents of the file at h at the
-// given offset. If length is nonzero, only a portion of the file is
-// returned. rd must be closed after use.
-func (b *restBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+// Load runs fn with a reader that yields the contents of the file at h at the
+// given offset.
+func (b *restBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+	return backend.DefaultLoad(ctx, h, length, offset, b.openReader, fn)
+}
+
+func (b *restBackend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -281,10 +281,13 @@ func (wr wrapReader) Close() error {
 	return err
 }
 
-// Load returns a reader that yields the contents of the file at h at the
-// given offset. If length is nonzero, only a portion of the file is
-// returned. rd must be closed after use.
-func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+// Load runs fn with a reader that yields the contents of the file at h at the
+// given offset.
+func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
+}
+
+func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -327,10 +327,13 @@ func (r *SFTP) Save(ctx context.Context, h restic.Handle, rd io.Reader) (err err
 	return errors.Wrap(r.c.Chmod(filename, backend.Modes.File), "Chmod")
 }
 
-// Load returns a reader that yields the contents of the file at h at the
-// given offset. If length is nonzero, only a portion of the file is
-// returned. rd must be closed after use.
-func (r *SFTP) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+// Load runs fn with a reader that yields the contents of the file at h at the
+// given offset.
+func (r *SFTP) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+	return backend.DefaultLoad(ctx, h, length, offset, r.openReader, fn)
+}
+
+func (r *SFTP) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -109,10 +109,13 @@ func (be *beSwift) Location() string {
 	return be.container
 }
 
-// Load returns a reader that yields the contents of the file at h at the
-// given offset. If length is nonzero, only a portion of the file is
-// returned. rd must be closed after use.
-func (be *beSwift) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+// Load runs fn with a reader that yields the contents of the file at h at the
+// given offset.
+func (be *beSwift) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
+}
+
+func (be *beSwift) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/test/benchmarks.go
+++ b/internal/backend/test/benchmarks.go
@@ -42,18 +42,13 @@ func (s *Suite) BenchmarkLoadFile(t *testing.B) {
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		rd, err := be.Load(context.TODO(), handle, 0, 0)
+		var n int
+		err := be.Load(context.TODO(), handle, 0, 0, func(rd io.Reader) (ierr error) {
+			n, ierr = io.ReadFull(rd, buf)
+			return ierr
+		})
 		if err != nil {
 			t.Fatal(err)
-		}
-
-		n, err := io.ReadFull(rd, buf)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err = rd.Close(); err != nil {
-			t.Fatalf("Close() returned error: %v", err)
 		}
 
 		if n != length {
@@ -84,18 +79,13 @@ func (s *Suite) BenchmarkLoadPartialFile(t *testing.B) {
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		rd, err := be.Load(context.TODO(), handle, testLength, 0)
+		var n int
+		err := be.Load(context.TODO(), handle, testLength, 0, func(rd io.Reader) (ierr error) {
+			n, ierr = io.ReadFull(rd, buf)
+			return ierr
+		})
 		if err != nil {
 			t.Fatal(err)
-		}
-
-		n, err := io.ReadFull(rd, buf)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err = rd.Close(); err != nil {
-			t.Fatalf("Close() returned error: %v", err)
 		}
 
 		if n != testLength {
@@ -128,18 +118,13 @@ func (s *Suite) BenchmarkLoadPartialFileOffset(t *testing.B) {
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		rd, err := be.Load(context.TODO(), handle, testLength, int64(testOffset))
+		var n int
+		err := be.Load(context.TODO(), handle, testLength, int64(testOffset), func(rd io.Reader) (ierr error) {
+			n, ierr = io.ReadFull(rd, buf)
+			return ierr
+		})
 		if err != nil {
 			t.Fatal(err)
-		}
-
-		n, err := io.ReadFull(rd, buf)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if err = rd.Close(); err != nil {
-			t.Fatalf("Close() returned error: %v", err)
 		}
 
 		if n != testLength {

--- a/internal/backend/utils.go
+++ b/internal/backend/utils.go
@@ -10,24 +10,11 @@ import (
 
 // LoadAll reads all data stored in the backend for the handle.
 func LoadAll(ctx context.Context, be restic.Backend, h restic.Handle) (buf []byte, err error) {
-	rd, err := be.Load(ctx, h, 0, 0)
-	if err != nil {
-		return nil, err
-	}
-
-	defer func() {
-		_, e := io.Copy(ioutil.Discard, rd)
-		if err == nil {
-			err = e
-		}
-
-		e = rd.Close()
-		if err == nil {
-			err = e
-		}
-	}()
-
-	return ioutil.ReadAll(rd)
+	err = be.Load(ctx, h, 0, 0, func(rd io.Reader) (ierr error) {
+		buf, ierr = ioutil.ReadAll(rd)
+		return ierr
+	})
+	return buf, err
 }
 
 // LimitedReadCloser wraps io.LimitedReader and exposes the Close() method.
@@ -45,4 +32,20 @@ func (l *LimitedReadCloser) Read(p []byte) (int, error) {
 // exposes the Close() method.
 func LimitReadCloser(r io.ReadCloser, n int64) *LimitedReadCloser {
 	return &LimitedReadCloser{ReadCloser: r, Reader: io.LimitReader(r, n)}
+}
+
+// DefaultLoad implements Backend.Load using lower-level openReader func
+func DefaultLoad(ctx context.Context, h restic.Handle, length int, offset int64,
+	openReader func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error),
+	fn func(rd io.Reader) error) error {
+	rd, err := openReader(ctx, h, length, offset)
+	if err != nil {
+		return err
+	}
+	err = fn(rd)
+	if err != nil {
+		rd.Close() // ignore secondary errors closing the reader
+		return err
+	}
+	return rd.Close()
 }

--- a/internal/backend/utils_test.go
+++ b/internal/backend/utils_test.go
@@ -3,11 +3,13 @@ package backend_test
 import (
 	"bytes"
 	"context"
+	"io"
 	"math/rand"
 	"testing"
 
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/mem"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
@@ -88,4 +90,55 @@ func TestLoadLargeBuffer(t *testing.T) {
 			continue
 		}
 	}
+}
+
+type mockReader struct {
+	closed bool
+}
+
+func (rd *mockReader) Read(p []byte) (n int, err error) {
+	return 0, nil
+}
+func (rd *mockReader) Close() error {
+	rd.closed = true
+	return nil
+}
+
+func TestDefaultLoad(t *testing.T) {
+
+	h := restic.Handle{Name: "id", Type: restic.DataFile}
+	rd := &mockReader{}
+
+	// happy case, assert correct parameters are passed around and content stream is closed
+	err := backend.DefaultLoad(context.TODO(), h, 10, 11, func(ctx context.Context, ih restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+		rtest.Equals(t, h, ih)
+		rtest.Equals(t, int(10), length)
+		rtest.Equals(t, int64(11), offset)
+
+		return rd, nil
+	}, func(ird io.Reader) error {
+		rtest.Equals(t, rd, ird)
+		return nil
+	})
+	rtest.OK(t, err)
+	rtest.Equals(t, true, rd.closed)
+
+	// unhappy case, assert producer errors are handled correctly
+	err = backend.DefaultLoad(context.TODO(), h, 10, 11, func(ctx context.Context, ih restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+		return nil, errors.Errorf("producer error")
+	}, func(ird io.Reader) error {
+		t.Fatalf("unexpected consumer invocation")
+		return nil
+	})
+	rtest.Equals(t, "producer error", err.Error())
+
+	// unhappy case, assert consumer errors are handled correctly
+	rd = &mockReader{}
+	err = backend.DefaultLoad(context.TODO(), h, 10, 11, func(ctx context.Context, ih restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+		return rd, nil
+	}, func(ird io.Reader) error {
+		return errors.Errorf("consumer error")
+	})
+	rtest.Equals(t, true, rd.closed)
+	rtest.Equals(t, "consumer error", err.Error())
 }

--- a/internal/cache/backend.go
+++ b/internal/cache/backend.go
@@ -121,17 +121,10 @@ func (b *Backend) cacheFile(ctx context.Context, h restic.Handle) error {
 		return nil
 	}
 
-	rd, err := b.Backend.Load(ctx, h, 0, 0)
+	err := b.Backend.Load(ctx, h, 0, 0, func(rd io.Reader) error {
+		return b.Cache.Save(h, rd)
+	})
 	if err != nil {
-		return err
-	}
-
-	if err = b.Cache.Save(h, rd); err != nil {
-		_ = rd.Close()
-		return err
-	}
-
-	if err = rd.Close(); err != nil {
 		// try to remove from the cache, ignore errors
 		_ = b.Cache.Remove(h)
 		return err
@@ -142,17 +135,22 @@ func (b *Backend) cacheFile(ctx context.Context, h restic.Handle) error {
 
 // loadFromCacheOrDelegate will try to load the file from the cache, and fall
 // back to the backend if that fails.
-func (b *Backend) loadFromCacheOrDelegate(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (b *Backend) loadFromCacheOrDelegate(ctx context.Context, h restic.Handle, length int, offset int64, consumer func(rd io.Reader) error) error {
 	rd, err := b.Cache.Load(h, length, offset)
-	if err == nil {
-		return rd, nil
+	if err != nil {
+		return b.Backend.Load(ctx, h, length, offset, consumer)
 	}
 
-	return b.Backend.Load(ctx, h, length, offset)
+	err = consumer(rd)
+	if err != nil {
+		rd.Close() // ignore secondary errors
+		return err
+	}
+	return rd.Close()
 }
 
 // Load loads a file from the cache or the backend.
-func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, consumer func(rd io.Reader) error) error {
 	b.inProgressMutex.Lock()
 	waitForFinish, inProgress := b.inProgress[h]
 	b.inProgressMutex.Unlock()
@@ -167,7 +165,12 @@ func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset 
 		debug.Log("Load(%v, %v, %v) from cache", h, length, offset)
 		rd, err := b.Cache.Load(h, length, offset)
 		if err == nil {
-			return rd, nil
+			err = consumer(rd)
+			if err != nil {
+				rd.Close() // ignore secondary errors
+				return err
+			}
+			return rd.Close()
 		}
 		debug.Log("error loading %v from cache: %v", h, err)
 	}
@@ -179,20 +182,20 @@ func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset 
 
 			err := b.cacheFile(ctx, h)
 			if err == nil {
-				return b.loadFromCacheOrDelegate(ctx, h, length, offset)
+				return b.loadFromCacheOrDelegate(ctx, h, length, offset, consumer)
 			}
 
 			debug.Log("error caching %v: %v", h, err)
 		}
 
 		debug.Log("Load(%v, %v, %v): partial file requested, delegating to backend", h, length, offset)
-		return b.Backend.Load(ctx, h, length, offset)
+		return b.Backend.Load(ctx, h, length, offset, consumer)
 	}
 
 	// if we don't automatically cache this file type, fall back to the backend
 	if _, ok := autoCacheFiles[h.Type]; !ok {
 		debug.Log("Load(%v, %v, %v): delegating to backend", h, length, offset)
-		return b.Backend.Load(ctx, h, length, offset)
+		return b.Backend.Load(ctx, h, length, offset, consumer)
 	}
 
 	debug.Log("auto-store %v in the cache", h)
@@ -200,11 +203,20 @@ func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset 
 
 	if err == nil {
 		// load the cached version
-		return b.Cache.Load(h, 0, 0)
+		rd, err := b.Cache.Load(h, 0, 0)
+		if err != nil {
+			return err
+		}
+		err = consumer(rd)
+		if err != nil {
+			rd.Close() // ignore secondary errors
+			return err
+		}
+		return rd.Close()
 	}
 
 	debug.Log("error caching %v: %v, falling back to backend", h, err)
-	return b.Backend.Load(ctx, h, length, offset)
+	return b.Backend.Load(ctx, h, length, offset, consumer)
 }
 
 // Stat tests whether the backend has a file. If it does not exist but still

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -195,19 +195,16 @@ func TestModifiedIndex(t *testing.T) {
 		Type: restic.IndexFile,
 		Name: "90f838b4ac28735fda8644fe6a08dbc742e57aaf81b30977b4fefa357010eafd",
 	}
-	f, err := repo.Backend().Load(context.TODO(), h, 0, 0)
+	err := repo.Backend().Load(context.TODO(), h, 0, 0, func(rd io.Reader) error {
+		// save the index again with a modified name so that the hash doesn't match
+		// the content any more
+		h2 := restic.Handle{
+			Type: restic.IndexFile,
+			Name: "80f838b4ac28735fda8644fe6a08dbc742e57aaf81b30977b4fefa357010eafd",
+		}
+		return repo.Backend().Save(context.TODO(), h2, rd)
+	})
 	test.OK(t, err)
-
-	// save the index again with a modified name so that the hash doesn't match
-	// the content any more
-	h2 := restic.Handle{
-		Type: restic.IndexFile,
-		Name: "80f838b4ac28735fda8644fe6a08dbc742e57aaf81b30977b4fefa357010eafd",
-	}
-	err = repo.Backend().Save(context.TODO(), h2, f)
-	test.OK(t, err)
-
-	test.OK(t, f.Close())
 
 	chkr := checker.New(repo)
 	hints, errs := chkr.LoadIndex(context.TODO())
@@ -262,33 +259,25 @@ type errorBackend struct {
 	ProduceErrors bool
 }
 
-func (b errorBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-	rd, err := b.Backend.Load(ctx, h, length, offset)
-	if err != nil {
-		return rd, err
-	}
-
-	if b.ProduceErrors {
-		return errorReadCloser{rd}, err
-	}
-
-	return rd, nil
+func (b errorBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, consumer func(rd io.Reader) error) error {
+	return b.Backend.Load(ctx, h, length, offset, func(rd io.Reader) error {
+		if b.ProduceErrors {
+			return consumer(errorReadCloser{rd})
+		}
+		return consumer(rd)
+	})
 }
 
 type errorReadCloser struct {
-	io.ReadCloser
+	io.Reader
 }
 
 func (erd errorReadCloser) Read(p []byte) (int, error) {
-	n, err := erd.ReadCloser.Read(p)
+	n, err := erd.Reader.Read(p)
 	if n > 0 {
 		induceError(p[:n])
 	}
 	return n, err
-}
-
-func (erd errorReadCloser) Close() error {
-	return erd.ReadCloser.Close()
 }
 
 // induceError flips a bit in the slice.

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -3,12 +3,16 @@ package repository
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/restic/restic/internal/cache"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/hashing"
 	"github.com/restic/restic/internal/restic"
 
 	"github.com/restic/restic/internal/backend"
@@ -653,4 +657,37 @@ func (r *Repository) SaveTree(ctx context.Context, t *restic.Tree) (restic.ID, e
 
 	_, err = r.SaveBlob(ctx, restic.TreeBlob, buf, id)
 	return id, err
+}
+
+// DownloadAndHash is all-in-one helper to download content of the file at h to a temporary filesystem location
+// and calculate ID of the contents. Returned (temporary) file is positioned at the beginning of the file;
+// it is reponsibility of the caller to close and delete the file.
+func DownloadAndHash(ctx context.Context, repo restic.Repository, h restic.Handle) (tmpfile *os.File, hash restic.ID, size int64, err error) {
+	tmpfile, err = fs.TempFile("", "restic-temp-")
+	if err != nil {
+		return nil, restic.ID{}, -1, errors.Wrap(err, "TempFile")
+	}
+
+	err = repo.Backend().Load(ctx, h, 0, 0, func(rd io.Reader) (ierr error) {
+		_, ierr = tmpfile.Seek(0, io.SeekStart)
+		if ierr == nil {
+			ierr = tmpfile.Truncate(0)
+		}
+		if ierr != nil {
+			return ierr
+		}
+		hrd := hashing.NewReader(rd, sha256.New())
+		size, ierr = io.Copy(tmpfile, hrd)
+		hash = restic.IDFromHash(hrd.Sum(nil))
+		return ierr
+	})
+
+	_, err = tmpfile.Seek(0, io.SeekStart)
+	if err != nil {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name())
+		return nil, restic.ID{}, -1, errors.Wrap(err, "Seek")
+	}
+
+	return tmpfile, hash, size, err
 }

--- a/internal/restic/backend.go
+++ b/internal/restic/backend.go
@@ -23,11 +23,15 @@ type Backend interface {
 	// Save stores the data in the backend under the given handle.
 	Save(ctx context.Context, h Handle, rd io.Reader) error
 
-	// Load returns a reader that yields the contents of the file at h at the
+	// Load runs fn with a reader that yields the contents of the file at h at the
 	// given offset. If length is larger than zero, only a portion of the file
-	// is returned. rd must be closed after use. If an error is returned, the
-	// ReadCloser must be nil.
-	Load(ctx context.Context, h Handle, length int, offset int64) (io.ReadCloser, error)
+	// is read.
+	//
+	// The function fn may be called multiple times during the same Load invocation
+	// and therefore must be idempotent.
+	//
+	// Implementations are encouraged to use backend.DefaultLoad
+	Load(ctx context.Context, h Handle, length int, offset int64, fn func(rd io.Reader) error) error
 
 	// Stat returns information about the File identified by h.
 	Stat(ctx context.Context, h Handle) (FileInfo, error)

--- a/internal/restic/readerat.go
+++ b/internal/restic/readerat.go
@@ -25,15 +25,14 @@ func ReaderAt(be Backend, h Handle) io.ReaderAt {
 // ReadAt reads from the backend handle h at the given position.
 func ReadAt(ctx context.Context, be Backend, h Handle, offset int64, p []byte) (n int, err error) {
 	debug.Log("ReadAt(%v) at %v, len %v", h, offset, len(p))
-	rd, err := be.Load(ctx, h, len(p), offset)
+
+	err = be.Load(ctx, h, len(p), offset, func(rd io.Reader) (ierr error) {
+		n, ierr = io.ReadFull(rd, p)
+
+		return ierr
+	})
 	if err != nil {
 		return 0, err
-	}
-
-	n, err = io.ReadFull(rd, p)
-	e := rd.Close()
-	if err == nil {
-		err = e
 	}
 
 	debug.Log("ReadAt(%v) ReadFull returned %v bytes", h, n)


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Reworked Backend.Load API to support retry errors during ongoing download.

### Was the change discussed in an issue or in the forum before?

See #527 and #1600

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's an entry in the `CHANGELOG.md` file that describe the changes for our users
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
