### PR TITLE
diff: Fix wrong bytes reported in diff stats (#2469)

### DIFF
--- a/changelog/unreleased/issue-2469
+++ b/changelog/unreleased/issue-2469
@@ -1,0 +1,5 @@
+Bugfix: Fix incorrect bytes stats in `diff` command
+
+In some cases, the wrong number of bytes (e.g. 16777215.998 TiB) were reported by the `diff` command. This is now fixed.
+
+https://github.com/restic/restic/issues/2469

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -66,7 +66,7 @@ type Comparer struct {
 type DiffStat struct {
 	Files, Dirs, Others  int
 	DataBlobs, TreeBlobs int
-	Bytes                int
+	Bytes                uint64
 }
 
 // Add adds stats information for node to s.
@@ -141,7 +141,7 @@ func updateBlobs(repo restic.Repository, blobs restic.BlobSet, stats *DiffStat) 
 			continue
 		}
 
-		stats.Bytes += int(size)
+		stats.Bytes += uint64(size)
 	}
 }
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Attempts to fix issue #2469, bytes stats in `diff` command being wrong.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Yes, hopefully closes #2469.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review