### PR TITLE
Display snapshot date when using `restic find`

### DIFF
--- a/changelog/unreleased/issue-2072
+++ b/changelog/unreleased/issue-2072
@@ -1,0 +1,5 @@
+Enhancement: Display snapshot date when using `restic find`
+
+Added the respective snapshot date to the output of `restic find`.
+
+https://github.com/restic/restic/issues/2072

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -160,7 +160,7 @@ func (s *statefulOutput) PrintPatternNormal(path string, node *restic.Node) {
 			Verbosef("\n")
 		}
 		s.oldsn = s.newsn
-		Verbosef("Found matching entries in snapshot %s\n", s.oldsn.ID().Str())
+		Verbosef("Found matching entries in snapshot %s from %s\n", s.oldsn.ID().Str(), s.oldsn.Time.Local().Format(TimeFormat))
 	}
 	Printf(formatNode(path, node, s.ListLong) + "\n")
 }


### PR DESCRIPTION
This PR addresses https://github.com/restic/restic/issues/2072 (besides the sorting)

What is the purpose of this change? What does it change?
--------------------------------------------------------
Display the snapshot date in the output of `restic find`:

`Found matching entries in snapshot 58c2c189 from 2019-03-19 08:55:42`

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
closes #2072 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
