### PR TITLE
s3: Allow specifying region

### DIFF
--- a/changelog/unreleased/pull-2350
+++ b/changelog/unreleased/pull-2350
@@ -2,7 +2,7 @@ Enhancement: Add option to configure S3 region
 
 We've added a new option for setting the region when accessing an S3-compatible
 service. For some providers, it is required to set this to a valid value. You
-can do that either by setting the environment variable `AWS_REGION` or using
-the option `s3.region`, e.g. like this: `-o s3.region="us-east-1"`.
+can do that either by setting the environment variable `AWS_DEFAULT_REGION` or
+using the option `s3.region`, e.g. like this: `-o s3.region="us-east-1"`.
 
 https://github.com/restic/restic/pull/2350

--- a/changelog/unreleased/pull-2350
+++ b/changelog/unreleased/pull-2350
@@ -1,0 +1,8 @@
+Enhancement: Add option to configure S3 region
+
+We've added a new option for setting the region when accessing an S3-compatible
+service. For some providers, it is required to set this to a valid value. You
+can do that either by setting the environment variable `AWS_REGION` or using
+the option `s3.region`, e.g. like this: `-o s3.region="us-east-1"`.
+
+https://github.com/restic/restic/pull/2350

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -485,6 +485,10 @@ func parseConfig(loc location.Location, opts options.Options) (interface{}, erro
 			cfg.Secret = os.Getenv("AWS_SECRET_ACCESS_KEY")
 		}
 
+		if cfg.Region == "" {
+			cfg.Region = os.Getenv("AWS_REGION")
+		}
+
 		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
 			return nil, err
 		}

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -486,7 +486,7 @@ func parseConfig(loc location.Location, opts options.Options) (interface{}, erro
 		}
 
 		if cfg.Region == "" {
-			cfg.Region = os.Getenv("AWS_REGION")
+			cfg.Region = os.Getenv("AWS_DEFAULT_REGION")
 		}
 
 		if err := opts.Apply(loc.Scheme, &cfg); err != nil {

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -197,10 +197,11 @@ default location:
     Please note that knowledge of your password is required to access the repository.
     Losing your password means that your data is irrecoverably lost.
 
-It is not possible at the moment to have restic create a new bucket in a
-different location, so you need to create it using a different program.
-Afterwards, the S3 server (``s3.amazonaws.com``) will redirect restic to
-the correct endpoint.
+If needed, you can manually specify the region to use by either setting the
+environment variable ``AWS_REGION`` or calling restic with an option parameter
+like ``-o s3.region="us-east-1"``. If the region is not specified, the default
+region is used. Afterwards, the S3 server (``s3.amazonaws.com``) will redirect
+restic to the correct endpoint.
 
 Until version 0.8.0, restic used a default prefix of ``restic``, so the files
 in the bucket were placed in a directory named ``restic``. If you want to

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -198,10 +198,10 @@ default location:
     Losing your password means that your data is irrecoverably lost.
 
 If needed, you can manually specify the region to use by either setting the
-environment variable ``AWS_REGION`` or calling restic with an option parameter
-like ``-o s3.region="us-east-1"``. If the region is not specified, the default
-region is used. Afterwards, the S3 server (``s3.amazonaws.com``) will redirect
-restic to the correct endpoint.
+environment variable ``AWS_DEFAULT_REGION`` or calling restic with an option
+parameter like ``-o s3.region="us-east-1"``. If the region is not specified,
+the default region is used. Afterwards, the S3 server (at least for AWS,
+``s3.amazonaws.com``) will redirect restic to the correct endpoint.
 
 Until version 0.8.0, restic used a default prefix of ``restic``, so the files
 in the bucket were placed in a directory named ``restic``. If you want to

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -20,9 +20,9 @@ type Config struct {
 	Layout        string `option:"layout" help:"use this backend layout (default: auto-detect)"`
 	StorageClass  string `option:"storage-class" help:"set S3 storage class (STANDARD, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING or REDUCED_REDUNDANCY)"`
 
-	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
-	MaxRetries  uint `option:"retries" help:"set the number of retries attempted"`
-	Region      string
+	Connections uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	MaxRetries  uint   `option:"retries" help:"set the number of retries attempted"`
+	Region      string `option:"region" help:"set region"`
 }
 
 // NewConfig returns a new Config with the default values filled in.

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -22,6 +22,7 @@ type Config struct {
 
 	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
 	MaxRetries  uint `option:"retries" help:"set the number of retries attempted"`
+	Region      string
 }
 
 // NewConfig returns a new Config with the default values filled in.

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -66,7 +66,7 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 			},
 		},
 	})
-	client, err := minio.NewWithCredentials(cfg.Endpoint, creds, !cfg.UseHTTP, "")
+	client, err := minio.NewWithCredentials(cfg.Endpoint, creds, !cfg.UseHTTP, cfg.Region)
 	if err != nil {
 		return nil, errors.Wrap(err, "minio.NewWithCredentials")
 	}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This PR adds the option `s3.region` and the environment variable `AWS_DEFAULT_REGION` to set the desired region for the s3 backend.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

This PR supersedes #2350, which was closed accidentally (and I do not have any
idea how or why). It adds my suggested changes, a changelog file, and
documentation about the new option.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I'm done, this Pull Request is ready for review