### PR TITLE
Add new flag masterkeyfile

### DIFF
--- a/changelog/unreleased/pull-2525
+++ b/changelog/unreleased/pull-2525
@@ -1,0 +1,9 @@
+Enhancement: Add flag `--masterkeyfile`
+
+We've added a new option for using the master key from a file.
+With this option, no key needs to be saved in the repo and no
+key derivation function is used. This may increase security
+and performance. However, you have to take care about your locally
+saved key file!
+
+https://github.com/restic/restic/pull/2525

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -33,25 +33,32 @@ func runInit(gopts GlobalOptions, args []string) error {
 		return errors.Fatalf("create repository at %s failed: %v\n", gopts.Repo, err)
 	}
 
-	gopts.password, err = ReadPasswordTwice(gopts,
-		"enter password for new repository: ",
-		"enter password again: ")
-	if err != nil {
-		return err
+	if gopts.MasterKeyFile == "" {
+		gopts.password, err = ReadPasswordTwice(gopts,
+			"enter password for new repository: ",
+			"enter password again: ")
+		if err != nil {
+			return err
+		}
 	}
 
 	s := repository.New(be)
 
-	err = s.Init(gopts.ctx, gopts.password)
+	err = s.Init(gopts.ctx, gopts.MasterKeyFile, gopts.password)
 	if err != nil {
 		return errors.Fatalf("create key in repository at %s failed: %v\n", gopts.Repo, err)
 	}
 
 	Verbosef("created restic repository %v at %s\n", s.Config().ID[:10], gopts.Repo)
 	Verbosef("\n")
-	Verbosef("Please note that knowledge of your password is required to access\n")
-	Verbosef("the repository. Losing your password means that your data is\n")
-	Verbosef("irrecoverably lost.\n")
+	if gopts.MasterKeyFile == "" {
+		Verbosef("Please note that knowledge of your password is required to access\n")
+		Verbosef("the repository. Losing your password means that your data is\n")
+		Verbosef("irrecoverably lost.\n")
+	} else {
+		Verbosef("Please note that you need the masterkey %s to access the repository\n", gopts.MasterKeyFile)
+		Verbosef("Losing your masterkey file means that your data is irrecoverably lost.\n")
+	}
 
 	return nil
 }

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -56,7 +56,7 @@ func runInit(gopts GlobalOptions, args []string) error {
 		Verbosef("the repository. Losing your password means that your data is\n")
 		Verbosef("irrecoverably lost.\n")
 	} else {
-		Verbosef("Please note that you need the masterkey %s to access the repository\n", gopts.MasterKeyFile)
+		Verbosef("Please note that you need the masterkey %s to access the repository.\n", gopts.MasterKeyFile)
 		Verbosef("Losing your masterkey file means that your data is irrecoverably lost.\n")
 	}
 

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -129,6 +129,9 @@ func deleteKey(ctx context.Context, repo *repository.Repository, name string) er
 	if name == repo.KeyName() {
 		return errors.Fatal("refusing to remove key currently used to access repository")
 	}
+	if repo.KeyName() == "master" {
+		Verbosef("Removing repository key with masterkey file.\n Make sure that you do not to loose the masterkey file if you delete all repository keys!\n")
+	}
 
 	h := restic.Handle{Type: restic.KeyFile, Name: name}
 	err := repo.Backend().Remove(ctx, h)

--- a/doc/070_encryption.rst
+++ b/doc/070_encryption.rst
@@ -54,17 +54,35 @@ per repository. In fact, you can use the ``list``, ``add``, ``remove``, and
 Using master key from file
 **************************
 
-The flag ``--masterkeyfile`` allows you to directly use a file for the master key. Then no key needs to be stored
-in the repository. Make sure your masterkey cannot be accessed by unauthorized persons and that you  have a backup
-of you masterkey file ready (e.g. print-out)!
+The flag ``--masterkeyfile`` allows you to directly use a file for the master key.
+This allows restic to be used without the need to save a key in the repository.
+The masterkey file can be used in combination with repository keys, e.g. use the masterkey
+file to backup from one source and a repository key from the other source.
 
+Please note that the master key is not encrypted and contains the key that is
+needed to decrypt the repository in plain text!
+Hence make sure your masterkey cannot be accessed by unauthorized persons!
+
+If you do not have a key stored in the repository and loose your masterkey file,
+your repository cannot be decrypted!
+Hence make sure to have a backup of you masterkey file (e.g. print-out)!
+
+Using the master key makes restic independent from a password-encrypted master key stored
+in the repository. This prevents a potential unknown weakness in the key derivation function
+(KDF) which is used to encrypt the master key.
+The trade-off is that you have to take extra care about your masterkey file. If you only use
+the masterkey file and no repository keys, you also loose the ability to access your repository
+with different passwords.
+
+
+Example of creating and using a repository only with the master-key:
 
 .. code-block:: console
 
     $ restic -r /srv/restic-repo --masterkeyfile master.key init
-    created restic repository f855d38126 at /tmp/repo
+    created restic repository f855d38126 at /srv/restic-repo
 
-    Please note that you need the masterkey tmp.master to access the repository
+    Please note that you need the masterkey master.key to access the repository.
     Losing your masterkey file means that your data is irrecoverably lost.
 
     $ restic -r /srv/restic-repo --masterkeyfile master.key key list
