### PR TITLE
HTTP reporting for backup+restore, CLI reporting gor restore

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -51,6 +51,9 @@ type GlobalOptions struct {
 	CACerts       []string
 	TLSClientCert string
 	CleanupCache  bool
+	StatusURL     string
+	StatusTime    int
+	StatusToken   string
 
 	LimitUploadKb   int
 	LimitDownloadKb int
@@ -100,6 +103,9 @@ func init() {
 	f.IntVar(&globalOptions.LimitUploadKb, "limit-upload", 0, "limits uploads to a maximum rate in KiB/s. (default: unlimited)")
 	f.IntVar(&globalOptions.LimitDownloadKb, "limit-download", 0, "limits downloads to a maximum rate in KiB/s. (default: unlimited)")
 	f.StringSliceVarP(&globalOptions.Options, "option", "o", []string{}, "set extended option (`key=value`, can be specified multiple times)")
+	f.StringVar(&globalOptions.StatusURL, "send-status-url", "", "URL for status monitoring")
+	f.IntVar(&globalOptions.StatusTime, "send-status-time", 5, "delay for status monitoring")
+	f.StringVar(&globalOptions.StatusToken, "send-status-token", os.Getenv("RESTIC_SEND_STATUS_TOKEN"), "token for status monitoring (default: $RESTIC_SEND_STATUS_TOKEN)")
 
 	restoreTerminal()
 }

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -201,6 +201,8 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string, p *ui.Restore) e
 	}
 
 	idx := restic.NewHardlinkIndex()
+	p.HTTP.State = ui.HTTPScanningData
+	p.HTTP.SendUpdate()
 	var totalFiles uint
 	var totalBytes uint64
 	res.traverseTree(ctx, dst, string(filepath.Separator), *res.sn.Tree, treeVisitor{
@@ -219,6 +221,8 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string, p *ui.Restore) e
 		leaveDir: func(node *restic.Node, target, location string) error { return nil },
 	})
 	p.ReportTotal("", archiver.ScanStats{Files: totalFiles, Bytes: totalBytes})
