### PR TITLE
Doc/fix man output

### DIFF
--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -21,11 +21,11 @@ The "diff" command shows differences from the first to the second snapshot. The
 first characters in each line display what has happened to a particular file or
 directory:
 
- +  The item was added
- -  The item was removed
- U  The metadata (access mode, timestamps, ...) for the item was updated
- M  The file's content was modified
- T  The type was changed, e.g. a file was made a symlink
+* +  The item was added
+* -  The item was removed
+* U  The metadata (access mode, timestamps, ...) for the item was updated
+* M  The file's content was modified
+* T  The type was changed, e.g. a file was made a symlink
 `,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -30,17 +30,13 @@ to calculate.
 
 The modes are:
 
-  restore-size: (default) Counts the size of the restored files.
-
-  files-by-contents: Counts total size of files, where a file is
-                     considered unique if it has unique contents.
-
-  raw-data: Counts the size of blobs in the repository, regardless
-			of how many files reference them.
-
-  blobs-per-file: A combination of files-by-contents and raw-data.
-
-Refer to the online manual for more details about each mode.
+* restore-size: (default) Counts the size of the restored files.
+* files-by-contents: Counts total size of files, where a file is
+   considered unique if it has unique contents.
+* raw-data: Counts the size of blobs in the repository, regardless of
+  how many files reference them.
+* blobs-per-file: A combination of files-by-contents and raw-data.
+* Refer to the online manual for more details about each mode.
 `,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -169,7 +169,7 @@ Browse repository objects
 
 Internally, a repository stores data of several different types
 described in the `design
-documentation <https://github.com/restic/restic/blob/master/doc/Design.rst>`__.
+documentation <https://github.com/restic/restic/blob/master/doc/design.rst>`__.
 You can ``list`` objects such as blobs, packs, index, snapshots, keys or
 locks with the following command:
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Fix some text format on generated man page.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No

Checklist
---------

- [ ] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
