### PR TITLE
Attempt to make issue template a bit clearer

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@
 Welcome! - We kindly ask that you:
 
   1. Fill out the issue template below - not doing so needs a good reason
-  2. Use the forum if you have a question rather than a bug or feature request.
+  2. Use the forum if you have a question rather than a bug or feature request
 
 The forum is at: https://forum.restic.net
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,13 +1,25 @@
 <!--
-NOTE: Not filling out the issue template needs a good reason, otherwise it may
-take a lot longer to find the problem! Please take the time to help us
-debugging the problem by collecting information, even if it seems irrelevant to
-you. Thanks!
 
-If you have a question, the forum at https://forum.restic.net is a better place.
-Please do not create issues for usage or documentation questions! We're using
-the GitHub issue tracker mainly for tracking bugs and feature requests.
+Welcome! - We kindly ask that you:
+
+  1. Fill out the issue template below - not doing so needs a good reason
+  2. Use the forum if you have a question rather than a bug or feature request.
+
+NOTE: Not filling out the issue template needs a good reason, as otherwise it
+may take a lot longer to find the problem, not to mention it can take up a lot
+more time which can otherwise be spent on development. Please also take the
+time to help us debug the issue by collecting relevant information, even if
+it doesn't seem to be relevant to you. Thanks!
+
+The forum is a better place for questions about restic or general suggestions
+and topics, e.g. usage or documentation questions! This issue tracker is mainly
+for tracking bugs and feature requests directly relating to the development of
+the software itself, rather than the project.
+
+Thanks for understanding, and for contributing to the project!
+
 -->
+
 
 ## Output of `restic version`
 
@@ -24,8 +36,8 @@ This section should include at least:
    information to diagnose the problem!
 -->
 
-
 ## What backend/server/service did you use to store the repository?
+
 
 
 ## Expected behavior
@@ -48,11 +60,13 @@ The more time you spend describing an easy way to reproduce the behavior (if
 this is possible), the easier it is for the project developers to fix it!
 -->
 
-
 ## Do you have any idea what may have caused this?
 
 
+
 ## Do you have an idea how to solve the issue?
+
+
 
 ## Did restic help you or made you happy in any way?
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,8 +2,8 @@
 
 Welcome! - We kindly ask that you:
 
-  1. Fill out the issue template below - not doing so needs a good reason
-  2. Use the forum if you have a question rather than a bug or feature request
+  1. Fill out the issue template below - not doing so needs a good reason.
+  2. Use the forum if you have a question rather than a bug or feature request.
 
 The forum is at: https://forum.restic.net
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -5,6 +5,8 @@ Welcome! - We kindly ask that you:
   1. Fill out the issue template below - not doing so needs a good reason
   2. Use the forum if you have a question rather than a bug or feature request.
 
+The forum is at: https://forum.restic.net
+
 NOTE: Not filling out the issue template needs a good reason, as otherwise it
 may take a lot longer to find the problem, not to mention it can take up a lot
 more time which can otherwise be spent on development. Please also take the


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Make the issue template a bit more explicit or "clear" in the initial part of it's comment, to encourage more people to fill it out or use the forum.

### Was the change discussed in an issue or in the forum before?

No.

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
