### PR TITLE
Limit index file size

### DIFF
--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -73,12 +73,12 @@ func rebuildIndex(ctx context.Context, repo restic.Repository, ignorePacks resti
 		return err
 	}
 
-	id, err := idx.Save(ctx, repo, supersedes)
+	ids, err := idx.Save(ctx, repo, supersedes)
 	if err != nil {
 		return errors.Fatalf("unable to save index, last error was: %v", err)
 	}
 
-	Verbosef("saved new index as %v\n", id.Str())
+	Verbosef("saved new indexes as %v\n", ids)
 
 	Verbosef("remove %d old index files\n", len(supersedes))
 

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -302,6 +302,21 @@ func TestIndexSave(t *testing.T) {
 	for _, err := range errs {
 		t.Errorf("checker found error: %v", err)
 	}
+
+	ctx, cancel := context.WithCancel(context.TODO())
+
+	errCh := make(chan error)
+	go checker.Structure(ctx, errCh)
+	i := 0
+	for err := range errCh {
+		t.Errorf("checker returned error: %v", err)
+		i++
+		if i == 10 {
+			t.Errorf("more than 10 errors returned, skipping the rest")
+			cancel()
+			break
+		}
+	}
 }
 
 func TestIndexAddRemovePack(t *testing.T) {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -369,7 +369,7 @@ func (r *Repository) SaveFullIndex(ctx context.Context) error {
 	return r.saveIndex(ctx, r.idx.FullIndexes()...)
 }
 
-const loadIndexParallelism = 20
+const loadIndexParallelism = 4
 
 // LoadIndex loads all index files from the backend in parallel and stores them
 // in the master index. The first error that occurred is returned.


### PR DESCRIPTION
This is an experiment that I'd like to get feedback on. You can checkout the branch run `restic rebuild-index` or `restic prune` and report back with the memory usage that you're seeing. After the first run of either command, also `restic backup` may do better in terms of memory usage.

One of the main reasons why restic uses so much memory during `rebuild-index` and `prune` is that it writes very very large index files. These consist of a large JSON document, serializing the data as JSON is memory intensive. When `backup` is run, these files need to be decrypted and then decoded.

The code in this branch creates several smaller instead of one very large index file. This is 100% backwards compatible change, restic already expects multiple index files and will work just fine.

Closes #1412 
Closes #979 
Closes #526