### PR TITLE
Mention Cache Directoy Tagging Standard in man page and help text

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -101,7 +101,7 @@ func init() {
 	f.StringArrayVar(&backupOptions.ExcludeFiles, "exclude-file", nil, "read exclude patterns from a `file` (can be specified multiple times)")
 	f.BoolVarP(&backupOptions.ExcludeOtherFS, "one-file-system", "x", false, "exclude other file systems")
 	f.StringArrayVar(&backupOptions.ExcludeIfPresent, "exclude-if-present", nil, "takes filename[:header], exclude contents of directories containing filename (except filename itself) if header of that file is as provided (can be specified multiple times)")
-	f.BoolVar(&backupOptions.ExcludeCaches, "exclude-caches", false, `excludes cache directories that are marked with a CACHEDIR.TAG file`)
+	f.BoolVar(&backupOptions.ExcludeCaches, "exclude-caches", false, `excludes cache directories that are marked with a CACHEDIR.TAG file. See http://bford.info/cachedir/spec.html for the Cache Directory Tagging Standard`)
 	f.BoolVar(&backupOptions.Stdin, "stdin", false, "read backup from stdin")
 	f.StringVar(&backupOptions.StdinFilename, "stdin-filename", "stdin", "file name to use when reading from stdin")
 	f.StringArrayVar(&backupOptions.Tags, "tag", nil, "add a `tag` for the new snapshot (can be specified multiple times)")

--- a/doc/man/restic-backup.1
+++ b/doc/man/restic-backup.1
@@ -26,7 +26,7 @@ given as the arguments.
 
 .PP
 \fB\-\-exclude\-caches\fP[=false]
-    excludes cache directories that are marked with a CACHEDIR.TAG file
+    excludes cache directories that are marked with a CACHEDIR.TAG file. See http://bford.info/cachedir/spec.html for the Cache Directory Tagging Standard
 
 .PP
 \fB\-\-exclude\-file\fP=[]

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -78,7 +78,7 @@ command:
 
     Flags:
       -e, --exclude pattern                  exclude a pattern (can be specified multiple times)
-          --exclude-caches                   excludes cache directories that are marked with a CACHEDIR.TAG file
+          --exclude-caches                   excludes cache directories that are marked with a CACHEDIR.TAG file. See http://bford.info/cachedir/spec.html for the Cache Directory Tagging Standard
           --exclude-file file                read exclude patterns from a file (can be specified multiple times)
           --exclude-if-present stringArray   takes filename[:header], exclude contents of directories containing filename (except filename itself) if header of that file is as provided (can be specified multiple times)
           --files-from string                read the files to backup from file (can be combined with file args/can be specified multiple times)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
This patch makes it more explicit what is meant by the CACHEDIR.TAG file
by referring to the "Cache Directory Tagging Standard".
It not only has to have this particular name, but also a specific content
(described at http://bford.info/cachedir/spec.html), which is not immediately
obvious to the user.

At least I did not realize right away that the CACHEDIR.TAG file is supposed to contain a Signature header and was confused by the error messages restic printed ("unexpected end of file").

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] (NOT RELEVANT) I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] (NOT RELEVANT) There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] (NOT RELEVANT) I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
