### PR TITLE
Make sure timestamps are valid

### DIFF
--- a/changelog/unreleased/issue-2174
+++ b/changelog/unreleased/issue-2174
@@ -1,0 +1,10 @@
+Bugfix: Save files with invalid timestamps
+
+When restic reads invalid timestamps (year is before 0000 or after 9999) it
+refused to read and archive the file. We've changed the behavior and will now
+save modified timestamps with the year set to either 0000 or 9999, the rest of
+the timestamp stays the same, so the file will be saved (albeit with a bogus
+timestamp).
+
+https://github.com/restic/restic/issues/2174
+https://github.com/restic/restic/issues/1173


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Sometimes restic gets bogus timestamps which cannot be converted to JSON, because the stdlib JSON encoder returns an error if the year is not within [0, 9999]. We now make sure that we at least record _some_ timestamp and cap the year either to 0000 or 9999. Before, restic would refuse to save the file at all, so this improves the status quo.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

closes #2174, #1173

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review