### PR TITLE
Fix find -i (case-insensitive search)

### DIFF
--- a/changelog/unreleased/pull-1861
+++ b/changelog/unreleased/pull-1861
@@ -1,0 +1,6 @@
+Bugfix: Fix case-insensitive search with restic find
+
+We've fixed the behavior for `restic find -i PATTERN`, which was
+broken in v0.9.1.
+
+https://github.com/restic/restic/pull/1861

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -198,12 +198,12 @@ func (f *Finder) findInSnapshot(ctx context.Context, sn *restic.Snapshot) error 
 			return false, nil
 		}
 
-		name := node.Name
+		normalizedNodepath := nodepath
 		if f.pat.ignoreCase {
-			name = strings.ToLower(name)
+			normalizedNodepath = strings.ToLower(nodepath)
 		}
 
-		foundMatch, err := filter.Match(f.pat.pattern, nodepath)
+		foundMatch, err := filter.Match(f.pat.pattern, normalizedNodepath)
 		if err != nil {
 			return false, err
 		}
@@ -213,7 +213,7 @@ func (f *Finder) findInSnapshot(ctx context.Context, sn *restic.Snapshot) error 
 			errIfNoMatch    error
 		)
 		if node.Type == "dir" {
-			childMayMatch, err := filter.ChildMatch(f.pat.pattern, nodepath)
+			childMayMatch, err := filter.ChildMatch(f.pat.pattern, normalizedNodepath)
 			if err != nil {
 				return false, err
 			}


### PR DESCRIPTION
### What is the purpose of this change? What does it change?

`restic find -i PATTERN` seems broken in tip, case-insensitive search does not work anymore.

### Was the change discussed in an issue or in the forum before?

Issue https://github.com/restic/restic/issues/1862

### Checklist

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
