### PR TITLE
archiver: Improve error handling

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -467,7 +467,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	p.V("start backup on %v", targets)
 	_, id, err := arch.Snapshot(gopts.ctx, targets, snapshotOpts)
 	if err != nil {
-		return err
+		return errors.Fatalf("unable to save snapshot: %v", err)
 	}
 
 	p.Finish()

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -480,7 +480,16 @@ func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, 
 
 	futureNodes := make(map[string]FutureNode)
 
-	for name, subatree := range atree.Nodes {
+	// iterate over the nodes of atree in lexicographic (=deterministic) order
+	names := make([]string, 0, len(atree.Nodes))
+	for name := range atree.Nodes {
+		names = append(names, name)
+	}
+	sort.Stable(sort.StringSlice(names))
+
+	for _, name := range names {
+		subatree := atree.Nodes[name]
+
 		// test if context has been cancelled
 		if ctx.Err() != nil {
 			return nil, ctx.Err()

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -218,6 +218,7 @@ func (arch *Archiver) SaveDir(ctx context.Context, snPath string, fi os.FileInfo
 	for _, name := range names {
 		// test if context has been cancelled
 		if ctx.Err() != nil {
+			debug.Log("context has been cancelled, aborting")
 			return FutureTree{}, ctx.Err()
 		}
 
@@ -767,7 +768,8 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 
 	t.Kill(nil)
 	werr := t.Wait()
-	if err != nil && errors.Cause(err) == context.Canceled {
+	debug.Log("err is %v, werr is %v", err, werr)
+	if err == nil || errors.Cause(err) == context.Canceled {
 		err = werr
 	}
 

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -271,6 +271,7 @@ func (fn *FutureNode) wait(ctx context.Context) {
 	switch {
 	case fn.isFile:
 		// wait for and collect the data for the file
+		fn.file.Wait(ctx)
 		fn.node = fn.file.Node()
 		fn.err = fn.file.Err()
 		fn.stats = fn.file.Stats()
@@ -281,6 +282,7 @@ func (fn *FutureNode) wait(ctx context.Context) {
 
 	case fn.isDir:
 		// wait for and collect the data for the dir
+		fn.dir.Wait(ctx)
 		fn.node = fn.dir.Node()
 		fn.stats = fn.dir.Stats()
 
@@ -713,13 +715,13 @@ func (arch *Archiver) runWorkers(ctx context.Context, t *tomb.Tomb) {
 
 	arch.fileSaver = NewFileSaver(ctx, t,
 		arch.FS,
-		arch.blobSaver,
+		arch.blobSaver.Save,
 		arch.Repo.Config().ChunkerPolynomial,
 		arch.Options.FileReadConcurrency, arch.Options.SaveBlobConcurrency)
 	arch.fileSaver.CompleteBlob = arch.CompleteBlob
 	arch.fileSaver.NodeFromFileInfo = arch.nodeFromFileInfo
 
-	arch.treeSaver = NewTreeSaver(ctx, t, arch.Options.SaveTreeConcurrency, arch.saveTree, arch.error)
+	arch.treeSaver = NewTreeSaver(ctx, t, arch.Options.SaveTreeConcurrency, arch.saveTree, arch.Error)
 }
 
 // Snapshot saves several targets and returns a snapshot.

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -293,7 +293,8 @@ func (fn *FutureNode) wait(ctx context.Context) {
 }
 
 // Save saves a target (file or directory) to the repo. If the item is
-// excluded,this function returns a nil node and error.
+// excluded,this function returns a nil node and error, with excluded set to
+// true.
 //
 // Errors and completion is needs to be handled by the caller.
 //

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -398,6 +398,7 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 		if err == nil {
 			arch.CompleteItem(snItem, previous, fn.node, fn.stats, time.Since(start))
 		} else {
+			debug.Log("SaveDir for %v returned error: %v", snPath, err)
 			return FutureNode{}, false, err
 		}
 

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -263,8 +263,8 @@ type FutureNode struct {
 
 	isFile bool
 	file   FutureFile
-	isDir  bool
-	dir    FutureTree
+	isTree bool
+	tree   FutureTree
 }
 
 func (fn *FutureNode) wait(ctx context.Context) {
@@ -280,15 +280,15 @@ func (fn *FutureNode) wait(ctx context.Context) {
 		fn.file = FutureFile{}
 		fn.isFile = false
 
-	case fn.isDir:
+	case fn.isTree:
 		// wait for and collect the data for the dir
-		fn.dir.Wait(ctx)
-		fn.node = fn.dir.Node()
-		fn.stats = fn.dir.Stats()
+		fn.tree.Wait(ctx)
+		fn.node = fn.tree.Node()
+		fn.stats = fn.tree.Stats()
 
 		// ensure the other stuff can be garbage-collected
-		fn.dir = FutureTree{}
-		fn.isDir = false
+		fn.tree = FutureTree{}
+		fn.isTree = false
 	}
 }
 
@@ -393,8 +393,8 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 		start := time.Now()
 		oldSubtree := arch.loadSubtree(ctx, previous)
 
-		fn.isDir = true
-		fn.dir, err = arch.SaveDir(ctx, snPath, fi, target, oldSubtree)
+		fn.isTree = true
+		fn.tree, err = arch.SaveDir(ctx, snPath, fi, target, oldSubtree)
 		if err == nil {
 			arch.CompleteItem(snItem, previous, fn.node, fn.stats, time.Since(start))
 		} else {

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -70,6 +70,8 @@ func saveFile(t testing.TB, repo restic.Repository, filename string, filesystem 
 	}
 
 	res := arch.fileSaver.Save(ctx, "/", file, fi, start, complete)
+
+	res.Wait(ctx)
 	if res.Err() != nil {
 		t.Fatal(res.Err())
 	}
@@ -620,6 +622,7 @@ func TestArchiverSaveDir(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			ft.Wait(ctx)
 			node, stats := ft.Node(), ft.Stats()
 
 			tmb.Kill(nil)
@@ -701,6 +704,7 @@ func TestArchiverSaveDirIncremental(t *testing.T) {
 			t.Fatal(err)
 		}
 
+		ft.Wait(ctx)
 		node, stats := ft.Node(), ft.Stats()
 
 		tmb.Kill(nil)

--- a/internal/archiver/blob_saver_test.go
+++ b/internal/archiver/blob_saver_test.go
@@ -1,0 +1,115 @@
+package archiver
+
+import (
+	"context"
+	"fmt"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
+	tomb "gopkg.in/tomb.v2"
+)
+
+var errTest = errors.New("test error")
+
+type saveFail struct {
+	idx    restic.Index
+	cnt    int32
+	failAt int32
+}
+
+func (b *saveFail) SaveBlob(ctx context.Context, t restic.BlobType, buf []byte, id restic.ID) (restic.ID, error) {
+	val := atomic.AddInt32(&b.cnt, 1)
+	if val == b.failAt {
+		return restic.ID{}, errTest
+	}
+
+	return id, nil
+}
+
+func (b *saveFail) Index() restic.Index {
+	return b.idx
+}
+
+func TestBlobSaver(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var tmb tomb.Tomb
+	saver := &saveFail{
+		idx: repository.NewIndex(),
+	}
+
+	b := NewBlobSaver(ctx, &tmb, saver, uint(runtime.NumCPU()))
+
+	var results []FutureBlob
+
+	for i := 0; i < 20; i++ {
+		buf := &Buffer{Data: []byte(fmt.Sprintf("foo%d", i))}
+		fb := b.Save(ctx, restic.DataBlob, buf)
+		results = append(results, fb)
+	}
+
+	for i, blob := range results {
+		blob.Wait(ctx)
+		if blob.Known() {
+			t.Errorf("blob %v is known, that should not be the case", i)
+		}
+	}
+
+	tmb.Kill(nil)
+
+	err := tmb.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestBlobSaverError(t *testing.T) {
+	var tests = []struct {
+		blobs  int
+		failAt int
+	}{
+		{20, 2},
+		{20, 5},
+		{20, 15},
+		{200, 150},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			var tmb tomb.Tomb
+			saver := &saveFail{
+				idx:    repository.NewIndex(),
+				failAt: int32(test.failAt),
+			}
+
+			b := NewBlobSaver(ctx, &tmb, saver, uint(runtime.NumCPU()))
+
+			var results []FutureBlob
+
+			for i := 0; i < test.blobs; i++ {
+				buf := &Buffer{Data: []byte(fmt.Sprintf("foo%d", i))}
+				fb := b.Save(ctx, restic.DataBlob, buf)
+				results = append(results, fb)
+			}
+
+			tmb.Kill(nil)
+
+			err := tmb.Wait()
+			if err == nil {
+				t.Errorf("expected error not found")
+			}
+
+			if err != errTest {
+				t.Fatalf("unexpected error found: %v", err)
+			}
+		})
+	}
+}

--- a/internal/archiver/doc.go
+++ b/internal/archiver/doc.go
@@ -1,0 +1,12 @@
+// Package archiver contains the code which reads files, splits them into
+// chunks and saves the data to the repository.
+//
+// An Archiver has a number of worker goroutines handling saving the different
+// data structures to the repository, the details are implemented by the
+// FileSaver, BlobSaver, and TreeSaver types.
+//
+// The main goroutine (the one calling Snapshot()) traverses the directory tree
+// and delegates all work to these worker pools. They return a type
+// (FutureFile, FutureBlob, and FutureTree) which can be resolved later, by
+// calling Wait() on it.
+package archiver

--- a/internal/archiver/file_saver.go
+++ b/internal/archiver/file_saver.go
@@ -117,10 +117,12 @@ func (s *FileSaver) Save(ctx context.Context, snPath string, file fs.File, fi os
 	case s.ch <- job:
 	case <-s.done:
 		debug.Log("not sending job, FileSaver is done")
+		_ = file.Close()
 		close(ch)
 		return FutureFile{ch: ch}
 	case <-ctx.Done():
 		debug.Log("not sending job, context is cancelled: %v", ctx.Err())
+		_ = file.Close()
 		close(ch)
 		return FutureFile{ch: ch}
 	}

--- a/internal/archiver/file_saver_test.go
+++ b/internal/archiver/file_saver_test.go
@@ -1,0 +1,97 @@
+package archiver
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/restic/chunker"
+	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/test"
+	tomb "gopkg.in/tomb.v2"
+)
+
+func createTestFiles(t testing.TB, num int) (files []string, cleanup func()) {
+	tempdir, cleanup := test.TempDir(t)
+
+	for i := 0; i < 15; i++ {
+		filename := fmt.Sprintf("testfile-%d", i)
+		err := ioutil.WriteFile(filepath.Join(tempdir, filename), []byte(filename), 0600)
+		if err != nil {
+			t.Fatal(err)
+		}
+		files = append(files, filepath.Join(tempdir, filename))
+	}
+
+	return files, cleanup
+}
+
+func startFileSaver(ctx context.Context, t testing.TB, fs fs.FS) (*FileSaver, *tomb.Tomb) {
+	var tmb tomb.Tomb
+
+	saveBlob := func(ctx context.Context, tpe restic.BlobType, buf *Buffer) FutureBlob {
+		ch := make(chan saveBlobResponse)
+		close(ch)
+		return FutureBlob{ch: ch}
+	}
+
+	workers := uint(runtime.NumCPU())
+	pol, err := chunker.RandomPolynomial()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	s := NewFileSaver(ctx, &tmb, fs, saveBlob, pol, workers, workers)
+	s.NodeFromFileInfo = restic.NodeFromFileInfo
+
+	return s, &tmb
+}
+
+func TestFileSaver(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	files, cleanup := createTestFiles(t, 15)
+	defer cleanup()
+
+	startFn := func() {}
+	completeFn := func(*restic.Node, ItemStats) {}
+
+	testFs := fs.Local{}
+	s, tmb := startFileSaver(ctx, t, testFs)
+
+	var results []FutureFile
+
+	for _, filename := range files {
+		f, err := testFs.Open(filename)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		fi, err := f.Stat()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		ff := s.Save(ctx, filename, f, fi, startFn, completeFn)
+		results = append(results, ff)
+	}
+
+	for _, file := range results {
+		file.Wait(ctx)
+		if file.Err() != nil {
+			t.Errorf("unable to save file: %v", file.Err())
+		}
+	}
+
+	tmb.Kill(nil)
+
+	err := tmb.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/archiver/tree_saver_test.go
+++ b/internal/archiver/tree_saver_test.go
@@ -1,0 +1,120 @@
+package archiver
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"runtime"
+	"sync/atomic"
+	"testing"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/restic"
+	tomb "gopkg.in/tomb.v2"
+)
+
+func TestTreeSaver(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var tmb tomb.Tomb
+
+	saveFn := func(context.Context, *restic.Tree) (restic.ID, ItemStats, error) {
+		return restic.NewRandomID(), ItemStats{TreeBlobs: 1, TreeSize: 123}, nil
+	}
+
+	errFn := func(snPath string, fi os.FileInfo, err error) error {
+		return nil
+	}
+
+	b := NewTreeSaver(ctx, &tmb, uint(runtime.NumCPU()), saveFn, errFn)
+
+	var results []FutureTree
+
+	for i := 0; i < 20; i++ {
+		node := &restic.Node{
+			Name: fmt.Sprintf("file-%d", i),
+		}
+
+		fb := b.Save(ctx, "/", node, nil)
+		results = append(results, fb)
+	}
+
+	for _, tree := range results {
+		tree.Wait(ctx)
+	}
+
+	tmb.Kill(nil)
+
+	err := tmb.Wait()
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTreeSaverError(t *testing.T) {
+	var tests = []struct {
+		trees  int
+		failAt int32
+	}{
+		{1, 1},
+		{20, 2},
+		{20, 5},
+		{20, 15},
+		{200, 150},
+	}
+
+	errTest := errors.New("test error")
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			var tmb tomb.Tomb
+
+			var num int32
+			saveFn := func(context.Context, *restic.Tree) (restic.ID, ItemStats, error) {
+				val := atomic.AddInt32(&num, 1)
+				if val == test.failAt {
+					t.Logf("sending error for request %v\n", test.failAt)
+					return restic.ID{}, ItemStats{}, errTest
+				}
+				return restic.NewRandomID(), ItemStats{TreeBlobs: 1, TreeSize: 123}, nil
+			}
+
+			errFn := func(snPath string, fi os.FileInfo, err error) error {
+				t.Logf("ignoring error %v\n", err)
+				return nil
+			}
+
+			b := NewTreeSaver(ctx, &tmb, uint(runtime.NumCPU()), saveFn, errFn)
+
+			var results []FutureTree
+
+			for i := 0; i < test.trees; i++ {
+				node := &restic.Node{
+					Name: fmt.Sprintf("file-%d", i),
+				}
+
+				fb := b.Save(ctx, "/", node, nil)
+				results = append(results, fb)
+			}
+
+			for _, tree := range results {
+				tree.Wait(ctx)
+			}
+
+			tmb.Kill(nil)
+
+			err := tmb.Wait()
+			if err == nil {
+				t.Errorf("expected error not found")
+			}
+
+			if err != errTest {
+				t.Fatalf("unexpected error found: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This commit changes how the worker goroutines for saving e.g. blobs interact. Before, it was possible to get stuck sending an instruction to archive a file or dir when no worker goroutines were available any more. This commit introduces a `done` channel for each of the worker pools, which is set to the channel returned by `tomb.Dying()`, so it is closed when the first worker returned an error.

Closes #1771