### PR TITLE
Minimal set of patches to get restic working on Solaris

### DIFF
--- a/changelog/0.8.3_2018-02-26/pull-1649
+++ b/changelog/0.8.3_2018-02-26/pull-1649
@@ -1,0 +1,3 @@
+Enhancement: Add illumos/Solaris support.
+
+https://github.com/restic/restic/pull/1649

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package main

--- a/cmd/restic/integration_fuse_test.go
+++ b/cmd/restic/integration_fuse_test.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package main

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -63,7 +63,8 @@ command to serve the repository with FUSE:
     Now serving /tmp/backup at /mnt/restic
     Don't forget to umount after quitting!
 
-Mounting repositories via FUSE is not possible on Windows and OpenBSD.
+Mounting repositories via FUSE is not possible on OpenBSD, Solaris/illumos
+and Windows.
 
 Restic supports storage and preservation of hard links. However, since
 hard links exist in the scope of a filesystem by definition, restoring

--- a/internal/backend/sftp/foreground_solaris.go
+++ b/internal/backend/sftp/foreground_solaris.go
@@ -1,0 +1,25 @@
+package sftp
+
+import (
+	"os/exec"
+	"syscall"
+
+	"github.com/restic/restic/internal/errors"
+)
+
+func startForeground(cmd *exec.Cmd) (bg func() error, err error) {
+	// run the command in it's own process group so that SIGINT
+	// is not sent to it.
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+	}
+
+	// start the process
+	err = cmd.Start()
+	if err != nil {
+		return nil, errors.Wrap(err, "cmd.Start")
+	}
+
+	bg = func() error { return nil }
+	return bg, nil
+}

--- a/internal/backend/sftp/foreground_unix.go
+++ b/internal/backend/sftp/foreground_unix.go
@@ -1,3 +1,4 @@
+// +build !solaris
 // +build !windows
 
 package sftp

--- a/internal/fuse/blob_size_cache.go
+++ b/internal/fuse/blob_size_cache.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/file_test.go
+++ b/internal/fuse/file_test.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/link.go
+++ b/internal/fuse/link.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/meta_dir.go
+++ b/internal/fuse/meta_dir.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/other.go
+++ b/internal/fuse/other.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package fuse

--- a/internal/restic/node_solaris.go
+++ b/internal/restic/node_solaris.go
@@ -1,0 +1,27 @@
+package restic
+
+import "syscall"
+
+func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
+	return nil
+}
+
+func (s statUnix) atim() syscall.Timespec { return s.Atim }
+func (s statUnix) mtim() syscall.Timespec { return s.Mtim }
+func (s statUnix) ctim() syscall.Timespec { return s.Ctim }
+
+// Getxattr retrieves extended attribute data associated with path.
+func Getxattr(path, name string) ([]byte, error) {
+	return nil, nil
+}
+
+// Listxattr retrieves a list of names of extended attributes associated with the
+// given path in the file system.
+func Listxattr(path string) ([]string, error) {
+	return nil, nil
+}
+
+// Setxattr associates name and data together as an attribute of path.
+func Setxattr(path, name string, data []byte) error {
+	return nil
+}

--- a/internal/restic/node_xattr.go
+++ b/internal/restic/node_xattr.go
@@ -1,4 +1,5 @@
 // +build !openbsd
+// +build !solaris
 // +build !windows
 
 package restic

--- a/internal/restic/progress_unix.go
+++ b/internal/restic/progress_unix.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin,!freebsd,!netbsd,!openbsd,!dragonfly
+// +build !windows,!darwin,!freebsd,!netbsd,!openbsd,!dragonfly,!solaris
 
 package restic
 


### PR DESCRIPTION
This effectively disables the xattr/fuse support. Also the sftp backend is disabled due to lack of `syscall.SYS_IOCTL` support in Go for Solaris.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

Allow restic to be built on the golang 'solaris' target. It was built and tested on SmartOS with `go version go1.9.3 solaris/amd64`

### Was the change discussed in an issue or in the forum before?

Closes #1576 

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] ~I have added tests for all changes in this PR~ (not needed?)
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review