### PR TITLE
Fix duplicate tree checks within `restic check`

### DIFF
--- a/changelog/unreleased/pull-2328
+++ b/changelog/unreleased/pull-2328
@@ -1,0 +1,8 @@
+Enhancement: Improve speed of check command
+
+We've improved the check command to traverse trees only once independent of
+whether they are contained in multiple snapshots. The check command is now much
+faster for repositories with a large number of snapshots.
+
+https://github.com/restic/restic/pull/2328
+https://github.com/restic/restic/issues/2284

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -259,7 +259,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 
 	if opts.CheckUnused {
 		for _, id := range chkr.UnusedBlobs() {
-			Verbosef("unused blob %v\n", id.Str())
+			Verbosef("unused blob %v\n", id)
 			errorsFound = true
 		}
 	}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -27,7 +27,6 @@ type Checker struct {
 		sync.Mutex
 		M map[restic.ID]bool
 	}
-	indexes map[restic.ID]*repository.Index
 
 	masterIndex *repository.MasterIndex
 
@@ -40,7 +39,6 @@ func New(repo restic.Repository) *Checker {
 		packs:       restic.NewIDSet(),
 		blobs:       restic.NewIDSet(),
 		masterIndex: repository.NewMasterIndex(),
-		indexes:     make(map[restic.ID]*repository.Index),
 		repo:        repo,
 	}
 
@@ -152,7 +150,6 @@ func (c *Checker) LoadIndex(ctx context.Context) (hints []error, errs []error) {
 				continue
 			}
 
