### PR TITLE
Optimize for dirs containing many entries (Introduce Node.Subtrees)

### DIFF
--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -356,21 +356,22 @@ func (f *Finder) findIDs(ctx context.Context, sn *restic.Snapshot) error {
 		}
 
 		if node.Type == "dir" && f.treeIDs != nil {
-			treeID := node.Subtree
-			found := false
-			if _, ok := f.treeIDs[treeID.Str()]; ok {
-				found = true
-			} else if _, ok := f.treeIDs[treeID.String()]; ok {
-				found = true
-			}
-			if found {
-				f.out.PrintObject("tree", treeID.String(), nodepath, "", sn)
-				f.itemsFound++
-				// Terminate if we have found all trees (and we are not
-				// looking for blobs)
-				if f.itemsFound >= len(f.treeIDs) && f.blobIDs == nil {
-					// Return an error to terminate the Walk
-					return true, errors.New("OK")
+			for _, treeID := range node.Subtrees {
+				found := false
+				if _, ok := f.treeIDs[treeID.Str()]; ok {
+					found = true
+				} else if _, ok := f.treeIDs[treeID.String()]; ok {
+					found = true
+				}
+				if found {
+					f.out.PrintObject("tree", treeID.String(), nodepath, "", sn)
+					f.itemsFound++
+					// Terminate if we have found all trees (and we are not
+					// looking for blobs)
+					if f.itemsFound >= len(f.treeIDs) && f.blobIDs == nil {
+						// Return an error to terminate the Walk
+						return true, errors.New("OK")
+					}
 				}
 			}
 		}

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -79,12 +79,13 @@ func runRecover(gopts GlobalOptions) error {
 		}
 
 		for _, node := range tree.Nodes {
-			if node.Type != "dir" || node.Subtree == nil {
+			if node.Type != "dir" {
 				continue
 			}
 
-			subtree := *node.Subtree
-			trees[subtree] = true
+			for _, st := range node.Subtrees {
+				trees[*st] = true
+			}
 		}
 	}
 	Verbosef("\ndone\n")
@@ -107,7 +108,7 @@ func runRecover(gopts GlobalOptions) error {
 			Type:       "dir",
 			Name:       id.Str(),
 			Mode:       0755,
-			Subtree:    &subtreeID,
+			Subtrees:   []*restic.ID{&subtreeID},
 			AccessTime: time.Now(),
 			ModTime:    time.Now(),
 			ChangeTime: time.Now(),

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -220,7 +220,7 @@ func statsWalkTree(repo restic.Repository, stats *statsContainer) walker.WalkFun
 							// is always a data blob since we're accessing it via a file's Content array
 							blobSize, found := repo.LookupBlobSize(blobID, restic.DataBlob)
 							if !found {
-								return true, fmt.Errorf("blob %s not found for tree %s", blobID, *node.Subtree)
+								return true, fmt.Errorf("blob %s not found for node %s", blobID, node)
 							}
 
 							// count the blob's size, then add this blob by this

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -939,8 +939,6 @@ func TestArchiverSaveDirIncremental(t *testing.T) {
 			}
 		}
 
-		t.Logf("node subtree %v", node.Subtree)
-
 		err = repo.Flush(ctx)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/archiver/tree_saver.go
+++ b/internal/archiver/tree_saver.go
@@ -37,12 +37,42 @@ func (s *FutureTree) Stats() ItemStats {
 	return s.res.stats
 }
 
+// FutureSubTree is returned by Save and will return the data once it
+// has been processed.
+type FutureSubTree struct {
+	ch  <-chan saveSubTreeResponse
+	res saveSubTreeResponse
+}
+
+// Wait blocks until the data has been received or ctx is cancelled.
+func (s *FutureSubTree) Wait(ctx context.Context) {
+	select {
+	case <-ctx.Done():
+		return
+	case res, ok := <-s.ch:
+		if ok {
+			s.res = res
+		}
+	}
+}
+
+// Node returns the ID.
+func (s *FutureSubTree) ID() *restic.ID {
+	return s.res.id
+}
+
+// Stats returns the stats for the file.
+func (s *FutureSubTree) Stats() ItemStats {
+	return s.res.stats
+}
+
 // TreeSaver concurrently saves incoming trees to the repo.
 type TreeSaver struct {
 	saveTree func(context.Context, *restic.Tree) (restic.ID, ItemStats, error)
 	errFn    ErrorFunc
 
 	ch   chan<- saveTreeJob
+	chst chan<- saveSubTreeJob
 	done <-chan struct{}
 }
 
@@ -50,9 +80,11 @@ type TreeSaver struct {
 // started, it is stopped when ctx is cancelled.
 func NewTreeSaver(ctx context.Context, t *tomb.Tomb, treeWorkers uint, saveTree func(context.Context, *restic.Tree) (restic.ID, ItemStats, error), errFn ErrorFunc) *TreeSaver {
 	ch := make(chan saveTreeJob)
+	chst := make(chan saveSubTreeJob)
 
 	s := &TreeSaver{
 		ch:       ch,
+		chst:     chst,
 		done:     t.Dying(),
 		saveTree: saveTree,
 		errFn:    errFn,
@@ -62,19 +94,22 @@ func NewTreeSaver(ctx context.Context, t *tomb.Tomb, treeWorkers uint, saveTree 
 		t.Go(func() error {
 			return s.worker(t.Context(ctx), ch)
 		})
+		t.Go(func() error {
+			return s.workerSubTree(t.Context(ctx), chst)
+		})
 	}
 
 	return s
 }
 
 // Save stores the dir d and returns the data once it has been completed.
-func (s *TreeSaver) Save(ctx context.Context, snPath string, node *restic.Node, nodes []FutureNode) FutureTree {
+func (s *TreeSaver) Save(ctx context.Context, snPath string, node *restic.Node, subtrees []FutureSubTree) FutureTree {
 	ch := make(chan saveTreeResponse, 1)
 	job := saveTreeJob{
-		snPath: snPath,
-		node:   node,
-		nodes:  nodes,
-		ch:     ch,
+		snPath:   snPath,
+		node:     node,
+		subtrees: subtrees,
+		ch:       ch,
 	}
 	select {
 	case s.ch <- job:
@@ -91,11 +126,33 @@ func (s *TreeSaver) Save(ctx context.Context, snPath string, node *restic.Node, 
 	return FutureTree{ch: ch}
 }
 
+// Save stores the dir d and returns the data once it has been completed.
+func (s *TreeSaver) SaveSubTree(ctx context.Context, nodes []FutureNode) FutureSubTree {
+	ch := make(chan saveSubTreeResponse, 1)
+	job := saveSubTreeJob{
+		nodes: nodes,
+		ch:    ch,
+	}
+	select {
+	case s.chst <- job:
+	case <-s.done:
+		debug.Log("not saving tree, TreeSaver is done")
+		close(ch)
+		return FutureSubTree{ch: ch}
+	case <-ctx.Done():
+		debug.Log("not saving tree, context is cancelled")
+		close(ch)
+		return FutureSubTree{ch: ch}
+	}
+
+	return FutureSubTree{ch: ch}
+}
+
 type saveTreeJob struct {
-	snPath string
-	nodes  []FutureNode
-	node   *restic.Node
-	ch     chan<- saveTreeResponse
+	snPath   string
+	subtrees []FutureSubTree
+	node     *restic.Node
+	ch       chan<- saveTreeResponse
 }
 
 type saveTreeResponse struct {
@@ -104,7 +161,63 @@ type saveTreeResponse struct {
 }
 
 // save stores the nodes as a tree in the repo.
-func (s *TreeSaver) save(ctx context.Context, snPath string, node *restic.Node, nodes []FutureNode) (*restic.Node, ItemStats, error) {
+func (s *TreeSaver) save(ctx context.Context, snPath string, node *restic.Node, subtrees []FutureSubTree) (*restic.Node, ItemStats, error) {
+	var stats ItemStats
+
+	if len(subtrees) == 1 {
+		fst := subtrees[0]
+		fst.Wait(ctx)
+		node.Subtree = fst.ID()
+		stats.Add(fst.Stats())
+	} else {
+		for _, fst := range subtrees {
+			fst.Wait(ctx)
+
+			debug.Log("insert %v", fst.ID())
+			node.Subtrees = append(node.Subtrees, fst.ID())
+			stats.Add(fst.Stats())
+		}
+	}
+
+	return node, stats, nil
+}
+
+func (s *TreeSaver) worker(ctx context.Context, jobs <-chan saveTreeJob) error {
+	for {
+		var job saveTreeJob
+		select {
+		case <-ctx.Done():
+			return nil
+		case job = <-jobs:
+		}
+
+		node, stats, err := s.save(ctx, job.snPath, job.node, job.subtrees)
+		if err != nil {
+			debug.Log("error saving tree blob: %v", err)
+			close(job.ch)
+			return err
+		}
+
+		job.ch <- saveTreeResponse{
+			node:  node,
+			stats: stats,
+		}
+		close(job.ch)
+	}
+}
+
+type saveSubTreeJob struct {
+	nodes []FutureNode
+	ch    chan<- saveSubTreeResponse
+}
+
+type saveSubTreeResponse struct {
+	id    *restic.ID
+	stats ItemStats
+}
+
+// save stores the nodes as a tree in the repo.
+func (s *TreeSaver) saveSubTree(ctx context.Context, nodes []FutureNode) (*restic.ID, ItemStats, error) {
 	var stats ItemStats
 
 	tree := restic.NewTree()
@@ -142,28 +255,27 @@ func (s *TreeSaver) save(ctx context.Context, snPath string, node *restic.Node, 
 		return nil, stats, err
 	}
 
-	node.Subtree = &id
-	return node, stats, nil
+	return &id, stats, nil
 }
 
-func (s *TreeSaver) worker(ctx context.Context, jobs <-chan saveTreeJob) error {
+func (s *TreeSaver) workerSubTree(ctx context.Context, jobs <-chan saveSubTreeJob) error {
 	for {
-		var job saveTreeJob
+		var job saveSubTreeJob
 		select {
 		case <-ctx.Done():
 			return nil
 		case job = <-jobs:
 		}
 
-		node, stats, err := s.save(ctx, job.snPath, job.node, job.nodes)
+		id, stats, err := s.saveSubTree(ctx, job.nodes)
 		if err != nil {
 			debug.Log("error saving tree blob: %v", err)
 			close(job.ch)
 			return err
 		}
 
-		job.ch <- saveTreeResponse{
-			node:  node,
+		job.ch <- saveSubTreeResponse{
+			id:    id,
 			stats: stats,
 		}
 		close(job.ch)

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -631,14 +631,16 @@ func (c *Checker) checkTree(id restic.ID, tree *restic.Tree) (errs []error) {
 				size += uint64(blobSize)
 			}
 		case "dir":
-			if node.Subtree == nil {
+			if node.Subtrees == nil {
 				errs = append(errs, Error{TreeID: id, Err: errors.Errorf("dir node %q has no subtree", node.Name)})
 				continue
 			}
 
-			if node.Subtree.IsNull() {
-				errs = append(errs, Error{TreeID: id, Err: errors.Errorf("dir node %q subtree id is null", node.Name)})
-				continue
+			for _, st := range node.Subtrees {
+				if st.IsNull() {
+					errs = append(errs, Error{TreeID: id, Err: errors.Errorf("dir node %q subtree id is null", node.Name)})
+					continue
+				}
 			}
 
 		case "symlink", "socket", "chardev", "dev", "fifo":

--- a/internal/restic/find.go
+++ b/internal/restic/find.go
@@ -20,17 +20,19 @@ func FindUsedBlobs(ctx context.Context, repo Repository, treeID ID, blobs BlobSe
 				blobs.Insert(BlobHandle{ID: blob, Type: DataBlob})
 			}
 		case "dir":
-			subtreeID := *node.Subtree
-			h := BlobHandle{ID: subtreeID, Type: TreeBlob}
-			if seen.Has(h) {
-				continue
-			}
+			for _, st := range node.Subtrees {
+				subtreeID := *st
+				h := BlobHandle{ID: subtreeID, Type: TreeBlob}
+				if seen.Has(h) {
+					continue
+				}
 
-			seen.Insert(h)
+				seen.Insert(h)
 
-			err := FindUsedBlobs(ctx, repo, subtreeID, blobs, seen)
-			if err != nil {
-				return err
+				err := FindUsedBlobs(ctx, repo, subtreeID, blobs, seen)
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -47,6 +47,7 @@ type Node struct {
 	Device             uint64              `json:"device,omitempty"` // in case of Type == "dev", stat.st_rdev
 	Content            IDs                 `json:"content"`
 	Subtree            *ID                 `json:"subtree,omitempty"`
+	Subtrees           []*ID               `json:"subtrees,omitempty"`
 
 	Error string `json:"error,omitempty"`
 
@@ -440,6 +441,23 @@ func (node Node) Equals(other Node) bool {
 		}
 	} else {
 		if other.Subtree != nil {
+			return false
+		}
+	}
+	if node.Subtrees != nil {
+		if other.Subtrees == nil {
+			return false
+		}
+		if len(node.Subtrees) != len(other.Subtrees) {
+			return false
+		}
+		for i := range node.Subtrees {
+			if !node.Subtrees[i].Equal(*other.Subtrees[i]) {
+				return false
+			}
+		}
+	} else {
+		if other.Subtrees != nil {
 			return false
 		}
 	}

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -431,6 +431,8 @@ func (node Node) Equals(other Node) bool {
 	if !node.sameExtendedAttributes(other) {
 		return false
 	}
+	// testing of Subtree can maybe omitted as Subtree should be only filled
+	// during Unmarshal and not in internal data sets...
 	if node.Subtree != nil {
 		if other.Subtree == nil {
 			return false

--- a/internal/restic/node_test.go
+++ b/internal/restic/node_test.go
@@ -119,7 +119,7 @@ var nodeTests = []restic.Node{
 	{
 		Name:       "testDir",
 		Type:       "dir",
-		Subtree:    nil,
+		Subtrees:   nil,
 		UID:        uint32(os.Getuid()),
 		GID:        uint32(os.Getgid()),
 		Mode:       0750 | os.ModeDir,
@@ -155,7 +155,7 @@ var nodeTests = []restic.Node{
 	{
 		Name:       "testDir",
 		Type:       "dir",
-		Subtree:    nil,
+		Subtrees:   nil,
 		UID:        uint32(os.Getuid()),
 		GID:        uint32(os.Getgid()),
 		Mode:       0750 | os.ModeDir,

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -50,6 +50,14 @@ type Repository interface {
 
 	LoadTree(context.Context, ID) (*Tree, error)
 	SaveTree(context.Context, *Tree) (ID, error)
+
+	NewSubtreeIterator(context.Context, *Node) SubtreeIterator
+}
+
+type SubtreeIterator interface {
+	Start()
+	Next() (*Node, error)
+	Node() *Node
 }
 
 // Lister allows listing files in a backend.

--- a/internal/restic/testing.go
+++ b/internal/restic/testing.go
@@ -9,9 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/restic/restic/internal/errors"
-
 	"github.com/restic/chunker"
+	"github.com/restic/restic/internal/errors"
 )
 
 // fakeFile returns a reader which yields deterministic pseudo-random data.
@@ -118,10 +117,10 @@ func (fs *fakeFileSystem) saveTree(ctx context.Context, seed int64, depth int) I
 			id := fs.saveTree(ctx, treeSeed, depth-1)
 
 			node := &Node{
-				Name:    fmt.Sprintf("dir-%v", treeSeed),
-				Type:    "dir",
-				Mode:    0755,
-				Subtree: &id,
+				Name:     fmt.Sprintf("dir-%v", treeSeed),
+				Type:     "dir",
+				Mode:     0755,
+				Subtrees: []*ID{&id},
 			}
 
 			tree.Nodes = append(tree.Nodes, node)

--- a/internal/restic/tree.go
+++ b/internal/restic/tree.go
@@ -91,8 +91,17 @@ func (t *Tree) Sort() {
 // Subtrees returns a slice of all subtree IDs of the tree.
 func (t *Tree) Subtrees() (trees IDs) {
 	for _, node := range t.Nodes {
-		if node.Type == "dir" && node.Subtree != nil {
-			trees = append(trees, *node.Subtree)
+		if node.Type == "dir" {
+			// can maybe omitted as Subtree should be only present during Unmarshal
+			// and not in internal data structure
+			if node.Subtree != nil {
+				trees = append(trees, *node.Subtree)
+			}
+			if node.Subtrees != nil {
+				for _, id := range node.Subtrees {
+					trees = append(trees, *id)
+				}
+			}
 		}
 	}
 

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -101,7 +101,7 @@ func (res *Restorer) traverseTree(ctx context.Context, target, location string, 
 		}
 
 		if node.Type == "dir" {
-			if node.Subtree == nil {
+			if node.Subtrees == nil {
 				return errors.Errorf("Dir without subtree in tree %v", treeID.Str())
 			}
 
@@ -113,9 +113,11 @@ func (res *Restorer) traverseTree(ctx context.Context, target, location string, 
 			}
 
 			if childMayBeSelected {
-				err = sanitizeError(res.traverseTree(ctx, nodeTarget, nodeLocation, *node.Subtree, visitor))
-				if err != nil {
-					return err
+				for _, st := range node.Subtrees {
+					err = sanitizeError(res.traverseTree(ctx, nodeTarget, nodeLocation, *st, visitor))
+					if err != nil {
+						return err
+					}
 				}
 			}
 

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -92,7 +92,7 @@ func saveDir(t testing.TB, repo restic.Repository, nodes map[string]Node, inode 
 				Name:    name,
 				UID:     uint32(os.Getuid()),
 				GID:     uint32(os.Getgid()),
-				Subtree: &id,
+				Subtrees: []*restic.ID{}&id},
 			})
 		default:
 			t.Fatalf("unknown node type %T", node)

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -35,9 +35,9 @@ func buildTreeMap(tree TestTree, m TreeMap) restic.ID {
 		case TestTree:
 			id := buildTreeMap(elem, m)
 			res.Insert(&restic.Node{
-				Name:    name,
-				Subtree: &id,
-				Type:    "dir",
+				Name:     name,
+				Subtrees: []*restic.ID{&id},
+				Type:     "dir",
 			})
 		default:
 			panic(fmt.Sprintf("invalid type %T", elem))


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

restic uses the `Tree` object to specify which files or subdirs are within a dir. A directory node specifies its contents by referring to a `Tree` object in `Node.Subtree`.
 A `Tree` is simply a list of `Nodes` and is stored in a single blob. 

This raises some problems if a directory contains many files:

- Trees need to be stored completely in memory leading to huge memory requirements
- Memory consumption is double or even 3x during operations like backup (actual tree, previous tree, json mashalling, etc) which makes the memory situation even more severe.
- Trees are usually processed sequentially disallowing efficient parallel processing
- Big blobs can be seen in the repository as they result in big packs. This can give attackers information about the repository without being able to decrypt the files

This PR introduces a new the object `Node.Subtrees` which is a list of `Tree` elements and consequently changes restics behaviour to use the new data structure. `Node.Subtree` is still be read and written if only one subtree exists. This allows this code to work with existing repositories.

As a consequence when having directories with many entries restic is faster and much less memory consuming while no difference can be seen with directories containing only few entries.

The PR is still WIP. Open points are implementation/change of tests and documentation. I would like to discuss the change before investing more time in exhaustive testing.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
closes #2446 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
