### PR TITLE
build: Preserve debug symbols in debug build

### DIFF
--- a/build.go
+++ b/build.go
@@ -395,8 +395,12 @@ func main() {
 
 	verbosePrintf("detected Go version %v\n", goVersion)
 
+	preserveSymbols := false
 	for i := range buildTags {
 		buildTags[i] = strings.TrimSpace(buildTags[i])
+		if buildTags[i] == "debug" || buildTags[i] == "profile" {
+			preserveSymbols = true
+		}
 	}
 
 	verbosePrintf("build tags: %s\n", buildTags)
@@ -423,7 +427,11 @@ func main() {
 	if version != "" {
 		constants["main.version"] = version
 	}
-	ldflags := "-s -w " + constants.LDFlags()
+	ldflags := constants.LDFlags()
+	if !preserveSymbols {
+		// Strip debug symbols.
+		ldflags = "-s -w " + ldflags
+	}
 	verbosePrintf("ldflags: %s\n", ldflags)
 
 	var (


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This change enables debug symbols in debug builds.
(It does so by disabling the stripping of debug symbols.)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No, but the impact is low, and it would have helped with #2284 a lot.

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [/] I have added tests for all changes in this PR EDIT: See below
- [/] I have added documentation for the changes (in the manual) EDIT: None necessary.
- [/] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)) EDIT: None necessary.
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review

Does this need testing at all?  I don't think so, but you tell me what should be done.