### PR TITLE
Fix small documentation error

### DIFF
--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -197,7 +197,7 @@ To only keep the last snapshot of all snapshots with both the tag ``foo`` and
 
 .. code-block:: console
 
-   $ restic forget --tag foo,tag bar --keep-last 1
+   $ restic forget --tag foo,bar --keep-last 1
 
 All the ``--keep-*`` options above only count
 hours/days/weeks/months/years which have a snapshot, so those without a


### PR DESCRIPTION
The example of the `tag` option of the `forget` command using multiple tags was wrong.



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

Documentation fix.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] ~~I have added tests for all changes in this PR~~
- [ ] ~~I have added documentation for the changes (in the manual)~~
- [ ] ~~There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [ ] ~~I have run `gofmt` on the code in all commits~~
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
