### PR TITLE
Skip tree serialization

### DIFF
--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1940,6 +1940,7 @@ func snapshot(t testing.TB, repo restic.Repository, fs fs.FS, parent restic.ID, 
 	defer cancel()
 
 	arch := New(repo, fs, Options{})
+	arch.WithAtime = true
 
 	sopts := SnapshotOptions{
 		Time:           time.Now(),

--- a/internal/archiver/tree_saver_test.go
+++ b/internal/archiver/tree_saver_test.go
@@ -36,7 +36,7 @@ func TestTreeSaver(t *testing.T) {
 			Name: fmt.Sprintf("file-%d", i),
 		}
 
-		fb := b.Save(ctx, "/", node, nil)
+		fb := b.Save(ctx, "/", node, nil, nil, nil)
 		results = append(results, fb)
 	}
 
@@ -97,7 +97,7 @@ func TestTreeSaverError(t *testing.T) {
 					Name: fmt.Sprintf("file-%d", i),
 				}
 
-				fb := b.Save(ctx, "/", node, nil)
+				fb := b.Save(ctx, "/", node, nil, nil, nil)
 				results = append(results, fb)
 			}
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Restic currently spends a lot of time serializing unchanged TreeNodes which are dropped after hashing the the resulting blob. This change compares the created TreeNode with the previous version from the repository. In case both have matching content, the serialization step is skipped and the blob ID of the old TreeNode is reused.

The TestArchiverSaveDirIncremental testcase is adapted to partially check the new code. As the new behavior is active when backing up changed trees, it is implicitly tested by the existing testcases. The pull request also contains a slightly unrelated fix for an archiver testcase.

However, I am unsure how to best check that the tree serialization is indeed skipped. Extending the Stats object for the test only seems to be the wrong way for me.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] No user visible change - There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
