### PR TITLE
fs: Handle absolute pathname for --stdin-filename

### DIFF
--- a/changelog/unreleased/issue-2063
+++ b/changelog/unreleased/issue-2063
@@ -1,0 +1,6 @@
+Bugfix: Allow absolute path for filename when backing up from stdin
+
+When backing up from stdin, handle directory path for `--stdin-filename`.
+This can be used to specify the full path for the backed-up file.
+
+https://github.com/restic/restic/issues/2063

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
+	"path"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -523,13 +524,14 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		if !gopts.JSON {
 			p.V("read data from stdin")
 		}
+		filename := path.Join("/", opts.StdinFilename)
 		targetFS = &fs.Reader{
 			ModTime:    timeStamp,
-			Name:       opts.StdinFilename,
+			Name:       filename,
 			Mode:       0644,
 			ReadCloser: os.Stdin,
 		}
-		targets = []string{opts.StdinFilename}
+		targets = []string{filename}
 	}
 
 	sc := archiver.NewScanner(targetFS)

--- a/internal/fs/fs_reader_test.go
+++ b/internal/fs/fs_reader_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"io/ioutil"
 	"os"
+	"path"
 	"sort"
 	"strings"
 	"testing"
@@ -163,8 +164,12 @@ func checkFileInfo(t testing.TB, fi os.FileInfo, filename string, modtime time.T
 		t.Errorf("ModTime() returned wrong value, want %v, got %v", modtime, fi.ModTime())
 	}
 
-	if fi.Name() != filename {
-		t.Errorf("Name() returned wrong value, want %q, got %q", filename, fi.Name())
+	if path.Base(fi.Name()) != fi.Name() {
+		t.Errorf("Name() returned is not base, want %q, got %q", path.Base(fi.Name()), fi.Name())
+	}
+
+	if fi.Name() != path.Base(filename) {
+		t.Errorf("Name() returned wrong value, want %q, got %q", path.Base(filename), fi.Name())
 	}
 }
 

--- a/internal/fs/fs_reader_test.go
+++ b/internal/fs/fs_reader_test.go
@@ -151,8 +151,8 @@ func verifyDirectoryContentsFI(t testing.TB, fs FS, dir string, want []os.FileIn
 }
 
 func checkFileInfo(t testing.TB, fi os.FileInfo, filename string, modtime time.Time, mode os.FileMode, isdir bool) {
-	if fi.IsDir() {
-		t.Errorf("IsDir returned true, want false")
+	if fi.IsDir() != isdir {
+		t.Errorf("IsDir returned %t, want %t", fi.IsDir(), isdir)
 	}
 
 	if fi.Mode() != mode {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Describe the changes here, as detailed as needed.
-->
Return valid directory info from Lstat() for parent directories of the specified filename. Previously only "/" and "." were valid directories.
Also set directory mode as this is checked by archiver.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.
-->
Closes #2063
Closes #1809

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
