### PR TITLE
stats: Show what was scanned and scanning mode used

### DIFF
--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -81,6 +81,10 @@ func runStats(gopts GlobalOptions, args []string) error {
 		}
 	}
 
+	if !gopts.JSON {
+		Printf("scanning...\n")
+	}
+
 	// create a container for the stats (and other needed state)
 	stats := &statsContainer{
 		uniqueFiles: make(map[fileID]struct{}),
@@ -144,6 +148,15 @@ func runStats(gopts GlobalOptions, args []string) error {
 		}
 		return nil
 	}
+
+	// inform the user what was scanned and how it was scanned
+	snapshotsScanned := snapshotIDString
+	if snapshotsScanned == "latest" {
+		snapshotsScanned = "the latest snapshot"
+	} else if snapshotsScanned == "" {
+		snapshotsScanned = "all snapshots"
+	}
+	Printf("Stats for %s in %s mode:\n", snapshotsScanned, countMode)
 
 	if stats.TotalBlobCount > 0 {
 		Printf("  Total Blob Count:   %d\n", stats.TotalBlobCount)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

`restic stats` now shows what was scanned and how the stats were computed (not with --json of course). Examples:

```plain
repository 343foo19 opened successfully, password is correct
scanning...
Stats for the latest snapshot in restore-size mode:
  Total File Count:   4809
        Total Size:   145.924 MiB
```

```plain
repository 343foo19 opened successfully, password is correct
scanning...
Stats for all snapshots in restore-size mode:
  Total File Count:   29671
        Total Size:   1.316 GiB
```


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

#1960

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual) **-- I don't think we need to change the docs for this**
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)) **-- This is a minor text change, do you still want a changelog entry? Just let me know.**
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review