### PR TITLE
cache: Recheck before downloading

### DIFF
--- a/internal/cache/backend.go
+++ b/internal/cache/backend.go
@@ -106,6 +106,11 @@ func (b *Backend) cacheFile(ctx context.Context, h restic.Handle) error {
 		return nil
 	}
 
+	// test again, maybe the file was cached in the meantime
+	if b.Cache.Has(h) {
+		return nil
+	}
+
 	err := b.Backend.Load(ctx, h, 0, 0, func(rd io.Reader) error {
 		return b.Cache.Save(h, rd)
 	})
@@ -122,7 +127,7 @@ func (b *Backend) cacheFile(ctx context.Context, h restic.Handle) error {
 	delete(b.inProgress, h)
 	b.inProgressMutex.Unlock()
 
-	return err
+	return nil
 }
 
 // loadFromCacheOrDelegate will try to load the file from the cache, and fall


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

recheck if another goroutine has already downloaded to the cache before
attempting it. A user reported that restic printed errors like this:
```
Load(<data/61db3a5d4c>, 0, 0) returned error, retrying after 689.290829ms: Create: open /tmp/restic-check-cache-551233426/a14636d2d23f0d08914fe85b74cf8a7828f73b5d6e6c465b6795086221200faf/data/61/61db3a5d4c79ca52bd1ddbe0f833480d9768b6af792affdb582d927764a11af8: file exists
```

This means that a goroutine was attempting to download a file, but by
the time it got to the actual download, the file was already there. We
now recheck if the file has been downloaded in the meantime.