### PR TITLE
cmd: Don't exit if printing to stdout or stderr fails (closes #2102)

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -181,7 +181,6 @@ func Printf(format string, args ...interface{}) {
 	_, err := fmt.Fprintf(globalOptions.stdout, format, args...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to write to stdout: %v\n", err)
-		Exit(100)
 	}
 }
 
@@ -222,7 +221,6 @@ func Warnf(format string, args ...interface{}) {
 	_, err := fmt.Fprintf(globalOptions.stderr, format, args...)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to write to stderr: %v\n", err)
-		Exit(100)
 	}
 }
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Removes the call to `Exit` if there is an error writing to stdout or stderr.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
#2102

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
