### PR TITLE
Optimize pack readHeader() implementation

### DIFF
--- a/changelog/0.8.2/pull-1574
+++ b/changelog/0.8.2/pull-1574
@@ -1,0 +1,7 @@
+Enhancement: Reduce number of remote requests reading pack header
+
+This change eliminates extra remote repository calls for most pack
+files and improves repository reindex and purge time.
+
+https://github.com/restic/restic/issues/1567
+https://github.com/restic/restic/pull/1574

--- a/internal/pack/pack_internal_test.go
+++ b/internal/pack/pack_internal_test.go
@@ -1,0 +1,46 @@
+package pack
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"testing"
+
+	"github.com/restic/restic/internal/crypto"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+type countingReaderAt struct {
+	delegate        io.ReaderAt
+	invocationCount int
+}
+
+func (rd *countingReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
+	rd.invocationCount++
+	return rd.delegate.ReadAt(p, off)
+}
+
+func TestReadHeaderEagerLoad(t *testing.T) {
+
+	testReadHeader := func(entryCount uint, expectedReadInvocationCount int) {
+		expectedHeader := rtest.Random(0, int(entryCount*entrySize)+crypto.Extension)
+
+		buf := &bytes.Buffer{}
+		buf.Write(rtest.Random(0, 100))                                     // pack blobs data
+		buf.Write(expectedHeader)                                           // pack header
+		binary.Write(buf, binary.LittleEndian, uint32(len(expectedHeader))) // pack header length
+
+		rd := &countingReaderAt{delegate: bytes.NewReader(buf.Bytes())}
+
+		header, err := readHeader(rd, int64(buf.Len()))
+		rtest.OK(t, err)
+
+		rtest.Equals(t, expectedHeader, header)
+		rtest.Equals(t, expectedReadInvocationCount, rd.invocationCount)
+	}
+
+	testReadHeader(1, 1)
+	testReadHeader(eagerEntries-1, 1)
+	testReadHeader(eagerEntries, 1)
+	testReadHeader(eagerEntries+1, 2)
+}


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Load pack header length and 15 header entries with single backend
request. This eliminates separate header Load() request for most pack
files and significantly improves index.New() performance.

### Was the change discussed in an issue or in the forum before?

See #1567

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
