### PR TITLE
Issue 2537

### DIFF
--- a/changelog/unreleased/issue-2537
+++ b/changelog/unreleased/issue-2537
@@ -1,0 +1,5 @@
+Bugfix: Fix incorrect file counts in `stats --mode restore-size` 
+
+The restore-size mode of stats was failing to count empty directories and some files with hard links
+
+https://github.com/restic/restic/issues/2537

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -239,12 +239,18 @@ func statsWalkTree(repo restic.Repository, stats *statsContainer) walker.WalkFun
 			// as this is a file in the snapshot, we can simply count its
 			// size without worrying about uniqueness, since duplicate files
 			// will still be restored
-			stats.TotalSize += node.Size
 			stats.TotalFileCount++
+
+			// TODO - Issue #2531 Handle hard links by identifying duplicate inodes.
+			// (Duplicates should appear in the file count, but not the size count)
+			stats.TotalSize += node.Size
+
+			return false, nil
 		}
 
 		return true, nil
 	}
+
 }
 
 // makeFileIDByContents returns a hash of the blob IDs of the


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

Corrects a file-counting issue in `restic stats --mode restore-size`.
 - Empty directories were being excluded from file counts
 - Some hard-linked files were being excluded from file counts

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://forum.restic.net/t/different-file-counts-with-stats-and-ls/2395
https://github.com/restic/restic/issues/2537

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
