### PR TITLE
Skip archiver.Scan before backup when --quiet is set

### DIFF
--- a/changelog/unreleased/issue-1160
+++ b/changelog/unreleased/issue-1160
@@ -1,0 +1,5 @@
+Enhancement: Improve backup speed by skipping the initial scan when the quiet flag is set
+
+We've improved the backup speed when the quiet flag -q or --quiet is set by skipping the initial scan which gathers information for displaying the progress bar and the ETA estimation.
+
+https://github.com/restic/restic/issues/1160

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -451,9 +451,12 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, args []string) error {
 		return true
 	}
 
-	stat, err := archiver.Scan(target, selectFilter, newScanProgress(gopts))
-	if err != nil {
-		return err
+	var stat restic.Stat
+	if !gopts.Quiet {
+		stat, err = archiver.Scan(target, selectFilter, newScanProgress(gopts))
+		if err != nil {
+			return err
+		}
 	}
 
 	arch := archiver.New(repo)

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -107,7 +107,9 @@ Subcommand that support showing progress information such as ``backup``,
 ``check`` and ``prune`` will do so unless the quiet flag ``-q`` or
 ``--quiet`` is set. When running from a non-interactive console progress
 reporting will be limited to once every 10 seconds to not fill your
-logs.
+logs. Use ``backup`` with the quiet flag ``-q`` or ``--quiet`` can skip
+the initial scan of the source directory, this may shorten the backup
+time needed for large directories.
 
 Additionally on Unix systems if ``restic`` receives a SIGUSR1 signal the
 current progress will written to the standard output so you can check up


### PR DESCRIPTION
### What is the purpose of this change? What does it change?
This PR ensures the backup command skips the `archiver.Scan()` before the backup actually starts when the quiet flag `-q` or `--quiet` is set.

The reason behind the change is because the scan result is only used for displaying the progress bar and ETA estimation, but the scan result is not used when the quiet flag is set.

By skipping the scan before backup, the backup speed improves on large directory trees, especially when the entire directory tree cannot entirely fit into page cache, in which case the directory tree was twice read from the disk before this change is made.

### Was the change discussed in an issue or in the forum before?
See issue #1160 

I don't think this PR completely closes the above issue. This is only a quick change to improve the backup performance in some use cases with a minimal change in the code and logic. 

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
