### PR TITLE
Optimize Repository.ListPack()

### DIFF
--- a/changelog/0.8.2/pull-1575
+++ b/changelog/0.8.2/pull-1575
@@ -1,0 +1,7 @@
+Enhancement: Reduce number of remote requests during Repository.ListPack()
+
+This change eliminates redundant remote repository calls and improves 
+repository reindex and purge time.
+
+https://github.com/restic/restic/issues/1567
+https://github.com/restic/restic/pull/1575

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -75,7 +75,7 @@ func selectBlobs(t *testing.T, repo restic.Repository, p float32) (list1, list2 
 	blobs := restic.NewBlobSet()
 
 	err := repo.List(context.TODO(), restic.DataFile, func(id restic.ID, size int64) error {
-		entries, _, err := repo.ListPack(context.TODO(), id)
+		entries, _, err := repo.ListPack(context.TODO(), id, size)
 		if err != nil {
 			t.Fatalf("error listing pack %v: %v", id, err)
 		}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -549,20 +549,15 @@ func (r *Repository) List(ctx context.Context, t restic.FileType, fn func(restic
 
 // ListPack returns the list of blobs saved in the pack id and the length of
 // the file as stored in the backend.
-func (r *Repository) ListPack(ctx context.Context, id restic.ID) ([]restic.Blob, int64, error) {
+func (r *Repository) ListPack(ctx context.Context, id restic.ID, size int64) ([]restic.Blob, int64, error) {
 	h := restic.Handle{Type: restic.DataFile, Name: id.String()}
 
-	blobInfo, err := r.Backend().Stat(ctx, h)
+	blobs, err := pack.List(r.Key(), restic.ReaderAt(r.Backend(), h), size)
 	if err != nil {
 		return nil, 0, err
 	}
 
-	blobs, err := pack.List(r.Key(), restic.ReaderAt(r.Backend(), h), blobInfo.Size)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return blobs, blobInfo.Size, nil
+	return blobs, size, nil
 }
 
 // Delete calls backend.Delete() if implemented, and returns an error

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -32,7 +32,7 @@ type Repository interface {
 	//
 	// The function fn is called in the same Goroutine List() was called from.
 	List(ctx context.Context, t FileType, fn func(ID, int64) error) error
-	ListPack(context.Context, ID) ([]Blob, int64, error)
+	ListPack(context.Context, ID, int64) ([]Blob, int64, error)
 
 	Flush(context.Context) error
 


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Use pack file size returned by Backend.List() to avoid extra per-pack
Backend.Stat() requests

### Was the change discussed in an issue or in the forum before?

See #1567

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
