### PR TITLE
Allows saving files/dirs on different file systems together with `--one-file-system`.

### DIFF
--- a/changelog/unreleased/issue-1854
+++ b/changelog/unreleased/issue-1854
@@ -1,0 +1,16 @@
+Bugfix: Allow saving files/dirs on different fs with `--one-file-system`
+
+restic now allows saving files/dirs on a different file system in a subdir
+correctly even when `--one-file-system` is specified. 
+
+The first thing the restic archiver code does is to build a tree of the target
+files/directories. If it detects that a parent directory is already included
+(e.g. `restic backup /foo /foo/bar/baz`), it'll ignore the latter argument.
+
+Without `--one-file-system`, that's perfectly valid: If `/foo` is to be
+archived, it will include `/foo/bar/baz`. But with `--one-file-system`,
+`/foo/bar/baz` may reside on a different file system, so it won't be included
+with `/foo`.
+
+https://github.com/restic/restic/issues/1854
+https://github.com/restic/restic/pull/1855

--- a/internal/fs/fs_helpers.go
+++ b/internal/fs/fs_helpers.go
@@ -1,0 +1,45 @@
+package fs
+
+import "os"
+
+// ReadDir reads the directory named by dirname within fs and returns a list of
+// directory entries.
+func ReadDir(fs FS, dirname string) ([]os.FileInfo, error) {
+	f, err := fs.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := f.Readdir(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	err = f.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}
+
+// ReadDirNames reads the directory named by dirname within fs and returns a
+// list of entry names.
+func ReadDirNames(fs FS, dirname string) ([]string, error) {
+	f, err := fs.Open(dirname)
+	if err != nil {
+		return nil, err
+	}
+
+	entries, err := f.Readdirnames(-1)
+	if err != nil {
+		return nil, err
+	}
+
+	err = f.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	return entries, nil
+}


### PR DESCRIPTION
Unroll archive trees so that files/dirs on a different file system can be saved together with `--one-file-system`.

Closes #1854


- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review