### PR TITLE
Rename OS X to macOS in the documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -174,7 +174,7 @@ locally as a pre-commit hook checks formatting before committing automatically,
 just copy this script to `.git/hooks/pre-commit`.
 
 For each pull request, several different systems run the integration tests on
-Linux, OS X and Windows. We won't merge any code that does not pass all tests
+Linux, macOS and Windows. We won't merge any code that does not pass all tests
 for all systems, so when a tests fails, try to find out what's wrong and fix
 it. If you need help on this, please leave a comment in the pull request, and
 we'll be glad to assist. Having a PR with failing integration tests is nothing

--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -71,7 +71,7 @@ avoid any conflicts:
 macOS
 =====
 
-If you are using Mac OS X, you can install restic using the
+If you are using macOS, you can install restic using the
 `homebrew <http://brew.sh/>`__ package manager:
 
 .. code-block:: console


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

macOS is the official name since the release of macOS 10.12 (Sierra). This renames instances of OS X and Mac OS X to macOS.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

This was partially fixed in https://github.com/restic/restic/commit/746182c5268be79758122b9894f351f7a879ac08, so this pull request can be considered a follow-up to that commit.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [N/A] I have added tests for all changes in this PR
- [N/A] I have added documentation for the changes (in the manual)
- [N/A] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [N/A] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review