### PR TITLE
Ignore username difference in TestMetadataChanged

### DIFF
--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -2085,6 +2085,10 @@ func TestMetadataChanged(t *testing.T) {
 
 	// make another snapshot
 	snapshotID, node3 := snapshot(t, repo, fs, snapshotID, "testfile")
+	// Override username and group to empty string - in case underlying system has user with UID 51234
+	// See https://github.com/restic/restic/issues/2372
+	node3.User = ""
+	node3.Group = ""
 
 	// make sure that metadata was recorded successfully
 	if !cmp.Equal(want, node3) {


### PR DESCRIPTION
In some (rare) cases "fake" UID 51234 may exist in a system running a
test. When this is the case, `cmp.Equal(want, node3)` will fail based on
difference between empty string and an actual username present in a
system.

Closes #2372.

What is the purpose of this change? What does it change?
--------------------------------------------------------

To fix github issue #2372

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No, consider this to be a proposal / start discussion. I did not put all my heart into this fix and not attached to it. Happy to discuss. :)

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
