### PR TITLE
Add support for ppc64le

### DIFF
--- a/changelog/unreleased/issue-2277
+++ b/changelog/unreleased/issue-2277
@@ -1,0 +1,5 @@
+Enhancement: Add support for ppc64le
+
+Adds support for ppc64le, the processor architecture from IBM.
+
+https://github.com/restic/restic/issues/2277

--- a/helpers/build-release-binaries/main.go
+++ b/helpers/build-release-binaries/main.go
@@ -251,7 +251,7 @@ func buildTargets(sourceDir, outputDir string, targets map[string][]string) {
 var defaultBuildTargets = map[string][]string{
 	"darwin":  []string{"386", "amd64"},
 	"freebsd": []string{"386", "amd64", "arm"},
-	"linux":   []string{"386", "amd64", "arm", "arm64"},
+	"linux":   []string{"386", "amd64", "arm", "arm64", "ppc64le"},
 	"openbsd": []string{"386", "amd64"},
 	"windows": []string{"386", "amd64"},
 }

--- a/run_integration_tests.go
+++ b/run_integration_tests.go
@@ -218,6 +218,7 @@ func (env *TravisEnvironment) Prepare() error {
 				"openbsd/386", "openbsd/amd64",
 				"netbsd/386", "netbsd/amd64",
 				"linux/arm", "freebsd/arm",
+				"linux/ppc64le",
 			}
 
 			if os.Getenv("RESTIC_BUILD_SOLARIS") == "0" {


### PR DESCRIPTION
This commit adds support for cross-compiling Restic for ppc64le
as part of the release process.

Add a new file:   changelog/unreleased/issue-2277
Modifies:   helpers/build-release-binaries/main.go
Modifies:   run_integration_tests.go



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

closes #2277

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
