### PR TITLE
Add flag --cache-all

### DIFF
--- a/internal/cache/backend.go
+++ b/internal/cache/backend.go
@@ -43,14 +43,10 @@ func (b *Backend) Remove(ctx context.Context, h restic.Handle) error {
 	return b.Cache.remove(h)
 }
 
-var autoCacheTypes = map[restic.FileType]struct{}{
-	restic.IndexFile:    {},
-	restic.SnapshotFile: {},
-}
-
 // Save stores a new file in the backend and the cache.
 func (b *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
-	if _, ok := autoCacheTypes[h.Type]; !ok {
+
+	if layout, ok := b.Cache.Layout[h.Type]; !ok || !layout.AutoCache {
 		return b.Backend.Save(ctx, h, rd)
 	}
 
@@ -82,11 +78,6 @@ func (b *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRea
 	}
 
 	return nil
-}
-
-var autoCacheFiles = map[restic.FileType]bool{
-	restic.IndexFile:    true,
-	restic.SnapshotFile: true,
 }
 
 func (b *Backend) cacheFile(ctx context.Context, h restic.Handle) error {
@@ -192,7 +183,7 @@ func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset 
 	}
 
 	// if we don't automatically cache this file type, fall back to the backend
-	if _, ok := autoCacheFiles[h.Type]; !ok {
+	if layout, ok := b.Cache.Layout[h.Type]; !ok || !layout.AutoCache {
 		debug.Log("Load(%v, %v, %v): delegating to backend", h, length, offset)
 		return b.Backend.Load(ctx, h, length, offset, consumer)
 	}

--- a/internal/cache/file.go
+++ b/internal/cache/file.go
@@ -17,7 +17,7 @@ func (c *Cache) filename(h restic.Handle) string {
 		panic("Name is empty or too short")
 	}
 	subdir := h.Name[:2]
-	return filepath.Join(c.path, cacheLayoutPaths[h.Type], subdir, h.Name)
+	return filepath.Join(c.Path, c.Layout[h.Type].Path, subdir, h.Name)
 }
 
 func (c *Cache) canBeCached(t restic.FileType) bool {
@@ -25,7 +25,7 @@ func (c *Cache) canBeCached(t restic.FileType) bool {
 		return false
 	}
 
-	if _, ok := cacheLayoutPaths[t]; !ok {
+	if _, ok := c.Layout[t]; !ok {
 		return false
 	}
 
@@ -181,7 +181,7 @@ func (c *Cache) list(t restic.FileType) (restic.IDSet, error) {
 	}
 
 	list := restic.NewIDSet()
-	dir := filepath.Join(c.path, cacheLayoutPaths[t])
+	dir := filepath.Join(c.Path, c.Layout[t].Path)
 	err := filepath.Walk(dir, func(name string, fi os.FileInfo, err error) error {
 		if err != nil {
 			return errors.Wrap(err, "Walk")

--- a/internal/cache/testing.go
+++ b/internal/cache/testing.go
@@ -12,7 +12,19 @@ import (
 func TestNewCache(t testing.TB) (*Cache, func()) {
 	dir, cleanup := test.TempDir(t)
 	t.Logf("created new cache at %v", dir)
-	cache, err := New(restic.NewRandomID().String(), dir)
+	cache, err := New(restic.NewRandomID().String(), dir, LayoutStandard)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cache, cleanup
+}
+
+// TestNewCacheAll returns a cache where all files are cached in a temporary
+// directory which is removed when cleanup is called.
+func TestNewCacheAll(t testing.TB) (*Cache, func()) {
+	dir, cleanup := test.TempDir(t)
+	t.Logf("created new cache at %v", dir)
+	cache, err := New("repo-"+restic.NewRandomID().String(), dir, LayoutAll)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Adds the flag --cache-all
When set, all files (including key, config, lock) are cached.
To do so, when the flag is set, the cache directory does not use repo ID
but the repo string given by -r.

Note: In order to correctly cache the config file, the PR #2505 is also required!

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

See issue #2504. 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
