### PR TITLE
Use processed bytes for summary

### DIFF
--- a/internal/ui/backup.go
+++ b/internal/ui/backup.go
@@ -49,6 +49,7 @@ type Backup struct {
 			Changed   uint
 			Unchanged uint
 		}
+		ProcessedBytes uint64
 		archiver.ItemStats
 	}
 }
@@ -259,6 +260,12 @@ func formatBytes(c uint64) string {
 func (b *Backup) CompleteItemFn(item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration) {
 	b.summary.Lock()
 	b.summary.ItemStats.Add(s)
+
+	// for the last item "/", current is nil
+	if current != nil {
+		b.summary.ProcessedBytes += current.Size
+	}
+
 	b.summary.Unlock()
 
 	if current == nil {
@@ -361,7 +368,7 @@ func (b *Backup) Finish() {
 	b.P("\n")
 	b.P("processed %v files, %v in %s",
 		b.summary.Files.New+b.summary.Files.Changed+b.summary.Files.Unchanged,
-		formatBytes(b.totalBytes),
+		formatBytes(b.summary.ProcessedBytes),
 		formatDuration(time.Since(b.start)),
 	)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

When restic reads the backup from stdin, the number of bytes processed
was always displayed as zero. The reason is that the UI for the archive
uses the total bytes as returned by the scanner, which is zero for
stdin. So instead we keep track of the real number of bytes processed
and print that at the end.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2136
Supersedes #2135




<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)