### PR TITLE
cache: Print message when new cache is created

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -376,6 +376,10 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		return s, nil
 	}
 
+	if c.Created && !opts.JSON {
+		Verbosef("created new cache in %v\n", c.Base)
+	}
+
 	// start using the cache
 	s.UseCache(c)
 

--- a/internal/cache/dir.go
+++ b/internal/cache/dir.go
@@ -68,25 +68,31 @@ func DefaultDir() (cachedir string, err error) {
 	return cachedir, nil
 }
 
-func mkdirCacheDir(cachedir string) error {
+// mkdirCacheDir ensures that the cache directory exists. It it didn't, created
+// is set to true.
+func mkdirCacheDir(cachedir string) (created bool, err error) {
+	var newCacheDir bool
+
 	fi, err := fs.Stat(cachedir)
 	if os.IsNotExist(errors.Cause(err)) {
 		err = fs.MkdirAll(cachedir, 0700)
 		if err != nil {
-			return errors.Wrap(err, "MkdirAll")
+			return true, errors.Wrap(err, "MkdirAll")
 		}
 
 		fi, err = fs.Stat(cachedir)
 		debug.Log("create cache dir %v", cachedir)
+
+		newCacheDir = true
 	}
 
 	if err != nil {
-		return errors.Wrap(err, "Stat")
+		return newCacheDir, errors.Wrap(err, "Stat")
 	}
 
 	if !fi.IsDir() {
-		return errors.Errorf("cache dir %v is not a directory", cachedir)
+		return newCacheDir, errors.Errorf("cache dir %v is not a directory", cachedir)
 	}
 
-	return nil
+	return newCacheDir, nil
 }


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Sometimes, users run restic without retaining the local cache directories. This was reported several times in the past.

Restic will now print a message whenever a new cache directory is created from scratch (i.e. it did not exist before), so users have a chance to recognize when the cache is not kept between different runs of restic.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

I don't think so.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review