### PR TITLE
Return an error when errors occured during backup

### DIFF
--- a/changelog/unreleased/pull-2546
+++ b/changelog/unreleased/pull-2546
@@ -1,0 +1,19 @@
+Change: Return exit code 3 when failing to backup all source data
+
+The backup command used to return a zero exit code as long as a snapshot
+could be created successfully, even if some of the source files could not
+be read (in which case the snapshot would contain the rest of the files).
+
+This made it hard for automation/scripts to detect failures/incomplete
+backups by looking at the exit code. Restic now returns the following exit
+codes for the backup command:
+
+ - 0 when the command was successful
+ - 1 when there was a fatal error (no snapshot created)
+ - 3 when some source data could not be read (incomplete snapshot created)
+
+https://github.com/restic/restic/pull/2546
+https://github.com/restic/restic/issues/956
+https://github.com/restic/restic/issues/2064
+https://github.com/restic/restic/issues/2526
+https://github.com/restic/restic/issues/2364

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -103,9 +103,13 @@ func main() {
 	}
 
 	var exitCode int
-	if err != nil {
+	switch err {
+	case nil:
+		exitCode = 0
+	case InvalidSourceData:
+		exitCode = 3
+	default:
 		exitCode = 1
 	}
-
 	Exit(exitCode)
 }

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -366,7 +366,6 @@ created as it would only be written at the very (successful) end of
 the backup operation.  Previous snapshots will still be there and will still
 work.
 
-
 Environment Variables
 *********************
 
@@ -424,3 +423,26 @@ are taken into account for various operations:
  * ``$XDG_CACHE_HOME/restic``, ``$HOME/.cache/restic``: :ref:`caching`.
  * ``$TMPDIR``: :ref:`temporary_files`.
  * ``$PATH/fusermount``: Binary for ``restic mount``.
+
+Exit status codes
+*****************
+
+Restic returns one of the following exit status codes after the backup command is run:
+
+ * 0 when the backup was successful (snapshot with all source files created)
+ * 1 when there was a fatal error (no snapshot created)
+ * 3 when some source files could not be read (incomplete snapshot with remaining files created)
+
+Fatal errors occur for example when restic is unable to write to the backup destination, when
+there are network connectivity issues preventing successful communication, or when an invalid
+password or command line argument is provided. When restic returns this exit status code, one
+should not expect a snapshot to have been created.
+
+Source file read errors occur when restic fails to read one or more files or directories that
+it was asked to back up, e.g. due to permission problems. Restic displays the number of source
+file read errors that occurred while running the backup. If there are errors of this type,
+restic will still try to complete the backup run with all the other files, and create a
+snapshot that then contains all but the unreadable files.
+
+One can use these exit status codes in scripts and other automation tools, to make them aware of
+the outcome of the backup run. To manually inspect the exit code in e.g. Linux, run ``echo $?``.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
This PR intents to fix Issue #2526 
`Backup.Run` counts errors but does not take any action on them. This PR changes this behaviour by returning an error if errors occured previously.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #2064
Fixes #2526
Fixes #2364

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
