### PR TITLE
Update Go version to 1.13.6 in Docker build script

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,7 +5,7 @@ set -e
 echo "Build binary using golang docker image"
 docker run --rm -ti \
     -v "`pwd`":/go/src/github.com/restic/restic \
-    -w /go/src/github.com/restic/restic golang:1.11.1-alpine go run build.go
+    -w /go/src/github.com/restic/restic golang:1.13.6-alpine go run build.go
 
 echo "Build docker image restic/restic:latest"
 docker build --rm -t restic/restic:latest -f docker/Dockerfile .


### PR DESCRIPTION
## What is the purpose of this change? What does it change?
Using Docker, Restic fails to build using Go 1.11 and needs Go 1.13 so I updated the build script.

## Was the change discussed in an issue or in the forum before?
I created an issue in #2551 

## Checklist
* [x]  I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
* [ ]  I have added tests for all changes in this PR
* [ ]  I have added documentation for the changes (in the manual)
* [ ]  There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
* [ ]  I have run `gofmt` on the code in all commits
* [x]  All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
* [x]  I'm done, this Pull Request is ready for review

