### PR TITLE
Allow multiple retries for interactive password input

### DIFF
--- a/changelog/unreleased/issue-2306
+++ b/changelog/unreleased/issue-2306
@@ -1,0 +1,7 @@
+Enhancement: Allow multiple retries for interactive password input
+
+Restic used to quit if the repository password was typed incorrectly once.
+Restic will now ask the user again for the repository password if typed incorrectly.
+The user will now get three tries to input the correct password before restic quits. 
+
+https://github.com/restic/restic/issues/2306

--- a/internal/repository/key.go
+++ b/internal/repository/key.go
@@ -18,7 +18,7 @@ import (
 
 var (
 	// ErrNoKeyFound is returned when no key for the repository could be decrypted.
-	ErrNoKeyFound = errors.Fatal("wrong password or no key found")
+	ErrNoKeyFound = errors.New("wrong password or no key found")
 
 	// ErrMaxKeysReached is returned when the maximum number of keys was checked and no key could be found.
 	ErrMaxKeysReached = errors.Fatal("maximum number of keys reached")


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
Restic will now allow multiple attempts to type the password for interactive password input.
<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #2306 
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
