### PR TITLE
cache: Don't return an error for truncated files

### DIFF
--- a/internal/cache/file.go
+++ b/internal/cache/file.go
@@ -127,7 +127,8 @@ func (c *Cache) Save(h restic.Handle, rd io.Reader) error {
 	if n <= crypto.Extension {
 		_ = f.Close()
 		_ = c.Remove(h)
-		return errors.Errorf("trying to cache truncated file %v", h)
+		debug.Log("trying to cache truncated file %v, removing", h)
+		return nil
 	}
 
 	if err = f.Close(); err != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

When a truncated file is cached, the function used to return an error,
which triggers the retry code so the truncated file is downloaded again
after a delay. That's not a good strategy, so now we'll just remove the
file from the cache again, and let the higher-level code retry without
the cache.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #1229
Closes #1328




<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- ~[ ] I have added documentation for the changes (in the manual)~
- ~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done