### PR TITLE
self-update: fix path to output file

### DIFF
--- a/cmd/restic/cmd_self_update.go
+++ b/cmd/restic/cmd_self_update.go
@@ -60,12 +60,14 @@ func runSelfUpdate(opts SelfUpdateOptions, gopts GlobalOptions, args []string) e
 
 	Printf("writing restic to %v\n", opts.Output)
 
-	v, err := selfupdate.DownloadLatestStableRelease(gopts.ctx, opts.Output, Verbosef)
+	v, err := selfupdate.DownloadLatestStableRelease(gopts.ctx, opts.Output, version, Verbosef)
 	if err != nil {
 		return errors.Fatalf("unable to update restic: %v", err)
 	}
 
-	Printf("successfully updated restic to version %v\n", v)
+	if v != version {
+		Printf("successfully updated restic to version %v\n", v)
+	}
 
 	return nil
 }

--- a/cmd/restic/cmd_self_update.go
+++ b/cmd/restic/cmd_self_update.go
@@ -1,4 +1,4 @@
-// +build selfupdate
+// xbuild selfupdate
 
 package main
 
@@ -36,10 +36,30 @@ func init() {
 	cmdRoot.AddCommand(cmdSelfUpdate)
 
 	flags := cmdSelfUpdate.Flags()
-	flags.StringVar(&selfUpdateOptions.Output, "output", os.Args[0], "Save the downloaded file as `filename`")
+	flags.StringVar(&selfUpdateOptions.Output, "output", "", "Save the downloaded file as `filename` (default: running binary itself)")
 }
 
 func runSelfUpdate(opts SelfUpdateOptions, gopts GlobalOptions, args []string) error {
+	if opts.Output == "" {
+		file, err := os.Executable()
+		if err != nil {
+			return errors.Wrap(err, "unable to find executable")
+		}
+
+		opts.Output = file
+	}
+
+	fi, err := os.Lstat(opts.Output)
+	if err != nil {
+		return err
+	}
+
+	if !fi.Mode().IsRegular() {
+		return errors.Errorf("output file %v is not a normal file, use --output to specify a different file", opts.Output)
+	}
+
+	Printf("writing restic to %v\n", opts.Output)
+
 	v, err := selfupdate.DownloadLatestStableRelease(gopts.ctx, opts.Output, Verbosef)
 	if err != nil {
 		return errors.Fatalf("unable to update restic: %v", err)

--- a/internal/selfupdate/download.go
+++ b/internal/selfupdate/download.go
@@ -106,7 +106,7 @@ func extractToFile(buf []byte, filename, target string, printf func(string, ...i
 // DownloadLatestStableRelease downloads the latest stable released version of
 // restic and saves it to target. It returns the version string for the newest
 // version. The function printf is used to print progress information.
-func DownloadLatestStableRelease(ctx context.Context, target string, printf func(string, ...interface{})) (version string, err error) {
+func DownloadLatestStableRelease(ctx context.Context, target, currentVersion string, printf func(string, ...interface{})) (version string, err error) {
 	if printf == nil {
 		printf = func(string, ...interface{}) {}
 	}
@@ -116,6 +116,11 @@ func DownloadLatestStableRelease(ctx context.Context, target string, printf func
 	rel, err := GitHubLatestRelease(ctx, "restic", "restic")
 	if err != nil {
 		return "", err
+	}
+
+	if rel.Version == currentVersion {
+		printf("restic is up to date\n")
+		return currentVersion, nil
 	}
 
 	printf("latest version is %v\n", rel.Version)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

It resolves #2041 by using the correct path to the binary (thanks
@wscott for the hint for `os.Executable()`!). In addition, `restic
self-update` now checks if an update is needed at all before attempting
to download the latest release.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------