### PR TITLE
add simple console output

### DIFF
--- a/changelog/unreleased/list-output
+++ b/changelog/unreleased/list-output
@@ -1,0 +1,4 @@
+Feature: Add list console output for backup
+
+We've added another console output option to backup for environments
+where parsing JSON is not feasible for better readability in logs

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -329,6 +329,20 @@ The tags can later be used to keep (or forget) snapshots with the ``forget``
 command. The command ``tag`` can be used to modify tags on an existing
 snapshot.
 
+Simple output
+*************
+
+By passing --listed-output (-l) to backup you get a line by line output. This
+may be useful in some environments where parsing JSON is not feasible.
+
+.. code-block:: console
+
+    type:status elapsed:0 remaining:0 files-total:1 files-done:0 files-current:[] bytes-total:32 bytes-done:0 error-count:0 percent-done:0.000000
+    type:status elapsed:0 remaining:0 files-total:725 files-done:91 files-current:[] bytes-total:105766588 bytes-done:61307336 error-count:0 percent-done:0.579647
+    type:file action:modified item:"/doc/040_backup.rst" duration:0.000234 data-size:15752
+    [...]
+    type:summary files-new:12 files-changed:5 dirs-new:0 dirs-changed:0 data-blobs:12 tree-blobs:1 data-added:270623 processed-files:2096 processed-files:122945416 duration:0.355123 snapshot:8ce801c4
+
 Space requirements
 ******************
 

