### PR TITLE
Use local time for user-provided time of backup

### DIFF
--- a/changelog/unreleased/pull-2095
+++ b/changelog/unreleased/pull-2095
@@ -1,0 +1,7 @@
+Bugfix: consistently use local time for snapshots times
+
+By default snapshots created with restic backup were set to local time,
+but when the --time flag was used the provided timestamp was parsed as
+UTC. With this change all snapshots times are set to local time.
+
+https://github.com/restic/restic/pull/2095

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -377,7 +377,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 
 	timeStamp := time.Now()
 	if opts.TimeStamp != "" {
-		timeStamp, err = time.Parse(TimeFormat, opts.TimeStamp)
+		timeStamp, err = time.ParseInLocation(TimeFormat, opts.TimeStamp, time.Local)
 		if err != nil {
 			return errors.Fatalf("error in time option: %v\n", err)
 		}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Snapshots created with the default `restic backup` behaviour of using the current time as time of backup use local time, but when the `--time` flag is used to force a specific time the resulting snapshot's time is set to UTC. This PR makes all snapshots use local time.



Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://forum.restic.net/t/which-timezone-does-forget-use/1166/2
https://github.com/restic/restic/issues/2065

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
