### PR TITLE
Optimize debug logs

### DIFF
--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -182,11 +182,11 @@ type Finder struct {
 
 func (f *Finder) findInTree(ctx context.Context, treeID restic.ID, prefix string) error {
 	if f.notfound.Has(treeID) {
-		debug.Log("%v skipping tree %v, has already been checked", prefix, treeID.Str())
+		debug.Log("%v skipping tree %v, has already been checked", prefix, treeID)
 		return nil
 	}
 
-	debug.Log("%v checking tree %v\n", prefix, treeID.Str())
+	debug.Log("%v checking tree %v\n", prefix, treeID)
 
 	tree, err := f.repo.LoadTree(ctx, treeID)
 	if err != nil {

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -186,7 +186,7 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 	bar = newProgressMax(!gopts.Quiet, uint64(len(snapshots)), "snapshots")
 	bar.Start()
 	for _, sn := range snapshots {
-		debug.Log("process snapshot %v", sn.ID().Str())
+		debug.Log("process snapshot %v", sn.ID())
 
 		err = restic.FindUsedBlobs(ctx, repo, *sn.Tree, usedBlobs, seenBlobs)
 		if err != nil {
@@ -197,7 +197,7 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 			return err
 		}
 
-		debug.Log("processed snapshot %v", sn.ID().Str())
+		debug.Log("processed snapshot %v", sn.ID())
 		bar.Report(restic.Stat{Blobs: 1})
 	}
 	bar.Done()

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -82,7 +82,7 @@ func changeTags(ctx context.Context, repo *repository.Repository, sn *restic.Sna
 			return false, err
 		}
 
-		debug.Log("new snapshot saved as %v", id.Str())
+		debug.Log("new snapshot saved as %v", id)
 
 		if err = repo.Flush(ctx); err != nil {
 			return false, err

--- a/internal/archiver/archive_reader.go
+++ b/internal/archiver/archive_reader.go
@@ -59,9 +59,9 @@ func (r *Reader) Archive(ctx context.Context, name string, rd io.Reader, p *rest
 			if err != nil {
 				return nil, restic.ID{}, err
 			}
-			debug.Log("saved blob %v (%d bytes)\n", id.Str(), chunk.Length)
+			debug.Log("saved blob %v (%d bytes)\n", id, chunk.Length)
 		} else {
-			debug.Log("blob %v already saved in the repo\n", id.Str())
+			debug.Log("blob %v already saved in the repo\n", id)
 		}
 
 		freeBuf(chunk.Data)
@@ -94,14 +94,14 @@ func (r *Reader) Archive(ctx context.Context, name string, rd io.Reader, p *rest
 		return nil, restic.ID{}, err
 	}
 	sn.Tree = &treeID
-	debug.Log("tree saved as %v", treeID.Str())
+	debug.Log("tree saved as %v", treeID)
 
 	id, err := repo.SaveJSONUnpacked(ctx, restic.SnapshotFile, sn)
 	if err != nil {
 		return nil, restic.ID{}, err
 	}
 
-	debug.Log("snapshot saved as %v", id.Str())
+	debug.Log("snapshot saved as %v", id)
 
 	err = repo.Flush(ctx)
 	if err != nil {

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -95,20 +95,20 @@ func (arch *Archiver) isKnownBlob(id restic.ID, t restic.BlobType) bool {
 
 // Save stores a blob read from rd in the repository.
 func (arch *Archiver) Save(ctx context.Context, t restic.BlobType, data []byte, id restic.ID) error {
-	debug.Log("Save(%v, %v)\n", t, id.Str())
+	debug.Log("Save(%v, %v)\n", t, id)
 
 	if arch.isKnownBlob(id, restic.DataBlob) {
-		debug.Log("blob %v is known\n", id.Str())
+		debug.Log("blob %v is known\n", id)
 		return nil
 	}
 
 	_, err := arch.repo.SaveBlob(ctx, t, data, id)
 	if err != nil {
-		debug.Log("Save(%v, %v): error %v\n", t, id.Str(), err)
+		debug.Log("Save(%v, %v): error %v\n", t, id, err)
 		return err
 	}
 
-	debug.Log("Save(%v, %v): new blob\n", t, id.Str())
+	debug.Log("Save(%v, %v): new blob\n", t, id)
 	return nil
 }
 
@@ -170,7 +170,7 @@ func (arch *Archiver) saveChunk(ctx context.Context, chunk chunker.Chunk, p *res
 	err := arch.Save(ctx, restic.DataBlob, chunk.Data, id)
 	// TODO handle error
 	if err != nil {
-		debug.Log("Save(%v) failed: %v", id.Str(), err)
+		debug.Log("Save(%v) failed: %v", id, err)
 		fmt.Printf("\nerror while saving data to the repo: %+v\n", err)
 		panic(err)
 	}
@@ -204,7 +204,7 @@ func updateNodeContent(node *restic.Node, results []saveResult) error {
 		node.Content[i] = b.id
 		bytes += b.bytes
 
-		debug.Log("  adding blob %s, %d bytes", b.id.Str(), b.bytes)
+		debug.Log("  adding blob %s, %d bytes", b.id, b.bytes)
 	}
 
 	if bytes != node.Size {
@@ -304,7 +304,7 @@ func (arch *Archiver) fileWorker(ctx context.Context, wg *sync.WaitGroup, p *res
 				contentMissing := false
 				for _, blob := range oldNode.Content {
 					if !arch.repo.Index().Has(blob, restic.DataBlob) {
-						debug.Log("   %v not using old data, %v is missing", e.Path(), blob.Str())
+						debug.Log("   %v not using old data, %v is missing", e.Path(), blob)
 						contentMissing = true
 						break
 					}
@@ -437,7 +437,7 @@ func (arch *Archiver) dirWorker(ctx context.Context, wg *sync.WaitGroup, p *rest
 			if err != nil {
 				panic(err)
 			}
-			debug.Log("save tree for %s: %v", dir.Path(), id.Str())
+			debug.Log("save tree for %s: %v", dir.Path(), id)
 			if id.IsNull() {
 				panic("invalid null subtree restic.ID return from SaveTreeJSON()")
 			}
@@ -770,7 +770,7 @@ func (arch *Archiver) Snapshot(ctx context.Context, p *restic.Progress, paths, t
 
 	// receive the top-level tree
 	root := (<-resCh).(*restic.Node)
-	debug.Log("root node received: %v", root.Subtree.Str())
+	debug.Log("root node received: %v", root.Subtree)
 	sn.Tree = root.Subtree
 
 	// load top-level tree again to see if it is empty
@@ -798,7 +798,7 @@ func (arch *Archiver) Snapshot(ctx context.Context, p *restic.Progress, paths, t
 		return nil, restic.ID{}, err
 	}
 
-	debug.Log("saved snapshot %v", id.Str())
+	debug.Log("saved snapshot %v", id)
 
 	return sn, id, nil
 }

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -180,6 +180,16 @@ func Log(f string, args ...interface{}) {
 		f += "\n"
 	}
 
+	type Shortener interface {
+		Str() string
+	}
+
+	for i, item := range args {
+		if shortener, ok := item.(Shortener); ok {
+			args[i] = shortener.Str()
+		}
+	}
+
 	pos := fmt.Sprintf("%s/%s:%d", dir, file, line)
 
 	formatString := fmt.Sprintf("%s\t%s\t%d\t%s", pos, fn, goroutine, f)
@@ -192,7 +202,8 @@ func Log(f string, args ...interface{}) {
 		opts.logger.Printf(formatString, args...)
 	}
 
-	if checkFilter(opts.files, fmt.Sprintf("%s/%s:%d", dir, file, line)) {
+	filename := fmt.Sprintf("%s/%s:%d", dir, file, line)
+	if checkFilter(opts.files, filename) {
 		dbgprint()
 		return
 	}

--- a/internal/debug/log_test.go
+++ b/internal/debug/log_test.go
@@ -19,7 +19,7 @@ func BenchmarkLogIDStr(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		debug.Log("id: %v", id.Str())
+		debug.Log("id: %v", id)
 	}
 }
 
@@ -29,6 +29,6 @@ func BenchmarkLogIDString(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		debug.Log("id: %v", id.String())
+		debug.Log("id: %s", id)
 	}
 }

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -34,10 +34,10 @@ func cleanupNodeName(name string) string {
 }
 
 func newDir(ctx context.Context, root *Root, inode, parentInode uint64, node *restic.Node) (*dir, error) {
-	debug.Log("new dir for %v (%v)", node.Name, node.Subtree.Str())
+	debug.Log("new dir for %v (%v)", node.Name, node.Subtree)
 	tree, err := root.repo.LoadTree(ctx, *node.Subtree)
 	if err != nil {
-		debug.Log("  error loading tree %v: %v", node.Subtree.Str(), err)
+		debug.Log("  error loading tree %v: %v", node.Subtree, err)
 		return nil, err
 	}
 	items := make(map[string]*restic.Node)
@@ -74,10 +74,10 @@ func replaceSpecialNodes(ctx context.Context, repo restic.Repository, node *rest
 }
 
 func newDirFromSnapshot(ctx context.Context, root *Root, inode uint64, snapshot *restic.Snapshot) (*dir, error) {
-	debug.Log("new dir for snapshot %v (%v)", snapshot.ID().Str(), snapshot.Tree.Str())
+	debug.Log("new dir for snapshot %v (%v)", snapshot.ID(), snapshot.Tree)
 	tree, err := root.repo.LoadTree(ctx, *snapshot.Tree)
 	if err != nil {
-		debug.Log("  loadTree(%v) failed: %v", snapshot.ID().Str(), err)
+		debug.Log("  loadTree(%v) failed: %v", snapshot.ID(), err)
 		return nil, err
 	}
 	items := make(map[string]*restic.Node)

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -90,7 +90,7 @@ type indexJSON struct {
 }
 
 func loadIndexJSON(ctx context.Context, repo restic.Repository, id restic.ID) (*indexJSON, error) {
-	debug.Log("process index %v\n", id.Str())
+	debug.Log("process index %v\n", id)
 
 	var idx indexJSON
 	err := repo.LoadJSONUnpacked(ctx, restic.IndexFile, id, &idx)
@@ -116,7 +116,7 @@ func Load(ctx context.Context, repo restic.Repository, p *restic.Progress) (*Ind
 	err := repo.List(ctx, restic.IndexFile, func(id restic.ID, size int64) error {
 		p.Report(restic.Stat{Blobs: 1})
 
-		debug.Log("Load index %v", id.Str())
+		debug.Log("Load index %v", id)
 		idx, err := loadIndexJSON(ctx, repo, id)
 		if err != nil {
 			return err
@@ -125,7 +125,7 @@ func Load(ctx context.Context, repo restic.Repository, p *restic.Progress) (*Ind
 		res := make(map[restic.ID]Pack)
 		supersedes[id] = restic.NewIDSet()
 		for _, sid := range idx.Supersedes {
-			debug.Log("  index %v supersedes %v", id.Str(), sid)
+			debug.Log("  index %v supersedes %v", id, sid)
 			supersedes[id].Insert(sid)
 		}
 
@@ -161,7 +161,7 @@ func Load(ctx context.Context, repo restic.Repository, p *restic.Progress) (*Ind
 			if _, ok := results[indexID]; !ok {
 				continue
 			}
-			debug.Log("  removing index %v, superseded by %v", indexID.Str(), superID.Str())
+			debug.Log("  removing index %v, superseded by %v", indexID, superID)
 			fmt.Fprintf(os.Stderr, "index %v can be removed, superseded by index %v\n", indexID.Str(), superID.Str())
 			delete(results, indexID)
 		}

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -398,7 +398,7 @@ func (idx *Index) SetID(id restic.ID) error {
 		return errors.New("ID already set")
 	}
 
-	debug.Log("ID set to %v", id.Str())
+	debug.Log("ID set to %v", id)
 	idx.id = id
 
 	return nil
@@ -550,7 +550,7 @@ func DecodeOldIndex(buf []byte) (idx *Index, err error) {
 
 // LoadIndexWithDecoder loads the index and decodes it with fn.
 func LoadIndexWithDecoder(ctx context.Context, repo restic.Repository, id restic.ID, fn func([]byte) (*Index, error)) (idx *Index, err error) {
-	debug.Log("Loading index %v", id.Str())
+	debug.Log("Loading index %v", id)
 
 	buf, err := repo.LoadAndDecrypt(ctx, restic.IndexFile, id)
 	if err != nil {

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -246,7 +246,7 @@ func (mi *MasterIndex) RebuildIndex(packBlacklist restic.IDSet) (*Index, error) 
 			return nil, err
 		}
 
-		debug.Log("adding index id %v to supersedes field", id.Str())
+		debug.Log("adding index id %v to supersedes field", id)
 
 		err = newIndex.AddToSupersedes(id)
 		if err != nil {

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -138,7 +138,7 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packe
 
 	// update blobs in the index
 	for _, b := range p.Packer.Blobs() {
-		debug.Log("  updating blob %v to pack %v", b.ID.Str(), id.Str())
+		debug.Log("  updating blob %v to pack %v", b.ID, id)
 		r.idx.Store(restic.PackedBlob{
 			Blob: restic.Blob{
 				Type:   b.Type,

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -48,7 +48,7 @@ func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, kee
 		}
 
 		hash := restic.IDFromHash(hrd.Sum(nil))
-		debug.Log("pack %v loaded (%d bytes), hash %v", packID.Str(), packLength, hash.Str())
+		debug.Log("pack %v loaded (%d bytes), hash %v", packID, packLength, hash)
 
 		if !packID.Equal(hash) {
 			return nil, errors.Errorf("hash does not match id: want %v, got %v", packID, hash)
@@ -64,7 +64,7 @@ func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, kee
 			return nil, err
 		}
 
-		debug.Log("processing pack %v, blobs: %v", packID.Str(), len(blobs))
+		debug.Log("processing pack %v, blobs: %v", packID, len(blobs))
 		var buf []byte
 		for _, entry := range blobs {
 			h := restic.BlobHandle{ID: entry.ID, Type: entry.Type}
@@ -109,7 +109,7 @@ func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, kee
 				return nil, err
 			}
 
-			debug.Log("  saved blob %v", entry.ID.Str())
+			debug.Log("  saved blob %v", entry.ID)
 
 			keepBlobs.Delete(h)
 		}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -66,7 +66,7 @@ func (r *Repository) PrefixLength(t restic.FileType) (int, error) {
 // LoadAndDecrypt loads and decrypts data identified by t and id from the
 // backend.
 func (r *Repository) LoadAndDecrypt(ctx context.Context, t restic.FileType, id restic.ID) (buf []byte, err error) {
-	debug.Log("load %v with id %v", t, id.Str())
+	debug.Log("load %v with id %v", t, id)
 
 	h := restic.Handle{Type: t, Name: id.String()}
 	buf, err = backend.LoadAll(ctx, r.be, h)
@@ -112,12 +112,12 @@ func (r *Repository) sortCachedPacks(blobs []restic.PackedBlob) []restic.PackedB
 // pack from the backend, the result is stored in plaintextBuf, which must be
 // large enough to hold the complete blob.
 func (r *Repository) loadBlob(ctx context.Context, id restic.ID, t restic.BlobType, plaintextBuf []byte) (int, error) {
-	debug.Log("load %v with id %v (buf len %v, cap %d)", t, id.Str(), len(plaintextBuf), cap(plaintextBuf))
+	debug.Log("load %v with id %v (buf len %v, cap %d)", t, id, len(plaintextBuf), cap(plaintextBuf))
 
 	// lookup packs
 	blobs, found := r.idx.Lookup(id, t)
 	if !found {
-		debug.Log("id %v not found in index", id.Str())
+		debug.Log("id %v not found in index", id)
 		return 0, errors.Errorf("id %v not found in repository", id)
 	}
 
@@ -126,7 +126,7 @@ func (r *Repository) loadBlob(ctx context.Context, id restic.ID, t restic.BlobTy
 
 	var lastError error
 	for _, blob := range blobs {
-		debug.Log("blob %v/%v found: %v", t, id.Str(), blob)
+		debug.Log("blob %v/%v found: %v", t, id, blob)
 
 		if blob.Type != t {
 			debug.Log("blob %v has wrong block type, want %v", blob, t)
@@ -206,7 +206,7 @@ func (r *Repository) SaveAndEncrypt(ctx context.Context, t restic.BlobType, data
 		id = &hashedID
 	}
 
-	debug.Log("save id %v (%v, %d bytes)", id.Str(), t, len(data))
+	debug.Log("save id %v (%v, %d bytes)", id, t, len(data))
 
 	// get buf from the pool
 	ciphertext := getBuf()
@@ -353,7 +353,7 @@ func (r *Repository) saveIndex(ctx context.Context, indexes ...*Index) error {
 			return err
 		}
 
-		debug.Log("Saved index %d as %v", i, sid.Str())
+		debug.Log("Saved index %d as %v", i, sid)
 	}
 
 	return nil
@@ -575,7 +575,7 @@ func (r *Repository) Close() error {
 // be large enough to hold the encrypted blob, since it is used as scratch
 // space.
 func (r *Repository) LoadBlob(ctx context.Context, t restic.BlobType, id restic.ID, buf []byte) (int, error) {
-	debug.Log("load blob %v into buf (len %v, cap %v)", id.Str(), len(buf), cap(buf))
+	debug.Log("load blob %v into buf (len %v, cap %v)", id, len(buf), cap(buf))
 	size, found := r.idx.LookupSize(id, t)
 	if !found {
 		return 0, errors.Errorf("id %v not found in repository", id)
@@ -608,7 +608,7 @@ func (r *Repository) SaveBlob(ctx context.Context, t restic.BlobType, buf []byte
 
 // LoadTree loads a tree from the repository.
 func (r *Repository) LoadTree(ctx context.Context, id restic.ID) (*restic.Tree, error) {
-	debug.Log("load tree %v", id.Str())
+	debug.Log("load tree %v", id)
 
 	size, found := r.idx.LookupSize(id, restic.TreeBlob)
 	if !found {

--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -225,7 +225,7 @@ func (l *Lock) Stale() bool {
 // Refresh refreshes the lock by creating a new file in the backend with a new
 // timestamp. Afterwards the old lock is removed.
 func (l *Lock) Refresh(ctx context.Context) error {
-	debug.Log("refreshing lock %v", l.lockID.Str())
+	debug.Log("refreshing lock %v", l.lockID)
 	id, err := l.createLock(ctx)
 	if err != nil {
 		return err
@@ -236,7 +236,7 @@ func (l *Lock) Refresh(ctx context.Context) error {
 		return err
 	}
 
-	debug.Log("new lock ID %v", id.Str())
+	debug.Log("new lock ID %v", id)
 	l.lockID = &id
 
 	return nil

--- a/internal/restic/restorer.go
+++ b/internal/restic/restorer.go
@@ -42,10 +42,10 @@ func NewRestorer(repo Repository, id ID) (*Restorer, error) {
 // restoreTo restores a tree from the repo to a destination. target is the path in
 // the file system, location within the snapshot.
 func (res *Restorer) restoreTo(ctx context.Context, target, location string, treeID ID, idx *HardlinkIndex) error {
-	debug.Log("%v %v %v", target, location, treeID.Str())
+	debug.Log("%v %v %v", target, location, treeID)
 	tree, err := res.repo.LoadTree(ctx, treeID)
 	if err != nil {
-		debug.Log("error loading tree %v: %v", treeID.Str(), err)
+		debug.Log("error loading tree %v: %v", treeID, err)
 		return res.Error(location, nil, err)
 	}
 

--- a/internal/walk/walk.go
+++ b/internal/walk/walk.go
@@ -36,8 +36,8 @@ func NewTreeWalker(ch chan<- loadTreeJob, out chan<- TreeJob) *TreeWalker {
 // Walk starts walking the tree given by id. When the channel done is closed,
 // processing stops.
 func (tw *TreeWalker) Walk(ctx context.Context, path string, id restic.ID) {
-	debug.Log("starting on tree %v for %v", id.Str(), path)
-	defer debug.Log("done walking tree %v for %v", id.Str(), path)
+	debug.Log("starting on tree %v for %v", id, path)
+	defer debug.Log("done walking tree %v for %v", id, path)
 
 	resCh := make(chan loadTreeResult, 1)
 	tw.ch <- loadTreeJob{
@@ -141,10 +141,10 @@ func loadTreeWorker(ctx context.Context, wg *sync.WaitGroup, in <-chan loadTreeJ
 				return
 			}
 
-			debug.Log("received job to load tree %v", job.id.Str())
+			debug.Log("received job to load tree %v", job.id)
 			tree, err := load(job.id)
 
-			debug.Log("tree %v loaded, error %v", job.id.Str(), err)
+			debug.Log("tree %v loaded, error %v", job.id, err)
 
 			select {
 			case job.res <- loadTreeResult{tree, err}:
@@ -168,7 +168,7 @@ const loadTreeWorkers = 10
 // file and directory it finds. When the channel done is closed, processing
 // stops.
 func Tree(ctx context.Context, repo TreeLoader, id restic.ID, jobCh chan<- TreeJob) {
-	debug.Log("start on %v, start workers", id.Str())
+	debug.Log("start on %v, start workers", id)
 
 	load := func(id restic.ID) (*restic.Tree, error) {
 		tree, err := repo.LoadTree(ctx, id)


### PR DESCRIPTION
The code in here optimizes debug.Log() calls when a restic ID is passed in. Before, the "shorten the string" method Str() was always called, which led to a function call and allocations happening even without the `debug` tag. Now, we're calling the `Str()` method via reflection on demand in the debug code, which is only active with the `debug` tag.

Idea by @MJDSys in #1549