### PR TITLE
Update Go for CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,15 +4,15 @@ sudo: false
 matrix:
   include:
     - os: linux
-      go: "1.9.x"
-      env: RESTIC_TEST_FUSE=0 RESTIC_TEST_CLOUD_BACKENDS=0 RESTIC_BUILD_SOLARIS=0
+      go: "1.10.x"
+      env: RESTIC_TEST_FUSE=0 RESTIC_TEST_CLOUD_BACKENDS=0
       cache:
         directories:
           - $HOME/.cache/go-build
           - $HOME/gopath/pkg/mod
 
     - os: linux
-      go: "1.10.x"
+      go: "1.11.x"
       env: RESTIC_TEST_FUSE=0 RESTIC_TEST_CLOUD_BACKENDS=0
       cache:
         directories:
@@ -21,7 +21,7 @@ matrix:
 
     # only run fuse and cloud backends tests on Travis for the latest Go on Linux
     - os: linux
-      go: "1.11.x"
+      go: "1.12.x"
       sudo: true
       cache:
         directories:
@@ -29,7 +29,7 @@ matrix:
           - $HOME/gopath/pkg/mod
 
     - os: osx
-      go: "1.11.x"
+      go: "1.12.x"
       env: RESTIC_TEST_FUSE=0 RESTIC_TEST_CLOUD_BACKENDS=0
       cache:
         directories:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -20,8 +20,8 @@ init:
 
 install:
   - rmdir c:\go /s /q
-  - appveyor DownloadFile https://dl.google.com/go/go1.11.windows-amd64.msi
-  - msiexec /i go1.11.windows-amd64.msi /q
+  - appveyor DownloadFile https://dl.google.com/go/go1.12.1.windows-amd64.msi
+  - msiexec /i go1.12.1.windows-amd64.msi /q
   - go version
   - go env
   - appveyor DownloadFile http://sourceforge.netcologne.de/project/gnuwin32/tar/1.13-1/tar-1.13-1-bin.zip -FileName tar.zip


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

It updates the Go versions used during CI.