### PR TITLE
Fixed unexpected 'pack file cannot be listed' error

### DIFF
--- a/changelog/0.8.3/issue-1633
+++ b/changelog/0.8.3/issue-1633
@@ -1,0 +1,6 @@
+Bugfix: Fixed unexpected 'pack file cannot be listed' error
+
+Due to regression introduced in 0.8.2, `rebuild-index` and `prune` commands
+failed to read pack files with size of 587, 588, 589 or 590 bytes.
+
+https://github.com/restic/restic/issues/1633


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

Fixes incorrect calculation of pack file header offset for certain pack files

### Was the change discussed in an issue or in the forum before?

See #1633

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
