### PR TITLE
forget docs: changing example to be more informative.

### DIFF
--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -220,11 +220,10 @@ is a safety feature: it prevents restic from removing many snapshots
 when no new ones are created. If it was implemented otherwise, running
 ``forget --keep-daily 4`` on a Friday would remove all snapshots!
 
-Another example: Suppose you make daily backups for 100 years. Then
-``forget --keep-daily 7 --keep-weekly 5 --keep-monthly 12 --keep-yearly 75``
-will keep the most recent 7 daily snapshots, then 4 (remember, 7 dailies
-already include a week!) last-day-of-the-weeks and 11 or 12
-last-day-of-the-months (11 or 12 depends if the 5 weeklies cross a month).
-And finally 75 last-day-of-the-year snapshots. All other snapshots are
-removed.
-
+Another example: Suppose you have made daily backups for 8 years.
+``forget --keep-daily 7 --keep-weekly 5 --keep-monthly 12 --keep-yearly 5``
+will keep the most recent 7 daily snapshots,
+4 (7 dailies already include a week) last-day-of-the-weeks,
+11 or 12 latest snapshots from each month and
+5 snapshots of the last days in 5 previous years last-day-of-the-year snapshots.
+In total 27-28 backupswill be kept. All other snapshots are removed.


### PR DESCRIPTION
 - Made the text a bit more informative and professional.
 - Made the example a bit more realistic.
 - Changed the wording from repetitive (last-day-of-the-*) to different explanations. That way, if one does not understand one explanation, an another could be understood.
 - Don't know, if readthedocs takes line brakes literally, but formatted the line brakes to make it more readable.



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
no
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
