### PR TITLE
Add support for sparse file restoration

### DIFF
--- a/changelog/unreleased/issue-79
+++ b/changelog/unreleased/issue-79
@@ -1,0 +1,5 @@
+Enhancement: Support for sparse file restoration
+
+Restore files with long runs of zeros as sparse on supported platforms
+
+https://github.com/restic/restic/issues/79

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -38,6 +38,7 @@ type RestoreOptions struct {
 	Paths              []string
 	Tags               restic.TagLists
 	Verify             bool
+	SparseFiles        bool
 }
 
 var restoreOptions RestoreOptions
@@ -56,6 +57,7 @@ func init() {
 	flags.Var(&restoreOptions.Tags, "tag", "only consider snapshots which include this `taglist` for snapshot ID \"latest\"")
 	flags.StringArrayVar(&restoreOptions.Paths, "path", nil, "only consider snapshots which include this (absolute) `path` for snapshot ID \"latest\"")
 	flags.BoolVar(&restoreOptions.Verify, "verify", false, "verify restored files content")
+	flags.BoolVar(&restoreOptions.SparseFiles, "sparse", false, "restore files as sparse when possible")
 }
 
 func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
@@ -122,7 +124,7 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	res, err := restorer.NewRestorer(repo, id)
+	res, err := restorer.NewRestorer(repo, id, opts.SparseFiles)
 	if err != nil {
 		Exitf(2, "creating restorer failed: %v\n", err)
 	}

--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -163,7 +163,7 @@ func newTestRepo(content []TestFile) *TestRepo {
 func restoreAndVerify(t *testing.T, tempdir string, content []TestFile) {
 	repo := newTestRepo(content)
 
-	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.idx)
+	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.idx, false)
 	r.files = repo.files
 
 	r.restoreFiles(context.TODO(), func(path string, err error) {

--- a/internal/restorer/fileswriter.go
+++ b/internal/restorer/fileswriter.go
@@ -104,7 +104,7 @@ func (w *filesWriter) writeToFile(path string, blob []byte) error {
 	return nil
 }
 
-func (w *filesWriter) seekInFile(path string, bytes int64) error {
+func (w *filesWriter) extendFile(path string, bytes int64) error {
 	wr, err := w.acquireWriter(path)
 	if err != nil {
 		return err

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -322,7 +322,7 @@ func TestRestorer(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := NewRestorer(repo, id)
+			res, err := NewRestorer(repo, id, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -440,7 +440,7 @@ func TestRestorerRelative(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := NewRestorer(repo, id)
+			res, err := NewRestorer(repo, id, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -671,7 +671,7 @@ func TestRestorerTraverseTree(t *testing.T) {
 			defer cleanup()
 			sn, id := saveSnapshot(t, repo, test.Snapshot)
 
-			res, err := NewRestorer(repo, id)
+			res, err := NewRestorer(repo, id, false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -29,7 +29,7 @@ func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
 		},
 	})
 
-	res, err := NewRestorer(repo, id)
+	res, err := NewRestorer(repo, id, false)
 	rtest.OK(t, err)
 
 	res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This is a tentative solution for restoring sparse files as discussed in issue #79. Since this implementation does not include a method to track which files were sparse to begin with, some files which were not sparse before but contain long runs of zeros will be made sparse.

The implementation is based on the observation that the chunker currently always returns a digest of 0 for a window of zeros. This results in chunks of zeros of minimum chunk size which all hash to the same ID. So, by comparing a blob's ID to that magic "zeros" ID we can quickly identify long runs of zeros and seek past them in the file instead of writing the zeros and allocating disk space.

There are likely numerous issues to discuss in this implementation. I consider it very much tentative and would like some feedback.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Yes, this is discussed in https://github.com/restic/restic/issues/79

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
