### PR TITLE
backend: Improve/Cleanup Save()

### DIFF
--- a/internal/archiver/archiver_duplication_test.go
+++ b/internal/archiver/archiver_duplication_test.go
@@ -48,7 +48,7 @@ func forgetfulBackend() restic.Backend {
 		return nil, errors.New("not found")
 	}
 
-	be.SaveFn = func(ctx context.Context, h restic.Handle, rd io.Reader) error {
+	be.SaveFn = func(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 		return nil
 	}
 

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -185,7 +185,7 @@ func (be *b2Backend) openReader(ctx context.Context, h restic.Handle, length int
 }
 
 // Save stores data in the backend at the handle.
-func (be *b2Backend) Save(ctx context.Context, h restic.Handle, rd io.Reader) error {
+func (be *b2Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/internal/backend/backend_error.go
+++ b/internal/backend/backend_error.go
@@ -45,7 +45,7 @@ func (be *ErrorBackend) fail(p float32) bool {
 }
 
 // Save stores the data in the backend under the given handle.
-func (be *ErrorBackend) Save(ctx context.Context, h restic.Handle, rd io.Reader) error {
+func (be *ErrorBackend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	if be.fail(be.FailSave) {
 		return errors.Errorf("Save(%v) random error induced", h)
 	}

--- a/internal/backend/backend_retry.go
+++ b/internal/backend/backend_retry.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/cenkalti/backoff"
 	"github.com/restic/restic/internal/debug"
-	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 )
 
@@ -47,23 +46,9 @@ func (be *RetryBackend) retry(ctx context.Context, msg string, f func() error) e
 }
 
 // Save stores the data in the backend under the given handle.
-func (be *RetryBackend) Save(ctx context.Context, h restic.Handle, rd io.Reader) error {
-	seeker, ok := rd.(io.Seeker)
-	if !ok {
-		return errors.Errorf("reader %T is not a seeker", rd)
-	}
-
-	pos, err := seeker.Seek(0, io.SeekCurrent)
-	if err != nil {
-		return errors.Wrap(err, "Seek")
-	}
-
-	if pos != 0 {
-		return errors.Errorf("reader is not at the beginning (pos %v)", pos)
-	}
-
+func (be *RetryBackend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	return be.retry(ctx, fmt.Sprintf("Save(%v)", h), func() error {
-		_, err := seeker.Seek(0, io.SeekStart)
+		err := rd.Rewind()
 		if err != nil {
 			return err
 		}

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -207,7 +207,7 @@ func (be *Backend) Path() string {
 }
 
 // Save stores data in the backend at the handle.
-func (be *Backend) Save(ctx context.Context, h restic.Handle, rd io.Reader) (err error) {
+func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	if err := h.Valid(); err != nil {
 		return err
 	}
@@ -250,6 +250,7 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd io.Reader) (err
 	info, err := be.service.Objects.Insert(be.bucketName,
 		&storage.Object{
 			Name: objName,
+			Size: uint64(rd.Length()),
 		}).Media(rd, cs).Do()
 
 	be.sem.ReleaseToken()

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -98,7 +98,7 @@ func (b *Local) IsNotExist(err error) bool {
 }
 
 // Save stores data in the backend at the handle.
-func (b *Local) Save(ctx context.Context, h restic.Handle, rd io.Reader) error {
+func (b *Local) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	debug.Log("Save %v", h)
 	if err := h.Valid(); err != nil {
 		return err

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -59,7 +59,7 @@ func (be *MemoryBackend) IsNotExist(err error) bool {
 }
 
 // Save adds new Data to the backend.
-func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd io.Reader) error {
+func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	if err := h.Valid(); err != nil {
 		return err
 	}

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -119,7 +119,7 @@ func (b *restBackend) Save(ctx context.Context, h restic.Handle, rd restic.Rewin
 	if err != nil {
 		return errors.Wrap(err, "NewRequest")
 	}
-	req.Header.Set("Content-Length", strconv.Itoa(rd.Length()))
+	req.Header.Set("Content-Length", strconv.FormatInt(rd.Length(), 10))
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Accept", contentTypeV2)
 

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -282,7 +282,7 @@ func Join(parts ...string) string {
 }
 
 // Save stores data in the backend at the handle.
-func (r *SFTP) Save(ctx context.Context, h restic.Handle, rd io.Reader) (err error) {
+func (r *SFTP) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	debug.Log("Save %v", h)
 	if err := r.clientError(); err != nil {
 		return err

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -156,8 +156,8 @@ func (be *beSwift) openReader(ctx context.Context, h restic.Handle, length int, 
 }
 
 // Save stores data in the backend at the handle.
-func (be *beSwift) Save(ctx context.Context, h restic.Handle, rd io.Reader) (err error) {
-	if err = h.Valid(); err != nil {
+func (be *beSwift) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
+	if err := h.Valid(); err != nil {
 		return err
 	}
 
@@ -171,7 +171,7 @@ func (be *beSwift) Save(ctx context.Context, h restic.Handle, rd io.Reader) (err
 	encoding := "binary/octet-stream"
 
 	debug.Log("PutObject(%v, %v, %v)", be.container, objName, encoding)
-	_, err = be.conn.ObjectPut(be.container, objName, rd, true, "", encoding, nil)
+	_, err := be.conn.ObjectPut(be.container, objName, rd, true, "", encoding, nil)
 	debug.Log("%v, err %#v", objName, err)
 
 	return errors.Wrap(err, "client.PutObject")

--- a/internal/backend/test/benchmarks.go
+++ b/internal/backend/test/benchmarks.go
@@ -14,7 +14,8 @@ func saveRandomFile(t testing.TB, be restic.Backend, length int) ([]byte, restic
 	data := test.Random(23, length)
 	id := restic.Hash(data)
 	handle := restic.Handle{Type: restic.DataFile, Name: id.String()}
-	if err := be.Save(context.TODO(), handle, bytes.NewReader(data)); err != nil {
+	err := be.Save(context.TODO(), handle, restic.NewByteReader(data))
+	if err != nil {
 		t.Fatalf("Save() error: %+v", err)
 	}
 	return data, handle
@@ -148,16 +149,11 @@ func (s *Suite) BenchmarkSave(t *testing.B) {
 	id := restic.Hash(data)
 	handle := restic.Handle{Type: restic.DataFile, Name: id.String()}
 
-	rd := bytes.NewReader(data)
-
+	rd := restic.NewByteReader(data)
 	t.SetBytes(int64(length))
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		if _, err := rd.Seek(0, 0); err != nil {
-			t.Fatal(err)
-		}
-
 		if err := be.Save(context.TODO(), handle, rd); err != nil {
 			t.Fatal(err)
 		}

--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -443,7 +443,7 @@ func (s *Suite) TestListCancel(t *testing.T) {
 
 type errorCloser struct {
 	io.ReadSeeker
-	l int
+	l int64
 	t testing.TB
 }
 
@@ -452,7 +452,7 @@ func (ec errorCloser) Close() error {
 	return errors.New("forbidden method close was called")
 }
 
-func (ec errorCloser) Length() int {
+func (ec errorCloser) Length() int64 {
 	return ec.l
 }
 
@@ -536,7 +536,7 @@ func (s *Suite) TestSave(t *testing.T) {
 
 	// wrap the tempfile in an errorCloser, so we can detect if the backend
 	// closes the reader
-	err = b.Save(context.TODO(), h, errorCloser{t: t, l: length, ReadSeeker: tmpfile})
+	err = b.Save(context.TODO(), h, errorCloser{t: t, l: int64(length), ReadSeeker: tmpfile})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/utils_test.go
+++ b/internal/backend/utils_test.go
@@ -24,7 +24,8 @@ func TestLoadAll(t *testing.T) {
 		data := rtest.Random(23+i, rand.Intn(MiB)+500*KiB)
 
 		id := restic.Hash(data)
-		err := b.Save(context.TODO(), restic.Handle{Name: id.String(), Type: restic.DataFile}, bytes.NewReader(data))
+		h := restic.Handle{Name: id.String(), Type: restic.DataFile}
+		err := b.Save(context.TODO(), h, restic.NewByteReader(data))
 		rtest.OK(t, err)
 
 		buf, err := backend.LoadAll(context.TODO(), b, restic.Handle{Type: restic.DataFile, Name: id.String()})
@@ -49,7 +50,8 @@ func TestLoadSmallBuffer(t *testing.T) {
 		data := rtest.Random(23+i, rand.Intn(MiB)+500*KiB)
 
 		id := restic.Hash(data)
-		err := b.Save(context.TODO(), restic.Handle{Name: id.String(), Type: restic.DataFile}, bytes.NewReader(data))
+		h := restic.Handle{Name: id.String(), Type: restic.DataFile}
+		err := b.Save(context.TODO(), h, restic.NewByteReader(data))
 		rtest.OK(t, err)
 
 		buf, err := backend.LoadAll(context.TODO(), b, restic.Handle{Type: restic.DataFile, Name: id.String()})
@@ -74,7 +76,8 @@ func TestLoadLargeBuffer(t *testing.T) {
 		data := rtest.Random(23+i, rand.Intn(MiB)+500*KiB)
 
 		id := restic.Hash(data)
-		err := b.Save(context.TODO(), restic.Handle{Name: id.String(), Type: restic.DataFile}, bytes.NewReader(data))
+		h := restic.Handle{Name: id.String(), Type: restic.DataFile}
+		err := b.Save(context.TODO(), h, restic.NewByteReader(data))
 		rtest.OK(t, err)
 
 		buf, err := backend.LoadAll(context.TODO(), b, restic.Handle{Type: restic.DataFile, Name: id.String()})

--- a/internal/cache/backend_test.go
+++ b/internal/cache/backend_test.go
@@ -28,7 +28,7 @@ func loadAndCompare(t testing.TB, be restic.Backend, h restic.Handle, data []byt
 }
 
 func save(t testing.TB, be restic.Backend, h restic.Handle, data []byte) {
-	err := be.Save(context.TODO(), h, bytes.NewReader(data))
+	err := be.Save(context.TODO(), h, restic.NewByteReader(data))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/mock/backend.go
+++ b/internal/mock/backend.go
@@ -12,7 +12,7 @@ import (
 type Backend struct {
 	CloseFn      func() error
 	IsNotExistFn func(err error) bool
-	SaveFn       func(ctx context.Context, h restic.Handle, rd io.Reader) error
+	SaveFn       func(ctx context.Context, h restic.Handle, rd restic.RewindReader) error
 	OpenReaderFn func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error)
 	StatFn       func(ctx context.Context, h restic.Handle) (restic.FileInfo, error)
 	ListFn       func(ctx context.Context, t restic.FileType, fn func(restic.FileInfo) error) error
@@ -56,7 +56,7 @@ func (m *Backend) IsNotExist(err error) bool {
 }
 
 // Save data in the backend.
-func (m *Backend) Save(ctx context.Context, h restic.Handle, rd io.Reader) error {
+func (m *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	if m.SaveFn == nil {
 		return errors.New("not implemented")
 	}

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -127,7 +127,7 @@ func TestUnpackReadSeeker(t *testing.T) {
 	id := restic.Hash(packData)
 
 	handle := restic.Handle{Type: restic.DataFile, Name: id.String()}
-	rtest.OK(t, b.Save(context.TODO(), handle, bytes.NewReader(packData)))
+	rtest.OK(t, b.Save(context.TODO(), handle, restic.NewByteReader(packData)))
 	verifyBlobs(t, bufs, k, restic.ReaderAt(b, handle), packSize)
 }
 
@@ -140,6 +140,6 @@ func TestShortPack(t *testing.T) {
 	id := restic.Hash(packData)
 
 	handle := restic.Handle{Type: restic.DataFile, Name: id.String()}
-	rtest.OK(t, b.Save(context.TODO(), handle, bytes.NewReader(packData)))
+	rtest.OK(t, b.Save(context.TODO(), handle, restic.NewByteReader(packData)))
 	verifyBlobs(t, bufs, k, restic.ReaderAt(b, handle), packSize)
 }

--- a/internal/repository/key.go
+++ b/internal/repository/key.go
@@ -1,7 +1,6 @@
 package repository
 
 import (
-	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -250,7 +249,7 @@ func AddKey(ctx context.Context, s *Repository, password string, template *crypt
 		Name: restic.Hash(buf).String(),
 	}
 
-	err = s.be.Save(ctx, h, bytes.NewReader(buf))
+	err = s.be.Save(ctx, h, restic.NewByteReader(buf))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -282,7 +282,7 @@ func (r *Repository) SaveUnpacked(ctx context.Context, t restic.FileType, p []by
 	id = restic.Hash(ciphertext)
 	h := restic.Handle{Type: t, Name: id.String()}
 
-	err = r.be.Save(ctx, h, bytes.NewReader(ciphertext))
+	err = r.be.Save(ctx, h, restic.NewByteReader(ciphertext))
 	if err != nil {
 		debug.Log("error saving blob %v: %v", h, err)
 		return restic.ID{}, err
@@ -456,11 +456,7 @@ func (r *Repository) LoadIndex(ctx context.Context) error {
 		}
 	}
 
-	if err := <-errCh; err != nil {
-		return err
-	}
-
-	return nil
+	return <-errCh
 }
 
 // LoadIndex loads the index id from backend and returns it.

--- a/internal/restic/backend.go
+++ b/internal/restic/backend.go
@@ -20,8 +20,8 @@ type Backend interface {
 	// Close the backend
 	Close() error
 
-	// Save stores the data in the backend under the given handle.
-	Save(ctx context.Context, h Handle, rd io.Reader) error
+	// Save stores the data from rd under the given handle.
+	Save(ctx context.Context, h Handle, rd RewindReader) error
 
 	// Load runs fn with a reader that yields the contents of the file at h at the
 	// given offset. If length is larger than zero, only a portion of the file

--- a/internal/restic/rewind_reader.go
+++ b/internal/restic/rewind_reader.go
@@ -1,0 +1,90 @@
+package restic
+
+import (
+	"bytes"
+	"io"
+
+	"github.com/restic/restic/internal/errors"
+)
+
+// RewindReader allows resetting the Reader to the beginning of the data.
+type RewindReader interface {
+	io.Reader
+
+	// Rewind rewinds the reader so the same data can be read again from the
+	// start.
+	Rewind() error
+
+	// Length returns the number of bytes that can be read from the Reader
+	// after calling Rewind.
+	Length() int
+}
+
+// ByteReader implements a RewindReader for a byte slice.
+type ByteReader struct {
+	*bytes.Reader
+	Len int
+}
+
+// Rewind restarts the reader from the beginning of the data.
+func (b *ByteReader) Rewind() error {
+	_, err := b.Reader.Seek(0, io.SeekStart)
+	return err
+}
+
+// Length returns the number of bytes read from the reader after Rewind is
+// called.
+func (b *ByteReader) Length() int {
+	return b.Len
+}
+
+// statically ensure that *ByteReader implements RewindReader.
+var _ RewindReader = &ByteReader{}
+
+// NewByteReader prepares a ByteReader that can then be used to read buf.
+func NewByteReader(buf []byte) *ByteReader {
+	return &ByteReader{
+		Reader: bytes.NewReader(buf),
+		Len:    len(buf),
+	}
+}
+
+// statically ensure that *FileReader implements RewindReader.
+var _ RewindReader = &FileReader{}
+
+// FileReader implements a RewindReader for an open file.
+type FileReader struct {
+	io.ReadSeeker
+	Len int
+}
+
+// Rewind seeks to the beginning of the file.
+func (f *FileReader) Rewind() error {
+	_, err := f.ReadSeeker.Seek(0, io.SeekStart)
+	return errors.Wrap(err, "Seek")
+}
+
+// Length returns the length of the file.
+func (f *FileReader) Length() int {
+	return f.Len
+}
+
+// NewFileReader wraps f in a *FileReader.
+func NewFileReader(f io.ReadSeeker) (*FileReader, error) {
+	pos, err := f.Seek(0, io.SeekEnd)
+	if err != nil {
+		return nil, errors.Wrap(err, "Seek")
+	}
+
+	fr := &FileReader{
+		ReadSeeker: f,
+		Len:        int(pos),
+	}
+
+	err = fr.Rewind()
+	if err != nil {
+		return nil, err
+	}
+
+	return fr, nil
+}

--- a/internal/restic/rewind_reader.go
+++ b/internal/restic/rewind_reader.go
@@ -17,13 +17,13 @@ type RewindReader interface {
 
 	// Length returns the number of bytes that can be read from the Reader
 	// after calling Rewind.
-	Length() int
+	Length() int64
 }
 
 // ByteReader implements a RewindReader for a byte slice.
 type ByteReader struct {
 	*bytes.Reader
-	Len int
+	Len int64
 }
 
 // Rewind restarts the reader from the beginning of the data.
@@ -34,7 +34,7 @@ func (b *ByteReader) Rewind() error {
 
 // Length returns the number of bytes read from the reader after Rewind is
 // called.
-func (b *ByteReader) Length() int {
+func (b *ByteReader) Length() int64 {
 	return b.Len
 }
 
@@ -45,7 +45,7 @@ var _ RewindReader = &ByteReader{}
 func NewByteReader(buf []byte) *ByteReader {
 	return &ByteReader{
 		Reader: bytes.NewReader(buf),
-		Len:    len(buf),
+		Len:    int64(len(buf)),
 	}
 }
 
@@ -55,7 +55,7 @@ var _ RewindReader = &FileReader{}
 // FileReader implements a RewindReader for an open file.
 type FileReader struct {
 	io.ReadSeeker
-	Len int
+	Len int64
 }
 
 // Rewind seeks to the beginning of the file.
@@ -65,7 +65,7 @@ func (f *FileReader) Rewind() error {
 }
 
 // Length returns the length of the file.
-func (f *FileReader) Length() int {
+func (f *FileReader) Length() int64 {
 	return f.Len
 }
 
@@ -78,7 +78,7 @@ func NewFileReader(f io.ReadSeeker) (*FileReader, error) {
 
 	fr := &FileReader{
 		ReadSeeker: f,
-		Len:        int(pos),
+		Len:        pos,
 	}
 
 	err = fr.Rewind()

--- a/internal/restic/rewind_reader_test.go
+++ b/internal/restic/rewind_reader_test.go
@@ -57,15 +57,15 @@ func TestFileReader(t *testing.T) {
 }
 
 func testRewindReader(t *testing.T, fn func() RewindReader, data []byte) {
-	seed := time.Now().Unix()
+	seed := time.Now().UnixNano()
 	t.Logf("seed is %d", seed)
 	rnd := rand.New(rand.NewSource(seed))
 
 	type ReaderTestFunc func(t testing.TB, r RewindReader, data []byte)
 	var tests = []ReaderTestFunc{
 		func(t testing.TB, rd RewindReader, data []byte) {
-			if rd.Length() != len(data) {
-				t.Fatalf("wrong length returned, want %d, got %d", len(data), rd.Length())
+			if rd.Length() != int64(len(data)) {
+				t.Fatalf("wrong length returned, want %d, got %d", int64(len(data)), rd.Length())
 			}
 
 			buf := make([]byte, len(data))
@@ -78,8 +78,8 @@ func testRewindReader(t *testing.T, fn func() RewindReader, data []byte) {
 				t.Fatalf("wrong data returned")
 			}
 
-			if rd.Length() != len(data) {
-				t.Fatalf("wrong length returned, want %d, got %d", len(data), rd.Length())
+			if rd.Length() != int64(len(data)) {
+				t.Fatalf("wrong length returned, want %d, got %d", int64(len(data)), rd.Length())
 			}
 
 			err = rd.Rewind()
@@ -87,11 +87,11 @@ func testRewindReader(t *testing.T, fn func() RewindReader, data []byte) {
 				t.Fatal(err)
 			}
 
-			if rd.Length() != len(data) {
-				t.Fatalf("wrong length returned, want %d, got %d", len(data), rd.Length())
+			if rd.Length() != int64(len(data)) {
+				t.Fatalf("wrong length returned, want %d, got %d", int64(len(data)), rd.Length())
 			}
 
-			buf2 := make([]byte, len(data))
+			buf2 := make([]byte, int64(len(data)))
 			_, err = io.ReadFull(rd, buf2)
 			if err != nil {
 				t.Fatal(err)
@@ -101,8 +101,8 @@ func testRewindReader(t *testing.T, fn func() RewindReader, data []byte) {
 				t.Fatalf("wrong data returned")
 			}
 
-			if rd.Length() != len(data) {
-				t.Fatalf("wrong length returned, want %d, got %d", len(data), rd.Length())
+			if rd.Length() != int64(len(data)) {
+				t.Fatalf("wrong length returned, want %d, got %d", int64(len(data)), rd.Length())
 			}
 		},
 		func(t testing.TB, rd RewindReader, data []byte) {

--- a/internal/restic/rewind_reader_test.go
+++ b/internal/restic/rewind_reader_test.go
@@ -1,0 +1,154 @@
+package restic
+
+import (
+	"bytes"
+	"io"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/test"
+)
+
+func TestByteReader(t *testing.T) {
+	buf := []byte("foobar")
+	fn := func() RewindReader {
+		return NewByteReader(buf)
+	}
+	testRewindReader(t, fn, buf)
+}
+
+func TestFileReader(t *testing.T) {
+	buf := []byte("foobar")
+
+	d, cleanup := test.TempDir(t)
+	defer cleanup()
+
+	filename := filepath.Join(d, "file-reader-test")
+	err := ioutil.WriteFile(filename, []byte("foobar"), 0600)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Open(filename)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		err := f.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	fn := func() RewindReader {
+		rd, err := NewFileReader(f)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return rd
+	}
+
+	testRewindReader(t, fn, buf)
+}
+
+func testRewindReader(t *testing.T, fn func() RewindReader, data []byte) {
+	seed := time.Now().Unix()
+	t.Logf("seed is %d", seed)
+	rnd := rand.New(rand.NewSource(seed))
+
+	type ReaderTestFunc func(t testing.TB, r RewindReader, data []byte)
+	var tests = []ReaderTestFunc{
+		func(t testing.TB, rd RewindReader, data []byte) {
+			if rd.Length() != len(data) {
+				t.Fatalf("wrong length returned, want %d, got %d", len(data), rd.Length())
+			}
+
+			buf := make([]byte, len(data))
+			_, err := io.ReadFull(rd, buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(buf, data) {
+				t.Fatalf("wrong data returned")
+			}
+
+			if rd.Length() != len(data) {
+				t.Fatalf("wrong length returned, want %d, got %d", len(data), rd.Length())
+			}
+
+			err = rd.Rewind()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if rd.Length() != len(data) {
+				t.Fatalf("wrong length returned, want %d, got %d", len(data), rd.Length())
+			}
+
+			buf2 := make([]byte, len(data))
+			_, err = io.ReadFull(rd, buf2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(buf2, data) {
+				t.Fatalf("wrong data returned")
+			}
+
+			if rd.Length() != len(data) {
+				t.Fatalf("wrong length returned, want %d, got %d", len(data), rd.Length())
+			}
+		},
+		func(t testing.TB, rd RewindReader, data []byte) {
+			// read first bytes
+			buf := make([]byte, rnd.Intn(len(data)))
+			_, err := io.ReadFull(rd, buf)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(buf, data[:len(buf)]) {
+				t.Fatalf("wrong data returned")
+			}
+
+			err = rd.Rewind()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			buf2 := make([]byte, rnd.Intn(len(data)))
+			_, err = io.ReadFull(rd, buf2)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(buf2, data[:len(buf2)]) {
+				t.Fatalf("wrong data returned")
+			}
+
+			// read remainder
+			buf3 := make([]byte, len(data)-len(buf2))
+			_, err = io.ReadFull(rd, buf3)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if !bytes.Equal(buf3, data[len(buf2):]) {
+				t.Fatalf("wrong data returned")
+			}
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			rd := fn()
+			test(t, rd, data)
+		})
+	}
+}


### PR DESCRIPTION
As mentioned in issue [#1560](https://github.com/restic/restic/pull/1560#issuecomment-364689346) this changes the signature for `backend.Save()`. It now takes a parameter of interface type `RewindReader`, so that the backend implementations or our `RetryBackend` middleware can reset the reader to the beginning and then retry an upload operation. 

The `RewindReader` interface also provides a `Length()` method, which is used in the backend to get the size of the data to be saved. This removes several ugly hacks we had to do to pull the size back out of the `io.Reader` passed to `Save()` before. In the `s3` and `rest` backend this is actively used.

New signature:
```go
// Save stores the data from rd under the given handle.
Save(ctx context.Context, h Handle, rd RewindReader) error
```

Ugly hacks removed:
 * https://github.com/restic/restic/blob/2866f3f31ce98b235010dc6c095e67fc915a83f7/internal/backend/backend_retry.go#L51-L63
 * https://github.com/restic/restic/blob/2866f3f31ce98b235010dc6c095e67fc915a83f7/internal/backend/s3/s3.go#L244-L253