### PR TITLE
Update Lock.Time in lock.Refresh()

### DIFF
--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -221,6 +221,7 @@ func (l *Lock) Stale() bool {
 // timestamp. Afterwards the old lock is removed.
 func (l *Lock) Refresh(ctx context.Context) error {
 	debug.Log("refreshing lock %v", l.lockID)
+	l.Time = time.Now()
 	id, err := l.createLock(ctx)
 	if err != nil {
 		return err

--- a/internal/restic/lock_test.go
+++ b/internal/restic/lock_test.go
@@ -225,6 +225,7 @@ func TestLockRefresh(t *testing.T) {
 
 	lock, err := restic.NewLock(context.TODO(), repo)
 	rtest.OK(t, err)
+	time0 := lock.Time
 
 	var lockID *restic.ID
 	err = repo.List(context.TODO(), restic.LockFile, func(id restic.ID, size int64) error {
@@ -238,6 +239,7 @@ func TestLockRefresh(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	time.Sleep(time.Millisecond)
 	rtest.OK(t, lock.Refresh(context.TODO()))
 
 	var lockID2 *restic.ID
@@ -254,5 +256,9 @@ func TestLockRefresh(t *testing.T) {
 
 	rtest.Assert(t, !lockID.Equal(*lockID2),
 		"expected a new ID after lock refresh, got the same")
+	lock2, err := restic.LoadLock(context.TODO(), repo, *lockID2)
+	rtest.OK(t, err)
+	rtest.Assert(t, lock2.Time.After(time0),
+		"expected a later timestamp after lock refresh")
 	rtest.OK(t, lock.Unlock())
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
Fix #2390.  Ensures that updated lock file written by lock.Refresh() has a new timestamp so that it will not be Stale for another 30 minutes.
<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
I've opened issue for discussion.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->
Closes #2390

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
