### PR TITLE
tiny formatting fix

### DIFF
--- a/cmd/restic/format.go
+++ b/cmd/restic/format.go
@@ -21,7 +21,7 @@ func formatBytes(c uint64) string {
 	case c > 1<<10:
 		return fmt.Sprintf("%.3f KiB", b/(1<<10))
 	default:
-		return fmt.Sprintf("%dB", c)
+		return fmt.Sprintf("%d B", c)
 	}
 }
 


### PR DESCRIPTION
I noticed this discrepancy when trying to parse the output of restic.
