### PR TITLE
Optimize in-memory index memory consumption

### DIFF
--- a/internal/repository/index_test.go
+++ b/internal/repository/index_test.go
@@ -442,6 +442,13 @@ func BenchmarkIndexHasKnown(b *testing.B) {
 	}
 }
 
+func BenchmarkIndexAlloc(b *testing.B) {
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		createRandomIndex(rand.New(rand.NewSource(0)))
+	}
+}
+
 func TestIndexHas(t *testing.T) {
 	type testEntry struct {
 		id             restic.ID


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Slightly reduce the memory usage of the in-memory index that is used by most restic commands. The memory usage should be 10-15% lower than before. This is achieved by optimizing for the usual situation where each blob is contained in a single pack file.

The pull request still needs tests which trigger the code paths with multiple packs. I'm not sure whether there are currently any tests that explicitly generate blobs which are stored in multiple packs.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The problem of high memory usage shows up in several issues #2284 , #1988 , #1723 . However, the approach of this pull request was not yet discussed in an issue. The underlying scalability issue is not tackled by this pull request.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] No user visible parts. I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review