### PR TITLE
Fix dumping issues with / and the first sub level

### DIFF
--- a/changelog/unreleased/issue-2254
+++ b/changelog/unreleased/issue-2254
@@ -1,0 +1,9 @@
+Bugfix: Fix tar issues when dumping `/`
+
+We've fixed an issue with dumping either `/` or files on the first sublevel
+e.g. `/foo` to tar. This also fixes tar dumping issues on Windows where this
+issue could also happen.
+
+https://github.com/restic/restic/issues/2254
+https://github.com/restic/restic/issues/2357
+https://github.com/restic/restic/pull/2255

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -59,7 +59,7 @@ func splitPath(p string) []string {
 	if d == "" || d == "/" {
 		return []string{f}
 	}
-	s := splitPath(path.Clean(path.Join("/", d)))
+	s := splitPath(path.Join("/", d))
 	return append(s, f)
 }
 

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -19,8 +19,10 @@ var cmdDump = &cobra.Command{
 	Use:   "dump [flags] snapshotID file",
 	Short: "Print a backed-up file to stdout",
 	Long: `
-The "dump" command extracts a single file from a snapshot from the repository and
-prints its contents to stdout.
+The "dump" command extracts files from a snapshot from the repository. If a
+single file is selected, it prints its contents to stdout. Folders are output
+as a tar file containing the contents of the specified folder.  Pass "/" as
+file name to dump the whole snapshot as a tar file.
 
 The special snapshot "latest" can be used to use the latest snapshot in the
 repository.

--- a/cmd/restic/cmd_dump_test.go
+++ b/cmd/restic/cmd_dump_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestDumpSplitPath(t *testing.T) {
+	testPaths := []struct {
+		path   string
+		result []string
+	}{
+		{"", []string{""}},
+		{"test", []string{"test"}},
+		{"test/dir", []string{"test", "dir"}},
+		{"test/dir/sub", []string{"test", "dir", "sub"}},
+		{"/", []string{""}},
+		{"/test", []string{"test"}},
+		{"/test/dir", []string{"test", "dir"}},
+		{"/test/dir/sub", []string{"test", "dir", "sub"}},
+	}
+	for _, path := range testPaths {
+		parts := splitPath(path.path)
+		rtest.Equals(t, path.result, parts)
+	}
+}

--- a/internal/dump/acl.go
+++ b/internal/dump/acl.go
@@ -1,4 +1,4 @@
-package main
+package dump
 
 // Adapted from https://github.com/maxymania/go-system/blob/master/posix_acl/posix_acl.go
 

--- a/internal/dump/acl_test.go
+++ b/internal/dump/acl_test.go
@@ -1,4 +1,4 @@
-package main
+package dump
 
 import (
 	"reflect"

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/restic/restic/internal/errors"
@@ -65,8 +66,13 @@ func tarTree(ctx context.Context, repo restic.Repository, rootNode *restic.Node,
 }
 
 func tarNode(ctx context.Context, tw *tar.Writer, node *restic.Node, repo restic.Repository) error {
+	relPath, err := filepath.Rel("/", node.Path)
+	if err != nil {
+		return err
+	}
+
 	header := &tar.Header{
-		Name:       node.Path,
+		Name:       relPath,
 		Size:       int64(node.Size),
 		Mode:       int64(node.Mode),
 		Uid:        int(node.UID),
@@ -86,7 +92,7 @@ func tarNode(ctx context.Context, tw *tar.Writer, node *restic.Node, repo restic
 		header.Typeflag = tar.TypeDir
 	}
 
-	err := tw.WriteHeader(header)
+	err = tw.WriteHeader(header)
 
 	if err != nil {
 		return errors.Wrap(err, "TarHeader ")

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -72,7 +72,7 @@ func tarNode(ctx context.Context, tw *tar.Writer, node *restic.Node, repo restic
 	}
 
 	header := &tar.Header{
-		Name:       relPath,
+		Name:       filepath.ToSlash(relPath),
 		Size:       int64(node.Size),
 		Mode:       int64(node.Mode),
 		Uid:        int(node.UID),

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -1,0 +1,158 @@
+package dump
+
+import (
+	"archive/tar"
+	"context"
+	"io"
+	"path"
+	"strings"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/walker"
+)
+
+// WriteTar will write the contents of the given tree, encoded as a tar to the given destination.
+// It will loop over all nodes in the tree and dump them recursively.
+func WriteTar(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error {
+	tw := tar.NewWriter(dst)
+
+	for _, rootNode := range tree.Nodes {
+		rootNode.Path = rootPath
+		err := tarTree(ctx, repo, rootNode, rootPath, tw)
+		if err != nil {
+			_ = tw.Close()
+			return err
+		}
+	}
+	return tw.Close()
+}
+
+func tarTree(ctx context.Context, repo restic.Repository, rootNode *restic.Node, rootPath string, tw *tar.Writer) error {
+	rootNode.Path = path.Join(rootNode.Path, rootNode.Name)
+	rootPath = rootNode.Path
+
+	if err := tarNode(ctx, tw, rootNode, repo); err != nil {
+		return err
+	}
+
+	// If this is no directory we are finished
+	if !IsDir(rootNode) {
+		return nil
+	}
+
+	err := walker.Walk(ctx, repo, *rootNode.Subtree, nil, func(_ restic.ID, nodepath string, node *restic.Node, err error) (bool, error) {
+		if err != nil {
+			return false, err
+		}
+		if node == nil {
+			return false, nil
+		}
+
+		node.Path = path.Join(rootPath, nodepath)
+
+		if IsFile(node) || IsLink(node) || IsDir(node) {
+			err := tarNode(ctx, tw, node, repo)
+			if err != nil {
+				return false, err
+			}
+		}
+
+		return false, nil
+	})
+
+	return err
+}
+
+func tarNode(ctx context.Context, tw *tar.Writer, node *restic.Node, repo restic.Repository) error {
+	header := &tar.Header{
+		Name:       node.Path,
+		Size:       int64(node.Size),
+		Mode:       int64(node.Mode),
+		Uid:        int(node.UID),
+		Gid:        int(node.GID),
+		ModTime:    node.ModTime,
+		AccessTime: node.AccessTime,
+		ChangeTime: node.ChangeTime,
+		PAXRecords: parseXattrs(node.ExtendedAttributes),
+	}
+
+	if IsLink(node) {
+		header.Typeflag = tar.TypeSymlink
+		header.Linkname = node.LinkTarget
+	}
+
+	if IsDir(node) {
+		header.Typeflag = tar.TypeDir
+	}
+
+	err := tw.WriteHeader(header)
+
+	if err != nil {
+		return errors.Wrap(err, "TarHeader ")
+	}
+
+	return GetNodeData(ctx, tw, repo, node)
+}
+
+func parseXattrs(xattrs []restic.ExtendedAttribute) map[string]string {
+	tmpMap := make(map[string]string)
+
+	for _, attr := range xattrs {
+		attrString := string(attr.Value)
+
+		if strings.HasPrefix(attr.Name, "system.posix_acl_") {
+			na := acl{}
+			na.decode(attr.Value)
+
+			if na.String() != "" {
+				if strings.Contains(attr.Name, "system.posix_acl_access") {
+					tmpMap["SCHILY.acl.access"] = na.String()
+				} else if strings.Contains(attr.Name, "system.posix_acl_default") {
+					tmpMap["SCHILY.acl.default"] = na.String()
+				}
+			}
+
+		} else {
+			tmpMap["SCHILY.xattr."+attr.Name] = attrString
+		}
+	}
+
+	return tmpMap
+}
+
+// GetNodeData will write the contents of the node to the given output
+func GetNodeData(ctx context.Context, output io.Writer, repo restic.Repository, node *restic.Node) error {
+	var (
+		buf []byte
+		err error
+	)
+	for _, id := range node.Content {
+		buf, err = repo.LoadBlob(ctx, restic.DataBlob, id, buf)
+		if err != nil {
+			return err
+		}
+
+		_, err = output.Write(buf)
+		if err != nil {
+			return errors.Wrap(err, "Write")
+		}
+
+	}
+	return nil
+}
+
+// IsDir checks if the given node is a directory
+func IsDir(node *restic.Node) bool {
+	return node.Type == "dir"
+}
+
+// IsLink checks if the given node as a link
+func IsLink(node *restic.Node) bool {
+	return node.Type == "symlink"
+}
+
+// IsFile checks if the given node is a file
+func IsFile(node *restic.Node) bool {
+	return node.Type == "file"
+}

--- a/internal/dump/tar_test.go
+++ b/internal/dump/tar_test.go
@@ -1,0 +1,179 @@
+package dump
+
+import (
+	"archive/tar"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/archiver"
+	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func prepareTempdirRepoSrc(t testing.TB, src archiver.TestDir) (tempdir string, repo restic.Repository, cleanup func()) {
+	tempdir, removeTempdir := rtest.TempDir(t)
+	repo, removeRepository := repository.TestRepository(t)
+
+	archiver.TestCreateFiles(t, tempdir, src)
+
+	cleanup = func() {
+		removeRepository()
+		removeTempdir()
+	}
+
+	return tempdir, repo, cleanup
+}
+
+func TestWriteTar(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   archiver.TestDir
+		target string
+	}{
+		{
+			name: "single file in root",
+			args: archiver.TestDir{
+				"file": archiver.TestFile{Content: "string"},
+			},
+			target: "/",
+		},
+		{
+			name: "multiple files in root",
+			args: archiver.TestDir{
+				"file1": archiver.TestFile{Content: "string"},
+				"file2": archiver.TestFile{Content: "string"},
+			},
+			target: "/",
+		},
+		{
+			name: "multiple files and folders in root",
+			args: archiver.TestDir{
+				"file1": archiver.TestFile{Content: "string"},
+				"file2": archiver.TestFile{Content: "string"},
+				"firstDir": archiver.TestDir{
+					"another": archiver.TestFile{Content: "string"},
+				},
+				"secondDir": archiver.TestDir{
+					"another2": archiver.TestFile{Content: "string"},
+				},
+			},
+			target: "/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tmpdir, repo, cleanup := prepareTempdirRepoSrc(t, tt.args)
+			defer cleanup()
+
+			arch := archiver.New(repo, fs.Track{FS: fs.Local{}}, archiver.Options{})
+
+			back := fs.TestChdir(t, tmpdir)
+			defer back()
+
+			sn, _, err := arch.Snapshot(ctx, []string{"."}, archiver.SnapshotOptions{})
+			rtest.OK(t, err)
+
+			tree, err := repo.LoadTree(ctx, *sn.Tree)
+			rtest.OK(t, err)
+
+			dst := &bytes.Buffer{}
+			if err := WriteTar(ctx, repo, tree, tt.target, dst); err != nil {
+				t.Fatalf("WriteTar() error = %v", err)
+			}
+			if err := checkTar(t, tmpdir, dst); err != nil {
+				t.Errorf("WriteTar() = tar does not match: %v", err)
+			}
+		})
+	}
+}
+
+func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {
+	tr := tar.NewReader(srcTar)
+
+	fileNumber := 0
+	tarFiles := 0
+
+	err := filepath.Walk(testDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Name() != filepath.Base(testDir) {
+			fileNumber++
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		matchPath := filepath.Join(testDir, hdr.Name)
+		match, err := os.Stat(matchPath)
+		if err != nil {
+			return err
+		}
+
+		// check metadata, tar header contains time rounded to seconds
+		fileTime := match.ModTime().Round(time.Second)
+		tarTime := hdr.ModTime
+		if !fileTime.Equal(tarTime) {
+			return fmt.Errorf("modTime does not match, got: %s, want: %s", fileTime, tarTime)
+		}
+
+		if hdr.Typeflag == tar.TypeDir {
+			// this is a folder
+			if hdr.Name == "." {
+				// we don't need to check the root folder
+				continue
+			}
+
+			if filepath.Base(hdr.Name) != match.Name() {
+				return fmt.Errorf("foldernames don't match got %v want %v", filepath.Base(hdr.Name), match.Name())
+			}
+
+		} else {
+			if match.Size() != hdr.Size {
+				return fmt.Errorf("size does not match got %v want %v", hdr.Size, match.Size())
+			}
+			contentsFile, err := ioutil.ReadFile(matchPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			contentsTar := &bytes.Buffer{}
+			_, err = io.Copy(contentsTar, tr)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if contentsTar.String() != string(contentsFile) {
+				return fmt.Errorf("contents does not match, got %s want %s", contentsTar, contentsFile)
+			}
+		}
+		tarFiles++
+	}
+
+	if tarFiles != fileNumber {
+		return fmt.Errorf("not the same amount of files got %v want %v", tarFiles, fileNumber)
+	}
+
+	return nil
+}

--- a/internal/dump/tar_test.go
+++ b/internal/dump/tar_test.go
@@ -147,8 +147,9 @@ func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {
 				continue
 			}
 
-			if filepath.Base(hdr.Name) != match.Name() {
-				return fmt.Errorf("foldernames don't match got %v want %v", filepath.Base(hdr.Name), match.Name())
+			filebase := filepath.ToSlash(match.Name())
+			if filepath.Base(hdr.Name) != filebase {
+				return fmt.Errorf("foldernames don't match got %v want %v", filepath.Base(hdr.Name), filebase)
 			}
 
 		} else {


### PR DESCRIPTION
There was an issue that prevented the dump command from working
correctly when either:

* `/` contained multiple nodes (e.g. `restic backup /`)
* dumping a file in the first sublevel was attempted (e.g. `/foo`)



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
Fixes #2254
<!--
Describe the changes here, as detailed as needed.
-->


<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
