### PR TITLE
ls: Add JSON output support for restic ls cmd

### DIFF
--- a/changelog/unreleased/pull-1953
+++ b/changelog/unreleased/pull-1953
@@ -1,5 +1,7 @@
 Enhancement: ls: Add JSON output support for restic ls cmd
 
-This PR enables users to get the output of `restic ls` in JSON format.
+We've implemented listing files in the repository with JSON as output, just
+pass `--json` as an option to `restic ls`. This makes the output of the command
+machine readable.
 
 https://github.com/restic/restic/pull/1953

--- a/changelog/unreleased/pull-1953
+++ b/changelog/unreleased/pull-1953
@@ -1,0 +1,5 @@
+Enhancement: ls: Add JSON output support for restic ls cmd
+
+This PR enables users to get the output of `restic ls` in JSON format.
+
+https://github.com/restic/restic/pull/1953

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -161,7 +161,7 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 				Snapshot:   sn,
 				ID:         sn.ID(),
 				ShortID:    sn.ID().Str(),
-				StructType: "Snapshot",
+				StructType: "snapshot",
 			}
 			lssnapshots = append(lssnapshots, lss)
 		}
@@ -178,7 +178,7 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 				ModTime:    node.ModTime,
 				AccessTime: node.AccessTime,
 				ChangeTime: node.ChangeTime,
-				StructType: "Node",
+				StructType: "node",
 			}
 			s := &lssnapshots[len(lssnapshots)-1]
 			s.Nodes = append(s.Nodes, lsn)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This PR adds support for JSON output for the restic ls command, using the existing global --json flag.

output truncated of : `./restic ls 1977f34d /doc/_static --json`

```json
[{
  "time": "2018-08-10T13:41:51.624627031+02:00",
  "tree": "0d7878997a8317b052105f933c2ff0920f2942ce61c4842de1b1ab067d305b35",
  "paths": ["/Users/kitone/go/src/github.com/restic/restic/doc"],
  "hostname": "hostname.local",
  "username": "kitone",
  "uid": 502,
  "gid": 20,
  "id": "1977f34d970e318bd3249f59ec8e87d5a8b17551cfb49664c0ba5f0d56e9a97c",
  "short_id": "1977f34d",
  "nodes": [{
    "name": "_static",
    "type": "dir",
    "path": "/doc/_static",
    "uid": 502,
    "gid": 20,
    "mode": 2147484141,
    "mtime": "2018-08-10T13:07:54+02:00",
    "atime": "2018-08-10T13:07:54+02:00",
    "ctime": "2018-08-10T13:07:54+02:00",
    "struct_type": "node"
  }, {
    "name": "css",
    "type": "dir",
    "path": "/doc/_static/css",
    "uid": 502,
    "gid": 20,
    "mode": 2147484141,
    "mtime": "2018-08-10T13:07:54+02:00",
    "atime": "2018-08-10T13:07:54+02:00",
    "ctime": "2018-08-10T13:07:54+02:00",
    "struct_type": "node"
  }, {
    "name": "favicon.ico",
    "type": "file",
    "path": "/doc/_static/favicon.ico",
    "uid": 502,
    "gid": 20,
    "size": 1406,
    "mode": 420,
    "mtime": "2018-08-10T13:07:54+02:00",
    "atime": "2018-08-10T13:07:54+02:00",
    "ctime": "2018-08-10T13:07:54+02:00",
    "struct_type": "node"
  }],
  "struct_type": "snapshot"
}]
```

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Previous PR : https://github.com/restic/restic/pull/1939

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review