### PR TITLE
list: Improve error message

### DIFF
--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -18,7 +18,7 @@ The "list" command allows listing objects in the repository based on type.
 `,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runList(globalOptions, args)
+		return runList(cmd, globalOptions, args)
 	},
 }
 
@@ -26,9 +26,9 @@ func init() {
 	cmdRoot.AddCommand(cmdList)
 }
 
-func runList(opts GlobalOptions, args []string) error {
+func runList(cmd *cobra.Command, opts GlobalOptions, args []string) error {
 	if len(args) != 1 {
-		return errors.Fatal("type not specified")
+		return errors.Fatal("type not specified, usage: " + cmd.Use)
 	}
 
 	repo, err := OpenRepository(opts)

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -86,7 +86,7 @@ func testRunList(t testing.TB, tpe string, opts GlobalOptions) restic.IDs {
 		globalOptions.stdout = os.Stdout
 	}()
 
-	rtest.OK(t, runList(opts, []string{tpe}))
+	rtest.OK(t, runList(cmdList, opts, []string{tpe}))
 	return parseIDsFromReader(t, buf)
 }
 


### PR DESCRIPTION
Before:

    $ restic list
    Fatal: type not specified

After:

    $ restic list
    Fatal: type not specified, usage: list [blobs|packs|index|snapshots|keys|locks]

Closes #1783