### PR TITLE
Examine file ctime when checking if files have changed.

### DIFF
--- a/changelog/unreleased/issue-2179
+++ b/changelog/unreleased/issue-2179
@@ -1,8 +1,15 @@
-Bugfix: Use ctime when checking for file changes
+Enhancement: Use ctime when checking for file changes
 
 Previously, restic only checked a file's mtime (along with other non-timestamp
-data) to decide if a file has changed. This could cause it to not notice changes
-if something edits a file and then resets the timestamp. Restic now also checks
-the ctime, so any modification to a file should be noticed.
+metadata) to decide if a file has changed. This could cause restic to not notice
+that a file has changed (and therefore continue to store the old version, as
+opposed to the modified version) if something edits the file and then resets the
+timestamp. Restic now also checks the ctime of files, so any modifications to a
+file should be noticed, and the modified file will be backed up. The ctime check
+will be disabled if the --ignore-inode flag was given.
+
+If this change causes problems for you, please open an issue, and we can look in
+to adding a seperate flag to disable just the ctime check.
 
 https://github.com/restic/restic/issues/2179
+https://github.com/restic/restic/pull/2212

--- a/changelog/unreleased/issue-2179
+++ b/changelog/unreleased/issue-2179
@@ -1,0 +1,8 @@
+Bugfix: Use ctime when checking for file changes
+
+Previously, restic only checked a file's mtime (along with other non-timestamp
+data) to decide if a file has changed. This could cause it to not notice changes
+if something edits a file and then resets the timestamp. Restic now also checks
+the ctime, so any modification to a file should be noticed.
+
+https://github.com/restic/restic/issues/2179

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -453,8 +453,13 @@ func fileChanged(fi os.FileInfo, node *restic.Node, ignoreInode bool) bool {
 		return true
 	}
 
-	// check size
+	// check status change timestamp
 	extFI := fs.ExtendedStat(fi)
+	if !extFI.ChangeTime.Equal(node.ChangeTime) {
+		return true
+	}
+
+	// check size
 	if uint64(fi.Size()) != node.Size || uint64(extFI.Size) != node.Size {
 		return true
 	}

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -455,7 +455,7 @@ func fileChanged(fi os.FileInfo, node *restic.Node, ignoreInode bool) bool {
 
 	// check status change timestamp
 	extFI := fs.ExtendedStat(fi)
-	if !extFI.ChangeTime.Equal(node.ChangeTime) {
+	if !ignoreInode && !extFI.ChangeTime.Equal(node.ChangeTime) {
 		return true
 	}
 

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -580,21 +580,14 @@ func TestFileChanged(t *testing.T) {
 		{
 			Name: "new-content-same-timestamp",
 			Modify: func(t testing.TB, filename string) {
-				fi, _ := os.Stat(filename)
+				fi, err := os.Stat(filename)
+				if err != nil {
+					t.Fatal(err)
+				}
 				extFI := fs.ExtendedStat(fi)
 				save(t, filename, bytes.ToUpper(defaultContent))
 				sleep()
-				ts := []syscall.Timespec{
-					{
-						Sec:  extFI.AccessTime.Unix(),
-						Nsec: int64(extFI.AccessTime.Nanosecond()),
-					},
-					{
-						Sec:  extFI.ModTime.Unix(),
-						Nsec: int64(extFI.ModTime.Nanosecond()),
-					},
-				}
-				syscall.UtimesNano(filename, ts)
+				setTimestamp(t, filename, extFI.AccessTime, extFI.ModTime)
 			},
 		},
 		{

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1,6 +1,7 @@
 package archiver
 
 import (
+	"bytes"
 	"context"
 	"io/ioutil"
 	"os"
@@ -574,6 +575,26 @@ func TestFileChanged(t *testing.T) {
 			Modify: func(t testing.TB, filename string) {
 				sleep()
 				save(t, filename, defaultContent)
+			},
+		},
+		{
+			Name: "new-content-same-timestamp",
+			Modify: func(t testing.TB, filename string) {
+				fi, _ := os.Stat(filename)
+				extFI := fs.ExtendedStat(fi)
+				save(t, filename, bytes.ToUpper(defaultContent))
+				sleep()
+				ts := []syscall.Timespec{
+					{
+						Sec:  extFI.AccessTime.Unix(),
+						Nsec: int64(extFI.AccessTime.Nanosecond()),
+					},
+					{
+						Sec:  extFI.ModTime.Unix(),
+						Nsec: int64(extFI.ModTime.Nanosecond()),
+					},
+				}
+				syscall.UtimesNano(filename, ts)
 			},
 		},
 		{

--- a/internal/fs/stat.go
+++ b/internal/fs/stat.go
@@ -22,6 +22,7 @@ type ExtendedFileInfo struct {
 
 	AccessTime time.Time // last access time stamp
 	ModTime    time.Time // last (content) modification time stamp
+	ChangeTime time.Time // last status change time stamp
 }
 
 // ExtendedStat returns an ExtendedFileInfo constructed from the os.FileInfo.

--- a/internal/fs/stat_bsd.go
+++ b/internal/fs/stat_bsd.go
@@ -30,6 +30,7 @@ func extendedStat(fi os.FileInfo) ExtendedFileInfo {
 
 		AccessTime: time.Unix(s.Atimespec.Unix()),
 		ModTime:    time.Unix(s.Mtimespec.Unix()),
+		ChangeTime: time.Unix(s.Ctimespec.Unix()),
 	}
 
 	return extFI

--- a/internal/fs/stat_unix.go
+++ b/internal/fs/stat_unix.go
@@ -30,6 +30,7 @@ func extendedStat(fi os.FileInfo) ExtendedFileInfo {
 
 		AccessTime: time.Unix(s.Atim.Unix()),
 		ModTime:    time.Unix(s.Mtim.Unix()),
+		ChangeTime: time.Unix(s.Ctim.Unix()),
 	}
 
 	return extFI

--- a/internal/fs/stat_windows.go
+++ b/internal/fs/stat_windows.go
@@ -27,5 +27,7 @@ func extendedStat(fi os.FileInfo) ExtendedFileInfo {
 	mtime := syscall.NsecToTimespec(s.LastWriteTime.Nanoseconds())
 	extFI.ModTime = time.Unix(mtime.Unix())
 
+	extFI.ChangeTime = extFI.ModTime
+
 	return extFI
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

This makes restic compare file ctimes (in addition to all of the existing checks) when it is deciding if a file has been modified.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Yes, closes #2179.

<!--
Link issues and relevant forum posts here.
-->

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [X] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
