### PR TITLE
sftp: support user@domain parsing as user

### DIFF
--- a/changelog/unreleased/pull-2423
+++ b/changelog/unreleased/pull-2423
@@ -1,0 +1,5 @@
+Enhancement: support user@domain parsing as user
+
+Added the ability for user@domain-like users to be authenticated over SFTP servers.
+
+https://github.com/restic/restic/pull/2423

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -78,6 +78,9 @@ You can also specify a relative (read: no slash (``/``) character at the
 beginning) directory, in this case the dir is relative to the remote
 user's home directory.
 
+Also, if the SFTP server is enforcing domain-confined users, you can
+specify the user this way: ``user@domain@host``.
+
 .. note:: Please be aware that sftp servers do not expand the tilde character
           (``~``) normally used as an alias for a user's home directory. If you
           want to specify a path relative to the user's home directory, pass a

--- a/internal/backend/sftp/config.go
+++ b/internal/backend/sftp/config.go
@@ -56,8 +56,11 @@ func ParseConfig(s string) (interface{}, error) {
 		host = data[0]
 		dir = data[1]
 		// split user and host at the "@"
-		data = strings.SplitN(host, "@", 2)
-		if len(data) == 2 {
+		data = strings.SplitN(host, "@", 3)
+		if len(data) == 3 {
+			user = data[0] + "@" + data[1]
+			host = data[2]
+		} else if len(data) == 2 {
 			user = data[0]
 			host = data[1]
 		}

--- a/internal/backend/sftp/config_test.go
+++ b/internal/backend/sftp/config_test.go
@@ -1,6 +1,8 @@
 package sftp
 
-import "testing"
+import (
+	"testing"
+)
 
 var configTests = []struct {
 	in  string
@@ -40,6 +42,10 @@ var configTests = []struct {
 	{
 		"sftp:user@host:/dir/subdir",
 		Config{User: "user", Host: "host", Path: "/dir/subdir"},
+	},
+	{
+		"sftp:user@domain@host:/dir/subdir",
+		Config{User: "user@domain", Host: "host", Path: "/dir/subdir"},
 	},
 	{
 		"sftp:host:../dir/subdir",


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This change allows `user@domain` to authenticate over SFTP servers.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
