### PR TITLE
WIP cmd_restore: expose filerestorer options in flags

### DIFF
--- a/changelog/unreleased/pull-2178
+++ b/changelog/unreleased/pull-2178
@@ -1,0 +1,15 @@
+Enhancement: expose filerestorer tunning parameters in cmd_restore command
+
+The `restic restore` command now exposes three new flags that control the 
+behaviour of the filerestorer.
+
+These new flags are the following:
+
+```
+--average-pack-size int    average pack size in bytes (default 5242880)
+--files-writer-count int   number of open files for restore (default 32)
+--worker-count int        number of workers for file restore (default 8)
+
+```
+
+https://github.com/restic/restic/pull/2178

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -20,7 +20,7 @@ import (
 // TODO avoid decrypting the same blob multiple times
 // TODO evaluate disabled debug logging overhead for large repositories
 
-const (
+var (
 	workerCount = 8
 
 	// max number of open output file handles

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -13,6 +13,13 @@ import (
 	"github.com/restic/restic/internal/restic"
 )
 
+// Options are the options available for the Restorer.
+type Options struct {
+	WorkerCount      int
+	FilesWriterCount int
+	AveragePackSize  int
+}
+
 // Restorer is used to restore a snapshot to a directory.
 type Restorer struct {
 	repo restic.Repository
@@ -25,7 +32,7 @@ type Restorer struct {
 var restorerAbortOnAllErrors = func(location string, err error) error { return err }
 
 // NewRestorer creates a restorer preloaded with the content from the snapshot id.
-func NewRestorer(repo restic.Repository, id restic.ID) (*Restorer, error) {
+func NewRestorer(repo restic.Repository, id restic.ID, opt *Options) (*Restorer, error) {
 	r := &Restorer{
 		repo:         repo,
 		Error:        restorerAbortOnAllErrors,
@@ -38,6 +45,12 @@ func NewRestorer(repo restic.Repository, id restic.ID) (*Restorer, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	// set package variables to option values
+	// these variables are defined in filerestorer.go
+	workerCount = opt.WorkerCount
+	averagePackSize = opt.AveragePackSize
+	filesWriterCount = opt.FilesWriterCount
 
 	return r, nil
 }

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -322,7 +322,7 @@ func TestRestorer(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := NewRestorer(repo, id)
+			res, err := NewRestorer(repo, id, &Options{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -440,7 +440,7 @@ func TestRestorerRelative(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := NewRestorer(repo, id)
+			res, err := NewRestorer(repo, id, &Options{})
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -671,7 +671,7 @@ func TestRestorerTraverseTree(t *testing.T) {
 			defer cleanup()
 			sn, id := saveSnapshot(t, repo, test.Snapshot)
 
-			res, err := NewRestorer(repo, id)
+			res, err := NewRestorer(repo, id, &Options{})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -29,7 +29,7 @@ func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
 		},
 	})
 
-	res, err := NewRestorer(repo, id)
+	res, err := NewRestorer(repo, id, &Options{})
 	rtest.OK(t, err)
 
 	res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
Expose internal tunnng options of the filerestorer on the restore command flags:

```
--average-pack-size int    average pack size in bytes (default 5242880)
--files-writer-count int   number of open files for restore (default 32)
--worker-count int        number of workers for file restore (default 8)
```

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
<!--
Link issues and relevant forum posts here.
-->
https://github.com/restic/restic/pull/2101
https://github.com/restic/restic/issues/2074

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
