### PR TITLE
Extend find --show-pack-id to work with --tree

### DIFF
--- a/changelog/unreleased/issue-2229
+++ b/changelog/unreleased/issue-2229
@@ -1,6 +1,0 @@
-Enhancement: Extend "restic find --show-pack-id" to support --tree
-
-This makes it possible to find the pack containing a specific tree, which is
-useful mostly in development.
-
-https://github.com/restic/restic/issues/2229

--- a/changelog/unreleased/issue-2229
+++ b/changelog/unreleased/issue-2229
@@ -1,0 +1,6 @@
+Enhancement: Extend "restic find --show-pack-id" to support --tree
+
+This makes it possible to find the pack containing a specific tree, which is
+useful mostly in development.
+
+https://github.com/restic/restic/issues/2229

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -62,7 +62,7 @@ func init() {
 	f.BoolVar(&findOptions.BlobID, "blob", false, "pattern is a blob-ID")
 	f.BoolVar(&findOptions.TreeID, "tree", false, "pattern is a tree-ID")
 	f.BoolVar(&findOptions.PackID, "pack", false, "pattern is a pack-ID")
-	f.BoolVar(&findOptions.ShowPackID, "show-pack-id", false, "display the pack-ID the blobs belong to (with --blob)")
+	f.BoolVar(&findOptions.ShowPackID, "show-pack-id", false, "display the pack-ID the blobs belong to (with --blob or --tree)")
 	f.BoolVarP(&findOptions.CaseInsensitive, "ignore-case", "i", false, "ignore case for pattern")
 	f.BoolVarP(&findOptions.ListLong, "long", "l", false, "use a long listing format showing size and mode")
 
@@ -442,27 +442,36 @@ func (f *Finder) packsToBlobs(ctx context.Context, packs []string) error {
 	return nil
 }
 
-func (f *Finder) findBlobsPacks(ctx context.Context) {
+func (f *Finder) findObjectPack(ctx context.Context, id string, t restic.BlobType) {
 	idx := f.repo.Index()
+
+	rid, err := restic.ParseID(id)
+	if err != nil {
+		Printf("Note: cannot find pack for object '%s', unable to parse ID: %v\n", id, err)
+		return
+	}
+
+	blobs, found := idx.Lookup(rid, t)
+	if !found {
+		Printf("Object %s not found in the index\n", rid.Str())
+		return
+	}
+
+	for _, b := range blobs {
+		if b.ID.Equal(rid) {
+			Printf("Object belongs to pack %s\n ... Pack %s: %s\n", b.PackID, b.PackID.Str(), b.String())
+			break
+		}
+	}
+}
+
+func (f *Finder) findObjectsPacks(ctx context.Context) {
 	for i := range f.blobIDs {
-		rid, err := restic.ParseID(i)
-		if err != nil {
-			Printf("Note: cannot find pack for blob '%s', unable to parse ID: %v\n", i, err)
-			continue
-		}
+		f.findObjectPack(ctx, i, restic.DataBlob)
+	}
 
-		blobs, found := idx.Lookup(rid, restic.DataBlob)
-		if !found {
-			Printf("Blob %s not found in the index\n", rid.Str())
-			continue
-		}
-
-		for _, b := range blobs {
-			if b.ID.Equal(rid) {
-				Printf("Blob belongs to pack %s\n ... Pack %s: %s\n", b.PackID, b.PackID.Str(), b.String())
-				break
-			}
-		}
+	for i := range f.treeIDs {
+		f.findObjectPack(ctx, i, restic.TreeBlob)
 	}
 }
 
@@ -557,8 +566,8 @@ func runFind(opts FindOptions, gopts GlobalOptions, args []string) error {
 	}
 	f.out.Finish()
 
-	if opts.ShowPackID && f.blobIDs != nil {
-		f.findBlobsPacks(ctx)
+	if opts.ShowPackID && (f.blobIDs != nil || f.treeIDs != nil) {
+		f.findObjectsPacks(ctx)
 	}
 
 	return nil


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Extends `find --show-pack-id` to work with `--tree`, this resolves #2229.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
This was not discussed, but was helpful to me when constructing a broken repository for #2224.

Checklist
---------
- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review

Comments on above:

* No tests because I couldn't find any tests for `--show-pack-id` at all, so I'm not sure if it's necessary.
* I updated the built-in help documentation for the option, but didn't update the manual because the manual doesn't mention `--show-pack-id`.