### PR TITLE
GS: Use generic http transport

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -231,6 +231,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "a7d099b3ce195ffc37adedb05a4386be38e6158925a1c0fe579efdc20fa11f6a"
+  inputs-digest = "336ac5c261c174cac89f9a7102b493f08edfbd51fd61d1673d1d2ec4132d80ab"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/changelog/0.8.2/pull-1594
+++ b/changelog/0.8.2/pull-1594
@@ -1,0 +1,7 @@
+Bugfix: Google Cloud Storage: Use generic HTTP transport
+
+It was discovered that the Google Cloud Storage backend did not use the generic
+HTTP transport, so things such as bandwidth limiting with `--limit-upload` did
+not work. This is resolved now.
+
+https://github.com/restic/restic/pull/1594

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -567,7 +567,7 @@ func open(s string, gopts GlobalOptions, opts options.Options) (restic.Backend, 
 	case "s3":
 		be, err = s3.Open(cfg.(s3.Config), rt)
 	case "gs":
-		be, err = gs.Open(cfg.(gs.Config))
+		be, err = gs.Open(cfg.(gs.Config), rt)
 	case "azure":
 		be, err = azure.Open(cfg.(azure.Config), rt)
 	case "swift":
@@ -628,7 +628,7 @@ func create(s string, opts options.Options) (restic.Backend, error) {
 	case "s3":
 		return s3.Create(cfg.(s3.Config), rt)
 	case "gs":
-		return gs.Create(cfg.(gs.Config))
+		return gs.Create(cfg.(gs.Config), rt)
 	case "azure":
 		return azure.Create(cfg.(azure.Config), rt)
 	case "swift":

--- a/internal/backend/gs/gs_test.go
+++ b/internal/backend/gs/gs_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/gs"
 	"github.com/restic/restic/internal/backend/test"
 	"github.com/restic/restic/internal/errors"
@@ -15,6 +16,11 @@ import (
 )
 
 func newGSTestSuite(t testing.TB) *test.Suite {
+	tr, err := backend.Transport(backend.TransportOptions{})
+	if err != nil {
+		t.Fatalf("cannot create transport for tests: %v", err)
+	}
+
 	return &test.Suite{
 		// do not use excessive data
 		MinimalData: true,
@@ -37,7 +43,7 @@ func newGSTestSuite(t testing.TB) *test.Suite {
 		Create: func(config interface{}) (restic.Backend, error) {
 			cfg := config.(gs.Config)
 
-			be, err := gs.Create(cfg)
+			be, err := gs.Create(cfg, tr)
 			if err != nil {
 				return nil, err
 			}
@@ -57,14 +63,14 @@ func newGSTestSuite(t testing.TB) *test.Suite {
 		// OpenFn is a function that opens a previously created temporary repository.
 		Open: func(config interface{}) (restic.Backend, error) {
 			cfg := config.(gs.Config)
-			return gs.Open(cfg)
+			return gs.Open(cfg, tr)
 		},
 
 		// CleanupFn removes data created during the tests.
 		Cleanup: func(config interface{}) error {
 			cfg := config.(gs.Config)
 
-			be, err := gs.Open(cfg)
+			be, err := gs.Open(cfg, tr)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
During the development of #1524 I discovered that the Google Cloud Storage backend did not yet use the HTTP transport, so things such as bandwidth limiting did not work. This commit does the necessary magic to make the GS library use our HTTP transport.