### PR TITLE
Add support for GOARM parameter when cross compiling

### DIFF
--- a/build.go
+++ b/build.go
@@ -193,6 +193,7 @@ func showUsage(output io.Writer) {
 	fmt.Fprintf(output, "         --enable-cgo    use CGO to link against libc\n")
 	fmt.Fprintf(output, "         --goos value    set GOOS for cross-compilation\n")
 	fmt.Fprintf(output, "         --goarch value  set GOARCH for cross-compilation\n")
+	fmt.Fprintf(output, "         --goarm value  set GOARM for cross-compilation\n")
 }
 
 func verbosePrintf(message string, args ...interface{}) {
@@ -218,13 +219,16 @@ func cleanEnv() (env []string) {
 }
 
 // build runs "go build args..." with GOPATH set to gopath.
-func build(cwd, goos, goarch, gopath string, args ...string) error {
+func build(cwd, goos, goarch, goarm, gopath string, args ...string) error {
 	a := []string{"build"}
 	a = append(a, "-asmflags", fmt.Sprintf("-trimpath=%s", gopath))
 	a = append(a, "-gcflags", fmt.Sprintf("-trimpath=%s", gopath))
 	a = append(a, args...)
 	cmd := exec.Command("go", a...)
 	cmd.Env = append(cleanEnv(), "GOPATH="+gopath, "GOARCH="+goarch, "GOOS="+goos)
+	if goarm != "" {
+		cmd.Env = append(cmd.Env, "GOARM="+goarm)
+	}
 	if !enableCGO {
 		cmd.Env = append(cmd.Env, "CGO_ENABLED=0")
 	}
@@ -397,6 +401,7 @@ func main() {
 
 	targetGOOS := runtime.GOOS
 	targetGOARCH := runtime.GOARCH
+	targetGOARM := ""
 
 	var outputFilename string
 
@@ -430,6 +435,9 @@ func main() {
 		case "--goarch":
 			skipNext = true
 			targetGOARCH = params[i+1]
+		case "--goarm":
+			skipNext = true
+			targetGOARM = params[i+1]
 		case "-h":
 			showUsage(os.Stdout)
 			return
@@ -514,7 +522,7 @@ func main() {
 		"-o", output, config.Main,
 	}
 
-	err = build(filepath.Join(gopath, "src"), targetGOOS, targetGOARCH, gopath, args...)
+	err = build(filepath.Join(gopath, "src"), targetGOOS, targetGOARCH, targetGOARM, gopath, args...)
 	if err != nil {
 		die("build failed: %v\n", err)
 	}

--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -113,6 +113,8 @@ supply the target OS and platform via the command-line options like this
 
     $ go run build.go --goos freebsd --goarch 386
 
+    $ go run build.go --goos linux --goarch arm --goarm 6
+    
 The resulting binary is statically linked and does not require any
 libraries.
 


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Go can cross compile to older ARM architectures (e.g. v5). In order to
do so one needs to use the GOARM parameter as documented in
https://github.com/golang/go/wiki/GoArm

### Was the change discussed in an issue or in the forum before?
no

### Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [X] I have added documentation for the changes (in the manual)
- [ ] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
