### PR TITLE
self-update: Don't cancel download after 30s

### DIFF
--- a/changelog/unreleased/issue-2181
+++ b/changelog/unreleased/issue-2181
@@ -1,0 +1,3 @@
+Bugfix: Don't cancel timeout after 30 seconds for self-update
+
+https://github.com/restic/restic/issues/2181

--- a/internal/selfupdate/github.go
+++ b/internal/selfupdate/github.go
@@ -112,9 +112,6 @@ func GitHubLatestRelease(ctx context.Context, owner, repo string) (Release, erro
 }
 
 func getGithubData(ctx context.Context, url string) ([]byte, error) {
-	ctx, cancel := context.WithTimeout(ctx, githubAPITimeout)
-	defer cancel()
-
 	req, err := http.NewRequest(http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

We have an API timeout for the `self-upate` commands for requests against the GitHub API. Accidentally, this timeout was also used for the download itself, which (depending on the available bandwidth) may take much longer. So don't use this timeout for the actual download.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2181

<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review