### PR TITLE
Display local time for all commands

### DIFF
--- a/changelog/unreleased/pull-2070
+++ b/changelog/unreleased/pull-2070
@@ -1,0 +1,7 @@
+Enhancement: Make all commands display timestamps in local time
+
+Restic used to drop the timezone information from displayed timestamps, it now
+converts timestamps to local time before printing them so the times can be
+easily compared to.
+
+https://github.com/restic/restic/pull/2070

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -213,7 +213,7 @@ func (s *statefulOutput) PrintObjectNormal(kind, id, nodepath, treeID string, sn
 	} else {
 		Printf(" ... path %s\n", nodepath)
 	}
-	Printf(" ... in snapshot %s (%s)\n", sn.ID().Str(), sn.Time.Format(TimeFormat))
+	Printf(" ... in snapshot %s (%s)\n", sn.ID().Str(), sn.Time.Local().Format(TimeFormat))
 }
 
 func (s *statefulOutput) PrintObject(kind, id, nodepath, treeID string, sn *restic.Snapshot) {

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -59,7 +59,7 @@ func listKeys(ctx context.Context, s *repository.Repository, gopts GlobalOptions
 			ID:       id.Str(),
 			UserName: k.Username,
 			HostName: k.Hostname,
-			Created:  k.Created.Format(TimeFormat),
+			Created:  k.Created.Local().Format(TimeFormat),
 		}
 
 		keys = append(keys, key)

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -184,7 +184,7 @@ func PrintSnapshots(stdout io.Writer, list restic.Snapshots, reasons []restic.Ke
 	for _, sn := range list {
 		data := snapshot{
 			ID:        sn.ID().Str(),
-			Timestamp: sn.Time.Format(TimeFormat),
+			Timestamp: sn.Time.Local().Format(TimeFormat),
 			Hostname:  sn.Hostname,
 			Tags:      sn.Tags,
 			Paths:     sn.Paths,

--- a/cmd/restic/format.go
+++ b/cmd/restic/format.go
@@ -90,6 +90,6 @@ func formatNode(path string, n *restic.Node, long bool) string {
 
 	return fmt.Sprintf("%s %5d %5d %6d %s %s%s",
 		mode|n.Mode, n.UID, n.GID, n.Size,
-		n.ModTime.Format(TimeFormat), path,
+		n.ModTime.Local().Format(TimeFormat), path,
 		target)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

It changes restic to display the local time for all timestamps shown as
the result of CLI commands, e.g. the `snapshots` command.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://forum.restic.net/t/snapshot-time-offset-by-4-hours/1133

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review