### PR TITLE
restore: Make sure the target directory exists

### DIFF
--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -197,6 +197,12 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 		}
 	}
 
+	// make sure the target directory exists
+	err = fs.MkdirAll(dst, 0777) // umask takes care of dir permissions
+	if err != nil {
+		return errors.Wrap(err, "MkdirAll")
+	}
+
 	idx := restic.NewHardlinkIndex()
 	return res.traverseTree(ctx, dst, string(filepath.Separator), *res.sn.Tree, treeVisitor{
 		enterDir: func(node *restic.Node, target, location string) error {

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -202,6 +202,16 @@ func TestRestorer(t *testing.T) {
 				"dir/file": "file in dir",
 			},
 		},
+		{
+			Snapshot: Snapshot{
+				Nodes: map[string]Node{
+					"topfile": File{"top-level file"},
+				},
+			},
+			Files: map[string]string{
+				"topfile": "top-level file",
+			},
+		},
 
 		// test cases with invalid/constructed names
 		{
@@ -272,6 +282,9 @@ func TestRestorer(t *testing.T) {
 
 			tempdir, cleanup := rtest.TempDir(t)
 			defer cleanup()
+
+			// make sure we're creating a new subdir of the tempdir
+			tempdir = filepath.Join(tempdir, "target")
 
 			res.SelectFilter = func(item, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
 				t.Logf("restore %v to %v", item, dstpath)


### PR DESCRIPTION


What is the purpose of this change? What does it change?
========================================================

Fixes restoring to a directory which does not yet exist, when only a
top-level file is to be restored.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
============================================================

https://github.com/restic/restic/pull/1719#issuecomment-405046865

<!--
Link issues and relevant forum posts here.
-->

Checklist
=========

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review