### PR TITLE
Add support for reading password from external command

### DIFF
--- a/changelog/unreleased/pull-2094
+++ b/changelog/unreleased/pull-2094
@@ -1,0 +1,8 @@
+Enhancement: Run command to get password
+
+We've added the `--password-command` option which allows specifying a command
+that restic runs every time the password for the repository is needed, so it
+can be integrated with a password manager or keyring. The option can also be
+set via the environment variable `$RESTIC_PASSWORD_COMMAND`.
+
+https://github.com/restic/restic/pull/2094

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -54,7 +54,7 @@ directories in an encrypted repository stored on different backends.
 		if c.Name() == "version" {
 			return nil
 		}
-		pwd, err := resolvePassword(globalOptions, "RESTIC_PASSWORD")
+		pwd, err := resolvePassword(globalOptions)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Resolving password failed: %v\n", err)
 			Exit(1)

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -21,6 +21,19 @@ using a local repository; the remaining sections of this chapter cover all the
 other options. You can skip to the next chapter once you've read the relevant
 section here.
 
+For automated backups, restic accepts the repository location in the
+environment variable ``RESTIC_REPOSITORY``. For the password, several options
+exist:
+
+ * Setting the environment variable ``RESTIC_PASSWORD``
+
+ * Specifying the path to a file with the password via the option
+   ``--password-file`` or the environment variable ``RESTIC_PASSWORD_FILE``
+
+ * Configuring a program to be called when the password is needed via the
+   option ``--password-command`` or the environment variable
+   ``RESTIC_PASSWORD_COMMAND``
+
 Local
 *****
 
@@ -40,11 +53,6 @@ command and enter the same password twice:
 
    Remembering your password is important! If you lose it, you won't be
    able to access data stored in the repository.
-
-For automated backups, restic accepts the repository location in the
-environment variable ``RESTIC_REPOSITORY``. The password can be read
-from a file (via the option ``--password-file`` or the environment variable
-``RESTIC_PASSWORD_FILE``) or the environment variable ``RESTIC_PASSWORD``.
 
 SFTP
 ****


### PR DESCRIPTION
This allows reading the password from an password manager (like [pass](https://www.passwordstore.org/))

Signed-off-by: Juergen Hoetzel <juergen@archlinux.org>



<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No
<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review

This is inspired by a feature of [mbsync](https://wiki.archlinux.org/index.php/isync): `mbsync` supports reading the password from an external command.

Using `pinentry-gnome3` I get a nice prompt when the GnuPG agent cache expired. 

This is my systemd/timer setup I use for doing daily backups without storing the password in a plaintext file:

* Oneshot-Service
```ini
juergen@samson:~ → systemctl --user cat restic
# /home/juergen/.config/systemd/user/restic.service
[Unit]
Description=Restic Backup

[Service]
Type=oneshot
Environment=RESTIC_PASSWORD_COMMAND='pass Backup/restic@samson'
Environment=RESTIC_REPOSITORY=sftp:restic@shaun:/ext/restic
ExecStart=/home/juergen/bin/restic backup ${HOME}/
```
* Timer
```ini
juergen@samson:~ → systemctl --user cat restic.timer
# /home/juergen/.config/systemd/user/restic.timer
[Unit]
Description=Run restic backup daily

[Timer]
OnCalendar=*-*-* 14:06:00
Persistent=true

[Install]
WantedBy=timers.target
```