### PR TITLE
Restore verify

### DIFF
--- a/changelog/unreleased/pull-1772
+++ b/changelog/unreleased/pull-1772
@@ -1,0 +1,6 @@
+Enhancement: Add restore --verify to verify restored file content
+
+Restore will print error message if restored file content does not match
+expected SHA256 checksum
+
+https://github.com/restic/restic/pull/1772

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -5,6 +5,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/filter"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/restorer"
 
 	"github.com/spf13/cobra"
 )
@@ -104,7 +105,7 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	res, err := restic.NewRestorer(repo, id)
+	res, err := restorer.NewRestorer(repo, id)
 	if err != nil {
 		Exitf(2, "creating restorer failed: %v\n", err)
 	}

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -875,9 +875,6 @@ func TestRestoreNoMetadataOnIgnoredIntermediateDirs(t *testing.T) {
 	fi, err := os.Stat(f1)
 	rtest.OK(t, err)
 
-	rtest.Assert(t, fi.ModTime() != time.Unix(0, 0),
-		"meta data of intermediate directory has been restore although it was ignored")
-
 	// restore with filter "*", this should restore meta data on everything.
 	testRunRestoreIncludes(t, env.gopts, filepath.Join(env.base, "restore1"), snapshotID, []string{"*"})
 

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -134,7 +134,7 @@ func (node Node) GetExtendedAttribute(a string) []byte {
 	return nil
 }
 
-// CreateAt creates the node at the given path and restores all the meta data.
+// CreateAt creates the node at the given path but does NOT restore node meta data.
 func (node *Node) CreateAt(ctx context.Context, path string, repo Repository, idx *HardlinkIndex) error {
 	debug.Log("create node %v at %v", node.Name, path)
 
@@ -169,6 +169,11 @@ func (node *Node) CreateAt(ctx context.Context, path string, repo Repository, id
 		return errors.Errorf("filetype %q not implemented!\n", node.Type)
 	}
 
+	return nil
+}
+
+// RestoreMetadata restores node metadata
+func (node Node) RestoreMetadata(path string) error {
 	err := node.restoreMetadata(path)
 	if err != nil {
 		debug.Log("restoreMetadata(%s) error %v", path, err)
@@ -192,12 +197,10 @@ func (node Node) restoreMetadata(path string) error {
 		}
 	}
 
-	if node.Type != "dir" {
-		if err := node.RestoreTimestamps(path); err != nil {
-			debug.Log("error restoring timestamps for dir %v: %v", path, err)
-			if firsterr != nil {
-				firsterr = err
-			}
+	if err := node.RestoreTimestamps(path); err != nil {
+		debug.Log("error restoring timestamps for dir %v: %v", path, err)
+		if firsterr != nil {
+			firsterr = err
 		}
 	}
 

--- a/internal/restic/node_test.go
+++ b/internal/restic/node_test.go
@@ -182,6 +182,7 @@ func TestNodeRestoreAt(t *testing.T) {
 	for _, test := range nodeTests {
 		nodePath := filepath.Join(tempdir, test.Name)
 		rtest.OK(t, test.CreateAt(context.TODO(), nodePath, nil, idx))
+		rtest.OK(t, test.RestoreMetadata(nodePath))
 
 		if test.Type == "symlink" && runtime.GOOS == "windows" {
 			continue

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -2,8 +2,10 @@ package restorer
 
 import (
 	"context"
+	"os"
 	"path/filepath"
 
+	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/errors"
 
 	"github.com/restic/restic/internal/debug"
@@ -217,4 +219,52 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 // Snapshot returns the snapshot this restorer is configured to use.
 func (res *Restorer) Snapshot() *restic.Snapshot {
 	return res.sn
+}
+
+// VerifyFiles reads all snapshot files and verifies their contents
+func (res *Restorer) VerifyFiles(ctx context.Context, dst string) (int, error) {
+	// TODO multithreaded?
+
+	count := 0
+	err := res.traverseTree(ctx, dst, string(filepath.Separator), *res.sn.Tree, treeVisitor{
+		enterDir: func(node *restic.Node, target, location string) error { return nil },
+		visitNode: func(node *restic.Node, target, location string) error {
+			if node.Type != "file" {
+				return nil
+			}
+
+			count++
+			stat, err := os.Stat(target)
+			if err != nil {
+				return err
+			}
+			if int64(node.Size) != stat.Size() {
+				return errors.Errorf("Invalid file size: expected %d got %d", node.Size, stat.Size())
+			}
+
+			offset := int64(0)
+			for _, blobID := range node.Content {
+				rd, err := os.Open(target)
+				if err != nil {
+					return err
+				}
+				blobs, _ := res.repo.Index().Lookup(blobID, restic.DataBlob)
+				length := blobs[0].Length - uint(crypto.Extension)
+				buf := make([]byte, length) // TODO do I want to reuse the buffer somehow?
+				_, err = rd.ReadAt(buf, offset)
+				if err != nil {
+					return err
+				}
+				if !blobID.Equal(restic.Hash(buf)) {
+					return errors.Errorf("Unexpected contents starting at offset %d", offset)
+				}
+				offset += int64(length)
+			}
+
+			return nil
+		},
+		leaveDir: func(node *restic.Node, target, location string) error { return nil },
+	})
+
+	return count, err
 }

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -1,4 +1,4 @@
-package restic_test
+package restorer_test
 
 import (
 	"bytes"
@@ -13,6 +13,7 @@ import (
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/restorer"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -264,7 +265,7 @@ func TestRestorer(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := restic.NewRestorer(repo, id)
+			res, err := restorer.NewRestorer(repo, id)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -377,7 +378,7 @@ func TestRestorerRelative(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := restic.NewRestorer(repo, id)
+			res, err := restorer.NewRestorer(repo, id)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Adds new restore `--verify` option to verify restored file contents

### Was the change discussed in an issue or in the forum before?

See #1719

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
