### PR TITLE
Read fresh metadata for unmodified files

### DIFF
--- a/changelog/unreleased/issue-2249
+++ b/changelog/unreleased/issue-2249
@@ -1,0 +1,6 @@
+Bugfix: Read fresh metadata for unmodified files
+
+Restic took all metadata for files which were detected as unmodified, not taking into account changed metadata (ownership, mode). This is now corrected.
+
+https://github.com/restic/restic/issues/2249
+https://github.com/restic/restic/pull/2252

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -384,12 +384,19 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 			return FutureNode{}, true, nil
 		}
 
-		// use previous node if the file hasn't changed
+		// use previous list of blobs if the file hasn't changed
 		if previous != nil && !fileChanged(fi, previous, arch.IgnoreInode) {
-			debug.Log("%v hasn't changed, returning old node", target)
+			debug.Log("%v hasn't changed, using old list of blobs", target)
 			arch.CompleteItem(snPath, previous, previous, ItemStats{}, time.Since(start))
 			arch.CompleteBlob(snPath, previous.Size)
-			fn.node = previous
+			fn.node, err = arch.nodeFromFileInfo(target, fi)
+			if err != nil {
+				return FutureNode{}, false, err
+			}
+
+			// copy list of blobs
+			fn.node.Content = previous.Content
+
 			_ = file.Close()
 			return fn, false, nil
 		}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Restic took all metadata for files which were detected as unmodified, not
taking into account changed metadata (ownership, mode). This PR corrects it,
only the list of blobs (=the content) is taken from the previous file, the
metadata is read anew.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2249

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review