### PR TITLE
Add defaults to command line help of --cache-dir

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -95,7 +95,7 @@ func init() {
 	f.CountVarP(&globalOptions.Verbose, "verbose", "v", "be verbose (specify --verbose multiple times or level `n`)")
 	f.BoolVar(&globalOptions.NoLock, "no-lock", false, "do not lock the repo, this allows some operations on read-only repos")
 	f.BoolVarP(&globalOptions.JSON, "json", "", false, "set output mode to JSON for commands that support it")
-	f.StringVar(&globalOptions.CacheDir, "cache-dir", "", "set the cache directory")
+	f.StringVar(&globalOptions.CacheDir, "cache-dir", "", "set the cache directory. (default: use system default cache directory)")
 	f.BoolVar(&globalOptions.NoCache, "no-cache", false, "do not use a local cache")
 	f.StringSliceVar(&globalOptions.CACerts, "cacert", nil, "`file` to load root certificates from (default: use system certificates)")
 	f.StringVar(&globalOptions.TLSClientCert, "tls-client-cert", "", "path to a file containing PEM encoded TLS client certificate and private key")

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -43,7 +43,7 @@ Usage help is available:
 
     Flags:
           --cacert file              file to load root certificates from (default: use system certificates)
-          --cache-dir string         set the cache directory
+          --cache-dir string         set the cache directory. (default: use system default cache directory)
           --cleanup-cache            auto remove old cache directories
       -h, --help                     help for restic
           --json                     set output mode to JSON for commands that support it
@@ -94,7 +94,7 @@ command:
 
     Global Flags:
           --cacert file              file to load root certificates from (default: use system certificates)
-          --cache-dir string         set the cache directory
+          --cache-dir string         set the cache directory. (default: use system default cache directory)
           --cleanup-cache            auto remove old cache directories
           --json                     set output mode to JSON for commands that support it
           --limit-download int       limits downloads to a maximum rate in KiB/s. (default: unlimited)


### PR DESCRIPTION

What is the purpose of this change? What does it change?
--------------------------------------------------------
This adds a simple clarification about the default values of `--cache-dir` to the output of `--help`.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
This is in reference to #1979 

Checklist
---------

- `[y]` I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- `[n]` I have added tests for all changes in this PR
- `[n]` I have added documentation for the changes (in the manual)
- `[n]` There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- `[y]` I have run `gofmt` on the code in all commits
- `[y]` All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- `[y]` I'm done, this Pull Request is ready for review

Additional Information
---------------------------
Note about `gofmt`: I did run it and my changes appear to be fine - but some files unrelated to my changes seem to be malformatted.