### PR TITLE
add description env var RESTIC_PASSWORD_COMMAND

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -355,7 +355,7 @@ environment variables. The following list of environment variables:
     RESTIC_REPOSITORY                   Location of repository (replaces -r)
     RESTIC_PASSWORD_FILE                Location of password file (replaces --password-file)
     RESTIC_PASSWORD                     The actual password for the repository
-    RESTIC_PASSWORD_COMMAND		Command printing the password for the repoaitory to stdout
+    RESTIC_PASSWORD_COMMAND             Command printing the password for the repository to stdout
 
     AWS_ACCESS_KEY_ID                   Amazon S3 access key ID
     AWS_SECRET_ACCESS_KEY               Amazon S3 secret access key

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -355,6 +355,7 @@ environment variables. The following list of environment variables:
     RESTIC_REPOSITORY                   Location of repository (replaces -r)
     RESTIC_PASSWORD_FILE                Location of password file (replaces --password-file)
     RESTIC_PASSWORD                     The actual password for the repository
+    RESTIC_PASSWORD_COMMAND		Command printing the password for the repoaitory to stdout
 
     AWS_ACCESS_KEY_ID                   Amazon S3 access key ID
     AWS_SECRET_ACCESS_KEY               Amazon S3 secret access key


### PR DESCRIPTION
The environment variable RESTIC_PASSWORD_COMMAND works but has
not been documented yet. e.g. it could contain a command that
would fetch the password from a local user keyring

enhances: https://github.com/restic/restic/pull/2094



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR: n/a
- [ ] I have added documentation for the changes (in the manual)
     Answer: I suggest a little change to the manual
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
     I think this one-line doc addition is not worht another changelog line
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