@@ -85,15 +103,16 @@ If you want to export the master key from an existing repository, you can use th
     Please note that knowledge of your password is required to access
     the repository. Losing your password means that your data is
     irrecoverably lost.
-    $ restic -r  /srv/restic-repo --quiet cat masterkey > key.master 
+    $ restic -r  /srv/restic-repo --quiet cat masterkey > master.key && chmod 400 key.master
     enter password for repository:
-    $ chmod 400 key.master
-    $ restic -r /srv/restic-repo --masterkeyfile key.master key list
+    $ restic -r /srv/restic-repo --masterkeyfile master.key key list
     repository a8e7f965 opened successfully
     ID        User        Host      Created
     ---------------------------------------------------
     335ca24b  username    kasimir   2015-08-12 13:35:05
     ---------------------------------------------------
-    $ restic -r /srv/restic-repo --masterkeyfile key.master key remove 335ca24b
+    $ restic -r /srv/restic-repo --masterkeyfile master.key key remove 335ca24b
     repository a8e7f965 opened successfully
+    Removing repository key with masterkey file.
+    Make sure that you do not to loose the masterkey file if you delete all repository keys!
     removed key 335ca24bc44d561f60b700bc2b52c1850dc1a97094d755dd7c1c185b91111d9b

--- a/doc/070_encryption.rst
+++ b/doc/070_encryption.rst
@@ -49,3 +49,51 @@ per repository. In fact, you can use the ``list``, ``add``, ``remove``, and
     ----------------------------------------------------------------------
      5c657874    username    kasimir   2015-08-12 13:35:05
     *eb78040b    username    kasimir   2015-08-12 13:29:57
+
+**************************
+Using master key from file
+**************************
+
+The flag ``--masterkeyfile`` allows you to directly use a file for the master key. Then no key needs to be stored
+in the repository. Make sure your masterkey cannot be accessed by unauthorized persons and that you  have a backup
+of you masterkey file ready (e.g. print-out)!
+
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo --masterkeyfile master.key init
+    created restic repository f855d38126 at /tmp/repo
+
+    Please note that you need the masterkey tmp.master to access the repository
+    Losing your masterkey file means that your data is irrecoverably lost.
+
+    $ restic -r /srv/restic-repo --masterkeyfile master.key key list
+    repository f855d381 opened successfully
+    ID  User  Host  Created
+    ------------------------
+    ------------------------
+
+If you want to export the master key from an existing repository, you can use the `cat masterkey` command:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo init
+    enter password for new repository: 
+    enter password again: 
+    created restic repository a8e7f96567 at /srv/restic-repo
+
+    Please note that knowledge of your password is required to access
+    the repository. Losing your password means that your data is
+    irrecoverably lost.
+    $ restic -r  /srv/restic-repo --quiet cat masterkey > key.master 
+    enter password for repository:
+    $ chmod 400 key.master
+    $ restic -r /srv/restic-repo --masterkeyfile key.master key list
+    repository a8e7f965 opened successfully
+    ID        User        Host      Created
+    ---------------------------------------------------
+    335ca24b  username    kasimir   2015-08-12 13:35:05
+    ---------------------------------------------------
+    $ restic -r /srv/restic-repo --masterkeyfile key.master key remove 335ca24b
+    repository a8e7f965 opened successfully
+    removed key 335ca24bc44d561f60b700bc2b52c1850dc1a97094d755dd7c1c185b91111d9b

--- a/doc/070_encryption.rst
+++ b/doc/070_encryption.rst
@@ -73,7 +73,7 @@ of you masterkey file ready (e.g. print-out)!
     ------------------------
     ------------------------
 
-If you want to export the master key from an existing repository, you can use the `cat masterkey` command:
+If you want to export the master key from an existing repository, you can use the ``cat masterkey`` command:
 
 .. code-block:: console
 

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -572,7 +572,7 @@ func LoadIndex(ctx context.Context, repo restic.Repository, id restic.ID) (*Inde
 // MasterKeyFile reads the master key from a given file
 func (r *Repository) MasterKeyFile(ctx context.Context, keyfile string) error {
 
-	buf, err := ioutil.ReadFile(keyfile) // just pass the file name
+	buf, err := ioutil.ReadFile(keyfile)
 	if err != nil {
 		debug.Log("ReadFile() returned error %v", err)
 		return errors.Wrap(err, "ReadFile")

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -54,7 +54,7 @@ func TestRepositoryWithBackend(t testing.TB, be restic.Backend) (r restic.Reposi
 	repo := New(be)
 
 	cfg := restic.TestCreateConfig(t, testChunkerPol)
-	err := repo.init(context.TODO(), test.TestPassword, cfg)
+	err := repo.init(context.TODO(), "", test.TestPassword, cfg)
 	if err != nil {
 		t.Fatalf("TestRepository(): initialize repo failed: %v", err)
 	}


### PR DESCRIPTION

What is the purpose of this change? What does it change?
--------------------------------------------------------

Add the new flag `--masterkeyfile` which allows to directly use the
master key from a file.
When `--masterkeyfile` is used from `restic init` the master key is
written to the given file and no key is created in the repo.
For all other commands, `--masterkeyfile` uses the master key in the
given file. No password is needed then.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Was discussed (don't remember the issue) and is able to solve #2128 
Also allows increased security if you do want to save the password-encrypted masterkey.
On low-end machines saving the overhead from the KDF may give you some benefit.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
