### PR TITLE
ignore not supported error on sync() when using local backend closes …

### DIFF
--- a/changelog/unreleased/issue-2395
+++ b/changelog/unreleased/issue-2395
@@ -1,0 +1,12 @@
+Enhancement: Ignore sync errors when operation not supported by local filesystem
+
+The local backend has been modified to work with filesystems which doesn't support
+the `sync` operation. This operation is normally used by restic to ensure that data
+files are fully written to disk before continuing.
+
+For these limited filesystems, saving a file in the backend would previously fail with
+an "operation not supported" error. This error is now ignored, which means that e.g.
+an SMB mount on macOS can now be used as storage location for a repository.
+
+https://github.com/restic/restic/issues/2395
+https://forum.restic.net/t/sync-errors-on-mac-over-smb/1859


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

This works around a "operation not supported" error on Sync() on macOS when using SMB mounted directories.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Related issue #2395
Related forum thread https://forum.restic.net/t/sync-errors-on-mac-over-smb/1859

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
