### PR TITLE
Add Scoop installation method to the documentation

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -139,6 +139,18 @@ restic can be installed from the official repo of Solus via the ``eopkg`` packag
 
     $ eopkg install restic
 
+Windows
+=======
+
+restic can be installed using `Scoop <https://scoop.sh/>`__:
+
+.. code-block:: console
+
+    scoop install restic
+
+Using this installation method, ``restic.exe`` will automatically be available
+in the ``PATH``. It can be called from cmd.exe or PowerShell by typing ``restic``.
+
 
 .. _official_binaries:
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This documents installing restic using [Scoop](https://scoop.sh) on Windows.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [N/A] I have added tests for all changes in this PR
- [N/A] I have added documentation for the changes (in the manual)
- [N/A] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [N/A] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review