### PR TITLE
Add a global option --wait-lock, fixes #719

### DIFF
--- a/changelog/unreleased/pull-2214
+++ b/changelog/unreleased/pull-2214
@@ -1,0 +1,7 @@
+Enhancement: Add --wait-lock option
+
+This option allows to specify a duration for which restic will wait if there
+already exists a conflicting lock within the repository.
+
+https://github.com/restic/restic/pull/2214
+https://github.com/restic/restic/issues/719

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -56,6 +56,7 @@ type GlobalOptions struct {
 	Quiet           bool
 	Verbose         int
 	NoLock          bool
+	WaitLock        time.Duration
 	JSON            bool
 	CacheDir        string
 	NoCache         bool
@@ -109,6 +110,7 @@ func init() {
 	f.BoolVarP(&globalOptions.Quiet, "quiet", "q", false, "do not output comprehensive progress report")
 	f.CountVarP(&globalOptions.Verbose, "verbose", "v", "be verbose (specify multiple times or a level using --verbose=`n`, max level/times is 3)")
 	f.BoolVar(&globalOptions.NoLock, "no-lock", false, "do not lock the repository, this allows some operations on read-only repositories")
+	f.DurationVar(&globalOptions.WaitLock, "wait-lock", 0, "wait if the repository is already locked, takes a value like 5m or 2h (default: don't wait)")
 	f.BoolVarP(&globalOptions.JSON, "json", "", false, "set output mode to JSON for commands that support it")
 	f.StringVar(&globalOptions.CacheDir, "cache-dir", "", "set the cache `directory`. (default: use system default cache directory)")
 	f.BoolVar(&globalOptions.NoCache, "no-cache", false, "do not use a local cache")

--- a/cmd/restic/lock_test.go
+++ b/cmd/restic/lock_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"context"
+	"github.com/restic/restic/internal/repository"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/test"
+)
+
+func TestLockWaitTimeout(t *testing.T) {
+	repo, cleanup := repository.TestRepository(t)
+	defer cleanup()
+
+	elock, err := lockRepoExclusive(context.TODO(), repo.(*repository.Repository))
+	test.OK(t, err)
+
+	wait := 2 * time.Second
+	oldWaitLock := globalOptions.WaitLock
+	globalOptions.WaitLock = wait
+	start := time.Now()
+	lock, err := lockRepo(context.TODO(), repo.(*repository.Repository))
+	duration := time.Since(start)
+	globalOptions.WaitLock = oldWaitLock
+	test.Assert(t, err != nil,
+		"create normal lock with exclusively locked repo didn't return an error")
+	test.Assert(t, strings.Contains(err.Error(), "repository is already locked exclusively"),
+		"create normal lock with exclusively locked repo didn't return the correct error")
+	test.Assert(t, duration >= wait,
+		"create normal lock with exclusively locked repo didn't wait for the specified timeout")
+
+	test.OK(t, lock.Unlock())
+	test.OK(t, elock.Unlock())
+}
+
+func TestLockWaitSuccess(t *testing.T) {
+	repo, cleanup := repository.TestRepository(t)
+	defer cleanup()
+
+	elock, err := lockRepoExclusive(context.TODO(), repo.(*repository.Repository))
+	test.OK(t, err)
+
+	wait := 2 * time.Second
+	time.AfterFunc(wait/2, func() {
+		test.OK(t, elock.Unlock())
+	})
+
+	oldWaitLock := globalOptions.WaitLock
+	globalOptions.WaitLock = wait
+	lock, err := lockRepo(context.TODO(), repo.(*repository.Repository))
+	globalOptions.WaitLock = oldWaitLock
+	test.OK(t, err)
+
+	test.OK(t, lock.Unlock())
+}

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -542,7 +542,10 @@ that the process is dead and considers the lock to be stale.
 When a new lock is to be created and no other conflicting locks are
 detected, restic creates a new lock, waits, and checks if other locks
 appeared in the repository. Depending on the type of the other locks and
-the lock to be created, restic either continues or fails.
+the lock to be created, restic either continues or fails. If the
+``--wait-lock`` option is specified, restic will automatically retry
+creating the lock periodically until it succeeds or the specified
+timeout expires.
 
 Backups and Deduplication
 =========================

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -63,6 +63,7 @@ Usage help is available:
           --repository-file file       file to read the repository location from (default: $RESTIC_REPOSITORY_FILE)
           --tls-client-cert file       path to a file containing PEM encoded TLS client certificate and private key
       -v, --verbose n                  be verbose (specify --verbose multiple times or level --verbose=n)
+          --wait-lock duration         wait if the repository is already locked, takes a value like 5m or 2h (default: don't wait)
 
     Use "restic [command] --help" for more information about a command.
 
@@ -128,6 +129,7 @@ command:
           --repository-file file       file to read the repository location from (default: $RESTIC_REPOSITORY_FILE)
           --tls-client-cert file       path to a file containing PEM encoded TLS client certificate and private key
       -v, --verbose n                  be verbose (specify --verbose multiple times or level --verbose=n)
+          --wait-lock duration         wait if the repository is already locked, takes a value like 5m or 2h (default: don't wait)
 
 Subcommand that support showing progress information such as ``backup``,
 ``check`` and ``prune`` will do so unless the quiet flag ``-q`` or


### PR DESCRIPTION
If the option is passed, restic will wait the specified duration of time and retry locking the repo every 10 seconds (or more often if the total timeout is relatively small).


What is the purpose of this change? What does it change?
--------------------------------------------------------
It adds an option `--wait-lock` that can be used to make restic wait and retry to lock the repo if there is a conflicting lock.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
#719

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
