### PR TITLE
backup: Fix deadlock

### DIFF
--- a/internal/archiver/scanner.go
+++ b/internal/archiver/scanner.go
@@ -58,6 +58,9 @@ func (s *Scanner) Scan(ctx context.Context, targets []string) error {
 		}
 	}
 
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
 	s.Result("", stats)
 	return nil
 }
@@ -107,6 +110,9 @@ func (s *Scanner) scan(ctx context.Context, stats ScanStats, target string) (Sca
 		stats.Others++
 	}
 
+	if ctx.Err() != nil {
+		return stats, ctx.Err()
+	}
 	s.Result(target, stats)
 	return stats, nil
 }


### PR DESCRIPTION
When the archiver is faster than the scanner, restic deadlocks. This
commit adds a `finished` channel to the struct in `ui/backup.go` so that
scanner results are ignored when the archiver is already finished.

Closes #1834