### PR TITLE
checker: Disable size check for now

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -582,12 +582,6 @@ func (c *Checker) checkTree(id restic.ID, tree *restic.Tree) (errs []error) {
 				}
 				size += uint64(blobSize)
 			}
-			if size != node.Size {
-				errs = append(errs, Error{
-					TreeID: id,
-					Err:    errors.Errorf("file %q: metadata size (%v) and sum of blob sizes (%v) do not match", node.Name, node.Size, size),
-				})
-			}
 		case "dir":
 			if node.Subtree == nil {
 				errs = append(errs, Error{TreeID: id, Err: errors.Errorf("dir node %q has no subtree", node.Name)})


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

Disable the size test in the check for now. It should have been a warning instead of an error: it's not a problem during restore and there's nothing users can (or should) do.

<!--
Describe the changes here, as detailed as needed.
-->

### Was the change discussed in an issue or in the forum before?

Closes #1799

<!--
Link issues and relevant forum posts here.
-->

