### PR TITLE
backup: Open repository before async status starts

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -385,6 +385,12 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 
 	var t tomb.Tomb
 
+	term.Print("open repository\n")
+	repo, err := OpenRepository(gopts)
+	if err != nil {
+		return err
+	}
+
 	p := ui.NewBackup(term, gopts.verbosity)
 
 	// use the terminal for stdout/stderr
@@ -405,12 +411,6 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	}
 
 	t.Go(func() error { return p.Run(t.Context(gopts.ctx)) })
-
-	p.V("open repository")
-	repo, err := OpenRepository(gopts)
-	if err != nil {
-		return err
-	}
 
 	p.V("lock repository")
 	lock, err := lockRepo(repo)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

This commit makes sure the prompt for reading the password happens before the (asynchronous) status process is started, otherwise it might happen that the prompt for the password is overwritten by the "open repository" text.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2080

<!--
Link issues and relevant forum posts here.
-->