### PR TITLE
Check errors returned by LoadIndex()

### DIFF
--- a/changelog/unreleased/plul-2321
+++ b/changelog/unreleased/plul-2321
@@ -1,0 +1,8 @@
+Bugfix: Check errors when loading index files
+
+Restic now checks and handles errors which occur when loading index files, the
+missing check leads to odd errors (and a stack trace printed to users) later.
+This was reported in the forum.
+
+https://github.com/restic/restic/pull/2321
+https://forum.restic.net/t/check-rebuild-index-prune/1848/13

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -440,6 +440,10 @@ func (r *Repository) LoadIndex(ctx context.Context) error {
 				idx, buf, err = LoadIndexWithDecoder(ctx, r, buf[:0], fi.ID, DecodeOldIndex)
 			}
 
+			if err != nil {
+				return errors.Wrap(err, fmt.Sprintf("unable to load index %v", fi.ID.Str()))
+			}
+
 			select {
 			case indexCh <- idx:
 			case <-ctx.Done():
@@ -475,7 +479,7 @@ func (r *Repository) LoadIndex(ctx context.Context) error {
 
 	err := wg.Wait()
 	if err != nil {
-		return err
+		return errors.Fatal(err.Error())
 	}
 
 	// remove index files from the cache which have been removed in the repo


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

Check and handle errors returned by `LoadIndex()`, that's missing right now.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Bug was reported in the forum here: https://forum.restic.net/t/check-rebuild-index-prune/1848/13

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review