### PR TITLE
Allow excluding files with $ via --exclude-file

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -158,7 +158,9 @@ Patterns use `filepath.Glob <https://golang.org/pkg/path/filepath/#Glob>`__ inte
 see `filepath.Match <https://golang.org/pkg/path/filepath/#Match>`__ for
 syntax. Patterns are tested against the full path of a file/dir to be saved,
 even if restic is passed a relative path to save. Environment-variables in
-exclude-files are expanded with `os.ExpandEnv <https://golang.org/pkg/os/#ExpandEnv>`__.
+exclude-files are expanded with `os.ExpandEnv <https://golang.org/pkg/os/#ExpandEnv>`__,
+so `/home/$USER/foo` will be expanded to `/home/bob/foo` for the user `bob`. To
+get a literal dollar sign, write `$$` to the file.
 
 Patterns need to match on complete path components. For example, the pattern ``foo``:
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

Previously it wasn't possbile to exclude files with a literal dollar
sign (`$`) via exclude files, now users can write `$$` for that.


<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #1857

<!--
Link issues and relevant forum posts here.
-->