### PR TITLE
ls: Implement directory filter, optionally subfolders

### DIFF
--- a/changelog/unreleased/1941
+++ b/changelog/unreleased/1941
@@ -1,0 +1,15 @@
+Enhancement: Add directory filter to ls command
+
+The ls command can now be filtered by directories, so that only files in the
+given directories will be shown. If the --recursive flag is specified, then
+ls will traverse subfolders and list their files as well.
+
+It used to be possible to specify multiple snapshots, but that has been
+replaced by only one snapshot and the possibility of specifying multiple
+directories.
+
+Specifying directories constrains the walk, which can significantly speed up
+the listing.
+
+https://github.com/restic/restic/issues/1940
+https://github.com/restic/restic/pull/1941

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -125,7 +125,15 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 					}
 				}
 				if !walk {
-					return false, walker.SkipNode
+					if node.Type == "dir" {
+						// signal Walk() that it should not descend into the tree.
+						return false, walker.SkipNode
+					}
+
+					// we must not return SkipNode for non-dir nodes because
+					// then the remaining nodes in the same tree would be
+					// skipped, so return nil instead
+					return false, nil
 				}
 
 				// this second iteration ensures that we get an exact match

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -106,7 +106,7 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 				// are not in matching trees or will not lead us to matching trees
 				var walk bool
 				for _, dir := range dirs {
-					approachingMatchingTree := fs.HasPathPrefix(nodeDir, dir)
+					approachingMatchingTree := fs.HasPathPrefix(nodepath, dir)
 					inMatchingTree := fs.HasPathPrefix(dir, nodepath)
 
 					// this condition is complex, but it basically requires that we

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -106,7 +106,17 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 				// are not in matching trees or will not lead us to matching trees
 				var walk bool
 				for _, dir := range dirs {
+
+					// the current node path is a prefix for one of the
+					// directories, so we're interested in something deeper in the
+					// tree. Example:
+					//   nodepath: "/test"
+					//   dir:      "/test/foo"
 					approachingMatchingTree := fs.HasPathPrefix(nodepath, dir)
+
+					// we're within one of the selected dirs, example:
+					//   nodepath: "/test/foo"
+					//   dir:      "/test"
 					inMatchingTree := fs.HasPathPrefix(dir, nodepath)
 
 					// this condition is complex, but it basically requires that we

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -11,7 +13,7 @@ import (
 )
 
 var cmdLs = &cobra.Command{
-	Use:   "ls [flags] [snapshot-ID ...]",
+	Use:   "ls [flags] [snapshot-ID] [dir...]",
 	Short: "List files in a snapshot",
 	Long: `
 The "ls" command allows listing files and directories in a snapshot.
@@ -26,10 +28,11 @@ The special snapshot-ID "latest" can be used to list files and directories of th
 
 // LsOptions collects all options for the ls command.
 type LsOptions struct {
-	ListLong bool
-	Host     string
-	Tags     restic.TagLists
-	Paths    []string
+	ListLong  bool
+	Host      string
+	Tags      restic.TagLists
+	Paths     []string
+	Recursive bool
 }
 
 var lsOptions LsOptions
@@ -43,6 +46,7 @@ func init() {
 	flags.StringVarP(&lsOptions.Host, "host", "H", "", "only consider snapshots for this `host`, when no snapshot ID is given")
 	flags.Var(&lsOptions.Tags, "tag", "only consider snapshots which include this `taglist`, when no snapshot ID is given")
 	flags.StringArrayVar(&lsOptions.Paths, "path", nil, "only consider snapshots which include this (absolute) `path`, when no snapshot ID is given")
+	flags.BoolVar(&lsOptions.Recursive, "recursive", false, "include files in subfolders of the listed directories")
 }
 
 func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
@@ -59,19 +63,48 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 		return err
 	}
 
+	// extract any specific directories to walk
+	dirs := args[1:]
+
 	ctx, cancel := context.WithCancel(gopts.ctx)
 	defer cancel()
-	for sn := range FindFilteredSnapshots(ctx, repo, opts.Host, opts.Tags, opts.Paths, args) {
+	for sn := range FindFilteredSnapshots(ctx, repo, opts.Host, opts.Tags, opts.Paths, args[:1]) {
 		Verbosef("snapshot %s of %v at %s):\n", sn.ID().Str(), sn.Paths, sn.Time)
 
 		err := walker.Walk(ctx, repo, *sn.Tree, nil, func(nodepath string, node *restic.Node, err error) (bool, error) {
 			if err != nil {
 				return false, err
 			}
-
 			if node == nil {
 				return false, nil
 			}
+
+			// apply any directory filters
+			if len(dirs) > 0 {
+				var nodeDir string
+				if !opts.Recursive {
+					// only needed for exact directory match; i.e. no subfolders
+					nodeDir = filepath.Dir(nodepath)
+				}
+				var match bool
+				for _, dir := range dirs {
+					if opts.Recursive {
+						if strings.HasPrefix(nodepath, dir) {
+							match = true
+							break
+						}
+					} else {
+						if nodeDir == dir {
+							match = true
+							break
+						}
+					}
+				}
+				if !match {
+					return true, nil
+				}
+			}
+
 			Printf("%s\n", formatNode(nodepath, node, lsOptions.ListLong))
 			return false, nil
 		})

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -65,15 +65,6 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 		return errors.Fatal("Invalid arguments, either give one or more snapshot IDs or set filters.")
 	}
 
-	repo, err := OpenRepository(gopts)
-	if err != nil {
-		return err
-	}
-
-	if err = repo.LoadIndex(gopts.ctx); err != nil {
-		return err
-	}
-
 	// extract any specific directories to walk
 	var dirs []string
 	if len(args) > 1 {
@@ -83,6 +74,15 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 				return errors.Fatal("All path filters must be absolute, starting with a forward slash '/'")
 			}
 		}
+	}
+
+	repo, err := OpenRepository(gopts)
+	if err != nil {
+		return err
+	}
+
+	if err = repo.LoadIndex(gopts.ctx); err != nil {
+		return err
 	}
 
 	ctx, cancel := context.WithCancel(gopts.ctx)

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -100,11 +100,13 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 
 			// apply any directory filters
 			if len(dirs) > 0 {
+				nodeDir := path.Dir(nodepath)
+
 				// this first iteration ensures we do not traverse branches that
 				// are not in matching trees or will not lead us to matching trees
 				var walk bool
 				for _, dir := range dirs {
-					approachingMatchingTree := fs.HasPathPrefix(nodepath, dir)
+					approachingMatchingTree := fs.HasPathPrefix(nodeDir, dir)
 					inMatchingTree := fs.HasPathPrefix(dir, nodepath)
 
 					// this condition is complex, but it basically requires that we
@@ -117,7 +119,7 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 					// to traverse subtrees that are too deep and won't match -- this
 					// extra check allows us to return SkipNode if we've gone TOO deep,
 					// which skips all its subfolders)
-					if approachingMatchingTree || opts.Recursive || (inMatchingTree && dir == path.Dir(nodepath)) {
+					if approachingMatchingTree || opts.Recursive || (inMatchingTree && dir == nodeDir) {
 						walk = true
 						break
 					}
@@ -143,7 +145,7 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 						match = true
 						break
 					}
-					if !opts.Recursive && path.Dir(nodepath) == dir {
+					if !opts.Recursive && nodeDir == dir {
 						match = true
 						break
 					}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Changes `restic ls` so that the syntax is:

```
restic ls snapshotID [dirs...]
```

instead of multiple snapshot IDs. Adds a new flag, `--recursive`, to allow matching subfolders of the given directories.

A directory filter constrains the walk to just the folder(s) specified in the arguments.

An `ls` that used to take 5 minutes now takes 50 seconds. (Most of that time is connecting to the repo, downloading the index, and decrypting it. The actual scan is instantaneous. It also uses less memory, since there are way fewer results.)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

#1940

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review