### PR TITLE
Fix display

### DIFF
--- a/internal/ui/backup.go
+++ b/internal/ui/backup.go
@@ -150,16 +150,18 @@ func (b *Backup) update(total, processed counter, errors uint, currentFiles map[
 			processed.Files, formatBytes(processed.Bytes), errors,
 		)
 	} else {
-		var eta string
+		var eta, percent string
 
 		if secs > 0 && processed.Bytes < total.Bytes {
 			eta = fmt.Sprintf(" ETA %s", formatSeconds(secs))
+			percent = formatPercent(processed.Bytes, total.Bytes)
+			percent += "  "
 		}
 
 		// include totals
-		status = fmt.Sprintf("[%s] %s  %v files %s, total %v files %v, %d errors%s",
+		status = fmt.Sprintf("[%s] %s%v files %s, total %v files %v, %d errors%s",
 			formatDuration(time.Since(b.start)),
-			formatPercent(processed.Bytes, total.Bytes),
+			percent,
 			processed.Files,
 			formatBytes(processed.Bytes),
 			total.Files,

--- a/internal/ui/termstatus/terminal_unix.go
+++ b/internal/ui/termstatus/terminal_unix.go
@@ -10,10 +10,15 @@ import (
 	isatty "github.com/mattn/go-isatty"
 )
 
-// clearLines will clear the current line and the n lines above. Afterwards the
-// cursor is positioned at the start of the first cleared line.
-func clearLines(wr io.Writer, fd uintptr) clearLinesFunc {
-	return posixClearLines
+// clearCurrentLine removes all characters from the current line and resets the
+// cursor position to the first column.
+func clearCurrentLine(wr io.Writer, fd uintptr) func(io.Writer, uintptr) {
+	return posixClearCurrentLine
+}
+
+// moveCursorUp moves the cursor to the line n lines above the current one.
+func moveCursorUp(wr io.Writer, fd uintptr) func(io.Writer, uintptr, int) {
+	return posixMoveCursorUp
 }
 
 // canUpdateStatus returns true if status lines can be printed, the process


### PR DESCRIPTION
This PR:
 * Adds code to hide the percentage until the total size is known
 * Keeps the cursor at the first column of the first status line so that messages printed to stdout or stderr by some other part of the progarm will still be visible. The message will overwrite the status lines, but those are easily reprinted on the next status update.