### PR TITLE
use latest instead of newest in forget language

### DIFF
--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -59,7 +59,7 @@ func init() {
 	f.IntVarP(&forgetOptions.Weekly, "keep-weekly", "w", 0, "keep the last `n` weekly snapshots")
 	f.IntVarP(&forgetOptions.Monthly, "keep-monthly", "m", 0, "keep the last `n` monthly snapshots")
 	f.IntVarP(&forgetOptions.Yearly, "keep-yearly", "y", 0, "keep the last `n` yearly snapshots")
-	f.VarP(&forgetOptions.Within, "keep-within", "", "keep snapshots that were created within `duration` before the newest (e.g. 1y5m7d)")
+	f.VarP(&forgetOptions.Within, "keep-within", "", "keep snapshots that are older than `duration` (eg. 1y5m7d) relative to the latest snapshot")
 
 	f.Var(&forgetOptions.KeepTags, "keep-tag", "keep snapshots with this `taglist` (can be specified multiple times)")
 	f.StringVar(&forgetOptions.Host, "host", "", "only consider snapshots with the given `host`")

--- a/doc/man/restic-forget.1
+++ b/doc/man/restic-forget.1
@@ -48,7 +48,7 @@ data after 'forget' was run successfully, see the 'prune' command.
 
 .PP
 \fB\-\-keep\-within\fP=
-    keep snapshots that were created within \fB\fCduration\fR before the newest (e.g. 1y5m7d)
+    keep snapshots that are older than \fB\fCduration\fR (eg. 1y5m7d) relative to the latest snapshot
 
 .PP
 \fB\-\-keep\-tag\fP=[]


### PR DESCRIPTION


What is the purpose of this change? What does it change?
--------------------------------------------------------
changes language for keep-within

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://forum.restic.net/t/forget-keep-within/1044/2
Checklist
---------

- [✓ ] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ✖] I have added tests for all changes in this PR
- [ ✓] I have added documentation for the changes (in the manual)
- [✖ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [✖ ] I have run `gofmt` on the code in all commits
- [ ✓] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ✓] I'm done, this Pull Request is ready for review
