### PR TITLE
dump: Use path instead of filepath

### DIFF
--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 
 	"github.com/restic/restic/internal/debug"
@@ -47,12 +48,12 @@ func init() {
 	flags.StringArrayVar(&dumpOptions.Paths, "path", nil, "only consider snapshots which include this (absolute) `path` for snapshot ID \"latest\"")
 }
 
-func splitPath(path string) []string {
-	d, f := filepath.Split(path)
+func splitPath(p string) []string {
+	d, f := path.Split(p)
 	if d == "" || d == "/" {
 		return []string{f}
 	}
-	s := splitPath(filepath.Clean(d))
+	s := splitPath(path.Clean(d))
 	return append(s, f)
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

Some time ago we changed the paths in the repo to always use a slash for separation, it seems we missed that the `dump` command still uses the `filepath` package, so on Windows backslashes are used.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2079

<!--
Link issues and relevant forum posts here.
-->