### PR TITLE
termstatus: detect and respect dumb terminals on Unix

### DIFF
--- a/internal/ui/termstatus/terminal_unix.go
+++ b/internal/ui/termstatus/terminal_unix.go
@@ -4,6 +4,7 @@ package termstatus
 
 import (
 	"io"
+	"os"
 
 	"golang.org/x/sys/unix"
 
@@ -24,7 +25,15 @@ func moveCursorUp(wr io.Writer, fd uintptr) func(io.Writer, uintptr, int) {
 // canUpdateStatus returns true if status lines can be printed, the process
 // output is not redirected to a file or pipe.
 func canUpdateStatus(fd uintptr) bool {
-	return isatty.IsTerminal(fd)
+	if !isatty.IsTerminal(fd) {
+		return false
+	}
+	term := os.Getenv("TERM")
+	if term == "" {
+		return false
+	}
+	// TODO actually read termcap db and detect if terminal supports what we need
+	return term != "dumb"
 }
 
 // getTermSize returns the dimensions of the given terminal.


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This PR improves restic console output on "dumb" unix terminals, which do not support cursor positioning commands. In practice this applies to emulated terminals found in tools like VSC Debug Output view or Jenkins build log.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
