### PR TITLE
Add "Including and Exluding Files" heading in docs

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -75,6 +75,9 @@ Now is a good time to run ``restic check`` to verify that all data
 is properly stored in the repository. You should run this command regularly
 to make sure the internal structure of the repository is free of errors.
 
+Including and Excluding Files 
+*****************************
+
 You can exclude folders and files by specifying exclude patterns, currently
 the exclude options are:
 


### PR DESCRIPTION
### What is the purpose of this change? What does it change?
Adds "Including and Exluding Files" heading in the backup section in the docs, for better readability and navigation.

### Was the change discussed in an issue or in the forum before?
No.

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
