### PR TITLE
Add --ignore-inode option to backup cmd

### DIFF
--- a/changelog/unreleased/pull-2205
+++ b/changelog/unreleased/pull-2205
@@ -1,0 +1,10 @@
+Enhancement: Add --ignore-inode option to backup cmd
+
+This option handles backup of virtual filesystems that do not keep fixed
+inodes for files, like Fuse-based, pCloud, etc. Ignoring inode changes allows
+to consider the file as unchanged if last modification date and size
+are unchanged.
+
+https://github.com/restic/restic/pull/2205
+https://github.com/restic/restic/pull/2047
+https://github.com/restic/restic/issues/1631

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -85,6 +85,7 @@ type BackupOptions struct {
 	FilesFrom           []string
 	TimeStamp           string
 	WithAtime           bool
+	IgnoreInode         bool
 }
 
 var backupOptions BackupOptions
@@ -112,6 +113,7 @@ func init() {
 	f.StringArrayVar(&backupOptions.FilesFrom, "files-from", nil, "read the files to backup from file (can be combined with file args/can be specified multiple times)")
 	f.StringVar(&backupOptions.TimeStamp, "time", "", "time of the backup (ex. '2012-11-01 22:08:41') (default: now)")
 	f.BoolVar(&backupOptions.WithAtime, "with-atime", false, "store the atime for all files and directories")
+	f.BoolVar(&backupOptions.IgnoreInode, "ignore-inode", false, "ignore inode number changes when checking for modified files")
 }
 
 // filterExisting returns a slice of all existing items, or an error if no
@@ -549,6 +551,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	arch.CompleteItem = p.CompleteItem
 	arch.StartFile = p.StartFile
 	arch.CompleteBlob = p.CompleteBlob
+	arch.IgnoreInode = opts.IgnoreInode
 
 	if parentSnapshotID == nil {
 		parentSnapshotID = &restic.ID{}

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -279,6 +279,10 @@ written, and the next backup needs to write new metadata again. If you really
 want to save the access time for files and directories, you can pass the
 ``--with-atime`` option to the ``backup`` command.
 
+In filesystems that do not support inode consistency, like FUSE-based ones and pCloud, it is
+possible to ignore inode on changed files comparison by passing ``--ignore-inode`` to
+``backup`` command.
+
 Reading data from stdin
 ***********************
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

revised version of https://github.com/restic/restic/pull/2047

This PR adds --ignore-inode option to backup command, in order to support those filesystems that don't support fixed inodes, typically Fuse, pCloud, etc.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://github.com/restic/restic/issues/1631
https://github.com/restic/restic/pull/2047

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
