### PR TITLE
archiver: Fix intermediate index upload

### DIFF
--- a/changelog/0.8.2/pull-1589
+++ b/changelog/0.8.2/pull-1589
@@ -1,0 +1,17 @@
+Bugfix: Complete intermediate index upload
+
+After a user posted a comprehensive report of what he observed, we were able to
+find a bug and correct it: During backup, restic uploads so-called
+"intermediate" index files. When the backup finishes during a transfer of such
+an intermediate index, the upload is cancelled, but the backup is finished
+without an error. This leads to an inconsistent state, where the snapshot
+references data that is contained in the repo, but is not referenced in any
+index.
+
+The situation can be resolved by building a new index with `rebuild-index`, but
+looks very confusing at first. Since all the data got uploaded to the repo
+successfully, there was no risk of data loss, just minor inconvenience for our
+users.
+
+https://github.com/restic/restic/pull/1589
+https://forum.restic.net/t/error-loading-tree-check-prune-and-forget-gives-error-b2-backend/406


### PR DESCRIPTION
A user discovered[1] that when the backup finishes during the upload of an intermediate index, the upload is cancelled and the index never fully saved, but the snapshot is saved and the backup finalizes without an error. This lead to a situation where a snapshot references data that is contained in the repo, but not referenced in any index, leading to strange error messages.

This commit uses a dedicated context to signal the intermediate index uploading routine to terminate after the last index has been uploaded. This way, an upload running when the backup finishes is completed before the routine terminates and the snapshot is saved.

[1] https://forum.restic.net/t/error-loading-tree-check-prune-and-forget-gives-error-b2-backend/406