### PR TITLE
Fix repo configfile

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -82,6 +82,10 @@ func (r *Repository) LoadAndDecrypt(ctx context.Context, buf []byte, t restic.Fi
 
 	debug.Log("load %v with id %v", t, id)
 
+	if t == restic.ConfigFile {
+		id = restic.ID{}
+	}
+
 	h := restic.Handle{Type: t, Name: id.String()}
 	err := r.be.Load(ctx, h, 0, 0, func(rd io.Reader) error {
 		// make sure this call is idempotent, in case an error occurs
@@ -295,7 +299,11 @@ func (r *Repository) SaveUnpacked(ctx context.Context, t restic.FileType, p []by
 
 	ciphertext = r.key.Seal(ciphertext, nonce, p, nil)
 
-	id = restic.Hash(ciphertext)
+	if t == restic.ConfigFile {
+		id = restic.ID{}
+	} else {
+		id = restic.Hash(ciphertext)
+	}
 	h := restic.Handle{Type: t, Name: id.String()}
 
 	err = r.be.Save(ctx, h, restic.NewByteReader(ciphertext))

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -274,6 +274,14 @@ func TestLoadJSONUnpacked(t *testing.T) {
 
 	rtest.Equals(t, sn.Hostname, sn2.Hostname)
 	rtest.Equals(t, sn.Username, sn2.Username)
+
+	var cf restic.Config
+
+	// load and check Config
+	err = repo.LoadJSONUnpacked(context.TODO(), restic.ConfigFile, id, &cf)
+	rtest.OK(t, err)
+
+	rtest.Equals(t, cf.ChunkerPolynomial, repository.TestChunkerPol)
 }
 
 var repoFixture = filepath.Join("testdata", "test-repo.tar.gz")

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -36,7 +36,7 @@ func TestBackend(t testing.TB) (be restic.Backend, cleanup func()) {
 	return mem.New(), func() {}
 }
 
-const testChunkerPol = chunker.Pol(0x3DA3358B4DC173)
+const TestChunkerPol = chunker.Pol(0x3DA3358B4DC173)
 
 // TestRepositoryWithBackend returns a repository initialized with a test
 // password. If be is nil, an in-memory backend is used. A constant polynomial
@@ -53,7 +53,7 @@ func TestRepositoryWithBackend(t testing.TB, be restic.Backend) (r restic.Reposi
 
 	repo := New(be)
 
-	cfg := restic.TestCreateConfig(t, testChunkerPol)
+	cfg := restic.TestCreateConfig(t, TestChunkerPol)
 	err := repo.init(context.TODO(), test.TestPassword, cfg)
 	if err != nil {
 		t.Fatalf("TestRepository(): initialize repo failed: %v", err)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
access to config file from repository was inconsistent and therefore unsafe for new possible backends. This is fixed in this PR.
See #2498. 

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
closes #2498 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have not added documentation for the changes, as I see no need to document it for users.
- There's no new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))  - dont't think this is necessary for this minor change.
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review