### PR TITLE
walker: Don't ignore empty trees by default

### DIFF
--- a/internal/walker/walker.go
+++ b/internal/walker/walker.go
@@ -63,6 +63,10 @@ func Walk(ctx context.Context, repo TreeLoader, root restic.ID, ignoreTrees rest
 func walk(ctx context.Context, repo TreeLoader, prefix string, tree *restic.Tree, ignoreTrees restic.IDSet, walkFn WalkFunc) (ignore bool, err error) {
 	var allNodesIgnored = true
 
+	if len(tree.Nodes) == 0 {
+		allNodesIgnored = false
+	}
+
 	sort.Slice(tree.Nodes, func(i, j int) bool {
 		return tree.Nodes[i].Name < tree.Nodes[j].Name
 	})

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -400,6 +400,62 @@ func TestWalker(t *testing.T) {
 				),
 			},
 		},
+		{
+			tree: TestTree{
+				"subdir1": TestTree{},
+				"subdir2": TestTree{},
+				"subdir3": TestTree{
+					"file": TestFile{},
+				},
+				"subdir4": TestTree{
+					"file": TestFile{},
+				},
+				"subdir5": TestTree{},
+				"subdir6": TestTree{},
+			},
+			checks: []checkFunc{
+				checkItemOrder([]string{
+					"/",
+					"/subdir1",
+					"/subdir2",
+					"/subdir3",
+					"/subdir3/file",
+					"/subdir4",
+					"/subdir4/file",
+					"/subdir5",
+					"/subdir6",
+				}),
+			},
+		},
+		{
+			tree: TestTree{
+				"subdir1": TestTree{},
+				"subdir2": TestTree{},
+				"subdir3": TestTree{
+					"file": TestFile{},
+				},
+				"subdir4": TestTree{},
+				"subdir5": TestTree{
+					"file": TestFile{},
+				},
+				"subdir6": TestTree{},
+			},
+			checks: []checkFunc{
+				checkIgnore(
+					map[string]struct{}{}, map[string]bool{
+						"/subdir2": true,
+					}, []string{
+						"/",
+						"/subdir1",
+						"/subdir2",
+						"/subdir3",
+						"/subdir3/file",
+						"/subdir5",
+						"/subdir5/file",
+					},
+				),
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Closes #1849


Don't ignore empty trees for `ls`


Closes #1849


- [x] I'm done, this Pull Request is ready for review