### PR TITLE
Docs: fixed escaping of argument in documentation

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -142,7 +142,7 @@ the exclude options are:
 -  ``--iexclude`` Same as ``--exclude`` but ignores the case of paths
 -  ``--exclude-caches`` Specified once to exclude folders containing a special file
 -  ``--exclude-file`` Specified one or more times to exclude items listed in a given file
--  ``--exclude-if-present foo`` Specified one or more times to exclude a folder's content if it contains a file called ``foo``` (optionally having a given header, no wildcards for the file name supported)
+-  ``--exclude-if-present foo`` Specified one or more times to exclude a folder's content if it contains a file called ``foo`` (optionally having a given header, no wildcards for the file name supported)
 
  Let's say we have a file called ``excludes.txt`` with the following content:
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

A inproperly formated argument "foo`" was visible in backup docs at https://restic.readthedocs.io/en/latest/040_backup.html

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

no

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
