### PR TITLE
Close file if file type has changed after initial stat

### DIFF
--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -377,6 +377,7 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 		// make sure it's still a file
 		if !fs.IsRegularFile(fi) {
 			err = errors.Errorf("file %v changed type, refusing to archive")
+			_ = file.Close()
 			err = arch.error(abstarget, fi, err)
 			if err != nil {
 				return FutureNode{}, false, err

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1991,7 +1991,7 @@ type StatFS struct {
 
 func (fs *StatFS) Lstat(name string) (os.FileInfo, error) {
 	if !fs.OnlyOverrideStat {
-		if fi, ok := fs.OverrideLstat[name]; ok {
+		if fi, ok := fs.OverrideLstat[fixpath(name)]; ok {
 			return fi, nil
 		}
 	}
@@ -2000,7 +2000,7 @@ func (fs *StatFS) Lstat(name string) (os.FileInfo, error) {
 }
 
 func (fs *StatFS) OpenFile(name string, flags int, perm os.FileMode) (fs.File, error) {
-	if fi, ok := fs.OverrideLstat[name]; ok {
+	if fi, ok := fs.OverrideLstat[fixpath(name)]; ok {
 		f, err := fs.FS.OpenFile(name, flags, perm)
 		if err != nil {
 			return nil, err

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1985,12 +1985,15 @@ func chmod(t testing.TB, filename string, mode os.FileMode) {
 type StatFS struct {
 	fs.FS
 
-	OverrideLstat map[string]os.FileInfo
+	OverrideLstat    map[string]os.FileInfo
+	OnlyOverrideStat bool
 }
 
 func (fs *StatFS) Lstat(name string) (os.FileInfo, error) {
-	if fi, ok := fs.OverrideLstat[name]; ok {
-		return fi, nil
+	if !fs.OnlyOverrideStat {
+		if fi, ok := fs.OverrideLstat[name]; ok {
+			return fi, nil
+		}
 	}
 
 	return fs.FS.Lstat(name)
@@ -2101,4 +2104,52 @@ func TestMetadataChanged(t *testing.T) {
 	TestEnsureFileContent(context.Background(), t, repo, "testfile", node3, files["testfile"].(TestFile))
 
 	checker.TestCheckRepo(t, repo)
+}
+
+func TestRacyFileSwap(t *testing.T) {
+	files := TestDir{
+		"file": TestFile{
+			Content: "foo bar test file",
+		},
+	}
+
+	tempdir, repo, cleanup := prepareTempdirRepoSrc(t, files)
+	defer cleanup()
+
+	back := fs.TestChdir(t, tempdir)
+	defer back()
+
+	// get metadata of current folder
+	fi := lstat(t, ".")
+	tempfile := filepath.Join(tempdir, "file")
+
+	statfs := &StatFS{
+		FS: fs.Local{},
+		OverrideLstat: map[string]os.FileInfo{
+			tempfile: fi,
+		},
+		OnlyOverrideStat: true,
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	var tmb tomb.Tomb
+
+	arch := New(repo, fs.Track{FS: statfs}, Options{})
+	arch.Error = func(item string, fi os.FileInfo, err error) error {
+		t.Logf("archiver error as expected for %v: %v", item, err)
+		return err
+	}
+	arch.runWorkers(tmb.Context(ctx), &tmb)
+
+	// fs.Track will panic if the file was not closed
+	_, excluded, err := arch.Save(ctx, "/", tempfile, nil)
+	if err == nil {
+		t.Errorf("Save() should have failed")
+	}
+
+	if excluded {
+		t.Errorf("Save() excluded the node, that's unexpected")
+	}
 }


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Fix the archiver to close a file even when its file type changes between the lstat and stat call.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The issue was discovered while taking a look at #2566, closes #2566.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
