### PR TITLE
mount: Add default-permissions flag to set FUSE option

### DIFF
--- a/changelog/unreleased/pull-2017
+++ b/changelog/unreleased/pull-2017
@@ -1,12 +1,11 @@
-Enhancement: mount: Enforce FUSE Unix permissions by default
+Enhancement: mount: Enforce FUSE Unix permissions with allow-other
 
-By default, `mount` will now respect the Unix permissions of the files within
-snapshots (this is done through the "DefaultPermissions" FUSE option).
+The fuse mount (`restic mount`) now lets the kernel check the permissions of
+the files within snapshots (this is done through the `DefaultPermissions` FUSE
+option) when the option `--allow-other` is specified.
 
 To restore the old behavior, we've added the `--no-default-permissions` option.
-This allows alll users that have access to the mountpoint to access all
-files within the snapshots. Normal FUSE rules apply, so `--allow-root`
-or `--allow-other` can be used to allow users besides the mounting user to
-access the mountpoint.
+This allows all users that have access to the mount point to access all
+files within the snapshots.
 
 https://github.com/restic/restic/pull/2017

--- a/changelog/unreleased/pull-2017
+++ b/changelog/unreleased/pull-2017
@@ -1,0 +1,12 @@
+Enhancement: mount: Enforce FUSE Unix permissions by default
+
+By default, `mount` will now respect the Unix permissions of the files within
+snapshots (this is done through the "DefaultPermissions" FUSE option).
+
+To restore the old behavior, we've added the `--no-default-permissions` option.
+This allows alll users that have access to the mountpoint to access all
+files within the snapshots. Normal FUSE rules apply, so `--allow-root`
+or `--allow-other` can be used to allow users besides the mounting user to
+access the mountpoint.
+
+https://github.com/restic/restic/pull/2017

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -53,13 +53,14 @@ For details please see the documentation for time.Format() at:
 
 // MountOptions collects all options for the mount command.
 type MountOptions struct {
-	OwnerRoot        bool
-	AllowRoot        bool
-	AllowOther       bool
-	Host             string
-	Tags             restic.TagLists
-	Paths            []string
-	SnapshotTemplate string
+	OwnerRoot            bool
+	AllowRoot            bool
+	AllowOther           bool
+	NoDefaultPermissions bool
+	Host                 string
+	Tags                 restic.TagLists
+	Paths                []string
+	SnapshotTemplate     string
 }
 
 var mountOptions MountOptions
@@ -71,6 +72,7 @@ func init() {
 	mountFlags.BoolVar(&mountOptions.OwnerRoot, "owner-root", false, "use 'root' as the owner of files and dirs")
 	mountFlags.BoolVar(&mountOptions.AllowRoot, "allow-root", false, "allow root user to access the data in the mounted directory")
 	mountFlags.BoolVar(&mountOptions.AllowOther, "allow-other", false, "allow other users to access the data in the mounted directory")
+	mountFlags.BoolVar(&mountOptions.NoDefaultPermissions, "no-default-permissions", false, "for 'allow-other', ignore Unix permissions and allow users to read all snapshot files")
 
 	mountFlags.StringVarP(&mountOptions.Host, "host", "H", "", `only consider snapshots for this host`)
 	mountFlags.Var(&mountOptions.Tags, "tag", "only consider snapshots which include this `taglist`")
@@ -120,7 +122,9 @@ func mount(opts MountOptions, gopts GlobalOptions, mountpoint string) error {
 		mountOptions = append(mountOptions, systemFuse.AllowOther())
 	}
 
-	mountOptions = append(mountOptions, systemFuse.DefaultPermissions())
+	if !opts.NoDefaultPermissions {
+		mountOptions = append(mountOptions, systemFuse.DefaultPermissions())
+	}
 
 	c, err := systemFuse.Mount(mountpoint, mountOptions...)
 	if err != nil {

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -120,10 +120,11 @@ func mount(opts MountOptions, gopts GlobalOptions, mountpoint string) error {
 
 	if opts.AllowOther {
 		mountOptions = append(mountOptions, systemFuse.AllowOther())
-	}
 
-	if !opts.NoDefaultPermissions {
-		mountOptions = append(mountOptions, systemFuse.DefaultPermissions())
+		// let the kernel check permissions unless it is explicitly disabled
+		if !opts.NoDefaultPermissions {
+			mountOptions = append(mountOptions, systemFuse.DefaultPermissions())
+		}
 	}
 
 	c, err := systemFuse.Mount(mountpoint, mountOptions...)

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -120,6 +120,8 @@ func mount(opts MountOptions, gopts GlobalOptions, mountpoint string) error {
 		mountOptions = append(mountOptions, systemFuse.AllowOther())
 	}
 
+	mountOptions = append(mountOptions, systemFuse.DefaultPermissions())
+
 	c, err := systemFuse.Mount(mountpoint, mountOptions...)
 	if err != nil {
 		return err


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This PR adds the new flag `--default-permissions` for the `mount` command, which enables the "DefaultPermissions" FUSE option. This option enforces the Unix permissions of the mounted filesystem. When this flag is disabled, any user can access any file from the restic FUSE mount if the `--allow-other` flag is set; when enabled, a user can only access a file from a snapshot if they could access it originally.

As a quick demo of this feature, I wrote up a quick gist: https://gist.github.com/kylewlacy/99ec3859955a25dbbb94a56ce1b4de42 (note that it requires root, or at least the ability to run as two different users).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No (I figured it was easier to discuss this feature by providing this small PR first, then iterating on it if needed)

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review

N.B. manpage changes need to be regenerated still (I tried regenerating them but there were other changes too, so I figured it would be easier to leave out of this PR for now). I can regenerate the manpages if needed though

I also didn't write any tests for this PR. First, there were no tests for the other FUSE-specific options so I wasn't sure it was warranted, and second, this test would be hard to write since it would involve running at least as a root user and a non-root user. I'd be happy to try my hand at writing some tests if anyone provided some suggestions/ideas for testing this kind of feature

Other notes
-----------

I'd be more than happy to discuss and iterate on the design on this feature. Personally, finding out this caveat with `restic mount --allow-other` was definitely a surprise to me, so maybe it would make sense to invert this? As in, maybe this PR should be changed so "DefaultPermissions" is set by default, with an optional flag to _disable_ it (that would be a breaking change though)