--- a/internal/ui/termliststatus/status.go
+++ b/internal/ui/termliststatus/status.go
@@ -1,0 +1,419 @@
+package termliststatus
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sort"
+	"sync"
+	"time"
+
+	"github.com/restic/restic/internal/archiver"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/ui"
+	"github.com/restic/restic/internal/ui/termstatus"
+)
+
+type counter struct {
+	Files, Dirs, Bytes uint64
+}
+
+type fileWorkerMessage struct {
+	filename string
+	done     bool
+}
+
+// Backup reports progress for the `backup` command in JSON.
+type Backup struct {
+	*ui.Message
+	*ui.StdioWrapper
+
+	MinUpdatePause time.Duration
+
+	term  *termstatus.Terminal
+	v     uint
+	start time.Time
+
+	totalBytes uint64
+
+	totalCh     chan counter
+	processedCh chan counter
+	errCh       chan struct{}
+	workerCh    chan fileWorkerMessage
+	finished    chan struct{}
+
+	summary struct {
+		sync.Mutex
+		Files, Dirs struct {
+			New       uint
+			Changed   uint
+			Unchanged uint
+		}
+		archiver.ItemStats
+	}
+}
+
+// NewBackup returns a new backup progress reporter.
+func NewBackup(term *termstatus.Terminal, verbosity uint) *Backup {
+	return &Backup{
+		Message:      ui.NewMessage(term, verbosity),
+		StdioWrapper: ui.NewStdioWrapper(term),
+		term:         term,
+		v:            verbosity,
+		start:        time.Now(),
+
+		// limit to 60fps by default
+		MinUpdatePause: time.Second / 60,
+
+		totalCh:     make(chan counter),
+		processedCh: make(chan counter),
+		errCh:       make(chan struct{}),
+		workerCh:    make(chan fileWorkerMessage),
+		finished:    make(chan struct{}),
+	}
+}
+
+// Run regularly updates the status lines. It should be called in a separate
+// goroutine.
+func (b *Backup) Run(ctx context.Context) error {
+	var (
+		lastUpdate       time.Time
+		total, processed counter
+		errors           uint
+		started          bool
+		currentFiles     = make(map[string]struct{})
+		secondsRemaining uint64
+	)
+
+	t := time.NewTicker(time.Second)
+	defer t.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-b.finished:
+			started = false
+		case t, ok := <-b.totalCh:
+			if ok {
+				total = t
+				started = true
+			} else {
+				// scan has finished
+				b.totalCh = nil
+				b.totalBytes = total.Bytes
+			}
+		case s := <-b.processedCh:
+			processed.Files += s.Files
+			processed.Dirs += s.Dirs
+			processed.Bytes += s.Bytes
+			started = true
+		case <-b.errCh:
+			errors++
+			started = true
+		case m := <-b.workerCh:
+			if m.done {
+				delete(currentFiles, m.filename)
+			} else {
+				currentFiles[m.filename] = struct{}{}
+			}
+		case <-t.C:
+			if !started {
+				continue
+			}
+
+			if b.totalCh == nil {
+				secs := float64(time.Since(b.start) / time.Second)
+				todo := float64(total.Bytes - processed.Bytes)
+				secondsRemaining = uint64(secs / float64(processed.Bytes) * todo)
+			}
+		}
+
+		// limit update frequency
+		if time.Since(lastUpdate) < b.MinUpdatePause {
+			continue
+		}
+		lastUpdate = time.Now()
+
+		b.update(total, processed, errors, currentFiles, secondsRemaining)
+	}
+}
+
+// update updates the status lines.
+func (b *Backup) update(total, processed counter, errors uint, currentFiles map[string]struct{}, secs uint64) {
+	status := statusUpdate{
+		MessageType:      "status",
+		SecondsElapsed:   uint64(time.Since(b.start) / time.Second),
+		SecondsRemaining: secs,
+		TotalFiles:       total.Files,
+		FilesDone:        processed.Files,
+		TotalBytes:       total.Bytes,
+		BytesDone:        processed.Bytes,
+		ErrorCount:       errors,
+	}
+
+	if total.Bytes > 0 {
+		status.PercentDone = float64(processed.Bytes) / float64(total.Bytes)
+	}
+
+	for filename := range currentFiles {
+		status.CurrentFiles = append(status.CurrentFiles, filename)
+	}
+	sort.Sort(sort.StringSlice(status.CurrentFiles))
+
+	_, _ = fmt.Fprintf(b.StdioWrapper.Stdout(), "type:status elapsed:%d remaining:%d files-total:%d files-done:%d files-current:%s bytes-total:%d bytes-done:%d error-count:%d percent-done:%f\n",
+		status.SecondsElapsed,
+		status.SecondsRemaining,
+		status.TotalFiles,
+		status.FilesDone,
+		status.CurrentFiles,
+		status.TotalBytes,
+		status.BytesDone,
+		status.ErrorCount,
+		status.PercentDone,
+	)
+
+}
+
+// ScannerError is the error callback function for the scanner, it prints the
+// error in verbose mode and returns nil.
+func (b *Backup) ScannerError(item string, fi os.FileInfo, err error) error {
+	_, _ = fmt.Fprintf(b.StdioWrapper.Stderr(), "type:error error:%s during:scan item:%s\n",
+		err,
+		item)
+	return nil
+}
+
+// Error is the error callback function for the archiver, it prints the error and returns nil.
+func (b *Backup) Error(item string, fi os.FileInfo, err error) error {
+	_, _ = fmt.Fprintf(b.StdioWrapper.Stderr(), "type:error error:%s during:archival item:%s\n",
+		err,
+		item)
+	b.errCh <- struct{}{}
+	return nil
+}
+
+// StartFile is called when a file is being processed by a worker.
+func (b *Backup) StartFile(filename string) {
+	b.workerCh <- fileWorkerMessage{
+		filename: filename,
+	}
+}
+
+// CompleteBlob is called for all saved blobs for files.
+func (b *Backup) CompleteBlob(filename string, bytes uint64) {
+	b.processedCh <- counter{Bytes: bytes}
+}
+
+// CompleteItem is the status callback function for the archiver when a
+// file/dir has been saved successfully.
+func (b *Backup) CompleteItem(item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration) {
+	b.summary.Lock()
+	b.summary.ItemStats.Add(s)
+	b.summary.Unlock()
+
+	if current == nil {
+		// error occurred, tell the status display to remove the line
+		b.workerCh <- fileWorkerMessage{
+			filename: item,
+			done:     true,
+		}
+		return
+	}
+
+	switch current.Type {
+	case "file":
+		b.processedCh <- counter{Files: 1}
+		b.workerCh <- fileWorkerMessage{
+			filename: item,
+			done:     true,
+		}
+	case "dir":
+		b.processedCh <- counter{Dirs: 1}
+	}
+
+	printVerbose := func(status *verboseUpdate) {
+		_, _ = fmt.Fprintf(b.StdioWrapper.Stdout(), "type:%s action:%s item:\"%s\" duration:%f data-size:%d\n", status.MessageType, status.Action, status.Item, status.Duration, status.DataSize)
+	}
+
+	if current.Type == "dir" {
+		if previous == nil {
+			printVerbose(&verboseUpdate{
+				MessageType:  "directory",
+				Action:       "new",
+				Item:         item,
+				Duration:     d.Seconds(),
+				DataSize:     s.DataSize,
+				MetadataSize: s.TreeSize,
+			})
+			b.summary.Lock()
+			b.summary.Dirs.New++
+			b.summary.Unlock()
+			return
+		}
+
+		if previous.Equals(*current) {
+			if b.v >= 3 {
+				printVerbose(&verboseUpdate{
+					MessageType:  "directory",
+					Action:       "unchanged",
+					Item:         item,
+					Duration:     d.Seconds(),
+					DataSize:     s.DataSize,
+					MetadataSize: s.TreeSize,
+				})
+			}
+			b.summary.Lock()
+			b.summary.Dirs.Unchanged++
+			b.summary.Unlock()
+		} else {
+			printVerbose(&verboseUpdate{
+				MessageType:  "directory",
+				Action:       "modified",
+				Item:         item,
+				Duration:     d.Seconds(),
+				DataSize:     s.DataSize,
+				MetadataSize: s.TreeSize,
+			})
+			b.summary.Lock()
+			b.summary.Dirs.Changed++
+			b.summary.Unlock()
+		}
+
+	} else if current.Type == "file" {
+
+		b.workerCh <- fileWorkerMessage{
+			done:     true,
+			filename: item,
+		}
+
+		if previous == nil {
+			printVerbose(&verboseUpdate{
+				MessageType:  "file",
+				Action:       "new",
+				Item:         item,
+				Duration:     d.Seconds(),
+				DataSize:     s.DataSize,
+				MetadataSize: s.TreeSize,
+			})
+			b.summary.Lock()
+			b.summary.Files.New++
+			b.summary.Unlock()
+			return
+		}
+
+		if previous.Equals(*current) {
+			if b.v >= 3 {
+				printVerbose(&verboseUpdate{
+					MessageType:  "file",
+					Action:       "unchanged",
+					Item:         item,
+					Duration:     d.Seconds(),
+					DataSize:     s.DataSize,
+					MetadataSize: s.TreeSize,
+				})
+			}
+			b.summary.Lock()
+			b.summary.Files.Unchanged++
+			b.summary.Unlock()
+		} else {
+			printVerbose(&verboseUpdate{
+				MessageType:  "file",
+				Action:       "modified",
+				Item:         item,
+				Duration:     d.Seconds(),
+				DataSize:     s.DataSize,
+				MetadataSize: s.TreeSize,
+			})
+			b.summary.Lock()
+			b.summary.Files.Changed++
+			b.summary.Unlock()
+		}
+	}
+}
+
+// ReportTotal sets the total stats up to now
+func (b *Backup) ReportTotal(item string, s archiver.ScanStats) {
+	select {
+	case b.totalCh <- counter{Files: uint64(s.Files), Dirs: uint64(s.Dirs), Bytes: s.Bytes}:
+	case <-b.finished:
+	}
+
+	if item == "" {
+		if b.v >= 2 {
+			_, _ = fmt.Fprintf(b.StdioWrapper.Stdout(), "scan_finished %f %d %d\n", time.Since(b.start).Seconds(), s.Bytes, s.Files)
+		}
+		close(b.totalCh)
+		return
+	}
+}
+
+// Finish prints the finishing messages.
+func (b *Backup) Finish(snapshotID restic.ID) {
+	close(b.finished)
+	_, _ = fmt.Fprintf(b.StdioWrapper.Stdout(), "type:summary files-new:%d files-changed:%d dirs-new:%d dirs-changed:%d data-blobs:%d tree-blobs:%d data-added:%d processed-files:%d processed-files:%d duration:%f snapshot:%s\n",
+		b.summary.Files.New,
+		b.summary.Files.Changed,
+		b.summary.Dirs.New,
+		b.summary.Dirs.Changed,
+		b.summary.ItemStats.DataBlobs,
+		b.summary.ItemStats.TreeBlobs,
+		b.summary.ItemStats.DataSize+b.summary.ItemStats.TreeSize,
+		b.summary.Files.New+b.summary.Files.Changed+b.summary.Files.Unchanged,
+		b.totalBytes,
+		time.Since(b.start).Seconds(),
+		snapshotID.Str())
+}
+
+// SetMinUpdatePause sets b.MinUpdatePause. It satisfies the
+// ArchiveProgressReporter interface.
+func (b *Backup) SetMinUpdatePause(d time.Duration) {
+	b.MinUpdatePause = d
+}
+
+type statusUpdate struct {
+	MessageType      string   `json:"message_type"` // "status"
+	SecondsElapsed   uint64   `json:"seconds_elapsed,omitempty"`
+	SecondsRemaining uint64   `json:"seconds_remaining,omitempty"`
+	PercentDone      float64  `json:"percent_done"`
+	TotalFiles       uint64   `json:"total_files,omitempty"`
+	FilesDone        uint64   `json:"files_done,omitempty"`
+	TotalBytes       uint64   `json:"total_bytes,omitempty"`
+	BytesDone        uint64   `json:"bytes_done,omitempty"`
+	ErrorCount       uint     `json:"error_count,omitempty"`
+	CurrentFiles     []string `json:"current_files,omitempty"`
+}
+
+type errorUpdate struct {
+	MessageType string `json:"message_type"` // "error"
+	Error       error  `json:"error"`
+	During      string `json:"during"`
+	Item        string `json:"item"`
+}
+
+type verboseUpdate struct {
+	MessageType  string  `json:"message_type"` // "verbose_status"
+	Action       string  `json:"action"`
+	Item         string  `json:"item"`
+	Duration     float64 `json:"duration"` // in seconds
+	DataSize     uint64  `json:"data_size"`
+	MetadataSize uint64  `json:"metadata_size"`
+	TotalFiles   uint    `json:"total_files"`
+}
+
+type summaryOutput struct {
+	MessageType         string  `json:"message_type"` // "summary"
+	FilesNew            uint    `json:"files_new"`
+	FilesChanged        uint    `json:"files_changed"`
+	FilesUnmodified     uint    `json:"files_unmodified"`
+	DirsNew             uint    `json:"dirs_new"`
+	DirsChanged         uint    `json:"dirs_changed"`
+	DirsUnmodified      uint    `json:"dirs_unmodified"`
+	DataBlobs           int     `json:"data_blobs"`
+	TreeBlobs           int     `json:"tree_blobs"`
+	DataAdded           uint64  `json:"data_added"`
+	TotalFilesProcessed uint    `json:"total_files_processed"`
+	TotalBytesProcessed uint64  `json:"total_bytes_processed"`
+	TotalDuration       float64 `json:"total_duration"` // in seconds
+	SnapshotID          string  `json:"snapshot_id"`
+}


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

It adds another option for outputting status information while backup process is ongoing.

Instead of printing out json (it is mutually exclusive to --JSON) it prints out line by line metrics

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

no

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR (completely based on jsonstatus)
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review