### PR TITLE
cache: Ensure failed downloads are retried

### DIFF
--- a/changelog/unreleased/issue-1833
+++ b/changelog/unreleased/issue-1833
@@ -1,0 +1,9 @@
+Bugfix: Fix caching files on error
+
+During `check` it may happen that different threads access the same file in the
+backend, which is then downloaded into the cache only once. When that fails,
+only the thread which is responsible for downloading the file signals the
+correct error. The other threads just assume that the file has been downloaded
+successfully and then get an error when they try to access the cached file.
+
+https://github.com/restic/restic/issues/1833


### PR DESCRIPTION
This fixes #1833, which consists of two different bugs:

 * The `defer` in `cacheFile()` may remove a channel from the `inProgress` map although it is not responsible for downloading the file

 * If the download fails, goroutines waiting for the file to be cached assumed that the file was there, there was no way to signal the error.