### PR TITLE
Fixed issue #1608 - Use --time argument properly

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -246,6 +246,17 @@ func readBackupFromStdin(opts BackupOptions, gopts GlobalOptions, args []string)
 		return errors.Fatal("filename is invalid (may not contain a directory, slash or backslash)")
 	}
 
+	var t time.Time
+	if opts.TimeStamp != "" {
+		parsedT, err := time.Parse("2006-01-02 15:04:05", opts.TimeStamp)
+		if err != nil {
+			return err
+		}
+		t = parsedT
+	} else {
+		t = time.Now()
+	}
+
 	if gopts.password == "" {
 		return errors.Fatal("unable to read password from stdin when data is to be read from stdin, use --password-file or $RESTIC_PASSWORD")
 	}
@@ -270,6 +281,7 @@ func readBackupFromStdin(opts BackupOptions, gopts GlobalOptions, args []string)
 		Repository: repo,
 		Tags:       opts.Tags,
 		Hostname:   opts.Hostname,
+		TimeStamp:  t,
 	}
 
 	_, id, err := r.Archive(gopts.ctx, fn, os.Stdin, newArchiveStdinProgress(gopts))

--- a/internal/archiver/archive_reader.go
+++ b/internal/archiver/archive_reader.go
@@ -17,8 +17,9 @@ import (
 type Reader struct {
 	restic.Repository
 
-	Tags     []string
-	Hostname string
+	Tags      []string
+	Hostname  string
+	TimeStamp time.Time
 }
 
 // Archive reads data from the reader and saves it to the repo.
@@ -26,9 +27,8 @@ func (r *Reader) Archive(ctx context.Context, name string, rd io.Reader, p *rest
 	if name == "" {
 		return nil, restic.ID{}, errors.New("no filename given")
 	}
-
 	debug.Log("start archiving %s", name)
-	sn, err := restic.NewSnapshot([]string{name}, r.Tags, r.Hostname, time.Now())
+	sn, err := restic.NewSnapshot([]string{name}, r.Tags, r.Hostname, r.TimeStamp)
 	if err != nil {
 		return nil, restic.ID{}, err
 	}


### PR DESCRIPTION
Backups via stdin will now handle --time argument and pass it down as
expected

### What is the purpose of this change? What does it change?

Fix issue raised via #1608.
Not sure if I took the best approach, so feel free to suggest something different.

### Was the change discussed in an issue or in the forum before?

Closes #1608 

### Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
