### PR TITLE
Docs: add installation guide for openSUSE

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -109,6 +109,15 @@ On FreeBSD (11 and probably later versions), you can install restic using ``pkg 
 
     # pkg install restic
 
+openSUSE
+========
+
+On openSUSE (leap 15.0 and greater, and tumbleweed), you can install restic using the ``zypper`` package manager:
+
+.. code-block:: console
+
+    # zypper install restic
+
 RHEL & CentOS
 =============
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?

Add installation guide on openSUSE.

Fix #2115 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review