### PR TITLE
Accept both singular and plural for --group-by (#2330)

### DIFF
--- a/changelog/unreleased/issue-2330
+++ b/changelog/unreleased/issue-2330
@@ -1,0 +1,6 @@
+Enhancement: Make `--group-by` accept both singular and plural
+
+One can now use the values `host`/`hosts`, `path`/`paths` and
+`tag` / `tags` interchangeably in the `--group-by` argument.
+
+https://github.com/restic/restic/issues/2330

--- a/internal/restic/snapshot_group.go
+++ b/internal/restic/snapshot_group.go
@@ -31,11 +31,11 @@ func GroupSnapshots(snapshots Snapshots, options string) (map[string]Snapshots, 
 
 	for _, option := range GroupOptionList {
 		switch option {
-		case "host":
+		case "host", "hosts":
 			GroupByHost = true
-		case "paths":
+		case "path", "paths":
 			GroupByPath = true
-		case "tags":
+		case "tag", "tags":
 			GroupByTag = true
 		case "":
 		default:


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Makes the `--group-by` argument accept both singular and plural forms of its possible values, interchangeably.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Yes, closes #2330.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review