### PR TITLE
On OpenBSD only root can set sticky bit

### DIFF
--- a/internal/restic/node_test.go
+++ b/internal/restic/node_test.go
@@ -209,8 +209,11 @@ func TestNodeRestoreAt(t *testing.T) {
 			rtest.Assert(t, test.GID == n2.GID,
 				"%v: GID doesn't match (%v != %v)", test.Type, test.GID, n2.GID)
 			if test.Type != "symlink" {
-				rtest.Assert(t, test.Mode == n2.Mode,
-					"%v: mode doesn't match (0%o != 0%o)", test.Type, test.Mode, n2.Mode)
+				// On OpenBSD only root can set sticky bit (see sticky(8)).
+				if runtime.GOOS != "openbsd" && test.Name == "testSticky" {
+					rtest.Assert(t, test.Mode == n2.Mode,
+						"%v: mode doesn't match (0%o != 0%o)", test.Type, test.Mode, n2.Mode)
+				}
 			}
 		}
 


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Fix tests on OpenBSD. Currently the sticky bit test in `internal/restic/node_test.go` is broken on OpenBSD. From the man page for [sticky(8)](https://man.openbsd.org/sticky), only root can set the sticky bit. (Thanks @brycied00d for the man page clue stick :D)

### Was the change discussed in an issue or in the forum before?

No.

### Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
