### PR TITLE
Fix JSON Printf issues with format verbs

### DIFF
--- a/changelog/unreleased/issue-2281
+++ b/changelog/unreleased/issue-2281
@@ -1,0 +1,7 @@
+Bugfix: Handle format verbs like '%' properly in `find` output
+
+The JSON or "normal" output of the `find` command can now deal with file names
+that contain substrings which the Golang `fmt` package considers "format verbs"
+like `%s`.
+
+https://github.com/restic/restic/issues/2281

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -156,7 +156,7 @@ func (s *statefulOutput) PrintPatternJSON(path string, node *restic.Node) {
 	if s.hits > 0 {
 		Printf(",")
 	}
-	Printf(string(b))
+	Print(string(b))
 	s.hits++
 }
 
@@ -168,7 +168,7 @@ func (s *statefulOutput) PrintPatternNormal(path string, node *restic.Node) {
 		s.oldsn = s.newsn
 		Verbosef("Found matching entries in snapshot %s from %s\n", s.oldsn.ID().Str(), s.oldsn.Time.Local().Format(TimeFormat))
 	}
-	Printf(formatNode(path, node, s.ListLong) + "\n")
+	Println(formatNode(path, node, s.ListLong))
 }
 
 func (s *statefulOutput) PrintPattern(path string, node *restic.Node) {
@@ -207,7 +207,7 @@ func (s *statefulOutput) PrintObjectJSON(kind, id, nodepath, treeID string, sn *
 	if s.hits > 0 {
 		Printf(",")
 	}
-	Printf(string(b))
+	Print(string(b))
 	s.hits++
 }
 

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -189,6 +189,22 @@ func Printf(format string, args ...interface{}) {
 	}
 }
 
+// Print writes the message to the configured stdout stream.
+func Print(args ...interface{}) {
+	_, err := fmt.Fprint(globalOptions.stdout, args...)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to write to stdout: %v\n", err)
+	}
+}
+
+// Println writes the message to the configured stdout stream.
+func Println(args ...interface{}) {
+	_, err := fmt.Fprintln(globalOptions.stdout, args...)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "unable to write to stdout: %v\n", err)
+	}
+}
+
 // Verbosef calls Printf to write the message when the verbose flag is set.
 func Verbosef(format string, args ...interface{}) {
 	if globalOptions.verbosity >= 1 {

--- a/cmd/restic/global_test.go
+++ b/cmd/restic/global_test.go
@@ -1,0 +1,28 @@
+package main
+
+import (
+	"bytes"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func Test_PrintFunctionsRespectsGlobalStdout(t *testing.T) {
+	gopts := globalOptions
+	defer func() {
+		globalOptions = gopts
+	}()
+
+	buf := bytes.NewBuffer(nil)
+	globalOptions.stdout = buf
+
+	for _, p := range []func(){
+		func() { Println("message") },
+		func() { Print("message\n") },
+		func() { Printf("mes%s\n", "sage") },
+	} {
+		p()
+		rtest.Equals(t, "message\n", buf.String())
+		buf.Reset()
+	}
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Describe the changes here, as detailed as needed.
-->

Currently, the JSON string is output via `Printf`. This means that if there is a format string inside the JSON, there is an error - see https://github.com/restic/restic/issues/2281 for an example.

Note that I've split the PR into two commits: the first just fixes the bug, the second replaces other occurrences of `Printf` with `fmt.Print` or `fmt.Println` where appropriate.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes https://github.com/restic/restic/issues/2281.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
