### PR TITLE
Fix build on FreeBSD for Go < 1.12

### DIFF
--- a/internal/restic/node_freebsd_go111.go
+++ b/internal/restic/node_freebsd_go111.go
@@ -1,4 +1,4 @@
-// +build freebsd,go1.12
+// +build freebsd,!go1.12
 
 package restic
 
@@ -8,8 +8,8 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
-func (node Node) device() uint64 {
-	return node.Device
+func (node Node) device() int {
+	return int(node.Device)
 }
 
 func (s statUnix) atim() syscall.Timespec { return s.Atimespec }


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

It fixes the build on FreeBSD for Go < 1.12 (accidentally broken by #2197)