### PR TITLE
Count hard-linked files correctly in stats command

### DIFF
--- a/changelog/unreleased/issue-2531
+++ b/changelog/unreleased/issue-2531
@@ -1,0 +1,5 @@
+Bugfix: Fix incorrect size calculation in `stats --mode restore-size` 
+
+The restore-size mode of stats was counting hard-linked files as if they were independent.
+
+https://github.com/restic/restic/issues/2531

--- a/changelog/unreleased/issue-2537
+++ b/changelog/unreleased/issue-2537
@@ -1,0 +1,5 @@
+Bugfix: Fix incorrect file counts in `stats --mode restore-size` 
+
+The restore-size mode of stats was failing to count empty directories and some files with hard links.
+
+https://github.com/restic/restic/issues/2537

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -247,8 +247,13 @@ func statsWalkTree(repo restic.Repository, stats *statsContainer) walker.WalkFun
 			// as this is a file in the snapshot, we can simply count its
 			// size without worrying about uniqueness, since duplicate files
 			// will still be restored
-			stats.TotalSize += node.Size
 			stats.TotalFileCount++
+
+			// TODO - Issue #2531 Handle hard links by identifying duplicate inodes.
+			// (Duplicates should appear in the file count, but not the size count)
+			stats.TotalSize += node.Size
+
+			return false, nil
 		}
 
 		return true, nil


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Corrects an issue where the `stats --mode restore-size` command would include hard-linked files multiple times when calculating the total restore size.

Note that this PR also includes the fix for Issue 2537.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2537.
Closes #2531.

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
