### PR TITLE
Json forget

### DIFF
--- a/changelog/unreleased/issue-2184
+++ b/changelog/unreleased/issue-2184
@@ -1,0 +1,8 @@
+Enhancement: Add --json support to forget command
+
+The forget command now supports the --json argument, outputting the
+information about what is (or would-be) kept and removed from the
+repository.
+
+https://github.com/restic/restic/issues/2184
+https://github.com/restic/restic/pull/2185

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -236,6 +236,8 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 			}
 			addJSONSnapshots(&fg.Remove, remove)
 
+			fg.Reasons = reasons
+
 			jsonGroups = append(jsonGroups, &fg)
 
 			removeSnapshots += len(remove)
@@ -271,11 +273,12 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 
 // ForgetGroup helps to print what is forgotten in JSON.
 type ForgetGroup struct {
-	Tags   []string   `json:"tags"`
-	Host   string     `json:"host"`
-	Paths  []string   `json:"paths"`
-	Keep   []Snapshot `json:"keep"`
-	Remove []Snapshot `json:"remove"`
+	Tags    []string            `json:"tags"`
+	Host    string              `json:"host"`
+	Paths   []string            `json:"paths"`
+	Keep    []Snapshot          `json:"keep"`
+	Remove  []Snapshot          `json:"remove"`
+	Reasons []restic.KeepReason `json:"reasons"`
 }
 
 func addJSONSnapshots(js *[]Snapshot, list restic.Snapshots) {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
This makes the `--json` option work with the `forget` command.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
I created issue #2184 to describe this.

Closes #2184

<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
  (it could be argued that this is already described in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
