### PR TITLE
[WIP] Warn when stdin is empty

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -146,6 +146,9 @@ func readLinesFromFile(filename string) ([]string, error) {
 
 	if filename == "-" {
 		data, err = ioutil.ReadAll(os.Stdin)
+		if len(data) == 0 {
+			Warnf("backing up from stdin but received 0 bytes from stdin\n")
+		}
 	} else {
 		data, err = textfile.Read(filename)
 	}


### PR DESCRIPTION
Stdin being empty most likely indicates the command used for stdin failing for some reason (think of a mysqldump that couldn't connect). This pull request isn't really done, and I'm not a go developer, but I wanted to run this idea by the team and making the (pseudo) code change seemed like an easier way to explain the behaviour I'm looking for.

What is the purpose of this change? What does it change?
--------------------------------------------------------

Print an error message to stdout when stdin is empty and --stdin is used

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review