### PR TITLE
rclone: Rework backend option parsing

### DIFF
--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -127,8 +127,6 @@ func New(cfg Config, lim limiter.Limiter) (*Backend, error) {
 			return nil, err
 		}
 		args = append(args, a...)
-	} else {
-		args = append(args, "rclone")
 	}
 
 	// then add the arguments
@@ -139,10 +137,6 @@ func New(cfg Config, lim limiter.Limiter) (*Backend, error) {
 		}
 
 		args = append(args, a...)
-	} else {
-		args = append(args,
-			"serve", "restic", "--stdio",
-			"--b2-hard-delete", "--drive-use-trash=false")
 	}
 
 	// finally, add the remote

--- a/internal/backend/rclone/config.go
+++ b/internal/backend/rclone/config.go
@@ -15,15 +15,19 @@ type Config struct {
 	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
 }
 
+var defaultConfig = Config{
+	Program:     "rclone",
+	Args:        "serve restic --stdio --b2-hard-delete --drive-use-trash=false",
+	Connections: 5,
+}
+
 func init() {
 	options.Register("rclone", Config{})
 }
 
 // NewConfig returns a new Config with the default values filled in.
 func NewConfig() Config {
-	return Config{
-		Connections: 5,
-	}
+	return defaultConfig
 }
 
 // ParseConfig parses the string s and extracts the remote server URL.

--- a/internal/backend/rclone/config_test.go
+++ b/internal/backend/rclone/config_test.go
@@ -14,7 +14,9 @@ func TestParseConfig(t *testing.T) {
 			"rclone:local:foo:/bar",
 			Config{
 				Remote:      "local:foo:/bar",
-				Connections: 5,
+				Program:     defaultConfig.Program,
+				Args:        defaultConfig.Args,
+				Connections: defaultConfig.Connections,
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

This change allows passing no arguments to rclone, using `-o
rclone.args=""`. It is helpful when running rclone remotely via SSH
using a key with a forced command (via `command=` in `authorized_keys`).

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

On IRC

<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [-] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review