### PR TITLE
Added support for --prefix and --strip-components options on backup

### DIFF
--- a/changelog/unreleased/pull-2010
+++ b/changelog/unreleased/pull-2010
@@ -1,0 +1,18 @@
+Enhancement: Add support for --prefix and --strip-components options on backup
+
+We've added two options that rewrite target paths upon backup:
+
+--prefix=/foo/bar prepends a relative or absolute path;
+--strip-components=n strips n components from target path.
+
+The rationale for these options is to allow different paths to look equal
+upon parent snapshot id selection.
+
+For instance, when backing up ZFS snapshots from
+<mountpoint>/.zfs/snapshot/<snapshot-id>, user could run restic from
+CWD=<mountpoint>/.zfs/snapshot/<snapshot-id> using "." as target, and
+pass --prefix=<mountpoint> as option. This way, multiple ZFS snapshots
+could be stacked as restic snapshots with correct parent-child relationship.
+
+https://github.com/restic/restic/issues/555
+https://github.com/restic/restic/pull/2010

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -107,7 +107,7 @@ func init() {
 	f.StringVar(&backupOptions.TimeStamp, "time", "", "time of the backup (ex. '2012-11-01 22:08:41') (default: now)")
 	f.BoolVar(&backupOptions.WithAtime, "with-atime", false, "store the atime for all files and directories")
 	f.StringVar(&backupOptions.RootPrefix, "prefix", "", "apply a prefix to target paths")
-	f.IntVar(&backupOptions.RootStrip, "strip-components", 0, "strip NUMBER leading components from target paths")
+	f.IntVar(&backupOptions.RootStrip, "strip-components", 0, "strip `n` leading components from target paths")
 }
 
 // filterExisting returns a slice of all existing items, or an error if no

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -151,7 +151,7 @@ func runDump(opts DumpOptions, gopts GlobalOptions, args []string) error {
 	var id restic.ID
 
 	if snapshotIDString == "latest" {
-		id, err = restic.FindLatestSnapshot(ctx, repo, opts.Paths, opts.Tags, opts.Host)
+		id, err = restic.FindLatestSnapshot(ctx, repo, opts.Paths, opts.Tags, opts.Host, "", 0)
 		if err != nil {
 			Exitf(1, "latest snapshot for criteria not found: %v Paths:%v Host:%v", err, opts.Paths, opts.Host)
 		}

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -96,7 +96,7 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 	var id restic.ID
 
 	if snapshotIDString == "latest" {
-		id, err = restic.FindLatestSnapshot(ctx, repo, opts.Paths, opts.Tags, opts.Host)
+		id, err = restic.FindLatestSnapshot(ctx, repo, opts.Paths, opts.Tags, opts.Host, "", 0)
 		if err != nil {
 			Exitf(1, "latest snapshot for criteria not found: %v Paths:%v Host:%v", err, opts.Paths, opts.Host)
 		}

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -94,7 +94,7 @@ func runStats(gopts GlobalOptions, args []string) error {
 
 		var sID restic.ID
 		if snapshotIDString == "latest" {
-			sID, err = restic.FindLatestSnapshot(ctx, repo, []string{}, []restic.TagList{}, snapshotByHost)
+			sID, err = restic.FindLatestSnapshot(ctx, repo, []string{}, []restic.TagList{}, snapshotByHost, "", 0)
 			if err != nil {
 				return errors.Fatalf("latest snapshot for criteria not found: %v", err)
 			}

--- a/cmd/restic/find.go
+++ b/cmd/restic/find.go
@@ -22,7 +22,7 @@ func FindFilteredSnapshots(ctx context.Context, repo *repository.Repository, hos
 			// Process all snapshot IDs given as arguments.
 			for _, s := range snapshotIDs {
 				if s == "latest" {
-					id, err = restic.FindLatestSnapshot(ctx, repo, paths, tags, host)
+					id, err = restic.FindLatestSnapshot(ctx, repo, paths, tags, host, "", 0)
 					if err != nil {
 						Warnf("Ignoring %q, no snapshot matched given filter (Paths:%v Tags:%v Host:%v)\n", s, paths, tags, host)
 						usedFilter = true

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -705,6 +705,8 @@ type SnapshotOptions struct {
 	Excludes       []string
 	Time           time.Time
 	ParentSnapshot restic.ID
+	RootPrefix     string
+	RootStrip      int
 }
 
 // loadParentTree loads a tree referenced by snapshot id. If id is null, nil is returned.
@@ -807,7 +809,7 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 		return nil, restic.ID{}, err
 	}
 
-	sn, err := restic.NewSnapshot(targets, opts.Tags, opts.Hostname, opts.Time)
+	sn, err := restic.NewSnapshot(targets, opts.Tags, opts.Hostname, opts.Time, opts.RootPrefix, opts.RootStrip)
 	sn.Excludes = opts.Excludes
 	if !opts.ParentSnapshot.IsNull() {
 		id := opts.ParentSnapshot

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1566,7 +1566,7 @@ func TestArchiverSnapshotPrefixStrip(t *testing.T) {
 			}
 
 			t.Logf("targets: %v", targets)
-			sn, snapshotID, err := arch.Snapshot(ctx, targets, SnapshotOptions{Time: time.Now()})
+			sn, snapshotID, err := arch.Snapshot(ctx, targets, SnapshotOptions{Time: time.Now(), RootPrefix: test.prefix, RootStrip: test.strip})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/archiver/testing.go
+++ b/internal/archiver/testing.go
@@ -341,3 +341,25 @@ func TestEnsureSnapshot(t testing.TB, repo restic.Repository, snapshotID restic.
 
 	TestEnsureTree(ctx, t, "/", repo, *sn.Tree, dir)
 }
+
+// TestEnsureSnapshotPaths tests if the snapshot in the repo has exactly the same
+// paths as paths.
+func TestEnsureSnapshotPaths(t testing.TB, repo restic.Repository, snapshotID restic.ID, paths []string) {
+	test.Helper(t).Helper()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sn, err := restic.LoadSnapshot(ctx, repo, snapshotID)
+	if err != nil {
+		t.Fatal(err)
+		return
+	}
+	if len(sn.Paths) != len(paths) {
+		t.Errorf("snapshot has different path count %d, expected %d", len(sn.Paths), len(paths))
+	}
+	for i, v := range sn.Paths {
+		if v != paths[i] {
+			t.Errorf("snapshot path %v is different from expected path %v", v, paths[i])
+		}
+	}
+}

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -28,10 +28,11 @@ type Snapshot struct {
 }
 
 func pathSplit(path string) (root string, lst []string) {
-	for root = filepath.Clean(path); ; {
+        root = path
+        for {
 		var file string
-		root, file = filepath.Split(root)
-		if file == "" {
+		root, file = filepath.Split(filepath.Clean(root))
+		if file == "." || file == "" {
 			break
 		}
 		lst = append([]string{file}, lst...)

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -63,7 +63,7 @@ func pathStripPrefix(path string, prefix string, strip int) string {
 	}
 	if prefix != "" {
 		pathRoot = prefix
-	} else {
+	} else if strip == 0 {
 		absPath, err := filepath.Abs(pathRoot)
 		if err == nil {
 			pathRoot = absPath

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -69,7 +69,7 @@ func pathStripPrefix(path string, prefix string, strip int) string {
 			pathRoot = absPath
 		}
 	}
-	return filepath.Join(append([]string{pathRoot}, pathList...)...)
+	return filepath.Clean(filepath.Join(append([]string{pathRoot}, pathList...)...))
 }
 
 // NewSnapshot returns an initialized snapshot struct for the current user and

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -45,7 +45,8 @@ func pathSplit(path string) (root string, lst []string) {
 
 
 // pathStripPrefix strips zero or more leading path elements from a path
-// and optionally applies a prefix. Finally, if no prefix is applied, absolute path is resolved.
+// and optionally applies a prefix. Finally, if no prefix or stripping are applied,
+// absolute path is resolved.
 func pathStripPrefix(path string, prefix string, strip int) string {
 	pathRoot, pathList := pathSplit(path)
 	if strip > 0 {

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -27,6 +27,9 @@ type Snapshot struct {
 	id *ID // plaintext ID, used during restore
 }
 
+// pathSplit takes a path and returns its root part and a list of its path elements.
+// For absolute paths, root result is "/" for Unix and Plan9, drive letter for Windows.
+// For relative paths, root result is empty.
 func pathSplit(path string) (root string, lst []string) {
         root = path
         for {
@@ -40,7 +43,10 @@ func pathSplit(path string) (root string, lst []string) {
 	return
 }
 
-func pathMangle(path string, prefix string, strip int) string {
+
+// pathStripPrefix strips zero or more leading path elements from a path
+// and optionally applies a prefix. Finally, if no prefix is applied, absolute path is resolved.
+func pathStripPrefix(path string, prefix string, strip int) string {
 	pathRoot, pathList := pathSplit(path)
 	if strip > 0 {
 		stripFinal := strip
@@ -69,7 +75,7 @@ func pathMangle(path string, prefix string, strip int) string {
 func NewSnapshot(paths []string, tags []string, hostname string, time time.Time, prefix string, strip int) (*Snapshot, error) {
 	absPaths := make([]string, 0, len(paths))
 	for _, path := range paths {
-		absPaths = append(absPaths, pathMangle(path, prefix, strip))
+		absPaths = append(absPaths, pathStripPrefix(path, prefix, strip))
 	}
 
 	sn := &Snapshot{

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -43,12 +43,15 @@ func pathSplit(path string) (root string, lst []string) {
 func pathMangle(path string, prefix string, strip int) string {
 	pathRoot, pathList := pathSplit(path)
 	if strip > 0 {
-		var stripRoot int
+		stripFinal := strip
 		if pathRoot != "" {
-			stripRoot++
+			pathRoot = ""
+			stripFinal--
 		}
-		pathList = pathList[strip-stripRoot:]
-		pathRoot = ""
+		if stripFinal > len(pathList) {
+			stripFinal = len(pathList)
+		}
+		pathList = pathList[stripFinal:]
 	}
 	if prefix != "" {
 		pathRoot = prefix

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -51,8 +51,10 @@ func pathStripPrefix(path string, prefix string, strip int) string {
 	if strip > 0 {
 		stripFinal := strip
 		if pathRoot != "" {
+			if pathRoot != "/" {
+				stripFinal--
+			}
 			pathRoot = ""
-			stripFinal--
 		}
 		if stripFinal > len(pathList) {
 			stripFinal = len(pathList)

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -17,7 +17,7 @@ func FindLatestSnapshot(ctx context.Context, repo Repository, targets []string, 
 	var err error
 	absTargets := make([]string, 0, len(targets))
 	for _, target := range targets {
-		absTargets = append(absTargets, pathMangle(target, prefix, strip))
+		absTargets = append(absTargets, pathStripPrefix(target, prefix, strip))
 	}
 
 	var (

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/restic/restic/internal/errors"
@@ -14,17 +13,11 @@ import (
 var ErrNoSnapshotFound = errors.New("no snapshot found")
 
 // FindLatestSnapshot finds latest snapshot with optional target/directory, tags and hostname filters.
-func FindLatestSnapshot(ctx context.Context, repo Repository, targets []string, tagLists []TagList, hostname string) (ID, error) {
+func FindLatestSnapshot(ctx context.Context, repo Repository, targets []string, tagLists []TagList, hostname string, prefix string, strip int) (ID, error) {
 	var err error
 	absTargets := make([]string, 0, len(targets))
 	for _, target := range targets {
-		if !filepath.IsAbs(target) {
-			target, err = filepath.Abs(target)
-			if err != nil {
-				return ID{}, errors.Wrap(err, "Abs")
-			}
-		}
-		absTargets = append(absTargets, filepath.Clean(target))
+		absTargets = append(absTargets, pathMangle(target, prefix, strip))
 	}
 
 	var (

--- a/internal/restic/snapshot_test.go
+++ b/internal/restic/snapshot_test.go
@@ -23,18 +23,18 @@ func TestPathSplit(t *testing.T) {
 	}{
 		{
 			"foo",
-			"foo",
-			[]string{},
+			"",
+			[]string{"foo"},
 		},
 		{
 			"foo/bar",
-			"foo",
-			[]string{"bar"},
+			"",
+			[]string{"foo", "bar"},
 		},
 		{
 			"/home/user/work",
-			"/home",
-			[]string{"user", "work"},
+			"/",
+			[]string{"home", "user", "work"},
 		},
 	}
 

--- a/internal/restic/snapshot_test.go
+++ b/internal/restic/snapshot_test.go
@@ -52,7 +52,7 @@ func TestPathSplit(t *testing.T) {
 	}
 }
 
-func TestPathMangle(t *testing.T) {
+func TestPathSplitPrefix(t *testing.T) {
 	var tests = []struct {
 		Path   string
 		Prefix string
@@ -133,7 +133,7 @@ func TestPathMangle(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			res := pathMangle(test.Path, test.Prefix, test.Strip)
+			res := pathStripPrefix(test.Path, test.Prefix, test.Strip)
 			if res != test.Result {
 				t.Fatalf("wrong result, want %q, got %q", res, test.Result)
 			}

--- a/internal/restic/snapshot_test.go
+++ b/internal/restic/snapshot_test.go
@@ -11,6 +11,6 @@ import (
 func TestNewSnapshot(t *testing.T) {
 	paths := []string{"/home/foobar"}
 
-	_, err := restic.NewSnapshot(paths, nil, "foo", time.Now())
+	_, err := restic.NewSnapshot(paths, nil, "foo", time.Now(), "", 0)
 	rtest.OK(t, err)
 }

--- a/internal/restic/snapshot_test.go
+++ b/internal/restic/snapshot_test.go
@@ -1,16 +1,142 @@
-package restic_test
+package restic
 
 import (
 	"testing"
 	"time"
 
-	"github.com/restic/restic/internal/restic"
+	"github.com/google/go-cmp/cmp"
 	rtest "github.com/restic/restic/internal/test"
 )
 
 func TestNewSnapshot(t *testing.T) {
 	paths := []string{"/home/foobar"}
 
-	_, err := restic.NewSnapshot(paths, nil, "foo", time.Now(), "", 0)
+	_, err := NewSnapshot(paths, nil, "foo", time.Now(), "", 0)
 	rtest.OK(t, err)
+}
+
+func TestPathSplit(t *testing.T) {
+	var tests = []struct {
+		Input     string
+		Root      string
+		Remainder []string
+	}{
+		{
+			"foo",
+			"foo",
+			[]string{},
+		},
+		{
+			"foo/bar",
+			"foo",
+			[]string{"bar"},
+		},
+		{
+			"/home/user/work",
+			"/home",
+			[]string{"user", "work"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			root, rest := pathSplit(test.Input)
+			if root != test.Root {
+				t.Errorf("wrong root path returned, want %q, got %q", test.Root, root)
+			}
+
+			if !cmp.Equal(test.Remainder, rest) {
+				t.Fatal(cmp.Diff(test.Remainder, rest))
+			}
+		})
+	}
+}
+
+func TestPathMangle(t *testing.T) {
+	var tests = []struct {
+		Path   string
+		Prefix string
+		Strip  int
+		Result string
+	}{
+		{
+			Path:   "foo",
+			Result: "foo",
+		},
+		{
+			Path:   "/home/user",
+			Result: "/home/user",
+		},
+		{
+			Path:   "../home/user",
+			Result: "../home/user",
+		},
+		{
+			Path:   "foo/bar",
+			Strip:  1,
+			Result: "bar",
+		},
+		{
+			Path:   "foo/bar",
+			Strip:  2,
+			Result: "",
+		},
+		{
+			Path:   "foo/bar",
+			Strip:  3,
+			Result: "",
+		},
+		{
+			Path:   "/home/user/foo/bar",
+			Strip:  1,
+			Result: "user/foo/bar",
+		},
+		{
+			Path:   "/home/user/foo/bar",
+			Strip:  2,
+			Result: "foo/bar",
+		},
+		{
+			Path:   "/home/user/foo/bar",
+			Strip:  3,
+			Result: "bar",
+		},
+		{
+			Path:   "/home/user/foo/bar",
+			Prefix: "/srv/backup",
+			Result: "/srv/backup/home/user/foo/bar",
+		},
+		{
+			Path:   "../user/foo/bar",
+			Prefix: "/srv/backup",
+			Result: "/srv/user/foo/bar",
+		},
+		{
+			Path:   "/home/user/foo/bar",
+			Strip:  1,
+			Prefix: "/srv/backup",
+			Result: "/srv/backup/user/foo/bar",
+		},
+		{
+			Path:   "/home/user/foo/bar",
+			Strip:  2,
+			Prefix: "/srv/backup",
+			Result: "/srv/backup/foo/bar",
+		},
+		{
+			Path:   "../user/foo/bar",
+			Strip:  1,
+			Prefix: "/srv/backup",
+			Result: "/srv/user/user/foo/bar",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			res := pathMangle(test.Path, test.Prefix, test.Strip)
+			if res != test.Result {
+				t.Fatalf("wrong result, want %q, got %q", res, test.Result)
+			}
+		})
+	}
 }

--- a/internal/restic/snapshot_test.go
+++ b/internal/restic/snapshot_test.go
@@ -1,6 +1,7 @@
 package restic
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -53,6 +54,10 @@ func TestPathSplit(t *testing.T) {
 }
 
 func TestPathSplitPrefix(t *testing.T) {
+	mustAbs := func (path string) (ret string) {
+		ret, _ = filepath.Abs(path)
+		return
+	}
 	var tests = []struct {
 		Path   string
 		Prefix string
@@ -61,7 +66,7 @@ func TestPathSplitPrefix(t *testing.T) {
 	}{
 		{
 			Path:   "foo",
-			Result: "foo",
+			Result: mustAbs("foo"),
 		},
 		{
 			Path:   "/home/user",
@@ -69,7 +74,7 @@ func TestPathSplitPrefix(t *testing.T) {
 		},
 		{
 			Path:   "../home/user",
-			Result: "../home/user",
+			Result: mustAbs("../home/user"),
 		},
 		{
 			Path:   "foo/bar",
@@ -79,12 +84,12 @@ func TestPathSplitPrefix(t *testing.T) {
 		{
 			Path:   "foo/bar",
 			Strip:  2,
-			Result: "",
+			Result: ".",
 		},
 		{
 			Path:   "foo/bar",
 			Strip:  3,
-			Result: "",
+			Result: ".",
 		},
 		{
 			Path:   "/home/user/foo/bar",
@@ -127,7 +132,7 @@ func TestPathSplitPrefix(t *testing.T) {
 			Path:   "../user/foo/bar",
 			Strip:  1,
 			Prefix: "/srv/backup",
-			Result: "/srv/user/user/foo/bar",
+			Result: "/srv/backup/user/foo/bar",
 		},
 	}
 
@@ -135,7 +140,7 @@ func TestPathSplitPrefix(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			res := pathStripPrefix(test.Path, test.Prefix, test.Strip)
 			if res != test.Result {
-				t.Fatalf("wrong result, want %q, got %q", res, test.Result)
+				t.Fatalf("wrong result, want %q, got %q", test.Result, res)
 			}
 		})
 	}

--- a/internal/restic/testing.go
+++ b/internal/restic/testing.go
@@ -164,7 +164,7 @@ func TestCreateSnapshot(t testing.TB, repo Repository, at time.Time, depth int, 
 	t.Logf("create fake snapshot at %s with seed %d", at, seed)
 
 	fakedir := fmt.Sprintf("fakedir-at-%v", at.Format("2006-01-02 15:04:05"))
-	snapshot, err := NewSnapshot([]string{fakedir}, []string{"test"}, "foo", time.Now())
+	snapshot, err := NewSnapshot([]string{fakedir}, []string{"test"}, "foo", time.Now(), "", 0)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -123,7 +123,7 @@ func saveSnapshot(t testing.TB, repo restic.Repository, snapshot Snapshot) (*res
 		t.Fatal(err)
 	}
 
-	sn, err := restic.NewSnapshot([]string{"test"}, nil, "", time.Now())
+	sn, err := restic.NewSnapshot([]string{"test"}, nil, "", time.Now(), "", 0)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

Adds --prefix and --strip-components to "restic backup" command. These options allow the user to manipulate the root directory paths saved in the snapshot.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

It was previously discussed in issue #555 

<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
