### PR TITLE
Restructure and complement exclude options doc

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -80,7 +80,7 @@ the exclude options are:
 
 -  ``--exclude`` Specified one or more times to exclude one or more items
 -  ``--exclude-caches`` Specified once to exclude folders containing a special file
--  ``--exclude-file`` Specified one time to exclude items listed in a given file
+-  ``--exclude-file`` Specified one or more times to exclude items listed in a given file
 -  ``--exclude-if-present`` Specified one or more times to exclude a folders content
    if it contains a given file (optionally having a given header)
 

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -75,8 +75,16 @@ Now is a good time to run ``restic check`` to verify that all data
 is properly stored in the repository. You should run this command regularly
 to make sure the internal structure of the repository is free of errors.
 
-You can exclude folders and files by specifying exclude-patterns. Either
-specify them with multiple ``--exclude``'s or one ``--exclude-file``
+You can exclude folders and files by specifying exclude patterns, currently
+the exclude options are:
+
+-  ``--exclude`` Specified one or more times to exclude one or more items
+-  ``--exclude-caches`` Specified once to exclude folders containing a special file
+-  ``--exclude-file`` Specified one time to exclude items listed in a given file
+-  ``--exclude-if-present`` Specified one or more times to exclude a folders content
+   if it contains a given file (optionally having a given header)
+
+Basic example:
 
 .. code-block:: console
 
@@ -86,6 +94,8 @@ specify them with multiple ``--exclude``'s or one ``--exclude-file``
     # exclude foo/x/y/z/bar foo/x/bar foo/bar
     foo/**/bar
     $ restic -r /tmp/backup backup ~/work --exclude=*.c --exclude-file=exclude
+
+Please see ``restic help backup`` for more specific information about each exclude option.
 
 Patterns use `filepath.Glob <https://golang.org/pkg/path/filepath/#Glob>`__ internally,
 see `filepath.Match <https://golang.org/pkg/path/filepath/#Match>`__ for syntax.


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Fixes #1498 by adding the two missing `--exclude-*` options of the `backup` command to the documentation. Also reformats and restructures it slightly to make it clearer.

### Was the change discussed in an issue or in the forum before?

Yes, in #1498.

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
