### PR TITLE
add JSON output support for restic key list cmd

### DIFF
--- a/changelog/unreleased/pull-1853
+++ b/changelog/unreleased/pull-1853
@@ -1,0 +1,6 @@
+Enhancement: Add JSON output support to `restic key list`
+
+This PR enables users to get the output of `restic key list` in JSON in addition
+to the existing table format.
+
+https://github.com/restic/restic/pull/1853


### PR DESCRIPTION
Signed-off-by: Steve Kriss <steve@heptio.com>

### What is the purpose of this change? What does it change?

This PR adds support for JSON output for the `restic key list` command, using the existing global `--json` flag. It outputs the same fields to JSON as are already output to a table.

### Was the change discussed in an issue or in the forum before?

No - minor addition.

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
