### PR TITLE
--one-file-system unsupported on Windows

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -204,6 +204,9 @@ backup ``/sys`` or ``/dev`` on a Linux system:
 
     $ restic -r /srv/restic-repo backup --one-file-system /
 
+.. note:: ``--one-file-system`` is currently unsupported on Windows, and will
+    cause the backup to immediately fail with an error.
+
 By using the ``--files-from`` option you can read the files you want to
 backup from one or more files. This is especially useful if a lot of files have
 to be backed up that are not in the same folder or are maybe pre-filtered


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Small documentation change to note that `--one-file-system` is unsupported on Windows.  Restic bails with the unhelpful message `Device IDs are not supported on Windows`.  (Arguably, we should also handle that error more gracefully, or simply ignore the flag altogether on Windows.)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------
~Struck~ items do not apply; this is a doc-only PR.

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] ~I have added tests for all changes in this PR~
- [x] I have added documentation for the changes (in the manual)
- [ ] ~There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~
- [ ] ~I have run `gofmt` on the code in all commits~
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
