### PR TITLE
Change priority of AWS credential providers to accept AWS_SESSION_TOKEN

### DIFF
--- a/changelog/0.8.3_2018-02-26/pull-1647
+++ b/changelog/0.8.3_2018-02-26/pull-1647
@@ -1,0 +1,8 @@
+Enhancement: Change priority of AWS credential providers to accept AWS_SESSION_TOKEN
+
+Before, it was not possible to use s3 backend with AWS temporary security credentials(with AWS_SESSION_TOKEN).
+This change gives higher priority to credentials.EnvAWS credentials provider.
+
+https://github.com/restic/restic/issues/1477
+https://github.com/restic/restic/pull/1479
+https://github.com/restic/restic/pull/1647

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -48,6 +48,7 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 	// AWS env variables such as AWS_ACCESS_KEY_ID
 	// Minio env variables such as MINIO_ACCESS_KEY
 	creds := credentials.NewChainCredentials([]credentials.Provider{
+		&credentials.EnvAWS{},
 		&credentials.Static{
 			Value: credentials.Value{
 				AccessKeyID:     cfg.KeyID,
@@ -59,7 +60,6 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 				Transport: http.DefaultTransport,
 			},
 		},
-		&credentials.EnvAWS{},
 		&credentials.EnvMinio{},
 	})
 	client, err := minio.NewWithCredentials(cfg.Endpoint, creds, !cfg.UseHTTP, "")


### PR DESCRIPTION
### What is the purpose of this change? What does it change?
It is currently not possible to use the restic S3 backend with IAM credentials that are temporary and scoped to a subdirectory. The first one requires restic to accept AWS_SESSION_TOKEN credentials.
The current priority of AWS credential providers ignore AWS_SESSION_TOKEN env variable.

### Was the change discussed in an issue or in the forum before?
This pull request aims to solve the issue as described here #1477
https://github.com/restic/restic/pull/1479


### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
