### PR TITLE
Adds warning re performance of prune

### DIFF
--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -23,6 +23,13 @@ data that was referenced by the snapshot from the repository. This can
 be automated with the ``--prune`` option of the ``forget`` command,
 which runs ``prune`` automatically if snapshots have been removed.
 
+.. Warning::
+
+   Pruning snapshots can be a very time-consuming process, taking nearly
+   as long as backups themselves. During a prune operation, the index is
+   locked and backups cannot be completed. Performance improvements are 
+   planned for this feature.
+
 It is advisable to run ``restic check`` after pruning, to make sure
 you are alerted, should the internal data structures of the repository
 be damaged.


### PR DESCRIPTION
I went pretty loud with this, but I think the performance is bad enough that it's really worth highlighting, especially since it locks the index during the prune.



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

Adds warning re prune performance

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Forum, here:  https://forum.restic.net/t/pruning-multiple-snapshots-simultaneously-fasters/837/2

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
