### PR TITLE
check: Use --cache-dir argument

### DIFF
--- a/changelog/unreleased/issue-1880
+++ b/changelog/unreleased/issue-1880
@@ -1,0 +1,7 @@
+Bugfix: Use `--cache-dir` argument for `check` command
+
+`check` command now uses a specific cache directory if set using the `--cache-dir` argument.
+
+The `--cache-dir` argument was not used by the `check` command, instead a cache directory was created in the temporary directory.
+
+https://github.com/restic/restic/issues/1880

--- a/changelog/unreleased/issue-1880
+++ b/changelog/unreleased/issue-1880
@@ -1,7 +1,12 @@
 Bugfix: Use `--cache-dir` argument for `check` command
 
-`check` command now uses a specific cache directory if set using the `--cache-dir` argument.
+`check` command now uses a temporary sub-directory of the specified directory
+if set using the `--cache-dir` argument. If not set, the cache directory is
+created in the default temporary directory as before.
+In either case a temporary cache is used to ensure the actual repository is
+checked (rather than a local copy).
 
-The `--cache-dir` argument was not used by the `check` command, instead a cache directory was created in the temporary directory.
+The `--cache-dir` argument was not used by the `check` command, instead a
+cache directory was created in the temporary directory.
 
 https://github.com/restic/restic/issues/1880

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -122,8 +122,8 @@ func newReadProgress(gopts GlobalOptions, todo restic.Stat) *restic.Progress {
 // prepareCheckCache configures a special cache directory for check.
 //
 //  * if --with-cache is specified, the default cache is used
-//  * if the user provides --cache-dir, the specified directory is used
 //  * if the user explicitly requested --no-cache, we don't use any cache
+//  * if the user provides --cache-dir, we use a cache in a temporary sub-directory of the specified directory and the sub-directory is deleted after the check
 //  * by default, we use a cache in a temporary directory that is deleted after the check
 func prepareCheckCache(opts CheckOptions, gopts *GlobalOptions) (cleanup func()) {
 	cleanup = func() {}
@@ -132,18 +132,15 @@ func prepareCheckCache(opts CheckOptions, gopts *GlobalOptions) (cleanup func())
 		return cleanup
 	}
 
-	if gopts.CacheDir != "" {
-		// use the specified cache directory, no setup needed
-		return cleanup
-	}
-
 	if gopts.NoCache {
 		// don't use any cache, no setup needed
 		return cleanup
 	}
 
+	cachedir := gopts.CacheDir
+
 	// use a cache in a temporary directory
-	tempdir, err := ioutil.TempDir("", "restic-check-cache-")
+	tempdir, err := ioutil.TempDir(cachedir, "restic-check-cache-")
 	if err != nil {
 		// if an error occurs, don't use any cache
 		Warnf("unable to create temporary directory for cache during check, disabling cache: %v\n", err)

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -122,12 +122,18 @@ func newReadProgress(gopts GlobalOptions, todo restic.Stat) *restic.Progress {
 // prepareCheckCache configures a special cache directory for check.
 //
 //  * if --with-cache is specified, the default cache is used
+//  * if the user provides --cache-dir, the specified directory is used
 //  * if the user explicitly requested --no-cache, we don't use any cache
 //  * by default, we use a cache in a temporary directory that is deleted after the check
 func prepareCheckCache(opts CheckOptions, gopts *GlobalOptions) (cleanup func()) {
 	cleanup = func() {}
 	if opts.WithCache {
 		// use the default cache, no setup needed
+		return cleanup
+	}
+
+	if gopts.CacheDir != "" {
+		// use the specified cache directory, no setup needed
 		return cleanup
 	}
 


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

`check` command now uses a specific cache directory if set using the `--cache-dir` argument.

<!--
Describe the changes here, as detailed as needed.
-->

### Was the change discussed in an issue or in the forum before?

Closes #1880

<!--
Link issues and relevant forum posts here.
-->

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
