### PR TITLE
Output directory size in cache command

### DIFF
--- a/cmd/restic/cmd_cache.go
+++ b/cmd/restic/cmd_cache.go
@@ -152,10 +152,15 @@ func runCache(opts CacheOptions, gopts GlobalOptions, args []string) error {
 func dirSize(path string) (int64, error) {
 	var size int64
 	err := filepath.Walk(path, func(_ string, info os.FileInfo, err error) error {
+		if err != nil || info == nil {
+			return err
+		}
+
 		if !info.IsDir() {
 			size += info.Size()
 		}
-		return err
+
+		return nil
 	})
 	return size, err
 }

--- a/cmd/restic/cmd_cache.go
+++ b/cmd/restic/cmd_cache.go
@@ -128,7 +128,7 @@ func runCache(opts CacheOptions, gopts GlobalOptions, args []string) error {
 
 		var size string
 		if !opts.NoSize {
-			bytes, err := dirSize(fmt.Sprintf("%s/%s", cachedir, entry.Name()))
+			bytes, err := dirSize(filepath.Join(cachedir, entry.Name()))
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
This PR adds an additional column to the table printed by `restic cache` that contains the size of the cache directory. There is also a new flag `--no-size` which disables this column as computation can be expensive for large cache directories.

```
$ ./restic cache 
Repo ID     Last Used     Old  Size
------------------------------------------
426f9cb6c8  246 days ago  yes  360.365 MiB
469099403b  1 days ago         679.077 MiB
8af3cec4e8  1 days ago           8.097 KiB
8a28008e9b  0 days ago          11.687 KiB
------------------------------------------
4 cache dirs in /home/j/.cache/restic
```

```
$ ./restic cache --no-size
Repo ID     Last Used     Old
-----------------------------
426f9cb6c8  246 days ago  yes
469099403b  1 days ago
8af3cec4e8  1 days ago
8a28008e9b  0 days ago
-----------------------------
4 cache dirs in /home/j/.cache/restic
```

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Resolves #2028 

<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
