### PR TITLE
Minor docs fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1117,7 +1117,7 @@ Details
    Exploiting the vulnerability requires a Linux/Unix system which saves backups via restic and
    a Windows systems which restores files from the repo. In addition, the attackers need to be able
    to create create files with arbitrary names which are then saved to the restic repo. For
-   example, by creating a file named "..\test.txt" (which is a perfectly legal filename on Linux)
+   example, by creating a file named `..\test.txt` (which is a perfectly legal filename on Linux)
    and restoring a snapshot containing this file on Windows, it would be written to the parent of
    the target directory.
 

--- a/cmd/restic/cmd_generate.go
+++ b/cmd/restic/cmd_generate.go
@@ -12,7 +12,7 @@ var cmdGenerate = &cobra.Command{
 	Use:   "generate [command]",
 	Short: "Generate manual pages and auto-completion files (bash, zsh)",
 	Long: `
-The "generate" command writes automatically generated files like the man pages
+The "generate" command writes automatically generated files (like the man pages
 and the auto-completion files for bash and zsh).
 `,
 	DisableAutoGenTag: true,

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -36,7 +36,8 @@ The modes are:
 * raw-data: Counts the size of blobs in the repository, regardless of
   how many files reference them.
 * blobs-per-file: A combination of files-by-contents and raw-data.
-* Refer to the online manual for more details about each mode.
+
+Refer to the online manual for more details about each mode.
 `,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {

--- a/doc/man/restic-generate.1
+++ b/doc/man/restic-generate.1
@@ -15,7 +15,7 @@ restic\-generate \- Generate manual pages and auto\-completion files (bash, zsh)
 
 .SH DESCRIPTION
 .PP
-The "generate" command writes automatically generated files like the man pages
+The "generate" command writes automatically generated files (like the man pages
 and the auto\-completion files for bash and zsh).
 
 

--- a/doc/man/restic-stats.1
+++ b/doc/man/restic-stats.1
@@ -40,7 +40,8 @@ raw\-data: Counts the size of blobs in the repository, regardless of
 how many files reference them.
 .IP \(bu 2
 blobs\-per\-file: A combination of files\-by\-contents and raw\-data.
-.IP \(bu 2
+
+.PP
 Refer to the online manual for more details about each mode.
 
 .RE


### PR DESCRIPTION
Just some minor documentation fixes.

Note that I updated `doc/man/restic-stats.1` manually rather than through `restic generate` since I don't have a Go build environment at the moment.  Please verify that `generate` produces the same output.