### PR TITLE
Use `--host` for all commands, deprecate --hostname

### DIFF
--- a/changelog/unreleased/issue-1967
+++ b/changelog/unreleased/issue-1967
@@ -1,0 +1,7 @@
+Enhancement: Use `--host` everywhere
+
+We now use the flag `--host` for all commands which need a host name, using
+`--hostname` (e.g. for `restic backup`) still works, but will print a
+deprecation warning. Also, add the short option `-H` where possible.
+
+https://github.com/restic/restic/issues/1967

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -62,11 +62,12 @@ func init() {
 	f.VarP(&forgetOptions.Within, "keep-within", "", "keep snapshots that were created within `duration` before the newest (e.g. 1y5m7d)")
 
 	f.Var(&forgetOptions.KeepTags, "keep-tag", "keep snapshots with this `taglist` (can be specified multiple times)")
-	// Sadly the commonly used shortcut `H` is already used.
 	f.StringVar(&forgetOptions.Host, "host", "", "only consider snapshots with the given `host`")
-	// Deprecated since 2017-03-07.
-	f.StringVar(&forgetOptions.Host, "hostname", "", "only consider snapshots with the given `hostname` (deprecated)")
+	f.StringVar(&forgetOptions.Host, "hostname", "", "only consider snapshots with the given `hostname`")
+	f.MarkDeprecated("hostname", "use --host")
+
 	f.Var(&forgetOptions.Tags, "tag", "only consider snapshots which include this `taglist` in the format `tag[,tag,...]` (can be specified multiple times)")
+
 	f.StringArrayVar(&forgetOptions.Paths, "path", nil, "only consider snapshots which include this (absolute) `path` (can be specified multiple times)")
 	f.BoolVarP(&forgetOptions.Compact, "compact", "c", false, "use compact format")
 

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -48,7 +48,7 @@ func init() {
 	cmdRoot.AddCommand(cmdStats)
 	f := cmdStats.Flags()
 	f.StringVar(&countMode, "mode", countModeRestoreSize, "counting mode: restore-size (default), files-by-contents, blobs-per-file, or raw-data")
-	f.StringVar(&snapshotByHost, "host", "", "filter latest snapshot by this hostname")
+	f.StringVar(&snapshotByHost, "host", "H", "filter latest snapshot by this hostname")
 }
 
 func runStats(gopts GlobalOptions, args []string) error {


### PR DESCRIPTION
We now use the flag `--host` for all commands which need a host name, using `--hostname` (e.g. for `restic backup`) still works, but will print a deprecation warning. Also, add the short option `-H` where possible.

Closes #1967