### PR TITLE
sftp: Use MkdirAll provided by the client

### DIFF
--- a/changelog/unreleased/issue-2518
+++ b/changelog/unreleased/issue-2518
@@ -1,0 +1,16 @@
+Bugfix: Do not crash with Synology NAS sftp server
+
+It was found that when restic is used to store data on an sftp server on a
+Synology NAS with a relative path (one which does not start with a slash), it
+may go into an endless loop trying to create directories on the server. We've
+fixed this bug by using a function oft the sftp library instead of our own
+implementation.
+
+The bug was discovered because the Synology sftp server behaves erratic with
+non-absolute path (e.g. `home/restic-repo`). This can be resolved by just using
+an absolute path instead (`/home/restic-repo`). We've also added a paragraph in
+the FAQ.
+
+https://github.com/restic/restic/issues/2518
+https://github.com/restic/restic/issues/2363
+https://github.com/restic/restic/pull/2530

--- a/changelog/unreleased/issue-2518
+++ b/changelog/unreleased/issue-2518
@@ -3,7 +3,7 @@ Bugfix: Do not crash with Synology NAS sftp server
 It was found that when restic is used to store data on an sftp server on a
 Synology NAS with a relative path (one which does not start with a slash), it
 may go into an endless loop trying to create directories on the server. We've
-fixed this bug by using a function oft the sftp library instead of our own
+fixed this bug by using a function in the sftp library instead of our own
 implementation.
 
 The bug was discovered because the Synology sftp server behaves erratic with

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -142,6 +142,9 @@ is not slowed down, which is particularly useful for servers.
 Creating new repo on a Synology NAS via sftp fails
 --------------------------------------------------
 
+For using restic with a Synology NAS via sftp, please make sure that the
+specified path is absolute, it must start with a slash (``/``).
+
 Sometimes creating a new restic repository on a Synology NAS via sftp fails
 with an error similar to the following:
 
@@ -160,8 +163,8 @@ different than the directory structure on the device and maybe even as exposed
 via other protocols.
 
 
-Try removing the /volume1 prefix in your paths. If this does not work, use sftp
-and ls to explore the SFTP file system hierarchy on your NAS.
+Try removing the ``/volume1`` prefix in your paths. If this does not work, use
+sftp and ls to explore the SFTP file system hierarchy on your NAS.
 
 The following may work:
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

Use the `MkdirAll()` function provided by the sftp client library instead of
our own implementation, which seems to contain a bug.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2518
Closes #2363 
Closes #596 

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I'm done, this Pull Request is ready for review