### PR TITLE
Added copr repositories for RHEL/Centos/Fedora

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -62,6 +62,28 @@ installed from the official repos, e.g. with ``apt-get``:
 .. warning:: Please be aware that, at the time of writing, Debian *stable*
    has ``restic`` version 0.3.3 which is very old. The *testing* and *unstable*
    branches have recent versions of ``restic``.
+   
+RHEL & CentOS
+=============
+
+restic can be installed via copr repository.
+
+.. code-block:: console
+
+    $ yum install yum-plugin-copr
+    $ yum copr enable copart/restic
+    $ yum install restic
+
+Fedora
+======
+
+restic can be installed via copr repository.
+
+.. code-block:: console
+
+    $ dnf install dnf-plugin-core
+    $ dnf copr enable copart/restic
+    $ dnf install restic
 
 Pre-compiled Binary
 *******************


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Added links to a repo I created to make it easier to install/maintain restic on Fedora, Centos, and RHEL.  The install also sets up man pages as well as BASH/ZSH type ahead.

### Was the change discussed in an issue or in the forum before?

No

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in a subdir of `changelog/x.y.z` that describe the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
