### PR TITLE
Remove moot sudo usage from documentation

### DIFF
--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -66,7 +66,7 @@ backup with the intention to make you restore malicious data:
 
 .. code-block:: console
 
-    $ sudo echo "boom" >> backup/index/d795ffa99a8ab8f8e42cec1f814df4e48b8f49129360fb57613df93739faee97
+    $ echo "boom" >> backup/index/d795ffa99a8ab8f8e42cec1f814df4e48b8f49129360fb57613df93739faee97
 
 In order to detect these things, it is a good idea to regularly use the
 ``check`` command to test whether everything is alright, your precious


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

That usage of sudo only applies to the echo command itself. It has no
effect on the permissions of the stdout redirect.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