-			c.indexes[res.ID] = res.Index
 			c.masterIndex.Insert(res.Index)
 
 			debug.Log("process blobs")

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -535,8 +535,9 @@ func filterTrees(ctx context.Context, backlog restic.IDs, loaderChan chan<- rest
 				debug.Log("received job with nil tree pointer: %v (ID %v)", j.error, j.ID)
 				err = errors.New("tree is nil and error is nil")
 			} else {
-				debug.Log("subtrees for tree %v: %v", j.ID, j.Tree.Subtrees())
-				for _, id := range j.Tree.Subtrees() {
+				subtrees := j.Tree.Subtrees()
+				debug.Log("subtrees for tree %v: %v", j.ID, subtrees)
+				for _, id := range subtrees {
 					if id.IsNull() {
 						// We do not need to raise this error here, it is
 						// checked when the tree is checked. Just make sure

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -537,13 +537,12 @@ func (c *Checker) filterTrees(ctx context.Context, backlog restic.IDs, loaderCha
 
 			debug.Log("input job tree %v", j.ID)
 
-			var err error
-
 			if j.error != nil {
 				debug.Log("received job with error: %v (tree %v, ID %v)", j.error, j.Tree, j.ID)
 			} else if j.Tree == nil {
 				debug.Log("received job with nil tree pointer: %v (ID %v)", j.error, j.ID)
-				err = errors.New("tree is nil and error is nil")
+				// send a new job with the new error instead of the old one
+				j = treeJob{ID: j.ID, error: errors.New("tree is nil and error is nil")}
 			} else {
 				subtrees := j.Tree.Subtrees()
 				debug.Log("subtrees for tree %v: %v", j.ID, subtrees)
@@ -559,11 +558,6 @@ func (c *Checker) filterTrees(ctx context.Context, backlog restic.IDs, loaderCha
 					}
 					backlog = append(backlog, id)
 				}
-			}
-
-			if err != nil {
-				// send a new job with the new error instead of the old one
-				j = treeJob{ID: j.ID, error: err}
 			}
 
 			job = j

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -493,7 +493,9 @@ func (c *Checker) filterTrees(ctx context.Context, backlog restic.IDs, loaderCha
 
 	for {
 		if loadCh == nil && len(backlog) > 0 {
-			nextTreeID, backlog = backlog[0], backlog[1:]
+			// process last added ids first, that is traverse the tree in depth-first order
+			ln := len(backlog) - 1
+			nextTreeID, backlog = backlog[ln], backlog[:ln]
 
 			// use a separate flag for processed trees to ensure that check still processes trees
 			// even when a file references a tree blob
@@ -545,7 +547,9 @@ func (c *Checker) filterTrees(ctx context.Context, backlog restic.IDs, loaderCha
 			} else {
 				subtrees := j.Tree.Subtrees()
 				debug.Log("subtrees for tree %v: %v", j.ID, subtrees)
-				for _, id := range subtrees {
+				// iterate backwards over subtree to compensate backwards traversal order of nextTreeID selection
+				for i := len(subtrees) - 1; i >= 0; i-- {
+					id := subtrees[i]
 					if id.IsNull() {
 						// We do not need to raise this error here, it is
 						// checked when the tree is checked. Just make sure

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -157,13 +157,13 @@ func TestUnreferencedBlobs(t *testing.T) {
 	}
 	test.OK(t, repo.Backend().Remove(context.TODO(), snapshotHandle))
 
-	unusedBlobsBySnapshot := restic.IDs{
-		restic.TestParseID("58c748bbe2929fdf30c73262bd8313fe828f8925b05d1d4a87fe109082acb849"),
-		restic.TestParseID("988a272ab9768182abfd1fe7d7a7b68967825f0b861d3b36156795832c772235"),
-		restic.TestParseID("c01952de4d91da1b1b80bc6e06eaa4ec21523f4853b69dc8231708b9b7ec62d8"),
-		restic.TestParseID("bec3a53d7dc737f9a9bee68b107ec9e8ad722019f649b34d474b9982c3a3fec7"),
-		restic.TestParseID("2a6f01e5e92d8343c4c6b78b51c5a4dc9c39d42c04e26088c7614b13d8d0559d"),
-		restic.TestParseID("18b51b327df9391732ba7aaf841a4885f350d8a557b2da8352c9acf8898e3f10"),
+	unusedBlobsBySnapshot := restic.BlobHandles{
+		restic.TestParseHandle("58c748bbe2929fdf30c73262bd8313fe828f8925b05d1d4a87fe109082acb849", restic.DataBlob),
+		restic.TestParseHandle("988a272ab9768182abfd1fe7d7a7b68967825f0b861d3b36156795832c772235", restic.DataBlob),
+		restic.TestParseHandle("c01952de4d91da1b1b80bc6e06eaa4ec21523f4853b69dc8231708b9b7ec62d8", restic.TreeBlob),
+		restic.TestParseHandle("bec3a53d7dc737f9a9bee68b107ec9e8ad722019f649b34d474b9982c3a3fec7", restic.TreeBlob),
+		restic.TestParseHandle("2a6f01e5e92d8343c4c6b78b51c5a4dc9c39d42c04e26088c7614b13d8d0559d", restic.TreeBlob),
+		restic.TestParseHandle("18b51b327df9391732ba7aaf841a4885f350d8a557b2da8352c9acf8898e3f10", restic.DataBlob),
 	}
 
 	sort.Sort(unusedBlobsBySnapshot)

--- a/internal/restic/testing.go
+++ b/internal/restic/testing.go
@@ -200,3 +200,8 @@ func TestParseID(s string) ID {
 
 	return id
 }
+
+// TestParseHandle parses s as a ID, panics if that fails and creates a BlobHandle with t.
+func TestParseHandle(s string, t BlobType) BlobHandle {
+	return BlobHandle{ID: TestParseID(s), Type: t}
+}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Running `restic check` for large repositories is currently really slow. I had one run for an 8 TB repository with roughly 40 million files that took approximately one week to complete (Using GOMAXPROCS=1 to avoid interference with other processes on the server)

This is partially caused by decoding for each snapshot, every referenced tree blobs. The integrity check later on checks a tree blob only a single time and ignores later repetitions. Decoding a JSON file is not particularly fast (and the necessary index lookups are even slower, see #2284 ).

This change ensures that tree blobs are only decoded once. As I had to modify the blobRefs map anyways, it is now also used to track whether a blob is listed in an index or not, thereby obsoleting the blob IDSet.

The checker now also traverses the tree blobs in depth-first order which better matches the traversal order of the backup code.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

The change is related but not identical to issue #2284 .

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] No user visible changes - I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
