### PR TITLE
Add S3 file creds and reorder creds chain

### DIFF
--- a/changelog/unreleased/pull-1782
+++ b/changelog/unreleased/pull-1782
@@ -1,0 +1,7 @@
+Enhancement: Use default AWS credentials chain for S3 backend
+
+Adds support for file credentials to the S3 backend (e.g. ~/.aws/credentials),
+and reorders the credentials chain for the S3 backend to match AWS's standard,
+which is static credentials, env vars, credentials file, and finally remote.
+
+https://github.com/restic/restic/pull/1782

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -55,6 +55,8 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 				SecretAccessKey: cfg.Secret,
 			},
 		},
+		&credentials.FileAWSCredentials{},
+		&credentials.FileMinioClient{},
 		&credentials.IAM{
 			Client: &http.Client{
 				Transport: http.DefaultTransport,


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

1. Adds support for an AWS credentials file, which is part of the default AWS credentials chain.
2. Reorders the S3 backend's credentials chain to be standard (static -> env vars -> files -> remote)

Note that my main need is #1; I'd be open to deferring #2 if there's some specific reason why the standard order for the credentials chain shouldn't be used.

Also, there are currently no tests for the credentials chain, so please provide guidance if it's necessary to add something here.

### Was the change discussed in an issue or in the forum before?

No.

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
