### PR TITLE
Strip spaces from items read via --files-from

### DIFF
--- a/changelog/0.8.2/issue-1590
+++ b/changelog/0.8.2/issue-1590
@@ -1,0 +1,7 @@
+Bugfix: Strip spaces for lines read via --files-from
+
+Leading and trailing spaces in lines read via `--files-from` are now stripped,
+so it behaves the same as with lines read via `--exclude-file`.
+
+https://github.com/restic/restic/issues/1590
+https://github.com/restic/restic/pull/1613

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -304,7 +304,7 @@ func readLinesFromFile(filename string) ([]string, error) {
 
 	scanner := bufio.NewScanner(r)
 	for scanner.Scan() {
-		line := scanner.Text()
+		line := strings.TrimSpace(scanner.Text())
 		// ignore empty lines
 		if line == "" {
 			continue


### PR DESCRIPTION
In #1590, it was mentioned that while lines read from exclude files via `--exclude-file` have leading and trailing spaces stripped, this is not the case for lines read via `--files-from`. This commit fixes that, spaces are always stripped.

Closes #1590