### PR TITLE
Add --retries flag

### DIFF
--- a/changelog/unreleased/issue-2504
+++ b/changelog/unreleased/issue-2504
@@ -1,0 +1,8 @@
+Enhancement: Add --retries flag
+
+Restic used to retry backend operation 10 times before cancelling.
+This causes problems for 'cold storage' backends where you can have a large retrieve time.
+With the new flag you can finetune the maximum number of retries.
+
+https://github.com/restic/restic/issues/2504
+https://github.com/restic/restic/pull/2515


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Adds the new flag --retries to set the maximum number of retries for file operations.
If the number of retires is set higher than 20, restic will print out a warning.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

See issue #2504, first open point.
Closes #3223 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- I have not added tests for all changes in this PR
- I have added no documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review