### PR TITLE
Debian stable has restic 0.9.4

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -48,10 +48,6 @@ installed from the official repos, e.g. with ``apt-get``:
     $ apt-get install restic
 
 
-.. warning:: Please be aware that, at the time of writing, Debian *stable*
-   has ``restic`` version 0.3.3 which is very old. The *testing* and *unstable*
-   branches have recent versions of ``restic``.
-
 Fedora
 ======
 


### PR DESCRIPTION
Debian now has restic 0.9.4+ds-2+b1 in stable (buster)



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
Removed the warning for Debian stable carrying old version of restic

<!--
Describe the changes here, as detailed as needed.
-->
As of July 6, 2019, Debian has changed it's stable branch over to "buster" [Announcement](https://www.debian.org/News/2019/20190706) 
and the restic package has been updated to 0.9.4. [Package Browser](https://packages.debian.org/buster/resticl)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Not in issues or in forum

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
