### PR TITLE
Support NetBSD without fuse

### DIFF
--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/cmd/restic/integration_fuse_test.go
+++ b/cmd/restic/integration_fuse_test.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -66,7 +66,7 @@ func isSymlink(fi os.FileInfo) bool {
 
 func sameModTime(fi1, fi2 os.FileInfo) bool {
 	switch runtime.GOOS {
-	case "darwin", "freebsd", "openbsd":
+	case "darwin", "freebsd", "openbsd", "netbsd":
 		if isSymlink(fi1) && isSymlink(fi2) {
 			return true
 		}

--- a/internal/fs/stat_bsd.go
+++ b/internal/fs/stat_bsd.go
@@ -1,4 +1,4 @@
-// +build freebsd darwin
+// +build freebsd darwin netbsd
 
 package fs
 

--- a/internal/fs/stat_unix.go
+++ b/internal/fs/stat_unix.go
@@ -1,4 +1,4 @@
-// +build !windows,!darwin,!freebsd
+// +build !windows,!darwin,!freebsd,!netbsd
 
 package fs
 

--- a/internal/fuse/blob_size_cache.go
+++ b/internal/fuse/blob_size_cache.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/internal/fuse/file_test.go
+++ b/internal/fuse/file_test.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/internal/fuse/link.go
+++ b/internal/fuse/link.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/internal/fuse/meta_dir.go
+++ b/internal/fuse/meta_dir.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/internal/fuse/other.go
+++ b/internal/fuse/other.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/internal/restic/node_netbsd.go
+++ b/internal/restic/node_netbsd.go
@@ -1,0 +1,27 @@
+package restic
+
+import "syscall"
+
+func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
+	return nil
+}
+
+func (s statUnix) atim() syscall.Timespec { return s.Atimespec }
+func (s statUnix) mtim() syscall.Timespec { return s.Mtimespec }
+func (s statUnix) ctim() syscall.Timespec { return s.Ctimespec }
+
+// Getxattr retrieves extended attribute data associated with path.
+func Getxattr(path, name string) ([]byte, error) {
+	return nil, nil
+}
+
+// Listxattr retrieves a list of names of extended attributes associated with the
+// given path in the file system.
+func Listxattr(path string) ([]string, error) {
+	return nil, nil
+}
+
+// Setxattr associates name and data together as an attribute of path.
+func Setxattr(path, name string, data []byte) error {
+	return nil
+}

--- a/internal/restic/node_test.go
+++ b/internal/restic/node_test.go
@@ -210,7 +210,7 @@ func TestNodeRestoreAt(t *testing.T) {
 				"%v: GID doesn't match (%v != %v)", test.Type, test.GID, n2.GID)
 			if test.Type != "symlink" {
 				// On OpenBSD only root can set sticky bit (see sticky(8)).
-				if runtime.GOOS != "openbsd" && test.Name == "testSticky" {
+				if runtime.GOOS != "openbsd" && runtime.GOOS != "netbsd" && test.Name == "testSticky" {
 					rtest.Assert(t, test.Mode == n2.Mode,
 						"%v: mode doesn't match (0%o != 0%o)", test.Type, test.Mode, n2.Mode)
 				}
@@ -228,7 +228,7 @@ func AssertFsTimeEqual(t *testing.T, label string, nodeType string, t1 time.Time
 	// Go currently doesn't support setting timestamps of symbolic links on darwin and bsd
 	if nodeType == "symlink" {
 		switch runtime.GOOS {
-		case "darwin", "freebsd", "openbsd":
+		case "darwin", "freebsd", "openbsd", "netbsd":
 			return
 		}
 	}

--- a/internal/restic/node_xattr.go
+++ b/internal/restic/node_xattr.go
@@ -1,3 +1,4 @@
+// +build !netbsd
 // +build !openbsd
 // +build !solaris
 // +build !windows

--- a/run_integration_tests.go
+++ b/run_integration_tests.go
@@ -134,6 +134,7 @@ func (env *TravisEnvironment) Prepare() error {
 				"darwin/386", "darwin/amd64",
 				"freebsd/386", "freebsd/amd64",
 				"openbsd/386", "openbsd/amd64",
+				"netbsd/386", "netbsd/amd64",
 				"linux/arm", "freebsd/arm",
 			}
 


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

To make `restic` built on NetBSD.

### Was the change discussed in an issue or in the forum before?

Closes #1847

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
