### PR TITLE
Add support for ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,13 @@ branches:
   only:
     - master
 
-notifications:
-  irc:
-    channels:
-      - "chat.freenode.net#restic"
-    on_success: change
-    on_failure: change
-    skip_join: true
+#notifications:
+#  irc:
+#    channels:
+#      - "chat.freenode.net#restic"
+#    on_success: change
+#    on_failure: change
+#    skip_join: true
 
 install:
   - go version

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,14 @@ matrix:
           - $HOME/.cache/go-build
           - $HOME/gopath/pkg/mod
 
+    - os: linux-ppc64le
+      go: "1.12.x"
+      sudo: true
+      cache:
+        directories:
+          - $HOME/.cache/go-build
+          - $HOME/gopath/pkg/mod
+
     - os: osx
       go: "1.12.x"
       env: RESTIC_TEST_FUSE=0 RESTIC_TEST_CLOUD_BACKENDS=0

--- a/helpers/build-release-binaries/main.go
+++ b/helpers/build-release-binaries/main.go
@@ -251,7 +251,7 @@ func buildTargets(sourceDir, outputDir string, targets map[string][]string) {
 var defaultBuildTargets = map[string][]string{
 	"darwin":  []string{"386", "amd64"},
 	"freebsd": []string{"386", "amd64", "arm"},
-	"linux":   []string{"386", "amd64", "arm", "arm64"},
+	"linux":   []string{"386", "amd64", "arm", "arm64", "ppc64le"},
 	"openbsd": []string{"386", "amd64"},
 	"windows": []string{"386", "amd64"},
 }

--- a/run_integration_tests.go
+++ b/run_integration_tests.go
@@ -218,6 +218,7 @@ func (env *TravisEnvironment) Prepare() error {
 				"openbsd/386", "openbsd/amd64",
 				"netbsd/386", "netbsd/amd64",
 				"linux/arm", "freebsd/arm",
+				"linux/ppc64le",
 			}
 
 			if os.Getenv("RESTIC_BUILD_SOLARIS") == "0" {


### PR DESCRIPTION
    This commit adds support for ppc64le (IBM POWER processor),
    and enables it to build on Power using Travis.

Signed-off-by: Rafael Peria de Sene <rpsene@br.ibm.com>

What is the purpose of this change? What does it change?
--------------------------------------------------------

This PR adds support for building Restic on Power (ppc64le). This can be seen as the start point of the discussion on how to add official support for Power.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
This PR solves the issue #2277, but I understand that more discussing may be required.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review

For testing on Power, it is possble to request free access to a VM at https://minicloud.parqtec.unicamp.br/

Logs
-------

Build on ppc64le, Ubuntu 18.04:

```
root@rpsene-restic:~/restic# ls
CHANGELOG.md     LICENSE     VERSION       changelog  doc     go.mod   internal
CONTRIBUTING.md  Makefile    appveyor.yml  cmd        doc.go  go.sum   run_integration_tests.go
GOVERNANCE.md    README.rst  build.go      contrib    docker  helpers  vendor
root@rpsene-restic:~/restic# go build ./cmd/restic
go: finding github.com/dnaeon/go-vcr v1.0.1
go: finding github.com/pkg/errors v0.8.1
go: finding github.com/elithrar/simple-scrypt v1.3.0
go: finding github.com/hashicorp/golang-lru v0.5.1
go: finding github.com/inconshreveable/mousetrap v1.0.0
go: finding github.com/dgrijalva/jwt-go v3.2.0+incompatible
go: finding github.com/minio/minio-go v6.0.14+incompatible
go: finding github.com/cpuguy83/go-md2man v1.0.10
go: finding google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7
go: finding cloud.google.com/go v0.37.4
go: finding github.com/satori/go.uuid v1.2.0
go: finding golang.org/x/sys v0.0.0-20190422165155-953cdadca894
go: finding github.com/spf13/pflag v1.0.3
go: finding github.com/pkg/sftp v1.10.0
go: finding github.com/gopherjs/gopherjs v0.0.0-20190411002643-bd77b112433e
go: finding github.com/smartystreets/assertions v0.0.0-20190401211740-f487f9de1cd3
go: finding gopkg.in/ini.v1 v1.42.0
go: finding contrib.go.opencensus.io/exporter/ocagent v0.4.12
go: finding golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd
go: finding github.com/spf13/cobra v0.0.3
go: finding golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
go: finding google.golang.org/grpc v1.20.1
go: finding github.com/google/go-cmp v0.2.0
go: finding github.com/kurin/blazer v0.5.3
go: finding golang.org/x/time v0.0.0-20181108054448-85acf8d2951c
go: finding bazil.org/fuse v0.0.0-20180421153158-65cc252bf669
go: finding google.golang.org/appengine v1.5.0
go: finding github.com/marstr/guid v1.1.0
go: finding github.com/pkg/profile v1.3.0
go: finding github.com/google/pprof v0.0.0-20181206194817-3ea8567a2e57
go: finding golang.org/x/sync v0.0.0-20190227155943-e225da77a7e6
go: finding google.golang.org/grpc v1.19.1
go: finding github.com/russross/blackfriday v1.5.2
go: finding google.golang.org/api v0.3.1
go: finding google.golang.org/appengine v1.4.0
go: finding golang.org/x/lint v0.0.0-20190301231843-5614ed5bae6f
go: finding golang.org/x/sys v0.0.0-20190412213103-97732733099d
go: finding github.com/juju/ratelimit v1.0.1
go: finding golang.org/x/lint v0.0.0-20190227174305-5b3e6a55c961
go: finding github.com/census-instrumentation/opencensus-proto v0.2.0
go: finding github.com/golang/protobuf v1.3.1
go: finding honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099
go: finding golang.org/x/text v0.3.0
go: finding golang.org/x/exp v0.0.0-20190121172915-509febef88a4
go: finding github.com/googleapis/gax-go/v2 v2.0.4
go: finding github.com/mitchellh/go-homedir v1.1.0
go: finding github.com/Azure/go-autorest v12.0.0+incompatible
go: finding gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
go: finding github.com/golang/mock v1.1.1
go: finding github.com/pkg/xattr v0.4.1
go: finding github.com/kr/fs v0.1.0
go: finding golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
go: finding github.com/client9/misspell v0.3.4
go: finding github.com/BurntSushi/toml v0.3.1
go: finding cloud.google.com/go v0.34.0
go: finding golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
go: finding github.com/Azure/azure-sdk-for-go v27.3.0+incompatible
go: finding golang.org/x/sync v0.0.0-20190423024810-112230192c58
go: finding golang.org/x/net v0.0.0-20180826012351-8a410e7b638d
go: finding golang.org/x/tools v0.0.0-20190114222345-bf090417da8b
go: finding github.com/stretchr/testify v1.3.0
go: finding github.com/golang/mock v1.2.0
go: finding golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4
go: finding github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
go: finding golang.org/x/net v0.0.0-20190424024845-afe8014c977f
go: finding google.golang.org/genproto v0.0.0-20180817151627-c66870c02cf8
go: finding github.com/golang/protobuf v1.2.0
go: finding google.golang.org/genproto v0.0.0-20190307195333-5fe7a883aa19
go: finding golang.org/x/tools v0.0.0-20190226205152-f727befe758c
go: finding golang.org/x/tools v0.0.0-20190311212946-11955173bddd
go: finding github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024
go: finding honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a
go: finding github.com/pmezard/go-difflib v1.0.0
go: finding google.golang.org/appengine v1.1.0
go: finding github.com/grpc-ecosystem/grpc-gateway v1.8.5
go: finding google.golang.org/grpc v1.19.0
go: finding golang.org/x/sys v0.0.0-20181021155630-eda9bb28ed51
go: finding github.com/stretchr/objx v0.1.0
go: finding go.opencensus.io v0.20.2
go: finding gopkg.in/yaml.v2 v2.2.2
go: finding golang.org/x/oauth2 v0.0.0-20190226205417-e64efc72b421
go: finding golang.org/x/net v0.0.0-20190108225652-1e06a53dbb7e
go: finding github.com/go-ini/ini v1.42.0
go: finding google.golang.org/api v0.3.2
go: finding github.com/davecgh/go-spew v1.1.0
go: finding golang.org/x/sync v0.0.0-20181108010431-42b317875d0f
go: finding golang.org/x/tools v0.0.0-20190312170243-e65039ee4138
go: finding golang.org/x/net v0.0.0-20190311183353-d8887717615a
go: finding github.com/ncw/swift v1.0.47
go: finding github.com/smartystreets/goconvey v0.0.0-20190330032615-68dc04aab96a
go: finding github.com/restic/chunker v0.2.0
go: finding golang.org/x/net v0.0.0-20181220203305-927f97764cc3
go: finding github.com/kr/pretty v0.1.0
go: finding github.com/ghodss/yaml v1.0.0
go: finding github.com/cenkalti/backoff v2.1.1+incompatible
go: finding cloud.google.com/go v0.26.0
go: finding golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be
go: finding github.com/google/martian v2.1.0+incompatible
go: finding github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af
go: finding gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7
go: finding golang.org/x/lint v0.0.0-20181026193005-c67002cb31c3
go: finding go.opencensus.io v0.20.1
go: finding gopkg.in/resty.v1 v1.12.0
go: finding github.com/openzipkin/zipkin-go v0.1.6
go: finding github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1
go: finding golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f
go: finding google.golang.org/genproto v0.0.0-20190404172233-64821d5d2107
go: finding github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c
go: finding gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405
go: finding github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d
go: finding github.com/jtolds/gls v4.20.0+incompatible
go: finding golang.org/x/lint v0.0.0-20190313153728-d0100b6bd8b3
go: finding golang.org/x/sys v0.0.0-20181107165924-66b7b1311ac8
go: finding golang.org/x/sys v0.0.0-20180830151530-49385e6e1522
go: finding golang.org/x/net v0.0.0-20190213061140-3a22650c66bd
go: finding github.com/mattn/go-isatty v0.0.7
go: finding golang.org/x/tools v0.0.0-20190328211700-ab21143f2384
go: finding golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a
go: finding github.com/apache/thrift v0.12.0
go: finding github.com/hashicorp/golang-lru v0.5.0
go: finding golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2
go: finding github.com/kr/text v0.1.0
go: finding google.golang.org/grpc v1.17.0
go: finding github.com/onsi/ginkgo v1.7.0
go: finding github.com/eapache/go-resiliency v1.1.0
go: finding github.com/Shopify/toxiproxy v2.1.4+incompatible
go: finding github.com/prometheus/client_golang v0.9.3-0.20190127221311-3c4408c8b829
go: finding github.com/gorilla/context v1.1.1
go: finding golang.org/x/net v0.0.0-20181114220301-adae6a3d119a
go: finding github.com/golang/snappy v0.0.0-20180518054509-2e65f85255db
go: finding github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21
go: finding github.com/davecgh/go-spew v1.1.1
go: finding github.com/kr/pty v1.1.1
go: finding golang.org/x/tools v0.0.0-20180828015842-6cd1fcedba52
go: finding github.com/onsi/gomega v1.4.3
go: finding github.com/eapache/queue v1.1.0
go: finding github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a
go: finding golang.org/x/sys v0.0.0-20181122145206-62eef0e2fa9b
go: finding github.com/gorilla/mux v1.6.2
go: finding gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127
go: finding honnef.co/go/tools v0.0.0-20180728063816-88497007e858
go: finding golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223
go: finding github.com/gogo/protobuf v1.2.0
go: finding github.com/pierrec/lz4 v2.0.5+incompatible
go: finding github.com/kisielk/gotool v1.0.0
go: finding github.com/Shopify/sarama v1.19.0
go: finding golang.org/x/net v0.0.0-20180724234803-3673e40ba225
go: finding github.com/prometheus/client_model v0.0.0-20190115171406-56726106282f
go: finding github.com/beorn7/perks v0.0.0-20180321164747-3a771d992973
go: finding golang.org/x/net v0.0.0-20180906233101-161cd47e91fd
go: finding golang.org/x/net v0.0.0-20190125091013-d26f9f9a57f3
go: finding golang.org/x/sys v0.0.0-20180909124046-d0be0721c37e
go: finding github.com/hpcloud/tail v1.0.0
go: finding github.com/prometheus/common v0.2.0
go: finding gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7
go: finding github.com/onsi/ginkgo v1.6.0
go: finding gopkg.in/yaml.v2 v2.2.1
go: finding github.com/prometheus/procfs v0.0.0-20190117184657-bf6a532e95b1
go: finding gopkg.in/fsnotify.v1 v1.4.7
go: finding github.com/fsnotify/fsnotify v1.4.7
go: finding github.com/pkg/errors v0.8.0
go: finding github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf
go: finding github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223
go: finding github.com/matttproud/golang_protobuf_extensions v1.0.1
go: finding github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc
go: finding github.com/julienschmidt/httprouter v1.2.0
go: finding github.com/go-kit/kit v0.8.0
go: finding github.com/go-logfmt/logfmt v0.3.0
go: finding github.com/prometheus/client_golang v0.9.1
go: finding github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515
go: finding github.com/sirupsen/logrus v1.2.0
go: finding github.com/gogo/protobuf v1.1.1
go: finding github.com/prometheus/client_model v0.0.0-20180712105110-5c3871d89910
go: finding github.com/go-stack/stack v1.8.0
go: finding golang.org/x/sys v0.0.0-20181116152217-5ac8a444bdc5
go: finding github.com/prometheus/procfs v0.0.0-20181005140218-185b4288413d
go: finding gopkg.in/alecthomas/kingpin.v2 v2.2.6
go: finding github.com/stretchr/objx v0.1.1
go: finding golang.org/x/sys v0.0.0-20180905080454-ebe1bf3edb33
go: finding github.com/stretchr/testify v1.2.2
go: finding golang.org/x/crypto v0.0.0-20180904163835-0709b304e793
go: finding github.com/konsorten/go-windows-terminal-sequences v1.0.1
go: downloading bazil.org/fuse v0.0.0-20180421153158-65cc252bf669
go: downloading github.com/spf13/cobra v0.0.3
go: downloading golang.org/x/sync v0.0.0-20190423024810-112230192c58
go: downloading github.com/pkg/errors v0.8.1
go: downloading github.com/restic/chunker v0.2.0
go: downloading golang.org/x/net v0.0.0-20190424024845-afe8014c977f
go: downloading github.com/elithrar/simple-scrypt v1.3.0
go: downloading github.com/pkg/xattr v0.4.1
go: extracting github.com/restic/chunker v0.2.0
go: extracting github.com/pkg/errors v0.8.1
go: extracting golang.org/x/sync v0.0.0-20190423024810-112230192c58
go: downloading golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd
go: extracting github.com/elithrar/simple-scrypt v1.3.0
go: extracting bazil.org/fuse v0.0.0-20180421153158-65cc252bf669
go: extracting github.com/pkg/xattr v0.4.1
go: downloading golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
go: extracting github.com/spf13/cobra v0.0.3
go: downloading golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
go: downloading gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
go: downloading github.com/juju/ratelimit v1.0.1
go: downloading google.golang.org/api v0.3.2
go: downloading github.com/cpuguy83/go-md2man v1.0.10
go: extracting gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637
go: extracting github.com/cpuguy83/go-md2man v1.0.10
go: extracting golang.org/x/oauth2 v0.0.0-20190402181905-9f3314589c9a
go: downloading gopkg.in/yaml.v2 v2.2.2
go: downloading github.com/kurin/blazer v0.5.3
go: extracting github.com/juju/ratelimit v1.0.1
go: downloading cloud.google.com/go v0.37.4
go: extracting gopkg.in/yaml.v2 v2.2.2
go: downloading github.com/spf13/pflag v1.0.3
go: extracting github.com/kurin/blazer v0.5.3
go: downloading github.com/mattn/go-isatty v0.0.7
go: extracting github.com/mattn/go-isatty v0.0.7
go: extracting github.com/spf13/pflag v1.0.3
go: downloading golang.org/x/sys v0.0.0-20190422165155-953cdadca894
go: extracting golang.org/x/net v0.0.0-20190424024845-afe8014c977f
go: extracting golang.org/x/crypto v0.0.0-20190422183909-d864b10871cd
go: downloading github.com/minio/minio-go v6.0.14+incompatible
go: downloading github.com/pkg/sftp v1.10.0
go: downloading github.com/ncw/swift v1.0.47
go: downloading github.com/Azure/azure-sdk-for-go v27.3.0+incompatible
go: downloading github.com/cenkalti/backoff v2.1.1+incompatible
go: extracting github.com/cenkalti/backoff v2.1.1+incompatible
go: extracting github.com/pkg/sftp v1.10.0
go: extracting github.com/ncw/swift v1.0.47
go: downloading github.com/kr/fs v0.1.0
go: downloading github.com/russross/blackfriday v1.5.2
go: extracting github.com/kr/fs v0.1.0
go: extracting github.com/russross/blackfriday v1.5.2
go: extracting github.com/minio/minio-go v6.0.14+incompatible
go: downloading github.com/go-ini/ini v1.42.0
go: extracting github.com/go-ini/ini v1.42.0
go: downloading github.com/mitchellh/go-homedir v1.1.0
go: extracting github.com/mitchellh/go-homedir v1.1.0
go: extracting golang.org/x/sys v0.0.0-20190422165155-953cdadca894
go: extracting cloud.google.com/go v0.37.4
go: extracting golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2
go: extracting google.golang.org/api v0.3.2
go: downloading go.opencensus.io v0.20.2
go: downloading google.golang.org/grpc v1.20.1
go: extracting go.opencensus.io v0.20.2
go: downloading github.com/hashicorp/golang-lru v0.5.1
go: extracting github.com/hashicorp/golang-lru v0.5.1
go: extracting google.golang.org/grpc v1.20.1
go: downloading google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7
go: downloading github.com/golang/protobuf v1.3.1
go: extracting github.com/golang/protobuf v1.3.1
go: extracting google.golang.org/genproto v0.0.0-20190418145605-e7d98fc518a7
go: extracting github.com/Azure/azure-sdk-for-go v27.3.0+incompatible
go: downloading github.com/Azure/go-autorest v12.0.0+incompatible
go: downloading github.com/satori/go.uuid v1.2.0
go: downloading github.com/marstr/guid v1.1.0
go: extracting github.com/satori/go.uuid v1.2.0
go: extracting github.com/marstr/guid v1.1.0
go: extracting github.com/Azure/go-autorest v12.0.0+incompatible
go: downloading contrib.go.opencensus.io/exporter/ocagent v0.4.12
go: downloading github.com/dgrijalva/jwt-go v3.2.0+incompatible
go: extracting contrib.go.opencensus.io/exporter/ocagent v0.4.12
go: downloading github.com/census-instrumentation/opencensus-proto v0.2.0
go: extracting github.com/dgrijalva/jwt-go v3.2.0+incompatible
go: extracting github.com/census-instrumentation/opencensus-proto v0.2.0
go: downloading github.com/grpc-ecosystem/grpc-gateway v1.8.5
go: extracting github.com/grpc-ecosystem/grpc-gateway v1.8.5
root@rpsene-restic:~/restic# ./restic version
restic 0.9.5-dev (compiled manually) compiled with go1.12.5 on linux/ppc64le
```

Tests Execution on ppc64le

```
root@rpsene-restic:~/restic# go test ./...
?   	github.com/restic/restic	[no test files]
ok  	github.com/restic/restic/cmd/restic	10.166s
?   	github.com/restic/restic/helpers/build-release-binaries	[no test files]
?   	github.com/restic/restic/helpers/prepare-release	[no test files]
--- FAIL: TestArchiverErrorReporting (0.02s)
    --- FAIL: TestArchiverErrorReporting/file-unreadable (0.00s)
        testing.go:30: using low-security KDF parameters for test
        config.go:65: disabling check of the chunker polynomial
        archiver_test.go:1773: chdir to /tmp/restic-test-042685594
        archiver_test.go:1790: expected error not returned by archiver
        panic.go:406: chdir back to /root/restic/internal/archiver
    --- FAIL: TestArchiverErrorReporting/file-unreadable-ignore-error (0.01s)
        testing.go:30: using low-security KDF parameters for test
        config.go:65: disabling check of the chunker polynomial
        archiver_test.go:1773: chdir to /tmp/restic-test-605894795
        archiver_test.go:1798: saved as 47d082b7
        archiver_test.go:1804: unexpected tree node "targetfile" found, want: archiver.TestDir{"other":archiver.TestFile{Content:"xxx"}}
        archiver_test.go:1807: chdir back to /root/restic/internal/archiver
    --- FAIL: TestArchiverErrorReporting/file-subdir-unreadable (0.00s)
        testing.go:30: using low-security KDF parameters for test
        config.go:65: disabling check of the chunker polynomial
        archiver_test.go:1773: chdir to /tmp/restic-test-037308290
        archiver_test.go:1790: expected error not returned by archiver
        panic.go:406: chdir back to /root/restic/internal/archiver
    --- FAIL: TestArchiverErrorReporting/file-subdir-unreadable-ignore-error (0.01s)
        testing.go:30: using low-security KDF parameters for test
        config.go:65: disabling check of the chunker polynomial
        archiver_test.go:1773: chdir to /tmp/restic-test-617289107
        archiver_test.go:1798: saved as 9ff01147
        archiver_test.go:1804: unexpected tree node "targetfile" found, want: archiver.TestDir{"other":archiver.TestFile{Content:"xxx"}}
        archiver_test.go:1807: chdir back to /root/restic/internal/archiver
--- FAIL: TestScannerError (0.00s)
    --- FAIL: TestScannerError/unreadable-dir (0.00s)
        scanner_test.go:228: chdir to /tmp/restic-test-086563272
        scanner_test.go:278: wrong final result, want
              archiver.ScanStats{Files:0x3, Dirs:0x2, Others:0x0, Bytes:0x1c}
            got:
              archiver.ScanStats{Files:0x5, Dirs:0x3, Others:0x0, Bytes:0x3c}
        scanner_test.go:280: chdir back to /root/restic/internal/archiver
FAIL
FAIL	github.com/restic/restic/internal/archiver	2.474s
ok  	github.com/restic/restic/internal/backend	3.394s
ok  	github.com/restic/restic/internal/backend/azure	(cached)
ok  	github.com/restic/restic/internal/backend/b2	(cached)
ok  	github.com/restic/restic/internal/backend/gs	(cached)
ok  	github.com/restic/restic/internal/backend/local	1.892s
ok  	github.com/restic/restic/internal/backend/location	(cached)
ok  	github.com/restic/restic/internal/backend/mem	(cached)
ok  	github.com/restic/restic/internal/backend/rclone	(cached)
ok  	github.com/restic/restic/internal/backend/rest	(cached)
ok  	github.com/restic/restic/internal/backend/s3	(cached)
ok  	github.com/restic/restic/internal/backend/sftp	(cached)
ok  	github.com/restic/restic/internal/backend/swift	(cached)
ok  	github.com/restic/restic/internal/backend/test	(cached)
ok  	github.com/restic/restic/internal/cache	0.474s
ok  	github.com/restic/restic/internal/checker	2.306s
ok  	github.com/restic/restic/internal/crypto	(cached)
ok  	github.com/restic/restic/internal/debug	(cached) [no tests to run]
?   	github.com/restic/restic/internal/errors	[no test files]
ok  	github.com/restic/restic/internal/filter	(cached)
ok  	github.com/restic/restic/internal/fs	0.120s
ok  	github.com/restic/restic/internal/fuse	(cached)
ok  	github.com/restic/restic/internal/hashing	(cached)
ok  	github.com/restic/restic/internal/index	(cached)
?   	github.com/restic/restic/internal/limiter	[no test files]
?   	github.com/restic/restic/internal/migrations	[no test files]
?   	github.com/restic/restic/internal/mock	[no test files]
ok  	github.com/restic/restic/internal/options	(cached)
ok  	github.com/restic/restic/internal/pack	(cached)
ok  	github.com/restic/restic/internal/repository	2.201s
ok  	github.com/restic/restic/internal/restic	2.003s
ok  	github.com/restic/restic/internal/restorer	0.036s
?   	github.com/restic/restic/internal/selfupdate	[no test files]
?   	github.com/restic/restic/internal/test	[no test files]
ok  	github.com/restic/restic/internal/textfile	(cached)
ok  	github.com/restic/restic/internal/ui	(cached)
?   	github.com/restic/restic/internal/ui/jsonstatus	[no test files]
ok  	github.com/restic/restic/internal/ui/table	(cached)
ok  	github.com/restic/restic/internal/ui/termstatus	(cached)
ok  	github.com/restic/restic/internal/walker	(cached)
```
