### PR TITLE
Add 'epoch' field to JSON output for 'snapshot' command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,6 @@ Summary
  * Enh #2139: Return error if no bytes could be read for `backup --stdin`
  * Enh #2205: Add --ignore-inode option to backup cmd
  * Enh #2220: Add config option to set S3 storage class
- * Enh #2315: Add 'epoch' field to json output for 'snapshot' command
 
 Details
 -------
@@ -139,11 +138,6 @@ Details
 
    https://github.com/restic/restic/issues/706
    https://github.com/restic/restic/pull/2220
-
- * Enhancement #2315: Add 'epoch' field to json output for 'snapshot' command
-
-   The JSON output for the 'snapshot' command now includes the timestamp of each snapshot formatted
-   as a unix epoch value. This makes it easier for machine processing of the timestamp (eg, sorting)
 
 
 Changelog for restic 0.9.4 (2019-01-06)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ Summary
  * Enh #2139: Return error if no bytes could be read for `backup --stdin`
  * Enh #2205: Add --ignore-inode option to backup cmd
  * Enh #2220: Add config option to set S3 storage class
+ * Enh #2315: Add 'epoch' field to json output for 'snapshot' command
 
 Details
 -------
@@ -138,6 +139,11 @@ Details
 
    https://github.com/restic/restic/issues/706
    https://github.com/restic/restic/pull/2220
+
+ * Enhancement #2315: Add 'epoch' field to json output for 'snapshot' command
+
+   The JSON output for the 'snapshot' command now includes the timestamp of each snapshot formatted
+   as a unix epoch value. This makes it easier for machine processing of the timestamp (eg, sorting)
 
 
 Changelog for restic 0.9.4 (2019-01-06)

--- a/changelog/unreleased/issue-2315
+++ b/changelog/unreleased/issue-2315
@@ -1,0 +1,6 @@
+Enh: Add 'epoch' field to json output for 'snapshot' command
+
+The JSON output for the 'snapshot' command now includes the timestamp of each snapshot formatted
+as a unix epoch value. This makes it easier for machine processing of the timestamp (eg, sorting)
+
+https://github.com/restic/restic/issues/2315

--- a/changelog/unreleased/issue-2315
+++ b/changelog/unreleased/issue-2315
@@ -1,4 +1,4 @@
-Enh: Add 'epoch' field to json output for 'snapshot' command
+Enhancement: Add 'epoch' field to json output for 'snapshot' command
 
 The JSON output for the 'snapshot' command now includes the timestamp of each snapshot formatted
 as a unix epoch value. This makes it easier for machine processing of the timestamp (eg, sorting)

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -277,12 +277,14 @@ func PrintSnapshotGroupHeader(stdout io.Writer, groupKeyJSON string) error {
 	return nil
 }
 
-// Snapshot helps to print Snaphots as JSON with their ID included.
+// Snapshot helps to print Snaphots as JSON with their ID included. Also add the timestamp
+// formatted as unix epoch.
 type Snapshot struct {
 	*restic.Snapshot
 
 	ID      *restic.ID `json:"id"`
 	ShortID string     `json:"short_id"`
+	Epoch   int64      `json:"epoch"`
 }
 
 // SnapshotGroup helps to print SnaphotGroups as JSON with their GroupReasons included.
@@ -311,6 +313,7 @@ func printSnapshotGroupJSON(stdout io.Writer, snGroups map[string]restic.Snapsho
 					Snapshot: sn,
 					ID:       sn.ID(),
 					ShortID:  sn.ID().Str(),
+					Epoch:    sn.Time.Unix(),
 				}
 				snapshots = append(snapshots, k)
 			}
@@ -334,6 +337,7 @@ func printSnapshotGroupJSON(stdout io.Writer, snGroups map[string]restic.Snapsho
 				Snapshot: sn,
 				ID:       sn.ID(),
 				ShortID:  sn.ID().Str(),
+				Epoch:    sn.Time.Unix(),
 			}
 			snapshots = append(snapshots, k)
 		}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Adds JSON output for the 'snapshot' command to include the timestamp of each snapshot formatted as a unix epoch value. This makes it easier for machine processing of the timestamp (eg, sorting)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Closes #2315.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
