### PR TITLE
stats: Improve error message for bad snapshot ID (fixes #1933)

### DIFF
--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -100,13 +100,13 @@ func runStats(gopts GlobalOptions, args []string) error {
 		} else {
 			sID, err = restic.FindSnapshot(repo, snapshotIDString)
 			if err != nil {
-				return err
+				Exitf(1, "error loading snapshot: %v", err)
 			}
 		}
 
 		snapshot, err := restic.LoadSnapshot(ctx, repo, sID)
 		if err != nil {
-			return err
+			Exitf(1, "error loading snapshot from repo: %v", err)
 		}
 
 		err = statsWalkSnapshot(ctx, snapshot, repo, stats)

--- a/internal/restic/backend_find.go
+++ b/internal/restic/backend_find.go
@@ -8,7 +8,7 @@ import (
 
 // ErrNoIDPrefixFound is returned by Find() when no ID for the given prefix
 // could be found.
-var ErrNoIDPrefixFound = errors.New("no ID found")
+var ErrNoIDPrefixFound = errors.New("no matching ID found")
 
 // ErrMultipleIDMatches is returned by Find() when multiple IDs with the given
 // prefix are found.


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Improves the error handling when `restic stats` is given a bad snapshot ID.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

#1933

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review


Not sure if you really need the changelog file for a minor text change -- let me know if that's the case.