### PR TITLE
backup: Clean target paths before finding parent

### DIFF
--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -24,7 +24,7 @@ func FindLatestSnapshot(ctx context.Context, repo Repository, targets []string, 
 				return ID{}, errors.Wrap(err, "Abs")
 			}
 		}
-		absTargets = append(absTargets, target)
+		absTargets = append(absTargets, filepath.Clean(target))
 	}
 
 	var (


### PR DESCRIPTION
This resolves an issue described in the forum where restic could not find a parent snapshot if the target path ends with a slash: https://forum.restic.net/t/new-archiver-code-please-test/623/23