### PR TITLE
Add ssh binary to docker image to allow sftp repository

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -2,6 +2,6 @@ FROM alpine:latest
 
 COPY restic /usr/bin
 
-RUN apk add --update --no-cache ca-certificates fuse
+RUN apk add --update --no-cache ca-certificates fuse openssh-client
 
 ENTRYPOINT ["/usr/bin/restic"]


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Add ssh binary to docker image to allow sftp repository

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
