### PR TITLE
Ignore s3 AccessDenied error, during creation of repository

### DIFF
--- a/changelog/0.8.3_2018-02-26/pull-1648
+++ b/changelog/0.8.3_2018-02-26/pull-1648
@@ -1,0 +1,6 @@
+Enhancement: Ignore AWS permission denied error when creating a repository.
+
+It's not possible to use s3 backend scoped to a subdirectory(with specific permissions).
+Restic doesn't try to create repository in a subdirectory, when 'bucket exists' of parent directory check fails due to permission issues.
+
+https://github.com/restic/restic/pull/1648


### PR DESCRIPTION
### What is the purpose of this change? What does it change?
On AWS s3 it is more common to share a bucket between users as there is an account limit on the number of buckets (100). In such cases, it makes sense to limit the operations on a certain prefix to a certain user. In such cases s3:HeadBucket will return forbidden and creation fails.

It's not possible to use s3 backend scoped to a subdirectory(with specific permissions).
Restic doesn't try to create repository in a subdirectory, when   'bucket exists' of parent directory check fails due to permission issues.

### Was the change discussed in an issue or in the forum before?
https://github.com/restic/restic/issues/1477
https://github.com/restic/restic/pull/1479

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
