### PR TITLE
prune: Correctly handle errors returned by Load()

### DIFF
--- a/changelog/unreleased/pull-2068
+++ b/changelog/unreleased/pull-2068
@@ -1,0 +1,6 @@
+Bugfix: Correctly return error loading data
+
+In one case during `prune` and `check`, an error loading data from the backend is not returned properly. This is now corrected.
+
+https://github.com/restic/restic/pull/2068
+https://github.com/restic/restic/issues/1999#issuecomment-433737921

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -7,13 +7,12 @@ import (
 	"os"
 	"sync"
 
-	"github.com/restic/restic/internal/errors"
-	"github.com/restic/restic/internal/restic"
-	"golang.org/x/sync/errgroup"
-
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/pack"
 	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
+	"golang.org/x/sync/errgroup"
 )
 
 // Checker runs various checks on a repository. It is advisable to create an
@@ -652,7 +651,7 @@ func checkPack(ctx context.Context, r restic.Repository, id restic.ID) error {
 	debug.Log("checking pack %v", id)
 	h := restic.Handle{Type: restic.DataFile, Name: id.String()}
 
-	packfile, hash, size, err := repository.DownloadAndHash(ctx, r, h)
+	packfile, hash, size, err := repository.DownloadAndHash(ctx, r.Backend(), h)
 	if err != nil {
 		return errors.Wrap(err, "checkPack")
 	}

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -6,11 +6,10 @@ import (
 	"os"
 
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/pack"
 	"github.com/restic/restic/internal/restic"
-
-	"github.com/restic/restic/internal/errors"
 )
 
 // Repack takes a list of packs together with a list of blobs contained in
@@ -24,7 +23,7 @@ func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, kee
 		// load the complete pack into a temp file
 		h := restic.Handle{Type: restic.DataFile, Name: packID.String()}
 
-		tempfile, hash, packLength, err := DownloadAndHash(ctx, repo, h)
+		tempfile, hash, packLength, err := DownloadAndHash(ctx, repo.Backend(), h)
 		if err != nil {
 			return nil, errors.Wrap(err, "Repack")
 		}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -9,16 +9,15 @@ import (
 	"io"
 	"os"
 
+	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/cache"
+	"github.com/restic/restic/internal/crypto"
+	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/hashing"
-	"github.com/restic/restic/internal/restic"
-
-	"github.com/restic/restic/internal/backend"
-	"github.com/restic/restic/internal/crypto"
-	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/pack"
+	"github.com/restic/restic/internal/restic"
 )
 
 // Repository is used to access a repository in a backend.
@@ -694,16 +693,21 @@ func (r *Repository) SaveTree(ctx context.Context, t *restic.Tree) (restic.ID, e
 	return id, err
 }
 
+// Loader allows loading data from a backend.
+type Loader interface {
+	Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error
+}
+
 // DownloadAndHash is all-in-one helper to download content of the file at h to a temporary filesystem location
 // and calculate ID of the contents. Returned (temporary) file is positioned at the beginning of the file;
 // it is reponsibility of the caller to close and delete the file.
-func DownloadAndHash(ctx context.Context, repo restic.Repository, h restic.Handle) (tmpfile *os.File, hash restic.ID, size int64, err error) {
+func DownloadAndHash(ctx context.Context, be Loader, h restic.Handle) (tmpfile *os.File, hash restic.ID, size int64, err error) {
 	tmpfile, err = fs.TempFile("", "restic-temp-")
 	if err != nil {
 		return nil, restic.ID{}, -1, errors.Wrap(err, "TempFile")
 	}
 
-	err = repo.Backend().Load(ctx, h, 0, 0, func(rd io.Reader) (ierr error) {
+	err = be.Load(ctx, h, 0, 0, func(rd io.Reader) (ierr error) {
 		_, ierr = tmpfile.Seek(0, io.SeekStart)
 		if ierr == nil {
 			ierr = tmpfile.Truncate(0)
@@ -716,6 +720,11 @@ func DownloadAndHash(ctx context.Context, repo restic.Repository, h restic.Handl
 		hash = restic.IDFromHash(hrd.Sum(nil))
 		return ierr
 	})
+	if err != nil {
+		tmpfile.Close()
+		os.Remove(tmpfile.Name())
+		return nil, restic.ID{}, -1, errors.Wrap(err, "Load")
+	}
 
 	_, err = tmpfile.Seek(0, io.SeekStart)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

A function used during `prune` does not handle errors returned by the backend correctly. This change returns the error when a file could not be loaded.


<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.
-->

https://github.com/restic/restic/issues/1999#issuecomment-433731875

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review