### PR TITLE
backend find: Check prefix length < snapshot IDs when searching

### DIFF
--- a/internal/restic/backend_find.go
+++ b/internal/restic/backend_find.go
@@ -24,7 +24,7 @@ func Find(be Lister, t FileType, prefix string) (string, error) {
 	defer cancel()
 
 	err := be.List(ctx, t, func(fi FileInfo) error {
-		if prefix == fi.Name[:len(prefix)] {
+		if len(fi.Name) >= len(prefix) && prefix == fi.Name[:len(prefix)] {
 			if match == "" {
 				match = fi.Name
 			} else {


### PR DESCRIPTION
Prevent "slice bounds out of range" error if prefix is longer than snapshot IDs.

This includes tests as well as other tests for the `backend_find`.Find function. Closes #2104.

What is the purpose of this change? What does it change?
--------------------------------------------------------
This fixes the slice bounds out of range issue described in #2104 by adding a length check to the conditional.  It also adds test cases for this failure and the expected errors/successful conditions of the Find function.

Was the change discussed in an issue or in the forum before?
#2104 

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [X] I have added tests for all changes in this PR
- [X] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review

