### PR TITLE
Escape subcommand in docker build script

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -4,7 +4,7 @@ set -e
 
 echo "Build binary using golang docker image"
 docker run --rm -ti \
-    -v `pwd`:/go/src/github.com/restic/restic \
+    -v "`pwd`":/go/src/github.com/restic/restic \
     -w /go/src/github.com/restic/restic golang:1.8.3-alpine go run build.go
 
 echo "Build docker image restic/restic:latest"


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
This change escapes the subcall to `pwd` in `build.sh` in order for it to work in directories containing spaces.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Closes #2001
This is **not my fix**. This PR simply contains the changes proposed in that issue.

<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
