### PR TITLE
Prune repack threshold

### DIFF
--- a/changelog/unreleased/issue-1985
+++ b/changelog/unreleased/issue-1985
@@ -1,0 +1,16 @@
+Enhancement: Add adjustable utilization threshold for re-writing packs during prune
+
+We've added the `--repack-threshold` flag to the `prune` command which
+allows the user to specify the maximum percentage of unused space to
+allow in a pack before prune will rewrite that pack. This gives the user
+some control over the read/write activity occurs on the backend, which
+is important for those backends with metered transactions.
+
+Setting the value of this new flag to zero causes prune to re-write
+packs with any amount of unused data (previous behavior). Setting the
+value to 100 causes prune to only re-write packs that are completely
+unused. The flag defaults to 20, which means that packs with less than
+20% unused data are not re-written while packs with 20% or more
+unused date are re-written.
+
+https://github.com/restic/restic/issues/1985

--- a/changelog/unreleased/issue-1985
+++ b/changelog/unreleased/issue-1985
@@ -1,4 +1,4 @@
-Enhancement: Add adjustable utilization threshold for re-writing packs during prune
+Enhancement: Add adjustment for re-writing packs during prune
 
 We've added the `--repack-threshold` flag to the `prune` command which
 allows the user to specify the maximum percentage of unused space to

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -238,7 +238,8 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 	if removeSnapshots > 0 && opts.Prune {
 		Verbosef("%d snapshots have been removed, running prune\n", removeSnapshots)
 		if !opts.DryRun {
-			return pruneRepository(gopts, repo)
+			pruneOptions := PruneOptions { RepackThreshold: 0 }
+			return pruneRepository(pruneOptions, gopts, repo)
 		}
 	}
 

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -238,7 +238,7 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 	if removeSnapshots > 0 && opts.Prune {
 		Verbosef("%d snapshots have been removed, running prune\n", removeSnapshots)
 		if !opts.DryRun {
-			pruneOptions := PruneOptions { RepackThreshold: DefaultRepackThreshold }
+			pruneOptions := PruneOptions{RepackThreshold: DefaultRepackThreshold}
 			return pruneRepository(pruneOptions, gopts, repo)
 		}
 	}

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -238,7 +238,7 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 	if removeSnapshots > 0 && opts.Prune {
 		Verbosef("%d snapshots have been removed, running prune\n", removeSnapshots)
 		if !opts.DryRun {
-			pruneOptions := PruneOptions { RepackThreshold: 0 }
+			pruneOptions := PruneOptions { RepackThreshold: DefaultRepackThreshold }
 			return pruneRepository(pruneOptions, gopts, repo)
 		}
 	}

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -13,6 +13,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const DefaultRepackThreshold int = 20
+
 var cmdPrune = &cobra.Command{
 	Use:   "prune [flags]",
 	Short: "Remove unneeded data from the repository",
@@ -37,7 +39,7 @@ func init() {
 	cmdRoot.AddCommand(cmdPrune)
 
 	f := cmdPrune.Flags()
-	f.IntVarP(&pruneOptions.RepackThreshold, "repack-threshold", "", 0, "only rebuild packs with at least `n`% unused space (default: 0)")
+	f.IntVarP(&pruneOptions.RepackThreshold, "repack-threshold", "", DefaultRepackThreshold, "only rebuild packs with at least `n`% unused space")
 
 	f.SortFlags = false
 }

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -209,7 +209,7 @@ func pruneRepository(opts PruneOptions, gopts GlobalOptions, repo restic.Reposit
 	bar.Done()
 	stats.usedBlobs = len(usedBlobs)
 
-	Verbosef("found %d of %d data blobs still in use, removing %d blobs\n",
+	Verbosef("found %d of %d data blobs still in use, %d blobs unused\n",
 		stats.usedBlobs, stats.totalBlobs, stats.totalBlobs-stats.usedBlobs)
 
 	if stats.usedBlobs > stats.totalBlobs {
@@ -284,12 +284,14 @@ func pruneRepository(opts PruneOptions, gopts GlobalOptions, repo restic.Reposit
 			return err
 		}
 		bar.Done()
+
+		removePacks.Merge(obsoletePacks)
 	}
 
-	removePacks.Merge(obsoletePacks)
-
-	if err = rebuildIndex(ctx, repo, removePacks); err != nil {
-		return err
+	if len(rewritePacks) != 0 || len(removePacks) != 0 {
+		if err = rebuildIndex(ctx, repo, removePacks); err != nil {
+			return err
+		}
 	}
 
 	if len(removePacks) != 0 {

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -31,7 +31,7 @@ referenced and therefore not needed any more.
 
 // PruneOptions collects all options for the prune command.
 type PruneOptions struct {
-	RepackThreshold   int
+	RepackThreshold int
 }
 
 var pruneOptions PruneOptions
@@ -128,16 +128,16 @@ func pruneRepository(opts PruneOptions, gopts GlobalOptions, repo restic.Reposit
 	}
 
 	var stats struct {
-		totalFiles		int
-		totalPacks		int
-		totalBlobs		int
-		totalBytes		uint64
-		snapshots		int
-		usedBlobs		int
-		duplicateBlobs	int
-		duplicateBytes	uint64
-		remainingBytes	uint64
-		removeBytes		uint64
+		totalFiles     int
+		totalPacks     int
+		totalBlobs     int
+		totalBytes     uint64
+		snapshots      int
+		usedBlobs      int
+		duplicateBlobs int
+		duplicateBytes uint64
+		remainingBytes uint64
+		removeBytes    uint64
 	}
 
 	Verbosef("counting files in repo\n")

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// DefaultRepackThreshold - Default value for --repack-threshold when it is not specified
 const DefaultRepackThreshold int = 20
 
 var cmdPrune = &cobra.Command{
@@ -161,10 +162,10 @@ func pruneRepository(opts PruneOptions, gopts GlobalOptions, repo restic.Reposit
 
 	blobCounts := make(map[restic.BlobHandle]int)
 	for _, pack := range idx.Packs {
-		stats.totalPacks += 1
+		stats.totalPacks++
 		stats.totalBytes += uint64(pack.Size)
 		for _, blob := range pack.Entries {
-			stats.totalBlobs += 1
+			stats.totalBlobs++
 			h := restic.BlobHandle{ID: blob.ID, Type: blob.Type}
 			blobCounts[h]++
 			if blobCounts[h] > 1 {

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -220,7 +220,7 @@ func testRunForget(t testing.TB, gopts GlobalOptions, args ...string) {
 }
 
 func testRunPrune(t testing.TB, gopts GlobalOptions) {
-	opts := PruneOptions{ RepackThreshold: DefaultRepackThreshold }
+	opts := PruneOptions{RepackThreshold: DefaultRepackThreshold}
 	rtest.OK(t, runPrune(opts, gopts))
 }
 

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -220,7 +220,8 @@ func testRunForget(t testing.TB, gopts GlobalOptions, args ...string) {
 }
 
 func testRunPrune(t testing.TB, gopts GlobalOptions) {
-	rtest.OK(t, runPrune(gopts))
+	opts := PruneOptions{}
+	rtest.OK(t, runPrune(opts, gopts))
 }
 
 func TestBackup(t *testing.T) {

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -220,7 +220,7 @@ func testRunForget(t testing.TB, gopts GlobalOptions, args ...string) {
 }
 
 func testRunPrune(t testing.TB, gopts GlobalOptions) {
-	opts := PruneOptions{}
+	opts := PruneOptions{ RepackThreshold: DefaultRepackThreshold }
 	rtest.OK(t, runPrune(opts, gopts))
 }
 

--- a/doc/bash-completion.sh
+++ b/doc/bash-completion.sh
@@ -1048,6 +1048,8 @@ _restic_prune()
     flags_with_completion=()
     flags_completion=()
 
+    flags+=("--repack-threshold=")
+    local_nonpersistent_flags+=("--repack-threshold=")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")

--- a/doc/bash-completion.sh
+++ b/doc/bash-completion.sh
@@ -1048,8 +1048,6 @@ _restic_prune()
     flags_with_completion=()
     flags_completion=()
 
-    flags+=("--repack-threshold=")
-    local_nonpersistent_flags+=("--repack-threshold=")
     flags+=("--help")
     flags+=("-h")
     local_nonpersistent_flags+=("--help")


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

This change adds the `--repack-threshold` flag to the `prune` command allowing users to specify the amount of unused space to allow in packs when removing data from the repository

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Discussed in Issue #1985

Closes #348
 
Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
