### PR TITLE
Make version output one line.

### DIFF
--- a/cmd/restic/cmd_version.go
+++ b/cmd/restic/cmd_version.go
@@ -16,7 +16,7 @@ and the version of this software.
 `,
 	DisableAutoGenTag: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("restic %s\ncompiled with %v on %v/%v\n",
+		fmt.Printf("restic %s compiled with %v on %v/%v\n",
 			version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	},
 }

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -66,7 +66,7 @@ func init() {
 
 func main() {
 	debug.Log("main %#v", os.Args)
-	debug.Log("restic %s, compiled with %v on %v/%v",
+	debug.Log("restic %s compiled with %v on %v/%v",
 		version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 	err := cmdRoot.Execute()
 


### PR DESCRIPTION
### What is the purpose of this change? What does it change?
Make `version` output one line instead of two.

### Was the change discussed in an issue or in the forum before?
No.

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/changelog-entry.tmpl))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
