### PR TITLE
WIP: Fill dir node info (fix #1863)

### DIFF
--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -397,6 +397,10 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 		fn.isTree = true
 		fn.tree, err = arch.SaveDir(ctx, snPath, fi, target, oldSubtree)
 		if err == nil {
+			fn.node, err = arch.nodeFromFileInfo(target, fi)
+			if err != nil {
+				return FutureNode{}, false, err
+			}
 			arch.CompleteItem(snItem, previous, fn.node, fn.stats, time.Since(start))
 		} else {
 			debug.Log("SaveDir for %v returned error: %v", snPath, err)


### PR DESCRIPTION
Closes: https://github.com/restic/restic/issues/1863

Seems that in the IsDir case, the node information was not filled (a nil was passed), concretely, Type parameter was not set to "dir", and because of that it was not counted on the final report. 

restic tests where executed without problems, but as I never touched restic internals before, I want try to test it a little bit more. 

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
