### PR TITLE
Clarify docs for Backblaze B2 support

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -329,9 +329,9 @@ dashboard on the "Buckets" page when signed into your B2 account:
 .. code-block:: console
 
     $ export B2_ACCOUNT_ID=<MY_APPLICATION_KEY_ID>
-    $ export B2_ACCOUNT_KEY=<MY_SECRET_ACCOUNT_KEY>
+    $ export B2_ACCOUNT_KEY=<MY_APPLICATION_KEY>
 
-.. note:: In case you want to use Backblaze Application Keys replace <MY_APPLICATION_KEY_ID> and <MY_SECRET_ACCOUNT_KEY> with <applicationKeyId> and <applicationKey> respectively.
+.. note:: As of version 0.9.2, restic supports both master and non-master `application keys <https://www.backblaze.com/b2/docs/application_keys.html>`__. If using a non-master application key, ensure that it is created with at least **read and write** access to the B2 bucket. On earlier versions of restic, a master application key is required.
 
 You can then initialize a repository stored at Backblaze B2. If the
 bucket does not exist yet and the credentials you passed to restic have the


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Clarifies the access privileges required for Backblaze B2 application keys.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Issue #2293 

Checklist
---------

Most items not applicable, since the proposed change is to documentation only.

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
