### PR TITLE
Ignore ExcludeOtherFs if Stdin is true

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -190,7 +190,7 @@ func (opts BackupOptions) Check(gopts GlobalOptions, args []string) error {
 // from being saved in a snapshot
 func collectRejectFuncs(opts BackupOptions, repo *repository.Repository, targets []string) (fs []RejectFunc, err error) {
 	// allowed devices
-	if opts.ExcludeOtherFS {
+	if opts.ExcludeOtherFS && !opts.Stdin {
 		f, err := rejectByDevice(targets)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
Closes: #1807

### What is the purpose of this change? What does it change?

Ignore one-file-system flag if stdin is used, as described on the issue:
> --one-file-system, which used to be (and should be) a no-op with --stdin

Seems that there wasn't any test for the ExcludeOtherFs option, and as this is a one line patch I'm not sure if it's needed to add tests for that.

As this is a minor regression fix, I didn't added new documentation nor updated the changelog either.

### Was the change discussed in an issue or in the forum before?

Yes, issue #1807

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
