### PR TITLE
Prefer https:// links in the documentation

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -72,7 +72,7 @@ macOS
 =====
 
 If you are using macOS, you can install restic using the
-`homebrew <http://brew.sh/>`__ package manager:
+`homebrew <https://brew.sh/>`__ package manager:
 
 .. code-block:: console
 

--- a/doc/090_participating.rst
+++ b/doc/090_participating.rst
@@ -85,7 +85,7 @@ back end is contained in `Design <https://restic.readthedocs.io/en/latest/design
 If you'd like to start contributing to restic, but don't know exactly
 what do to, have a look at this great article by Dave Cheney:
 `Suggestions for contributing to an Open Source
-project <http://dave.cheney.net/2016/03/12/suggestions-for-contributing-to-an-open-source-project>`__
+project <https://dave.cheney.net/2016/03/12/suggestions-for-contributing-to-an-open-source-project>`__
 A few issues have been tagged with the label ``help wanted``, you can
 start looking at those:
 https://github.com/restic/restic/labels/help%20wanted
@@ -113,7 +113,7 @@ Compatibility
 
 Backward compatibility for backups is important so that our users are
 always able to restore saved data. Therefore restic follows `Semantic
-Versioning <http://semver.org>`__ to clearly define which versions are
+Versioning <https://semver.org>`__ to clearly define which versions are
 compatible. The repository and data structures contained therein are
 considered the "Public API" in the sense of Semantic Versioning. This
 goes for all released versions of restic, this may not be the case for
@@ -128,7 +128,7 @@ prior versions.
 Building documentation
 **********************
 
-The restic documentation is built with `Sphinx <http://sphinx-doc.org>`__,
+The restic documentation is built with `Sphinx <https://www.sphinx-doc.org>`__,
 therefore building it locally requires a recent Python version and requirements listed in ``doc/requirements.txt``.
 This example will guide you through the process using `virtualenv <https://virtualenv.pypa.io>`__:
 

--- a/doc/cache.rst
+++ b/doc/cache.rst
@@ -9,7 +9,7 @@ Versions
 ========
 
 The cache directory is selected according to the `XDG base dir specification
-<http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
+<https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
 Each repository has its own cache sub-directory, consisting of the repository ID
 which is chosen at ``init``. All cache directories for different repos are
 independent of each other.

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -276,7 +276,7 @@ the IV for counter mode and the nonce for Poly1305. This operation needs
 three keys: A 32 byte for AES-256 for encryption, a 16 byte AES key and
 a 16 byte key for Poly1305. For details see the original paper `The
 Poly1305-AES message-authentication
-code <http://cr.yp.to/mac/poly1305-20050329.pdf>`__ by Dan Bernstein.
+code <https://cr.yp.to/mac/poly1305-20050329.pdf>`__ by Dan Bernstein.
 The data is then encrypted with AES-256 and afterwards a message
 authentication code (MAC) is computed over the ciphertext, everything is
 then stored as IV \|\| CIPHERTEXT \|\| MAC.

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -181,7 +181,7 @@ locks with the following command:
     d369ccc7d126594950bf74f0a348d5d98d9e99f3215082eb69bf02dc9b3e464c
 
 The ``find`` command searches for a given
-`pattern <http://golang.org/pkg/path/filepath/#Match>`__ in the
+`pattern <https://golang.org/pkg/path/filepath/#Match>`__ in the
 repository.
 
 .. code-block:: console


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

All the changed urls are available by way of https://. Most of them
already redirect.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.


Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
