### PR TITLE
cmd: restic: clean up sort.SliceStable usage 

### DIFF
--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -106,9 +106,7 @@ func newFilterLastSnapshotsKey(sn *restic.Snapshot) filterLastSnapshotsKey {
 // they will be joined and treated as one item.
 func FilterLastSnapshots(list restic.Snapshots) restic.Snapshots {
 	// Sort the snapshots so that the newer ones are listed first
-	sort.SliceStable(list, func(i, j int) bool {
-		return list[i].Time.After(list[j].Time)
-	})
+	sort.Stable(list)
 
 	var results restic.Snapshots
 	seen := make(map[filterLastSnapshotsKey]bool)
@@ -124,11 +122,8 @@ func FilterLastSnapshots(list restic.Snapshots) restic.Snapshots {
 
 // PrintSnapshots prints a text table of the snapshots in list to stdout.
 func PrintSnapshots(stdout io.Writer, list restic.Snapshots, compact bool) {
-
-	// always sort the snapshots so that the newer ones are listed last
-	sort.SliceStable(list, func(i, j int) bool {
-		return list[i].Time.Before(list[j].Time)
-	})
+	// Sort the snapshots so that the newer ones are listed last
+	sort.Stable(sort.Reverse(list))
 
 	// Determine the max widths for host and tag.
 	maxHost, maxTag := 10, 6


### PR DESCRIPTION
The older API is still available in the Go stdlib (and will remain there
forever, thanks to Go's backwards compatibility guarantees). By
switching back to the pre-1.8 API this allows restic to be built on
older distributions that don't have a newer Go compiler (though it turns
out some of our vendors use the newer API, this is something
distributions can patch out themselves).

It also (in my opinion) makes the code much more readable (since
time.Time implements sort.Interface, there's no need to explicitly
implement it using .After and .Before). We've been carrying this patch
in openSUSE for a couple of releases and nobody seems to have noticed an
issue with it.

Signed-off-by: Aleksa Sarai <cyphar@cyphar.com>

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
