### PR TITLE
Improve error message for readdir/readdirnames

### DIFF
--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -623,7 +623,7 @@ func readdir(filesystem fs.FS, dir string) ([]os.FileInfo, error) {
 	entries, err := f.Readdir(-1)
 	if err != nil {
 		_ = f.Close()
-		return nil, errors.Wrap(err, "Readdir")
+		return nil, errors.Wrapf(err, "Readdir %v failed: %v", dir, err)
 	}
 
 	err = f.Close()
@@ -644,7 +644,7 @@ func readdirnames(filesystem fs.FS, dir string) ([]string, error) {
 	entries, err := f.Readdirnames(-1)
 	if err != nil {
 		_ = f.Close()
-		return nil, errors.Wrap(err, "Readdirnames")
+		return nil, errors.Wrapf(err, "Readdirnames %v failed: %v", dir, err)
 	}
 
 	err = f.Close()


### PR DESCRIPTION
As mentioned in the forum[1], restic does not include the dir name when
readdir/readdirnames fails.

[1] https://forum.restic.net/t/readdirnames-readdirent-no-such-file-or-directory/653