### PR TITLE
Add --ignore-inode option to backup cmd.

### DIFF
--- a/changelog/unreleased/pull-2047
+++ b/changelog/unreleased/pull-2047
@@ -1,0 +1,9 @@
+Enhancement: Add --ignore-inode option to backup cmd
+
+This option handles backup of virtual filesystems that do not keep fixed
+inodes for files, like Fuse-based, pCloud, etc. Ignoring inode changes allows
+to consider the file as unchanged if last modification date and size
+are unchanged.
+
+https://github.com/restic/restic/pull/2047
+https://github.com/restic/restic/issues/1631

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -76,6 +76,7 @@ type BackupOptions struct {
 	FilesFrom        string
 	TimeStamp        string
 	WithAtime        bool
+	IgnoreInode      bool
 }
 
 var backupOptions BackupOptions
@@ -98,6 +99,7 @@ func init() {
 	f.StringVar(&backupOptions.FilesFrom, "files-from", "", "read the files to backup from file (can be combined with file args)")
 	f.StringVar(&backupOptions.TimeStamp, "time", "", "time of the backup (ex. '2012-11-01 22:08:41') (default: now)")
 	f.BoolVar(&backupOptions.WithAtime, "with-atime", false, "store the atime for all files and directories")
+	f.BoolVar(&backupOptions.IgnoreInode, "ignore-inode", false, "ignore inode number changes when checking for modified files")
 }
 
 // filterExisting returns a slice of all existing items, or an error if no
@@ -484,6 +486,9 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		Time:           timeStamp,
 		Hostname:       opts.Hostname,
 		ParentSnapshot: *parentSnapshotID,
+		ModIgnores: archiver.ModifiedIgnores{
+			Inode: opts.IgnoreInode,
+		},
 	}
 
 	uploader := archiver.IndexUploader{

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -271,6 +271,10 @@ written, and the next backup needs to write new metadata again. If you really
 want to save the access time for files and directories, you can pass the
 ``--with-atime`` option to the ``backup`` command.
 
+In filesystems that do not support inode consistency, like FUSE-based ones and pCloud, it is
+possible to ignore inode on changed files comparison by passing ``--ignore-inode`` to
+``backup`` command.
+
 Reading data from stdin
 ***********************
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This PR adds --ignore-inode option to backup command, in order to support those filesystems that don't support fixed inodes, typically Fuse, pCloud, etc.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

It was already discussed #1631.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
