### PR TITLE
corrected option s3.storage-class in documentation

### DIFF
--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -251,7 +251,7 @@ A snapshot was created and stored in the S3 bucket. By default backups to AWS S3
 
 .. code-block:: console
 
-  $ ./restic backup -o s3.storageclass=REDUCED_REDUNDANCY test.bin
+  $ ./restic backup -o s3.storage-class=REDUCED_REDUNDANCY test.bin
 
 This snapshot may now be restored:
 


### PR DESCRIPTION
Took me some time to figure out this error. All that was missing was a little "-".
s3.storageclass vs. s3.storage-class