### PR TITLE
Docs: Reword developer note in forget.

### DIFF
--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -216,8 +216,8 @@ Let's explain this with an example: Suppose you have only made a backup
 on each Sunday for 12 weeks. Then ``forget --keep-daily 4`` will keep
 the last four snapshots for the last four Sundays, but remove the rest.
 
-.. note:: Restic has a safety feature, preventing restic from removing many snapshots, when no newer exist.
-   If implemented otherwise, running ``forget --keep-daily 4`` on a Friday would remove all snapshots.
+Restic has a safety feature, preventing restic from removing many snapshots, when no newer exist.
+If implemented otherwise, running ``forget --keep-daily 4`` on a Friday would remove all snapshots.
 
 Another example: Suppose you make daily backups for 100 years. Then
 ``forget --keep-daily 7 --keep-weekly 5 --keep-monthly 12 --keep-yearly 75``

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -215,10 +215,9 @@ single snapshot on 2017-09-30 (Sat) will count as a daily, weekly and monthly.
 Let's explain this with an example: Suppose you have only made a backup
 on each Sunday for 12 weeks. Then ``forget --keep-daily 4`` will keep
 the last four snapshots for the last four Sundays, but remove the rest.
-Only counting the days which have a backup and ignore the ones without
-is a safety feature: it prevents restic from removing many snapshots
-when no new ones are created. If it was implemented otherwise, running
-``forget --keep-daily 4`` on a Friday would remove all snapshots!
+
+.. note:: Restic has a safety feature, preventing restic from removing many snapshots, when no newer exist.
+   If implemented otherwise, running ``forget --keep-daily 4`` on a Friday would remove all snapshots.
 
 Another example: Suppose you make daily backups for 100 years. Then
 ``forget --keep-daily 7 --keep-weekly 5 --keep-monthly 12 --keep-yearly 75``


### PR DESCRIPTION
When I went trough the docs, I had to read the text-block multiple times to understand, that the changed part did not belong together with the rest.

After 7 minutes, I did not find documentation on readthedocs markdown. Not sure, if correct.


<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->
<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
no
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
