### PR TITLE
Fix build on FreeBSD with Go 1.12

### DIFF
--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -321,11 +321,11 @@ func (node Node) createSymlinkAt(path string) error {
 }
 
 func (node *Node) createDevAt(path string) error {
-	return mknod(path, syscall.S_IFBLK|0600, int(node.Device))
+	return mknod(path, syscall.S_IFBLK|0600, node.device())
 }
 
 func (node *Node) createCharDevAt(path string) error {
-	return mknod(path, syscall.S_IFCHR|0600, int(node.Device))
+	return mknod(path, syscall.S_IFCHR|0600, node.device())
 }
 
 func (node *Node) createFifoAt(path string) error {

--- a/internal/restic/node_darwin.go
+++ b/internal/restic/node_darwin.go
@@ -6,6 +6,10 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
+func (node Node) device() int {
+	return int(node.Device)
+}
+
 func (s statUnix) atim() syscall.Timespec { return s.Atimespec }
 func (s statUnix) mtim() syscall.Timespec { return s.Mtimespec }
 func (s statUnix) ctim() syscall.Timespec { return s.Ctimespec }

--- a/internal/restic/node_freebsd.go
+++ b/internal/restic/node_freebsd.go
@@ -6,6 +6,10 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
+func (node Node) device() uint64 {
+	return node.Device
+}
+
 func (s statUnix) atim() syscall.Timespec { return s.Atimespec }
 func (s statUnix) mtim() syscall.Timespec { return s.Mtimespec }
 func (s statUnix) ctim() syscall.Timespec { return s.Ctimespec }

--- a/internal/restic/node_linux.go
+++ b/internal/restic/node_linux.go
@@ -32,6 +32,10 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
+func (node Node) device() int {
+	return int(node.Device)
+}
+
 func (s statUnix) atim() syscall.Timespec { return s.Atim }
 func (s statUnix) mtim() syscall.Timespec { return s.Mtim }
 func (s statUnix) ctim() syscall.Timespec { return s.Ctim }

--- a/internal/restic/node_netbsd.go
+++ b/internal/restic/node_netbsd.go
@@ -6,6 +6,10 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
+func (node Node) device() int {
+	return int(node.Device)
+}
+
 func (s statUnix) atim() syscall.Timespec { return s.Atimespec }
 func (s statUnix) mtim() syscall.Timespec { return s.Mtimespec }
 func (s statUnix) ctim() syscall.Timespec { return s.Ctimespec }

--- a/internal/restic/node_openbsd.go
+++ b/internal/restic/node_openbsd.go
@@ -6,6 +6,10 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
+func (node Node) device() int {
+	return int(node.Device)
+}
+
 func (s statUnix) atim() syscall.Timespec { return s.Atim }
 func (s statUnix) mtim() syscall.Timespec { return s.Mtim }
 func (s statUnix) ctim() syscall.Timespec { return s.Ctim }

--- a/internal/restic/node_solaris.go
+++ b/internal/restic/node_solaris.go
@@ -6,6 +6,10 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
+func (node Node) device() int {
+	return int(node.Device)
+}
+
 func (s statUnix) atim() syscall.Timespec { return s.Atim }
 func (s statUnix) mtim() syscall.Timespec { return s.Mtim }
 func (s statUnix) ctim() syscall.Timespec { return s.Ctim }

--- a/internal/restic/node_windows.go
+++ b/internal/restic/node_windows.go
@@ -22,6 +22,10 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
+func (node Node) device() int {
+	return int(node.Device)
+}
+
 // Getxattr retrieves extended attribute data associated with path.
 func Getxattr(path, name string) ([]byte, error) {
 	return nil, nil


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

syscall.Mknod was changed to take uint64 dev in Go 1.12 [1]
This PR unbreaks restic build on FreeBSD with Go 1.12.

[1] https://github.com/golang/go/commit/dc6eb200dd59dfedaa5259565b8ef1aa96a39271

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
