### PR TITLE
backend/rest: check HTTP error response for List

### DIFF
--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -335,7 +335,11 @@ func (b *restBackend) List(ctx context.Context, t restic.FileType, fn func(resti
 	b.sem.ReleaseToken()
 
 	if err != nil {
-		return errors.Wrap(err, "Get")
+		return errors.Wrap(err, "List")
+	}
+
+	if resp.StatusCode != 200 {
+		return errors.Errorf("List failed, server response: %v (%v)", resp.Status, resp.StatusCode)
 	}
 
 	if resp.Header.Get("Content-Type") == contentTypeV2 {


### PR DESCRIPTION
Before this change restic would attempt to JSON decode the error
message resulting in confusing `Decode: invalid character 'B' looking
for beginning of value` messages.  Afterwards it will return `List
failed, server response: 400 Bad Request (400)`

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

<!--
Describe the changes here, as detailed as needed.
-->

### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
