### PR TITLE
textfile: Refuse unreasonably large files

### DIFF
--- a/changelog/unreleased/issue-2150
+++ b/changelog/unreleased/issue-2150
@@ -1,0 +1,9 @@
+Bugfix: Refuse excessive --exclude file
+
+The options `--exclude` and `--exclude-file` are quite similar.  Confusing
+them caused restic to attempt parsing the "excluded" file as a list of
+filenames, which exhausted memory.  This change prevents behavior like this,
+and sanity checks all "text" files to have a sane size.
+I hope 512 MiB is a safe upper bound.
+
+https://github.com/restic/restic/issues/2150


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

A specific typo in the commadline arguments when calling restic used to cause memory exhaustion at the worst, and a crash at best:

```
$ restic backup --exclude-file /path/to/large/file .
repository caf84f45 opened successfully, password is correct
found 3 old cache directories in /home/user/.cache/restic, pass --cleanup-cache to remove them
runtime: out of memory: cannot allocate 12307693568-byte block (66322432 in use)
fatal error: out of memory

runtime stack:
runtime.throw(0xe2cf48, 0xd)
	/usr/local/go/src/runtime/panic.go:617 +0x72
runtime.largeAlloc(0x2dd987a00, 0xce0101, 0xc000030190)
	/usr/local/go/src/runtime/malloc.go:1057 +0x16b
runtime.mallocgc.func1()
	/usr/local/go/src/runtime/malloc.go:950 +0x46
runtime.systemstack(0x0)
	/usr/local/go/src/runtime/asm_amd64.s:351 +0x66
runtime.mstart()
	/usr/local/go/src/runtime/proc.go:1153

goroutine 1 [running]:
runtime.systemstack_switch()
	/usr/local/go/src/runtime/asm_amd64.s:311 fp=0xc002434f78 sp=0xc002434f70 pc=0x456cb0
runtime.mallocgc(0x2dd987a00, 0xc9dde0, 0x1, 0xc002435050)
	/usr/local/go/src/runtime/malloc.go:949 +0x872 fp=0xc002435018 sp=0xc002434f78 pc=0x40be72
runtime.makeslice(0xc9dde0, 0x2dd987a00, 0x2dd987a00, 0x42b7c1)
	/usr/local/go/src/runtime/slice.go:49 +0x6c fp=0xc002435048 sp=0xc002435018 pc=0x441e1c
bytes.makeSlice(0x2dd987a00, 0x0, 0x0, 0x0)
	/usr/local/go/src/bytes/buffer.go:232 +0x6d fp=0xc002435078 sp=0xc002435048 pc=0x46d69d
bytes.(*Buffer).grow(0xc0024350f8, 0x2dd987a00, 0xc002435160)
	/usr/local/go/src/bytes/buffer.go:145 +0x16f fp=0xc0024350c8 sp=0xc002435078 pc=0x46cfdf
bytes.(*Buffer).Grow(...)
	/usr/local/go/src/bytes/buffer.go:164
io/ioutil.readAll(0xf6e480, 0xc000128020, 0x2dd987a00, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/io/ioutil/ioutil.go:34 +0xa2 fp=0xc002435130 sp=0xc0024350c8 pc=0x5712f2
io/ioutil.ReadFile(0x7ffc1c4ae294, 0x1f, 0x0, 0x0, 0x0, 0x0, 0x0)
	/usr/local/go/src/io/ioutil/ioutil.go:73 +0xea fp=0xc002435188 sp=0xc002435130 pc=0x5714da
github.com/restic/restic/internal/textfile.Read(0x7ffc1c4ae294, 0x1f, 0x4, 0xc00034e000, 0x203000, 0x203000, 0xc002435258)
	/restic/internal/textfile/read.go:37 +0x39 fp=0xc0024351d8 sp=0xc002435188 pc=0x7dfc09
main.readExcludePatternsFromFiles.func2(0xc002435318, 0xe6ba68, 0xc002435328, 0x0, 0xc000128018)
	/restic/cmd/restic/cmd_backup.go:286 +0x4c fp=0xc0024352e0 sp=0xc0024351d8 pc=0xbf511c
<SNIP>
```

This patch changes it to this:
```
$ ~/workspace/restic/restic backup --exclude-file /path/to/large/file .
repository caf84f45 opened successfully, password is correct
found 3 old cache directories in /home/user/.cache/restic, pass --cleanup-cache to remove them
Fatal: Textfile /path/to/large/file is unreasonably large (12307692032B > 536870912B)
```

The idea here is that when a user actually means `--exclude /path/to/large/file`, it should cause too much trouble.  Before the patch, it looked like restic ran into a bug.  With the patch, the part "*textfile* read" should make the user wonder why restic is trying to parse `/path/to/large/file` as a text file.

(I took the liberty to censor username and filename in the above transcripts.)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

closes #2150

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review

Things where I need feedback
-------------------------

- This is my first time with go.  This was largely inspired by the implementation of [`ioutil.ReadFile`](https://golang.org/src/io/ioutil/ioutil.go#L52)
- How do I reasonably test this?  I know that I should add tests in `read_test.go`, but I would need a large file for that.
- I really hope that 512 MiB are "enough for everyone".  Path lengths are "usually" limited to 4K, so in order to exceed 512 MiB, there would need to be over 131072 files in that exclude list, and something in the order of 3 million is more likely.  That sounds like an error, and would cripple performance down the road anyway.