### PR TITLE
Specify user and host names when adding keys

### DIFF
--- a/changelog/unreleased/issue-2175
+++ b/changelog/unreleased/issue-2175
@@ -1,0 +1,9 @@
+Enhancement: Allow specifying user and host when creating keys
+
+When adding a new key to the repository, the username and hostname for the new
+key can be specified on the command line. This allows overriding the defaults,
+for example if you would prefer to use the FQDN to identify the host or if you
+want to add keys for several different hosts without having to run the key add
+command on those hosts.
+
+https://github.com/restic/restic/issues/2175

--- a/doc/070_encryption.rst
+++ b/doc/070_encryption.rst
@@ -29,6 +29,10 @@ The ``key`` command allows you to set multiple access keys or passwords
 per repository. In fact, you can use the ``list``, ``add``, ``remove``, and
 ``passwd`` (changes a password) sub-commands to manage these keys very precisely:
 
+By default the ``key add`` command will use the current user and host name when
+creating a key, to override these add ``key-username=<name>`` or
+``key-hostname=<host>`` to the arguments.
+
 .. code-block:: console
 
     $ restic -r /srv/restic-repo key list

--- a/doc/man/restic-key.1
+++ b/doc/man/restic-key.1
@@ -10,12 +10,16 @@ restic\-key \- Manage keys (passwords)
 
 .SH SYNOPSIS
 .PP
-\fBrestic key [list|add|remove|passwd] [ID] [flags]\fP
+\fBrestic key [list|add|remove|passwd] [ID] [key\-username=<username>] [key\-hostname=<hostname>] [flags]\fP
 
 
 .SH DESCRIPTION
 .PP
 The "key" command manages keys (passwords) for accessing the repository.
+
+.PP
+By default keys are added for the current user and hostname, this can be
+overridden by with the optional "key\-username" and "key\-hostname" parameters
 
 
 .SH OPTIONS

--- a/internal/repository/key.go
+++ b/internal/repository/key.go
@@ -58,7 +58,7 @@ var (
 // createMasterKey creates a new master key in the given backend and encrypts
 // it with the password.
 func createMasterKey(s *Repository, password string) (*Key, error) {
-	return AddKey(context.TODO(), s, password, nil)
+	return AddKey(context.TODO(), s, password, nil, nil, nil)
 }
 
 // OpenKey tries do decrypt the key specified by name with the given password.
@@ -199,7 +199,9 @@ func LoadKey(ctx context.Context, s *Repository, name string) (k *Key, err error
 }
 
 // AddKey adds a new key to an already existing repository.
-func AddKey(ctx context.Context, s *Repository, password string, template *crypto.Key) (*Key, error) {
+func AddKey(ctx context.Context, s *Repository, password string, hostname *string, username *string, template *crypto.Key) (*Key, error) {
+	var err error = nil
+
 	// make sure we have valid KDF parameters
 	if Params == nil {
 		p, err := crypto.Calibrate(KDFTimeout, KDFMemory)
@@ -220,14 +222,21 @@ func AddKey(ctx context.Context, s *Repository, password string, template *crypt
 		P:       Params.P,
 	}
 
-	hn, err := os.Hostname()
-	if err == nil {
-		newkey.Hostname = hn
+	if hostname == nil {
+		hn, err := os.Hostname()
+		if err == nil {
+			newkey.Hostname = hn
+		}
+	} else {
+		newkey.Hostname = *hostname
 	}
-
-	usr, err := user.Current()
-	if err == nil {
-		newkey.Username = usr.Username
+	if username == nil {
+		usr, err := user.Current()
+		if err == nil {
+			newkey.Username = usr.Username
+		}
+	} else {
+		newkey.Username = *username
 	}
 
 	// generate random salt


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

I've been working on managing my restic backups using Saltstack. Each repository has a master password used to create it, and each of the clients backing up to the repo has it's own password. What I want to do is add keys for all the clients to the repository without disclosing the master password to the client machines, which means I need to run the key add command on the backup server. As it is, this means all the keys have the same user and host details, which makes any further key management rather difficult.

I have added two new optional parameters for the key add command which allow you to specify the user and hostname to use for the new key. 

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
closes #2175 
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [X] I have added documentation for the changes (in the manual)
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
