### PR TITLE
Call b2.Reader.Verify() when reading from b2 backend

### DIFF
--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -147,6 +147,8 @@ func (be *b2Backend) Load(ctx context.Context, h restic.Handle, length int, offs
 	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
 }
 
+// verifyOnCloseReader calls b2.Reader.Verify() on close to check file
+// integrity.
 type verifyOnCloseReader struct {
 	*b2.Reader
 	name string
@@ -160,7 +162,8 @@ func (r verifyOnCloseReader) Close() error {
 
 	verr, hashCalculatable := r.Reader.Verify()
 	debug.Log("Verify result for %q: err=%v, hash calculatable=%t\n", r.name, verr, hashCalculatable)
-	return nil
+	// Non-nil only when hashCalculatable is true.
+	return verr
 }
 
 func (be *b2Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -160,10 +160,10 @@ func (r verifyOnCloseReader) Close() error {
 		return errors.Wrapf(err, "Close %q", r.name)
 	}
 
-	verr, hashCalculatable := r.Reader.Verify()
-	debug.Log("Verify result for %q: err=%v, hash calculatable=%t\n", r.name, verr, hashCalculatable)
+	err, hashCalculatable := r.Reader.Verify()
+	debug.Log("Verify result for %q: err=%v, hash calculatable=%t\n", r.name, err, hashCalculatable)
 	// Non-nil only when hashCalculatable is true.
-	return errors.Wrapf(verr, "Verify %q", r.name)
+	return errors.Wrapf(err, "Verify %q", r.name)
 }
 
 func (be *b2Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -157,13 +157,13 @@ type verifyOnCloseReader struct {
 func (r verifyOnCloseReader) Close() error {
 	err := r.Reader.Close()
 	if err != nil {
-		return err
+		return errors.Wrapf(err, "Close %q", r.name)
 	}
 
 	verr, hashCalculatable := r.Reader.Verify()
 	debug.Log("Verify result for %q: err=%v, hash calculatable=%t\n", r.name, verr, hashCalculatable)
 	// Non-nil only when hashCalculatable is true.
-	return verr
+	return errors.Wrapf(verr, "Verify %q", r.name)
 }
 
 func (be *b2Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
It calls b2.Reader.Verify(), which verifies files downloaded from b2 with the sha1
information provided by b2 (which is already being calculated, but not used).
<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Filed https://github.com/restic/restic/issues/2302 for the underlying issue. Closes #2302.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
