### PR TITLE
cat snapshot: Do not display a stack trace with invalid IDs

### DIFF
--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -58,7 +58,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 			// find snapshot id with prefix
 			id, err = restic.FindSnapshot(repo, args[1])
 			if err != nil {
-				return err
+				return errors.Fatalf("could not find snapshot: %v\n", err)
 			}
 		}
 	}


### PR DESCRIPTION
Don't show a stack trace when "restic cat snapshot" is invoked with
invalid/nonexistent IDs.

### What is the purpose of this change? What does it change?

This patch makes restic more user-friendly and consistent by not displaying a stack trace when the user calls `restic cat snapshot ID` with an invalid ID.

Behavior without the patch:
```
% restic cat snapshot 12345678
repository 24a9cce4 opened successfully, password is correct
no ID found
github.com/restic/restic/internal/restic.init
	src/github.com/restic/restic/internal/restic/backend_find.go:11
github.com/restic/restic/internal/archiver.init
	<autogenerated>:1
main.init
	<autogenerated>:1
runtime.main
	/opt/go/src/runtime/proc.go:186
runtime.goexit
	/opt/go/src/runtime/asm_amd64.s:2361
zsh: exit 1
```

Behavior with the patch:
```
% restic cat snapshot 12345678
repository 24a9cce4 opened successfully, password is correct
Fatal: could not find snapshot: no ID found

zsh: exit 1
```

### Was the change discussed in an issue or in the forum before?

It was briefly discussed with fd0 on IRC.

### Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review

I'm not sure this change requires a changelog entry, please let me know if it needs one...