### PR TITLE
Remove archiver progress "data processed" bandwith

### DIFF
--- a/changelog/0.8.2/pull-1595
+++ b/changelog/0.8.2/pull-1595
@@ -1,0 +1,11 @@
+Bugfix: backup: Remove bandwidth display
+
+This commit removes the bandwidth displayed during backup process. It is
+misleading and seldomly correct, because it's neither the "read
+bandwidth" (only for the very first backup) nor the "upload bandwidth".
+Many users are confused about (and rightly so), c.f. #1581, #1033, #1591
+
+We'll eventually replace this display with something more relevant when
+the new archiver code is ready.
+
+https://github.com/restic/restic/pull/1595

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -138,10 +138,9 @@ func newArchiveProgress(gopts GlobalOptions, todo restic.Stat) *restic.Progress 
 
 		itemsDone := s.Files + s.Dirs
 
-		status1 := fmt.Sprintf("[%s] %s  %s/s  %s / %s  %d / %d items  %d errors  ",
+		status1 := fmt.Sprintf("[%s] %s  %s / %s  %d / %d items  %d errors  ",
 			formatDuration(d),
 			formatPercent(s.Bytes, todo.Bytes),
-			formatBytes(bps),
 			formatBytes(s.Bytes), formatBytes(todo.Bytes),
 			itemsDone, itemsTodo,
 			s.Errors)
@@ -162,7 +161,7 @@ func newArchiveProgress(gopts GlobalOptions, todo restic.Stat) *restic.Progress 
 	}
 
 	archiveProgress.OnDone = func(s restic.Stat, d time.Duration, ticker bool) {
-		fmt.Printf("\nduration: %s, %s\n", formatDuration(d), formatRate(todo.Bytes, d))
+		fmt.Printf("\nduration: %s\n", formatDuration(d))
 	}
 
 	return archiveProgress
@@ -206,7 +205,7 @@ func newArchiveStdinProgress(gopts GlobalOptions) *restic.Progress {
 	}
 
 	archiveProgress.OnDone = func(s restic.Stat, d time.Duration, ticker bool) {
-		fmt.Printf("\nduration: %s, %s\n", formatDuration(d), formatRate(s.Bytes, d))
+		fmt.Printf("\nduration: %s\n", formatDuration(d))
 	}
 
 	return archiveProgress


### PR DESCRIPTION
This commit removes the bandwidth displayed during backup process. It is
misleading and seldomly correct, because it's neither the "read
bandwidth" (only for the very first backup) nor the "upload bandwidth".
Many users are confused about (and rightly so), c.f. #1581, #1033, #1591

We'll eventually replace this display with something more relevant when
 #1494 is done.