### PR TITLE
Doc Addition: Wasabi repo setup instructions

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -234,7 +234,7 @@ credentials of your Minio Server.
     $ export AWS_ACCESS_KEY_ID=<YOUR-MINIO-ACCESS-KEY-ID>
     $ export AWS_SECRET_ACCESS_KEY= <YOUR-MINIO-SECRET-ACCESS-KEY>
 
-Now you can easily initialize restic to use Minio server as backend with
+Now you can easily initialize restic to use Minio server as a backend with
 this command.
 
 .. code-block:: console
@@ -243,6 +243,35 @@ this command.
     enter password for new backend:
     enter password again:
     created restic backend 6ad29560f5 at s3:http://localhost:9000/restic1
+    Please note that knowledge of your password is required to access
+    the repository. Losing your password means that your data is irrecoverably lost.
+
+Wasabi
+************
+
+`Wasabi <https://wasabi.com>`__ is a low cost AWS S3 conformant object storage provider.
+Due to it's S3 conformance, Wasabi can be used as a storage provider for a restic repository.
+
+-  Create a Wasabi bucket using the `Wasabi Console <https://console.wasabisys.com>`__.
+-  Determine the correct Wasabi service URL for your bucket `here <https://wasabi-support.zendesk.com/hc/en-us/articles/360015106031-What-are-the-service-URLs-for-Wasabi-s-different-regions->__`.
+
+You must first setup the following environment variables with the
+credentials of your Wasabi account.
+
+.. code-block:: console
+
+    $ export AWS_ACCESS_KEY_ID=<YOUR-WASABI-ACCESS-KEY-ID>
+    $ export AWS_SECRET_ACCESS_KEY=<YOUR-WASABI-SECRET-ACCESS-KEY>
+
+Now you can easily initialize restic to use Wasabi as a backend with
+this command.
+
+.. code-block:: console
+
+    $ ./restic -r s3:https://<WASABI-SERVICE-URL>/<WASABI-BUCKET-NAME> init
+    enter password for new backend:
+    enter password again:
+    created restic backend xxxxxxxxxx at s3:https://<WASABI-SERVICE-URL>/<WASABI-BUCKET-NAME>
     Please note that knowledge of your password is required to access
     the repository. Losing your password means that your data is irrecoverably lost.
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This is an addition to the 'preparing a new repo' documentation that adds specific instructions for the AWS S3 conformant object storage provider [Wasabi](https://wasabi.com). **NOTE**: I am not affiliated with Wasabi and wrote this as a service to restic not to Wasabi. This PR does not necessarily change anything, it simply adds more repo specific information to the documentation. Most of the content for this documentation addition was taken from the [Wasabi support topic on restic backups](https://wasabi-support.zendesk.com/hc/en-us/articles/115002240372-How-do-I-use-Restic-with-Wasabi-).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Not to my knowledge. I have seen some discussion of Wasabi across the restic forum and I believe Wasabi is being used by many restic users, hence why I thought specific documentation would be useful.

Checklist
---------
**PR Author Note**: These have been checked for clarity however this PR only changes one documentation file.

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
