### PR TITLE
Add upper bound for t in --read-data-subset=n/t

### DIFF
--- a/changelog/unreleased/issue-2301
+++ b/changelog/unreleased/issue-2301
@@ -1,0 +1,7 @@
+Bugfix: Add upper bound for t in --read-data-subset=n/t
+
+256 is the effective maximum for t, but restic would allow larger
+values, leading to strange behavior.
+
+https://github.com/restic/restic/issues/2301
+https://github.com/restic/restic/pull/2304


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
Adds an upper bound for t in --read-data-subset=n/t. See https://github.com/restic/restic/issues/2301 for behavior without this bound.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Closes #2301.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review

I think this change is simple enough to not need tests or extra docs, but am happy to add any if needed.