### PR TITLE
Make backend tests more helpful

### DIFF
--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -249,6 +249,19 @@ func (s *Suite) TestList(t *testing.T) {
 	b := s.open(t)
 	defer s.close(t, b)
 
+	// Check that the backend is empty to start with
+	var found []string
+	err := b.List(context.TODO(), restic.DataFile, func(fi restic.FileInfo) error {
+		found = append(found, fi.Name)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("List returned error %v", err)
+	}
+	if found != nil {
+		t.Fatalf("backend not empty at start of test - contains: %v", found)
+	}
+
 	list1 := make(map[restic.ID]int64)
 
 	for i := 0; i < numTestFiles; i++ {
@@ -324,7 +337,7 @@ func (s *Suite) TestList(t *testing.T) {
 		handles = append(handles, restic.Handle{Type: restic.DataFile, Name: id.String()})
 	}
 
-	err := s.delayedRemove(t, b, handles...)
+	err = s.delayedRemove(t, b, handles...)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -784,7 +797,7 @@ func (s *Suite) TestBackend(t *testing.T) {
 		// create blob
 		h := restic.Handle{Type: tpe, Name: ts.id}
 		err := b.Save(context.TODO(), h, strings.NewReader(ts.data))
-		test.Assert(t, err != nil, "expected error for %v, got %v", h, err)
+		test.Assert(t, err != nil, "backend has allowed overwrite of existing blob: expected error for %v, got %v", h, err)
 
 		// remove and recreate
 		err = s.delayedRemove(t, b, h)


### PR DESCRIPTION
  * In TestList check that directory is empty first
  * Improve error message in TestBackend

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

Make the backend test suite a bit more helpful.

<!--
Describe the changes here, as detailed as needed.
-->

### Was the change discussed in an issue or in the forum before?

The change would have helped me greatly trying to track down the extra files as reported in #1561 as I spent ages looking at the wrong test failure!  The extra files were caused by the previous test failing.  I added a comment there too for the next person :-)

<!--
Link issues and relevant forum posts here.
-->

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
