### PR TITLE
Slightly increment size for TestIncrementalBackup

### DIFF
--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -576,7 +576,7 @@ func TestBackupExclude(t *testing.T) {
 }
 
 const (
-	incrementalFirstWrite  = 6 * 1042 * 1024
+	incrementalFirstWrite  = 10 * 1042 * 1024
 	incrementalSecondWrite = 1 * 1042 * 1024
 	incrementalThirdWrite  = 1 * 1042 * 1024
 )


### PR DESCRIPTION
This should make the test more reliable, it should hit the accidental
"repo is has grown too much" way less often.