### PR TITLE
Document installation with MacPorts

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -78,6 +78,12 @@ If you are using macOS, you can install restic using the
 
     $ brew install restic
 
+You may also install it using `MacPorts <https://www.macports.org/>`__:
+
+.. code-block:: console
+
+    $ sudo port install restic
+
 Nix & NixOS
 ===========
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Restic has been recently added to [MacPorts](https://www.macports.org/) (package name [restic](https://www.macports.org/ports.php?by=name&substr=restic))

This change just documents the now available alternative of using macports to install Restic on Mac OS.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No

Checklist
---------

This is a documentation-only change, so the code-oriented checks here do not apply.

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
