### PR TITLE
find command: don't abort on tree load errors

### DIFF
--- a/changelog/unreleased/issue-2224
+++ b/changelog/unreleased/issue-2224
@@ -1,0 +1,9 @@
+Bugfix: Don't abort the find command when a tree can't be loaded
+
+Change the find command so that missing trees don't result in a crash.
+Instead, the error is logged to the debug log, and the tree ID is displayed
+along with the snapshot it belongs to.  This makes it possible to recover
+repositories that are missing trees by forgetting the snapshots they are used
+in.
+
+https://github.com/restic/restic/issues/2224

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -258,9 +258,13 @@ func (f *Finder) findInSnapshot(ctx context.Context, sn *restic.Snapshot) error 
 	}
 
 	f.out.newsn = sn
-	return walker.Walk(ctx, f.repo, *sn.Tree, f.ignoreTrees, func(_ restic.ID, nodepath string, node *restic.Node, err error) (bool, error) {
+	return walker.Walk(ctx, f.repo, *sn.Tree, f.ignoreTrees, func(parentTreeID restic.ID, nodepath string, node *restic.Node, err error) (bool, error) {
 		if err != nil {
-			return false, err
+			debug.Log("Error loading tree %v: %v", parentTreeID, err)
+
+			Printf("Unable to load tree %s\n ... which belongs to snapshot %s.\n", parentTreeID, sn.ID())
+
+			return false, walker.SkipNode
 		}
 
 		if node == nil {
@@ -340,7 +344,11 @@ func (f *Finder) findIDs(ctx context.Context, sn *restic.Snapshot) error {
 	f.out.newsn = sn
 	return walker.Walk(ctx, f.repo, *sn.Tree, f.ignoreTrees, func(parentTreeID restic.ID, nodepath string, node *restic.Node, err error) (bool, error) {
 		if err != nil {
-			return false, err
+			debug.Log("Error loading tree %v: %v", parentTreeID, err)
+
+			Printf("Unable to load tree %s\n ... which belongs to snapshot %s.\n", parentTreeID, sn.ID())
+
+			return false, walker.SkipNode
 		}
 
 		if node == nil {


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
As per #2224, this changes find not to abort when a tree can't be found.  Instead, the tree ID and referent snapshot ID are displayed.  This makes it easier to recover a broken repository by forgetting any snapshots that refer to missing objects.

Closes #2224

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
A few times on the forum:

* https://forum.restic.net/t/repository-damaged-after-accidentally-deleting-data-files/1516/17
* https://forum.restic.net/t/unable-to-check-or-prune/1239/12

Checklist
---------
- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review

Comments on above:

* There's a few cursory tests for find, but not ones that use many of the options.  This is also a particularly hard change to construct a test repository for, at least automatically.
* It was not documented before that find stops on a tree load error, so there aren't really any sensible changes to be made.