### PR TITLE
http backend: Parse the correct argument when loading --tls-client-cert

### DIFF
--- a/changelog/unreleased/pull-1746
+++ b/changelog/unreleased/pull-1746
@@ -1,0 +1,7 @@
+Bugfix: Correctly parse the argument to --tls-client-cert
+
+Previously, the --tls-client-cert method attempt to read ARGV[1] (hardcoded)
+instead of the argument that was passed to it. This has been corrected.
+
+https://github.com/restic/restic/issues/1745
+https://github.com/restic/restic/pull/1746

--- a/internal/backend/http_transport.go
+++ b/internal/backend/http_transport.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"net"
 	"net/http"
-	"os"
 	"strings"
 	"time"
 
@@ -28,7 +27,7 @@ type TransportOptions struct {
 // readPEMCertKey reads a file and returns the PEM encoded certificate and key
 // blocks.
 func readPEMCertKey(filename string) (certs []byte, key []byte, err error) {
-	data, err := ioutil.ReadFile(os.Args[1])
+	data, err := ioutil.ReadFile(filename)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "ReadFile")
 	}


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Resolves #1745 

### Was the change discussed in an issue or in the forum before?

https://github.com/restic/restic/issues/1745

### Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [X] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
