### PR TITLE
Documentation: minor RST syntax fixes

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -369,8 +369,7 @@ key file and the project ID as follows:
     $ export GOOGLE_PROJECT_ID=123123123123
     $ export GOOGLE_APPLICATION_CREDENTIALS=$HOME/.config/gs-secret-restic-key.json
 
-Restic uses  Google's client library to generate [default authentication
-material](https://developers.google.com/identity/protocols/application-default-credentials),
+Restic uses  Google's client library to generate `default authentication material`_,
 which means if you're running in Google Container Engine or are otherwise
 located on an instance with default service accounts then these should work out
 the box.
@@ -393,6 +392,7 @@ established.
 
 .. _service account: https://cloud.google.com/storage/docs/authentication#service_accounts
 .. _create a service account key: https://cloud.google.com/storage/docs/authentication#generating-a-private-key
+.. _default authentication material: https://developers.google.com/identity/protocols/application-default-credentials
 
 Other Services via rclone
 *************************

--- a/doc/100_references.rst
+++ b/doc/100_references.rst
@@ -625,9 +625,9 @@ are deleted, the particular snapshot vanished and all snapshots
 depending on data that has been added in the snapshot cannot be restored
 completely. Restic is not designed to detect this attack.
 
-******
+************
 Local Cache
-******
+***********
 
 In order to speed up certain operations, restic manages a local cache of data.
 This document describes the data structures for the local cache with version 1.


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

Fixes documentation generation.

1. Fix wrong RST syntax for link inside `030_preparing_a_new_repo.rst`
2. Avoid warning during compilation:
```
restic/doc/100_references.rst:628: WARNING: Title overline too short.

******
Local Cache
******
```

### Was the change discussed in an issue or in the forum before?

No, I was just reading the manual.

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR (not needed)
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)) (not needed, I guess)
- [x] I have run `gofmt` on the code in all commits (not needed)
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
