### PR TITLE
Expand Glob (wildcards character) in paths in file in --files-from

### DIFF
--- a/changelog/unreleased/pull-1891
+++ b/changelog/unreleased/pull-1891
@@ -1,6 +1,7 @@
-Enhancement: Accept glob in paths that are in file loaded with --file-from
+Enhancement: Accept glob in paths loaded via --files-from
 
-Before that, behaviour was different if paths were appended to command line or from a file, because wildcard characters were expanded by shell if appended to command line, but not expanded if loaded from file
+Before that, behaviour was different if paths were appended to command line or
+from a file, because wild card characters were expanded by shell if appended to
+command line, but not expanded if loaded from file.
+
 https://github.com/restic/restic/issues/1891
-
-

--- a/changelog/unreleased/pull-1891
+++ b/changelog/unreleased/pull-1891
@@ -1,0 +1,6 @@
+Enhancement: Accept glob in paths that are in file loaded with --file-from
+
+Before that, behaviour was different if paths were appended to command line or from a file, because wildcard characters were expanded by shell if appended to command line, but not expanded if loaded from file
+https://github.com/restic/restic/issues/1891
+
+

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -308,7 +309,7 @@ func collectTargets(opts BackupOptions, args []string) (targets []string, err er
 		var expanded []string
 		expanded, err := filepath.Glob(line)
 		if err != nil {
-			return nil, err
+			return nil, errors.WithMessage(err, fmt.Sprintf("pattern: %s", line))
 		}
 		lines = append(lines, expanded...)
 	}

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"io/ioutil"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -301,10 +302,21 @@ func collectTargets(opts BackupOptions, args []string) (targets []string, err er
 		return nil, err
 	}
 
+	// expand wildcards
+	var lines []string
+	for _, line := range fromfile {
+		var expanded []string
+		expanded, err := filepath.Glob(line)
+		if err != nil {
+			return nil, err
+		}
+		lines = append(lines, expanded...)
+	}
+
 	// merge files from files-from into normal args so we can reuse the normal
 	// args checks and have the ability to use both files-from and args at the
 	// same time
-	args = append(args, fromfile...)
+	args = append(args, lines...)
 	if len(args) == 0 && !opts.Stdin {
 		return nil, errors.Fatal("nothing to backup, please specify target files/dirs")
 	}

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -22,6 +22,10 @@ var Wrap = errors.Wrap
 // nil, Wrapf returns nil.
 var Wrapf = errors.Wrapf
 
+// WithMessage annotates err with a new message. If err is nil, WithMessage
+// returns nil.
+var WithMessage = errors.WithMessage
+
 // Cause returns the cause of an error. It will also unwrap certain errors,
 // e.g. *url.Error returned by the net/http client.
 func Cause(err error) error {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

Expand shell wildcard characters in paths that are in file specified in --files-from
<!--
Describe the changes here, as detailed as needed.
-->

### Was the change discussed in an issue or in the forum before?

Closes #1891
<!--
Link issues and relevant forum posts here.
-->

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] ~~I have added tests for all changes in this PR~~ not needed
- [x] ~~I have added documentation for the changes (in the manual)~~ not needed
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
