### PR TITLE
Added documentation about what happens if you run out of space during a backup

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -299,3 +299,17 @@ information. Just specify the tags for a snapshot one by one with ``--tag``:
 The tags can later be used to keep (or forget) snapshots with the ``forget``
 command. The command ``tag`` can be used to modify tags on an existing
 snapshot.
+
+Space requirements
+******************
+
+Restic currently assumes that your backup repository has sufficient space
+for the backup operation you are about to perform. This is a realistic
+assumption for many cloud providers, but may not be true when backing up
+to local disks.
+
+Should you run out of space during the middle of a backup, there will be
+some additional data in the repository, but the snapshop will never be
+created as it only would be written at the very (successful) end of
+the backup operation.  Previous snapshots will still be there and will still
+work.

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -309,7 +309,7 @@ assumption for many cloud providers, but may not be true when backing up
 to local disks.
 
 Should you run out of space during the middle of a backup, there will be
-some additional data in the repository, but the snapshop will never be
-created as it only would be written at the very (successful) end of
+some additional data in the repository, but the snapshot will never be
+created as it would only be written at the very (successful) end of
 the backup operation.  Previous snapshots will still be there and will still
 work.


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Document what happens if the repository runs out space during the backup.

### Was the change discussed in an issue or in the forum before?

https://forum.restic.net/t/limited-backup-destination-space/733/6

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [n/a] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [n/a] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [n/a] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
