### PR TITLE
key: Add --new-password-file flag for non-interactive password changes

### DIFF
--- a/changelog/unreleased/pull-1720
+++ b/changelog/unreleased/pull-1720
@@ -1,0 +1,7 @@
+Enhancement: Add --new-password-file flag for non-interactive password changes
+
+This makes it possible to change a repository password without being prompted.
+
+https://github.com/restic/restic/issues/827
+https://github.com/restic/restic/pull/1720
+https://forum.restic.net/t/changing-repo-password-without-prompt/591


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Makes it possible to change the password non-interactively.

I was unsuccessful trying to do it in a script by piping into stdin; restic expects 1000 bytes and the error check is wrong so it always returns an error even on early EOF; but even when corrected, I can only seem to pass one input, not two. Anyway, the whole thing doesn't matter if there's a nifty flag. :smile: 

### Was the change discussed in an issue or in the forum before?

Closes #827 

Also see https://forum.restic.net/t/changing-repo-password-without-prompt/591?u=matt

/cc @robbat2 and @HLeithner

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review

(There don't seem to be tests for the commands, and this is automatically documented by `restic key -h`, so I'm marking this as done, I guess?)