### PR TITLE
Fix #1519 and formatting in `forget` doc

### DIFF
--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -194,7 +194,7 @@ repository, restic will respond that no snapshots will be removed. To delete
 all snapshots, use ``--keep-last 1`` and then finally remove the last
 snapshot ID manually (by passing the ID to ``forget``).
 
-All snapshots are evaluated counted against all matching keep-* counts. A
+All snapshots are evaluated against all matching ``--keep-*`` counts. A
 single snapshot on 2017-09-30 (Sun) will count as a daily, weekly and monthly.
 
 Let's explain this with an example: Suppose you have only made a backup

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -188,6 +188,12 @@ All the ``--keep-*`` options above only count
 hours/days/weeks/months/years which have a snapshot, so those without a
 snapshot are ignored.
 
+For safety reasons, restic refuses to act on an "empty" policy. For example,
+if one were to specify ``--keep-last 0`` to forget *all* snapshots in the
+repository, restic will respond that no snapshots will be removed. To delete
+all snapshots, use ``--keep-last 1`` and then finally remove the last
+snapshot ID manually (by passing the ID to ``forget``).
+
 All snapshots are evaluated counted against all matching keep-* counts. A
 single snapshot on 2017-09-30 (Sun) will count as a daily, weekly and monthly.
 

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -145,19 +145,20 @@ tags use ``--group-by paths,tags``. The policy is then applied to each group of
 snapshots separately. This is a safety feature.
 
 The ``forget`` command accepts the following parameters:
+
 -  ``--keep-last n`` never delete the ``n`` last (most recent) snapshots
 -  ``--keep-hourly n`` for the last ``n`` hours in which a snapshot was
-made, keep only the last snapshot for each hour.
+   made, keep only the last snapshot for each hour.
 -  ``--keep-daily n`` for the last ``n`` days which have one or more
-snapshots, only keep the last one for that day.
+   snapshots, only keep the last one for that day.
 -  ``--keep-weekly n`` for the last ``n`` weeks which have one or more
-snapshots, only keep the last one for that week.
+   snapshots, only keep the last one for that week.
 -  ``--keep-monthly n`` for the last ``n`` months which have one or more
-snapshots, only keep the last one for that month.
+   snapshots, only keep the last one for that month.
 -  ``--keep-yearly n`` for the last ``n`` years which have one or more
-snapshots, only keep the last one for that year.
+   snapshots, only keep the last one for that year.
 -  ``--keep-tag`` keep all snapshots which have all tags specified by
-this option (can be specified multiple times).
+   this option (can be specified multiple times).
 
 Additionally, you can restrict removing snapshots to those which have a
 particular hostname with the ``--hostname`` parameter, or tags with the


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Fixes #1519 by documenting the fact that restic refuses to `forget` when given an "empty" policy. Also fixes some small formatting errors in the same `forget` doc.

### Was the change discussed in an issue or in the forum before?

Yes, #1519.

### Checklist

- [x] I have skimmed through the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
- [x] I like Gophers
