### PR TITLE
Add example to spot path expansion errros

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -66,7 +66,8 @@ The error here is that the tilde (~) in ``"~/documents"`` didn't get expanded as
     $ echo "$HOME/documents"
     /home/john/documents
 
-Expansions are handled by the shell only and not by restic.
+Most expansions are handled by the shell only and not by restic.
+Glob expansions like ** or * on the other hand are being handled by restic directly.
 
 How can I specify encryption passwords automatically?
 -----------------------------------------------------

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -27,6 +27,47 @@ strictly necessary. With high probability this is duplicate data. In
 order to clean it up, the command ``restic prune`` can be used. The
 cause of this bug is not yet known.
 
+I ran a ``restic`` command but it is not working as intented, what do I do now?
+-------------------------------------------------------------------------------
+
+If you are running a restic command and it is not working as you hoped it would, 
+there is an easy way of checking how your shell interpreted the command you are trying to run.
+
+Here is an example of a mistake in a forget rule that results in the rule not working correctly.
+A user wants to run the following ``restic forget`` command
+
+::
+
+$ restic backup --exclude "~/documents" ~
+
+.. important:: This command contains an intentional user error described in this paragraph.
+
+This command will result in a complete backup of ``~`` and it won't exclude the folder ``~/documents/`` which is intended.
+The problem is how the path to ``~/documents`` is passed to restic.
+
+In order so spot an issue like this you can make use of the following command preceeding your restic command.
+
+::
+
+    $ ruby -e 'puts ARGV.inspect' restic backup --exclude "~/documents" ~
+    ["restic", "backup", "--exclude", "~/documents", "/home/john"]
+
+As you can see, the command outputs every argument you have passed to the shell and expands it - this is what restic sees when you run your command.
+The error here is that the tilde (~) in ``"~/documents"`` didn't get expanded as it is quoted.
+
+::
+
+    $ echo ~/documents
+    /home/john/documents
+
+    $ echo "~/documents"
+    ~/document
+
+    $ echo "$HOME/documents"
+    /home/john/documents
+
+Expansions are handled by the shell only and not by restic.
+
 How can I specify encryption passwords automatically?
 -----------------------------------------------------
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
This change adds informational text to the [FAQ](doc/faq.rst). 
The information added describes on how to find out if there is a user based error for file path expansion not working as intended in a restic command.

As the wording goes: I am open to any suggestions to either rephrase it or to make it more clear if something isn't. Also if there a factual errors, please point them out and I will fix them.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Yes, on IRC.

<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