+	p.HTTP.State = ui.HTTPDoingRestore
+	p.HTTP.SendUpdate()
 	return res.traverseTree(ctx, dst, string(filepath.Separator), *res.sn.Tree, treeVisitor{
 		enterDir: func(node *restic.Node, target, location string) error {
 			// create dir with default permissions

--- a/internal/ui/http.go
+++ b/internal/ui/http.go
@@ -1,0 +1,45 @@
+package ui
+
+import "time"
+
+const (
+	// HTTPNone is "none" (shouldn't occur)
+	HTTPNone = iota
+	// HTTPReadingIndex is "indexing"
+	HTTPReadingIndex
+	// HTTPScanningData is "scanning"
+	HTTPScanningData
+	// HTTPDoingBackup is "doing_backup"
+	HTTPDoingBackup
+	// HTTPDoingRestore is "doing_restore"
+	HTTPDoingRestore
+	// HTTPDone is "done"
+	HTTPDone
+)
+
+type httpMessage struct {
+	Token      string    `json:"token"`
+	Action     string    `json:"action"` // "backup" or "restore"
+	Status     string    `json:"status"`
+	Snapshot   string    `json:"snapshot"`
+	StartTime  time.Time `json:"start-time"`
+	Successful bool      `json:"successful"`
+	ErrorMsg   string    `json:"error_msg"`
+
+	SecsElapsed    int64  `json:"elapsed"`
+	FilesProcessed uint   `json:"files_processed"`
+	BytesProcessed uint64 `json:"bytes_processed"`
+	NumErrors      uint   `json:"errors"`
+
+	// The fields below are only valid during a backup.
+	ETA    uint64 `json:"eta"`
+	HasETA bool   `json:"has_eta"` // True if no ETA is available
+
+	// The fields below are only valid for status=done.
+	FilesNew        uint `json:"files_new"`
+	FilesChanged    uint `json:"files_changed"`
+	FilesUnmodified uint `json:"files_unmodified"`
+	DirsNew         uint `json:"dirs_new"`
+	DirsChanged     uint `json:"dirs_changed"`
+	DirsUnmodified  uint `json:"dirs_unmodified"`
+}

--- a/internal/ui/http_backup.go
+++ b/internal/ui/http_backup.go
@@ -1,0 +1,139 @@
+package ui
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/restic/restic/internal/archiver"
+)
+
+// HTTPBackup contains the state of the HTTP reporter for backup
+type HTTPBackup struct {
+	enabled   bool
+	State     int
+	b         *Backup
+	ScanStats archiver.ScanStats
+	startTime time.Time
+
+	url      string
+	interval int
+	token    string
+}
+
+func (h HTTPBackup) send(message httpMessage) {
+	if message.Status == "none" {
+		return
+	}
+	j, err := json.Marshal(message)
+	if err != nil {
+		panic(err)
+	}
+	_, err = http.Post(h.url, "text/json", bytes.NewReader(j))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (h HTTPBackup) newMessage() httpMessage {
+	msg := httpMessage{
+		Token:     h.token,
+		Action:    "backup",
+		StartTime: h.startTime,
+	}
+	switch h.State {
+	case HTTPNone:
+		msg.Status = "none" // Should never occur
+	case HTTPReadingIndex:
+		msg.Status = "indexing"
+	case HTTPScanningData:
+		msg.Status = "scanning"
+	case HTTPDoingBackup:
+		msg.Status = "doing_backup"
+	case HTTPDone:
+		msg.Status = "done"
+	default:
+		panic("Unexpected state " + strconv.Itoa(h.State))
+	}
+	msg.Successful = true
+	msg.ErrorMsg = ""
+	return msg
+}
+
+func (h HTTPBackup) Error(err error) {
+	if !h.enabled {
+		return
+	}
+	msg := h.newMessage()
+	msg.Successful = false
+	msg.ErrorMsg = err.Error()
+	h.send(msg)
+}
+
+// SendUpdate sends a message with the current statistics.
+func (h HTTPBackup) SendUpdate() {
+	if !h.enabled {
+		return
+	}
+	msg := h.newMessage()
+	msg.SecsElapsed = int64(time.Since(h.b.start).Seconds())
+	if h.State == HTTPScanningData {
+		msg.FilesProcessed = h.ScanStats.Files
+		msg.BytesProcessed = h.ScanStats.Bytes
+	} else {
+		msg.FilesProcessed = h.b.processed.Files
+		msg.BytesProcessed = h.b.processed.Bytes
+	}
+	msg.NumErrors = h.b.errors
+	if (h.b.total.Files != 0 || h.b.total.Dirs != 0) && h.b.eta > 0 && h.b.processed.Bytes < h.b.total.Bytes {
+		msg.HasETA = true
+		msg.ETA = h.b.eta
+	}
+	h.send(msg)
+}
+
+// SendDone reports completion, sending a message with the final statistics.
+func (h *HTTPBackup) SendDone(snapshot string) {
+	if !h.enabled {
+		return
+	}
+	h.State = HTTPDone
+	msg := h.newMessage()
+	h.State = HTTPNone
+	msg.Snapshot = snapshot
+	msg.FilesNew = h.b.summary.Files.New
+	msg.FilesChanged = h.b.summary.Files.Changed
+	msg.FilesUnmodified = h.b.summary.Files.Unchanged
+	msg.DirsNew = h.b.summary.Dirs.New
+	msg.DirsChanged = h.b.summary.Dirs.Changed
+	msg.DirsUnmodified = h.b.summary.Dirs.Unchanged
+	msg.SecsElapsed = int64(time.Since(h.b.start).Seconds())
+	msg.FilesProcessed = h.b.processed.Files
+	msg.BytesProcessed = h.b.processed.Bytes
+	msg.NumErrors = h.b.errors
+	h.send(msg)
+}
+
+// NewHTTPBackup creates an HTTP reporter for backup
+func NewHTTPBackup(b *Backup, url string, interval int, token string) *HTTPBackup {
+	if url == "" {
+		return &HTTPBackup{}
+	}
+	ticker := time.NewTicker(time.Duration(interval * int(time.Second)))
+	instance := HTTPBackup{
+		enabled:   true,
+		url:       url,
+		interval:  interval,
+		token:     token,
+		b:         b,
+		startTime: time.Now(),
+	}
+	go func() {
+		for range ticker.C {
+			instance.SendUpdate()
+		}
+	}()
+	return &instance
+}

--- a/internal/ui/http_restore.go
+++ b/internal/ui/http_restore.go
@@ -1,0 +1,142 @@
+package ui
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/restic/restic/internal/archiver"
+)
+
+// HTTPRestore contains the state of the HTTP reporter for restoration
+type HTTPRestore struct {
+	enabled   bool
+	State     int
+	r         *Restore
+	ScanStats archiver.ScanStats
+	Snapshot  string
+	startTime time.Time
+
+	url      string
+	interval int
+	token    string
+}
+
+func (h HTTPRestore) send(message httpMessage) {
+	if message.Status == "none" {
+		return
+	}
+	j, err := json.Marshal(message)
+	if err != nil {
+		panic(err)
+	}
+	_, err = http.Post(h.url, "text/json", bytes.NewReader(j))
+	if err != nil {
+		panic(err)
+	}
+}
+
+func (h HTTPRestore) newMessage() httpMessage {
+	msg := httpMessage{
+		Token:     h.token,
+		Action:    "restore",
+		StartTime: h.startTime,
+		Snapshot:  h.Snapshot,
+	}
+	switch h.State {
+	case HTTPNone:
+		msg.Status = "none" // Should never occur
+	case HTTPReadingIndex:
+		msg.Status = "indexing"
+	case HTTPScanningData:
+		msg.Status = "scanning"
+	case HTTPDoingRestore:
+		msg.Status = "doing_restore"
+	case HTTPDone:
+		msg.Status = "done"
+	default:
+		panic("Unexpected state " + strconv.Itoa(h.State))
+	}
+	msg.Successful = true
+	msg.ErrorMsg = ""
+	return msg
+}
+
+func (h HTTPRestore) Error(err error) {
+	if !h.enabled {
+		return
+	}
+	msg := h.newMessage()
+	msg.Successful = false
+	msg.ErrorMsg = err.Error()
+	h.send(msg)
+}
+
+// SendUpdate sends a message with the current statistics.
+func (h HTTPRestore) SendUpdate() {
+	if !h.enabled {
+		return
+	}
+	msg := h.newMessage()
+	msg.SecsElapsed = int64(time.Since(h.r.start).Seconds())
+	if h.State == HTTPScanningData {
+		msg.FilesProcessed = h.ScanStats.Files
+		msg.BytesProcessed = h.ScanStats.Bytes
+	} else {
+		msg.FilesProcessed = h.r.processed.Files
+		msg.BytesProcessed = h.r.processed.Bytes
+	}
+	msg.NumErrors = h.r.errors
+	if (h.r.total.Files != 0 || h.r.total.Dirs != 0) && h.r.eta > 0 && h.r.processed.Bytes < h.r.total.Bytes {
+		msg.HasETA = true
+		msg.ETA = h.r.eta
+	}
+	h.send(msg)
+}
+
+// SendDone reports completion, sending a message with the final statistics.
+func (h *HTTPRestore) SendDone() {
+	if !h.enabled {
+		return
+	}
+	h.State = HTTPDone
+	msg := h.newMessage()
+	h.State = HTTPNone
+	msg.FilesNew = h.r.summary.Files.New
+	msg.FilesChanged = h.r.summary.Files.Changed
+	msg.FilesUnmodified = h.r.summary.Files.Unchanged
+	/*
+		msg.DirsNew = h.r.summary.Dirs.New
+		msg.DirsChanged = h.r.summary.Dirs.Changed
+		msg.DirsUnmodified = h.r.summary.Dirs.Unchanged
+	*/
+	msg.SecsElapsed = int64(time.Since(h.r.start).Seconds())
+	msg.FilesProcessed = h.r.processed.Files
+	msg.BytesProcessed = h.r.processed.Bytes
+	msg.NumErrors = h.r.errors
+	h.send(msg)
+}
+
+// NewHTTPRestore creates an HTTP reporter for restoring
+func NewHTTPRestore(r *Restore, url string, interval int, token string) *HTTPRestore {
+	if url == "" {
+		return &HTTPRestore{}
+	}
+	ticker := time.NewTicker(time.Duration(interval * int(time.Second)))
+	instance := HTTPRestore{
+		enabled:   true,
+		url:       url,
+		interval:  interval,
+		token:     token,
+		r:         r,
+		startTime: time.Now(),
+	}
+	go func() {
+		for range ticker.C {
+			instance.SendUpdate()
+		}
+	}()
+	return &instance
+}

--- a/internal/ui/restore.go
+++ b/internal/ui/restore.go
@@ -1,0 +1,312 @@
+package ui
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"time"
+
+	"github.com/restic/restic/internal/archiver"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/ui/termstatus"
+	"sync"
+)
+
+// Restore reports progress for the `restore` command.
+type Restore struct {
+	*Message
+	*StdioWrapper
+
+	MinUpdatePause time.Duration
+
+	term  *termstatus.Terminal
+	v     uint
+	start time.Time
+
+	totalBytes uint64
+
+	totalCh     chan counter
+	processedCh chan counter
+	errCh       chan struct{}
+	workerCh    chan fileWorkerMessage
+	finished    chan struct{}
+
+	total, processed counter
+	errors           uint
+	eta              uint64
+
+	summary struct {
+		sync.Mutex
+		Files, Dirs struct {
+			New       uint
+			Changed   uint
+			Unchanged uint
+		}
+		archiver.ItemStats
+	}
+}
+
+// NewRestore returns a new restoration progress reporter.
+func NewRestore(term *termstatus.Terminal, verbosity uint) *Restore {
+	ret := &Restore{
+		Message:      NewMessage(term, verbosity),
+		StdioWrapper: NewStdioWrapper(term),
+		term:         term,
+		v:            verbosity,
+		start:        time.Now(),
+
+		// limit to 60fps by default
+		MinUpdatePause: time.Second / 60,
+
+		totalCh:     make(chan counter),
+		processedCh: make(chan counter),
+		errCh:       make(chan struct{}),
+		workerCh:    make(chan fileWorkerMessage),
+		finished:    make(chan struct{}),
+	}
+	return ret
+}
+
+// Run regularly updates the status lines. It should be called in a separate
+// goroutine.
+func (b *Restore) Run(ctx context.Context) error {
+	var (
+		lastUpdate   time.Time
+		started      bool
+		currentFiles = make(map[string]struct{})
+	)
+
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-b.finished:
+			started = false
+			b.term.SetStatus([]string{""})
+		case t, ok := <-b.totalCh:
+			if ok {
+				b.total = t
+				started = true
+			} else {
+				// scan has finished
+				b.totalCh = nil
+				b.totalBytes = b.total.Bytes
+			}
+		case s := <-b.processedCh:
+			b.processed.Files += s.Files
+			b.processed.Dirs += s.Dirs
+			b.processed.Bytes += s.Bytes
+			started = true
+		case <-b.errCh:
+			b.errors++
+			started = true
+		case m := <-b.workerCh:
+			if m.done {
+				delete(currentFiles, m.filename)
+			} else {
+				currentFiles[m.filename] = struct{}{}
+			}
+		case <-t.C:
+			if !started {
+				continue
+			}
+
+			if b.totalCh == nil {
+				secs := float64(time.Since(b.start) / time.Second)
+				todo := float64(b.total.Bytes - b.processed.Bytes)
+				b.eta = uint64(secs / float64(b.processed.Bytes) * todo)
+			}
+		}
+
+		// limit update frequency
+		if time.Since(lastUpdate) < b.MinUpdatePause {
+			continue
+		}
+		lastUpdate = time.Now()
+
+		b.update(currentFiles)
+	}
+}
+
+// update updates the status lines.
+func (b *Restore) update(currentFiles map[string]struct{}) {
+	var status string
+	if b.total.Files == 0 && b.total.Dirs == 0 {
+		// no total count available yet
+		status = fmt.Sprintf("[%s] %v files, %s, %d errors",
+			formatDuration(time.Since(b.start)),
+			b.processed.Files, formatBytes(b.processed.Bytes), b.errors,
+		)
+	} else {
+		var eta, percent string
+
+		if b.eta > 0 {
+			eta = fmt.Sprintf(" ETA %s", formatSeconds(b.eta))
+		}
+		if b.processed.Bytes < b.total.Bytes {
+			percent = formatPercent(b.processed.Bytes, b.total.Bytes)
+			percent += "  "
+		}
+
+		// include totals
+		status = fmt.Sprintf("[%s] %s%v files %s, total %v files %v, %d errors%s",
+			formatDuration(time.Since(b.start)),
+			percent,
+			b.processed.Files,
+			formatBytes(b.processed.Bytes),
+			b.total.Files,
+			formatBytes(b.total.Bytes),
+			b.errors,
+			eta,
+		)
+	}
+
+	lines := make([]string, 0, len(currentFiles)+1)
+	for filename := range currentFiles {
+		lines = append(lines, filename)
+	}
+	sort.Sort(sort.StringSlice(lines))
+	lines = append([]string{status}, lines...)
+
+	b.term.SetStatus(lines)
+}
+
+// ScannerError is the error callback function for the scanner, it prints the
+// error in verbose mode and returns nil.
+func (b *Restore) ScannerError(item string, fi os.FileInfo, err error) error {
+	b.V("scan: %v\n", err)
+	return nil
+}
+
+// Error is the error callback function for the archiver, it prints the error and returns nil.
+func (b *Restore) Error(msg string, args ...interface{}) error {
+	b.E(msg, args...)
+	b.errCh <- struct{}{}
+	return nil
+}
+
+// StartFile is called when a file is being processed by a worker.
+func (b *Restore) StartFile(filename string) {
+	b.workerCh <- fileWorkerMessage{
+		filename: filename,
+	}
+}
+
+// CompleteBlob is called for all saved blobs for files.
+func (b *Restore) CompleteBlob(filename string, bytes uint64) {
+	b.processedCh <- counter{Bytes: bytes}
+}
+
+// CompleteItemFn is the status callback function for the archiver when a
+// file/dir has been saved successfully.
+func (b *Restore) CompleteItemFn(item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration) {
+	b.summary.Lock()
+	b.summary.ItemStats.Add(s)
+	b.summary.Unlock()
+
+	if current == nil {
+		// error occurred, tell the status display to remove the line
+		b.workerCh <- fileWorkerMessage{
+			filename: item,
+			done:     true,
+		}
+		return
+	}
+
+	switch current.Type {
+	case "file":
+		b.processedCh <- counter{Files: 1}
+		b.workerCh <- fileWorkerMessage{
+			filename: item,
+			done:     true,
+		}
+	case "dir":
+		b.processedCh <- counter{Dirs: 1}
+	}
+
+	if current.Type == "dir" {
+		if previous == nil {
+			b.VV("new       %v, saved in %.3fs (%v added, %v metadata)", item, d.Seconds(), formatBytes(s.DataSize), formatBytes(s.TreeSize))
+			b.summary.Lock()
+			b.summary.Dirs.New++
+			b.summary.Unlock()
+			return
+		}
+
+		if previous.Equals(*current) {
+			b.VV("unchanged %v", item)
+			b.summary.Lock()
+			b.summary.Dirs.Unchanged++
+			b.summary.Unlock()
+		} else {
+			b.VV("modified  %v, saved in %.3fs (%v added, %v metadata)", item, d.Seconds(), formatBytes(s.DataSize), formatBytes(s.TreeSize))
+			b.summary.Lock()
+			b.summary.Dirs.Changed++
+			b.summary.Unlock()
+		}
+
+	} else if current.Type == "file" {
+
+		b.workerCh <- fileWorkerMessage{
+			done:     true,
+			filename: item,
+		}
+
+		if previous == nil {
+			b.VV("new       %v, saved in %.3fs (%v added)", item, d.Seconds(), formatBytes(s.DataSize))
+			b.summary.Lock()
+			b.summary.Files.New++
+			b.summary.Unlock()
+			return
+		}
+
+		if previous.Equals(*current) {
+			b.VV("unchanged %v", item)
+			b.summary.Lock()
+			b.summary.Files.Unchanged++
+			b.summary.Unlock()
+		} else {
+			b.VV("modified  %v, saved in %.3fs (%v added)", item, d.Seconds(), formatBytes(s.DataSize))
+			b.summary.Lock()
+			b.summary.Files.Changed++
+			b.summary.Unlock()
+		}
+	}
+}
+
+// ReportTotal sets the total stats up to now
+func (b *Restore) ReportTotal(item string, s archiver.ScanStats) {
+	b.totalCh <- counter{Files: s.Files, Dirs: s.Dirs, Bytes: s.Bytes}
+
+	if item == "" {
+		b.V("scan finished in %.3fs: %v files, %s",
+			time.Since(b.start).Seconds(),
+			s.Files, formatBytes(s.Bytes),
+		)
+		close(b.totalCh)
+		return
+	}
+}
+
+// Finish prints the finishing messages.
+func (b *Restore) Finish() {
+	close(b.finished)
+
+	b.P("\n")
+	b.P("Files:       %5d new, %5d changed, %5d unmodified\n", b.summary.Files.New, b.summary.Files.Changed, b.summary.Files.Unchanged)
+	// r.P("Dirs:        %5d new, %5d changed, %5d unmodified\n", r.summary.Dirs.New, r.summary.Dirs.Changed, r.summary.Dirs.Unchanged)
+	b.V("Data Blobs:  %5d new\n", b.summary.ItemStats.DataBlobs)
+	b.V("Tree Blobs:  %5d new\n", b.summary.ItemStats.TreeBlobs)
+	b.P("Added:      %-5s\n", formatBytes(b.summary.ItemStats.DataSize+b.summary.ItemStats.TreeSize))
+	b.P("Errors:      %5d\n", b.errors)
+	b.P("\n")
+	b.P("processed %v files, %v in %s",
+		b.summary.Files.New+b.summary.Files.Changed+b.summary.Files.Unchanged,
+		formatBytes(b.totalBytes),
+		formatDuration(time.Since(b.start)),
+	)
+}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

During backups and restores, Restic will send progress data (how many files processed, how many bytes, how many folders unchanged, etc.) to an external HTTP server every few seconds. It also implements CLI reporting for restores, in a fashion similar to backups. 

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Yes: https://forum.restic.net/t/new-feature-http-reporting-for-backup-restore-cli-reporting-for-restore/824

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review

The development of this feature was sponsored by [InAsset](http://www.inasset.it/en/).