### PR TITLE
Verify before restore

### DIFF
--- a/changelog/unreleased/pull-2012
+++ b/changelog/unreleased/pull-2012
@@ -1,0 +1,6 @@
+Enhancement: restore: Only restore file if required
+
+During the `restore` process, we're now verifying if files exists
+locally and restore them only when required (mimic `rsync` behavior).
+
+https://github.com/restic/restic/pull/2012

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -187,6 +187,13 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 			return fs.MkdirAll(target, 0700)
 		},
 		visitNode: func(node *restic.Node, target, location string) error {
+
+			count := 0
+			// skip restore if verifyNode returns no errors
+			if node.Type == "file" && res.verifyNode(node, target, location, &count) == nil {
+				return nil
+			}
+
 			// create parent dir with default permissions
 			// #leaveDir restores dir metadata after visiting all children
 			err := fs.MkdirAll(filepath.Dir(target), 0700)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

* extract the operations done by the `--verify` option into function of `Restorer`
* verify the content of a node before restoring it (skip if already matching)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://github.com/restic/restic/issues/2011
Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
