### PR TITLE
Fix restic backup --one-file-system /

### DIFF
--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -229,11 +229,14 @@ func rejectByDevice(samples []string) (RejectFunc, error) {
 			panic(err)
 		}
 
-		for dir := item; dir != filepath.Dir(dir); dir = filepath.Dir(dir) {
+		for dir := item; ; dir = filepath.Dir(dir) {
 			debug.Log("item %v, test dir %v", item, dir)
 
 			allowedID, ok := allowed[dir]
 			if !ok {
+				if dir == filepath.Dir(dir) {
+					break
+				}
 				continue
 			}
 


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

This patch should fix the following panic when trying to backup the
root filesystem with the --one-file-system flag:

    % restic backup --one-file-system /
    (...)
    panic: item /, device id 2082 not found, allowedDevs: map[/:2082]

### Was the change discussed in an issue or in the forum before?

AFAICS it was introduced with the PR https://github.com/restic/restic/pull/1776
I've added a note to the issue https://github.com/restic/restic/issues/1775

### Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review

PTAL, I've only tested the '/' use case.