### PR TITLE
restorer: Add test for restore with include filter

### DIFF
--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -91,7 +91,7 @@ func saveDir(t testing.TB, repo restic.Repository, nodes map[string]Node) restic
 	return id
 }
 
-func saveSnapshot(t testing.TB, repo restic.Repository, snapshot Snapshot) (restic.Repository, restic.ID) {
+func saveSnapshot(t testing.TB, repo restic.Repository, snapshot Snapshot) (*restic.Snapshot, restic.ID) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
@@ -118,7 +118,7 @@ func saveSnapshot(t testing.TB, repo restic.Repository, snapshot Snapshot) (rest
 		t.Fatal(err)
 	}
 
-	return repo, id
+	return sn, id
 }
 
 // toSlash converts the OS specific path dir to a slash-separated path.

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -1,4 +1,4 @@
-package restorer_test
+package restorer
 
 import (
 	"bytes"
@@ -13,7 +13,6 @@ import (
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
-	"github.com/restic/restic/internal/restorer"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -301,7 +300,7 @@ func TestRestorer(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := restorer.NewRestorer(repo, id)
+			res, err := NewRestorer(repo, id)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -422,7 +421,7 @@ func TestRestorerRelative(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := restorer.NewRestorer(repo, id)
+			res, err := NewRestorer(repo, id)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

### What is the purpose of this change? What does it change?

Resolve an error with the restore command when an include filter is used.
<!--
Describe the changes here, as detailed as needed.
-->

#### Background:

traverseTree() was meant to call enterDir() whenever a directory is selected for restore, either explicitly or implicitly (=contains a file which is to be restored). After restoring a file, leaveDir() is called in reverse order for all intermediate directories so that the metadata can be restored.

When a directory is selected implicitly, the metadata for it is restored. This is different from the previous restorer behavior, which created implicitly selected intermediate directories with permissions 0700 (only user can read/write it).

This PR changes the behavior back to the old one. Only a directory is explicitly selected for restore, enterDir()/leaveDir() are called for it. Otherwise, only visitNode() is called, so visitNode() needs to make sure the parent directory exists. If the directory is explicitly included, leaveDir() will then restore the metadata correctly.

When we decide to change the behavior (restore metadata for all intermediate directories, even if selected implicitly), we should do that in the selection functions, not here.

This finally resolves #1870

### Was the change discussed in an issue or in the forum before?

Closes #1870
<!--
Link issues and relevant forum posts here.
-->

### Checklist

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
