### PR TITLE
Disable scanner for quiet backup

### DIFF
--- a/changelog/unreleased/pull-2336
+++ b/changelog/unreleased/pull-2336
@@ -1,0 +1,8 @@
+Enhancement: Faster backups in quiet mode
+
+Restic calculated the total file/directory count and size which, however,
+were not displayed when running with the quiet flag set. This speeds up
+backups as the file tree is only walked once.
+
+https://github.com/restic/restic/pull/2336
+

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -592,16 +592,18 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		targets = []string{filename}
 	}
 
-	sc := archiver.NewScanner(targetFS)
-	sc.SelectByName = selectByNameFilter
-	sc.Select = selectFilter
-	sc.Error = p.ScannerError
-	sc.Result = p.ReportTotal
+	if !gopts.Quiet {
+		sc := archiver.NewScanner(targetFS)
+		sc.SelectByName = selectByNameFilter
+		sc.Select = selectFilter
+		sc.Error = p.ScannerError
+		sc.Result = p.ReportTotal
 
-	if !gopts.JSON {
-		p.V("start scan on %v", targets)
+		if !gopts.JSON {
+			p.V("start scan on %v", targets)
+		}
+		t.Go(func() error { return sc.Scan(t.Context(gopts.ctx), targets) })
 	}
-	t.Go(func() error { return sc.Scan(t.Context(gopts.ctx), targets) })
 
 	arch := archiver.New(repo, targetFS, archiver.Options{})
 	arch.SelectByName = selectByNameFilter


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

The scanner's only purpose is to provide totals for file and directory counts and size. These are used to provide a sensible progress bar for the user. When running restic in quiet mode, no output is produced and thus there is no need to run the scanner. This saves the processing and syscalls required to walk over potentially millions of files.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] Already covered by 'cmd/restic/integration_test.TestQuietBackup'. I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
