### PR TITLE
Add scripting section to docs

### DIFF
--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -1,0 +1,39 @@
+..
+  Normally, there are no heading levels assigned to certain characters as the structure is
+  determined from the succession of headings. However, this convention is used in Python’s
+  Style Guide for documenting which you may follow:
+
+  # with overline, for parts
+  * for chapters
+  = for sections
+  - for subsections
+  ^ for subsubsections
+  " for paragraphs
+
+#########################
+Scripting
+#########################
+
+This is a list of how certain tasks may be accomplished when you use
+restic via scripts.
+
+Check if a repository is already initialized
+********************************************
+
+You may find a need to check if a repository is already initialized,
+perhaps to prevent your script from initializing a repository multiple
+times. The command ``snapshots`` may be used for this purpose:
+
+.. code-block:: console
+
+    $ restic -r /tmp/backup snapshots
+    Fatal: unable to open config file: Stat: stat /tmp/backup/config: no such file or directory
+    Is there a repository at the following location?
+    /tmp/backup
+
+If a repository does not exist, restic will return a non-zero exit code
+and print an error message. Note that restic will also return a non-zero
+exit code if a different error is encountered (e.g.: incorrect password
+to ``snapshots``) and it may print a different error message. If there
+are no errors, restic will return a zero exit code and print all the
+snapshots.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -12,6 +12,7 @@ Restic Documentation
    050_restore
    060_forget
    070_encryption
+   075_scripting
    080_examples
    090_participating
    100_references


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

I added a "Scripting" section to the documentation. It will be used to contain all the HOWTOs when people use restic via a scripting environment. There were no changes to the code.

### Was the change discussed in an issue or in the forum before?

Closes #1690.

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)

~- [ ] I have added tests for all changes in this PR~
~- [ ] I have added documentation for the changes (in the manual)~
~- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~
~- [ ] I have run `gofmt` on the code in all commits~
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review