### PR TITLE
Clarify B2 Application Keys once again

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -301,12 +301,7 @@ dashboard in on the "Buckets" page when signed into your B2 account:
     $ export B2_ACCOUNT_ID=<MY_ACCOUNT_ID>
     $ export B2_ACCOUNT_KEY=<MY_SECRET_ACCOUNT_KEY>
 
-You can either specify the so-called "Master Application Key" here (which can
-access any bucket at any path) or a dedicated "Application Key" created just
-for restic (which may be restricted to a specific bucket and/or path). The
-master key consists of a ``B2_ACCOUNT_ID`` and a ``B2_ACCOUNT_KEY``, and each
-application key also is a pair of ``B2_ACCOUNT_ID`` and ``B2_ACCOUNT_KEY``. The
-ID of an application key is much longer than the ID of the master key.
+.. note:: In case you want to use Backblaze Application Keys replace <MY_ACCOUNT_ID> and <MY_SECRET_ACCOUNT_KEY> with <applicationKeyId> and <applicationKey> respectively.
 
 You can then initialize a repository stored at Backblaze B2. If the
 bucket does not exist yet and the credentials you passed to restic have the


### PR DESCRIPTION
This is my view of documentation about Application Keys in Backblaze B2.


What is the purpose of this change? What does it change?
--------------------------------------------------------

Changes documentation about Backblaze's new feature implemented in #1914 as there was some misunderstanding about the new functionality.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
#1923 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
