### PR TITLE
Add support for $RESTIC_CACHE_DIR

### DIFF
--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -376,9 +376,10 @@ OS-specific cache folder:
  * macOS: ``~/Library/Caches/restic``
  * Windows: ``%LOCALAPPDATA%/restic``
 
-The command line parameter ``--cache-dir`` can each be used to override the
-default cache location. The parameter ``--no-cache`` disables the cache
-entirely. In this case, all data is loaded from the repo.
+The command line parameter ``--cache-dir`` or the environment variable
+``$RESTIC_CACHE_DIR`` can be used to override the default cache location.  The
+parameter ``--no-cache`` disables the cache entirely. In this case, all data
+is loaded from the repo.
 
 The cache is ephemeral: When a file cannot be read from the cache, it is loaded
 from the repository.

--- a/internal/cache/dir.go
+++ b/internal/cache/dir.go
@@ -12,17 +12,21 @@ import (
 
 // xdgCacheDir returns the cache directory according to XDG basedir spec, see
 // http://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html
+// unless RESTIC_CACHE_DIR is defined
 func xdgCacheDir() (string, error) {
+	cachedir := os.Getenv("RESTIC_CACHE_DIR")
 	xdgcache := os.Getenv("XDG_CACHE_HOME")
 	home := os.Getenv("HOME")
 
-	if xdgcache != "" {
+	if cachedir != "" {
+		return cachedir, nil
+	} else if xdgcache != "" {
 		return filepath.Join(xdgcache, "restic"), nil
 	} else if home != "" {
 		return filepath.Join(home, ".cache", "restic"), nil
 	}
 
-	return "", errors.New("unable to locate cache directory (XDG_CACHE_HOME and HOME unset)")
+	return "", errors.New("unable to locate cache directory (RESTIC_CACHE_DIR, XDG_CACHE_HOME and HOME unset)")
 }
 
 // windowsCacheDir returns the cache directory for Windows.


### PR DESCRIPTION
Add support for restic-specific $RESTIC_CACHE_DIR environment variable
to override the cache directory like --cache-dir would have.

What is the purpose of this change? What does it change?
--------------------------------------------------------

Add support for an environment variable named `$RESTIC_CACHE_DIR` to set the path to the cache directory path, as `--cache-dir` would have in command line. The variable is restic-specific so doesn't conflict with other XDG_*, useful when used with environment module or lmod on HPC clusters. Note that if `$RESTIC_CACHE_DIR` is not defined, the current behavior is unchanged.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://forum.restic.net/t/restic-specific-variable-for-cache-directory/2105

Closes #2143 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review