### PR TITLE
#1795 use unix.IoctlGetWinsize to get terminal size

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
   include:
     - os: linux
       go: "1.9.x"
-      env: RESTIC_TEST_FUSE=0 RESTIC_TEST_CLOUD_BACKENDS=0
+      env: RESTIC_TEST_FUSE=0 RESTIC_TEST_CLOUD_BACKENDS=0 RESTIC_BUILD_SOLARIS=0
 
     # only run fuse and cloud backends tests on Travis for the latest Go on Linux
     - os: linux

--- a/internal/ui/termstatus/terminal_unix.go
+++ b/internal/ui/termstatus/terminal_unix.go
@@ -4,8 +4,8 @@ package termstatus
 
 import (
 	"io"
-	"syscall"
-	"unsafe"
+
+	"golang.org/x/sys/unix"
 
 	isatty "github.com/mattn/go-isatty"
 )
@@ -30,10 +30,9 @@ func canUpdateStatus(fd uintptr) bool {
 // getTermSize returns the dimensions of the given terminal.
 // the code is taken from "golang.org/x/crypto/ssh/terminal"
 func getTermSize(fd uintptr) (width, height int, err error) {
-	var dimensions [4]uint16
-
-	if _, _, err := syscall.Syscall6(syscall.SYS_IOCTL, fd, uintptr(syscall.TIOCGWINSZ), uintptr(unsafe.Pointer(&dimensions)), 0, 0, 0); err != 0 {
+	ws, err := unix.IoctlGetWinsize(int(fd), unix.TIOCGWINSZ)
+	if err != nil {
 		return -1, -1, err
 	}
-	return int(dimensions[1]), int(dimensions[0]), nil
+	return int(ws.Col), int(ws.Row), nil
 }

--- a/run_integration_tests.go
+++ b/run_integration_tests.go
@@ -135,6 +135,7 @@ func (env *TravisEnvironment) Prepare() error {
 				"freebsd/386", "freebsd/amd64",
 				"openbsd/386", "openbsd/amd64",
 				"linux/arm", "freebsd/arm",
+				"solaris/amd64",
 			}
 		} else {
 			env.goxOSArch = []string{runtime.GOOS + "/" + runtime.GOARCH}

--- a/run_integration_tests.go
+++ b/run_integration_tests.go
@@ -135,7 +135,12 @@ func (env *TravisEnvironment) Prepare() error {
 				"freebsd/386", "freebsd/amd64",
 				"openbsd/386", "openbsd/amd64",
 				"linux/arm", "freebsd/arm",
-				"solaris/amd64",
+			}
+
+			if os.Getenv("RESTIC_BUILD_SOLARIS") == "0" {
+				msg("Skipping Solaris build\n")
+			} else {
+				env.goxOSArch = append(env.goxOSArch, "solaris/amd64")
 			}
 		} else {
 			env.goxOSArch = []string{runtime.GOOS + "/" + runtime.GOARCH}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

<!--
Describe the changes here, as detailed as needed.
-->

Use unix.IoctlGetWinsize to get the terminal size instead of syscall.SYS_IOCTL, which is not available on Solaris.
This fixes the build for Solaris/Illumos.

### Was the change discussed in an issue or in the forum before?

<!--
Link issues and relevant forum posts here.
-->
This solution was suggested in #1795 

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
