### PR TITLE
Fix rest-server tests

### DIFF
--- a/internal/backend/rest/rest_test.go
+++ b/internal/backend/rest/rest_test.go
@@ -22,7 +22,7 @@ func runRESTServer(ctx context.Context, t testing.TB, dir string) (*url.URL, fun
 		t.Skip(err)
 	}
 
-	cmd := exec.CommandContext(ctx, srv, "--path", dir)
+	cmd := exec.CommandContext(ctx, srv, "--no-auth", "--path", dir)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stdout
 	if err := cmd.Start(); err != nil {


### PR DESCRIPTION
Since today, the rest-server needs to be explicitly told (via `--no-auth`) that authentication is not necessary.