### PR TITLE
Optimize index

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -85,7 +85,10 @@ func New(ctx context.Context, repo ListLoader, ignorePacks restic.IDSet, p *rest
 			}
 
 			if res, ok := oldIdx.Packs[id]; ok {
-				if err := idx.AddPack(res.ID, res.Size, res.Entries); err != nil {
+				if err := idx.AddPack(res.ID, size, res.Entries); err != nil {
+					return err
+				}
+				if err:= oldIdx.RemovePack(id); err != nil {
 					return err
 				}
 				return nil

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -271,13 +271,11 @@ func Load(ctx context.Context, repo ListLoader, p *restic.Progress) (*Index, err
 	return index, nil
 }
 
-// AddPack adds a pack to the index. If this pack is already in the index, an
-// error is returned.
+// AddPack adds a pack to the index.
 func (idx *Index) AddPack(id restic.ID, size int64, entries []restic.Blob) error {
 	if _, ok := idx.Packs[id]; ok {
-		return errors.Errorf("pack %v already present in the index", id.Str())
+		debug.Log("pack %v already present in the index", id.Str())
 	}
-
 	idx.Packs[id] = Pack{ID: id, Size: size, Entries: entries}
 
 	return nil

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -88,7 +88,7 @@ func New(ctx context.Context, repo ListLoader, ignorePacks restic.IDSet, p *rest
 				if err := idx.AddPack(res.ID, size, res.Entries); err != nil {
 					return err
 				}
-				if err:= oldIdx.RemovePack(id); err != nil {
+				if err := oldIdx.RemovePack(id); err != nil {
 					return err
 				}
 				return nil


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Optimize creation of new index so that already existing index files are used.
Creation of new index is used at the moment in prune and rebuild-index.

With this pull request the index creation is much faster, especially for remote repositories.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The change is similar to one part of PR #2340 and the problem is discussed in many issues, e.g. #2162 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
