### PR TITLE
Don't run TestMetadataChanged test on Windows

### DIFF
--- a/internal/archiver/archiver_nowin_test.go
+++ b/internal/archiver/archiver_nowin_test.go
@@ -1,0 +1,98 @@
+// +build !windows
+
+package archiver
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/restic/restic/internal/checker"
+	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/restic"
+)
+
+func TestMetadataChanged(t *testing.T) {
+	files := TestDir{
+		"testfile": TestFile{
+			Content: "foo bar test file",
+		},
+	}
+
+	tempdir, repo, cleanup := prepareTempdirRepoSrc(t, files)
+	defer cleanup()
+
+	back := fs.TestChdir(t, tempdir)
+	defer back()
+
+	// get metadata
+	fi := lstat(t, "testfile")
+	want, err := restic.NodeFromFileInfo("testfile", fi)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fs := &StatFS{
+		FS: fs.Local{},
+		OverrideLstat: map[string]os.FileInfo{
+			"testfile": fi,
+		},
+	}
+
+	snapshotID, node2 := snapshot(t, repo, fs, restic.ID{}, "testfile")
+
+	// set some values so we can then compare the nodes
+	want.Content = node2.Content
+	want.Path = ""
+	want.ExtendedAttributes = nil
+
+	// make sure that metadata was recorded successfully
+	if !cmp.Equal(want, node2) {
+		t.Fatalf("metadata does not match:\n%v", cmp.Diff(want, node2))
+	}
+
+	// modify the mode
+	stat, ok := fi.Sys().(*syscall.Stat_t)
+	if ok {
+		// change a few values
+		stat.Mode = 0400
+		stat.Uid = 1234
+		stat.Gid = 1235
+
+		// wrap the os.FileInfo so we can return a modified stat_t
+		fi = wrappedFileInfo{
+			FileInfo: fi,
+			sys:      stat,
+			mode:     0400,
+		}
+		fs.OverrideLstat["testfile"] = fi
+	} else {
+		// skip the test on this platform
+		t.Skipf("unable to modify os.FileInfo, Sys() returned %T", fi.Sys())
+	}
+
+	want, err = restic.NodeFromFileInfo("testfile", fi)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// make another snapshot
+	snapshotID, node3 := snapshot(t, repo, fs, snapshotID, "testfile")
+
+	// set some values so we can then compare the nodes
+	want.Content = node2.Content
+	want.Path = ""
+	want.ExtendedAttributes = nil
+
+	// make sure that metadata was recorded successfully
+	if !cmp.Equal(want, node3) {
+		t.Fatalf("metadata does not match:\n%v", cmp.Diff(want, node2))
+	}
+
+	// make sure the content matches
+	TestEnsureFileContent(context.Background(), t, repo, "testfile", node3, files["testfile"].(TestFile))
+
+	checker.TestCheckRepo(t, repo)
+}

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -14,7 +14,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/restic/restic/internal/checker"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
@@ -126,9 +125,9 @@ func saveFile(t testing.TB, repo restic.Repository, filename string, filesystem 
 
 func TestArchiverSaveFile(t *testing.T) {
 	var tests = []TestFile{
-		TestFile{Content: ""},
-		TestFile{Content: "foo"},
-		TestFile{Content: string(restictest.Random(23, 12*1024*1024+1287898))},
+		{Content: ""},
+		{Content: "foo"},
+		{Content: string(restictest.Random(23, 12*1024*1024+1287898))},
 	}
 
 	for _, testfile := range tests {
@@ -204,9 +203,9 @@ func TestArchiverSaveFileReaderFS(t *testing.T) {
 
 func TestArchiverSave(t *testing.T) {
 	var tests = []TestFile{
-		TestFile{Content: ""},
-		TestFile{Content: "foo"},
-		TestFile{Content: string(restictest.Random(23, 12*1024*1024+1287898))},
+		{Content: ""},
+		{Content: "foo"},
+		{Content: string(restictest.Random(23, 12*1024*1024+1287898))},
 	}
 
 	for _, testfile := range tests {
@@ -2020,87 +2019,4 @@ func (fi wrappedFileInfo) Sys() interface{} {
 
 func (fi wrappedFileInfo) Mode() os.FileMode {
 	return fi.mode
-}
-
-func TestMetadataChanged(t *testing.T) {
-	files := TestDir{
-		"testfile": TestFile{
-			Content: "foo bar test file",
-		},
-	}
-
-	tempdir, repo, cleanup := prepareTempdirRepoSrc(t, files)
-	defer cleanup()
-
-	back := fs.TestChdir(t, tempdir)
-	defer back()
-
-	// get metadata
-	fi := lstat(t, "testfile")
-	want, err := restic.NodeFromFileInfo("testfile", fi)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	fs := &StatFS{
-		FS: fs.Local{},
-		OverrideLstat: map[string]os.FileInfo{
-			"testfile": fi,
-		},
-	}
-
-	snapshotID, node2 := snapshot(t, repo, fs, restic.ID{}, "testfile")
-
-	// set some values so we can then compare the nodes
-	want.Content = node2.Content
-	want.Path = ""
-	want.ExtendedAttributes = nil
-
-	// make sure that metadata was recorded successfully
-	if !cmp.Equal(want, node2) {
-		t.Fatalf("metadata does not match:\n%v", cmp.Diff(want, node2))
-	}
-
-	// modify the mode
-	stat, ok := fi.Sys().(*syscall.Stat_t)
-	if ok {
-		// change a few values
-		stat.Mode = 0400
-		stat.Uid = 1234
-		stat.Gid = 1235
-
-		// wrap the os.FileInfo so we can return a modified stat_t
-		fi = wrappedFileInfo{
-			FileInfo: fi,
-			sys:      stat,
-			mode:     0400,
-		}
-		fs.OverrideLstat["testfile"] = fi
-	} else {
-		// skip the test on this platform
-		t.Skipf("unable to modify os.FileInfo, Sys() returned %T", fi.Sys())
-	}
-
-	want, err = restic.NodeFromFileInfo("testfile", fi)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// make another snapshot
-	snapshotID, node3 := snapshot(t, repo, fs, snapshotID, "testfile")
-
-	// set some values so we can then compare the nodes
-	want.Content = node2.Content
-	want.Path = ""
-	want.ExtendedAttributes = nil
-
-	// make sure that metadata was recorded successfully
-	if !cmp.Equal(want, node3) {
-		t.Fatalf("metadata does not match:\n%v", cmp.Diff(want, node2))
-	}
-
-	// make sure the content matches
-	TestEnsureFileContent(context.Background(), t, repo, "testfile", node3, files["testfile"].(TestFile))
-
-	checker.TestCheckRepo(t, repo)
 }


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

Correct Windows build error https://ci.appveyor.com/project/fd0/restic
```
# github.com/restic/restic/internal/archiver [github.com/restic/restic/internal/archiver.test]
internal\archiver\archiver_test.go:2065:25: undefined: syscall.Stat_t
```