### PR TITLE
fix backup --json total_bytes_processed output

### DIFF
--- a/changelog/unreleased/issue-2429
+++ b/changelog/unreleased/issue-2429
@@ -1,0 +1,6 @@
+Bugfix: backup --json reports total_bytes_processed as 0
+
+We've fixed the json output of total_bytes_processed. The non-json output
+was already fixed with pull request #2138 but left the json output untouched.
+
+https://github.com/restic/restic/issues/2429

--- a/internal/ui/jsonstatus/status.go
+++ b/internal/ui/jsonstatus/status.go
@@ -49,6 +49,7 @@ type Backup struct {
 			Changed   uint
 			Unchanged uint
 		}
+		ProcessedBytes uint64
 		archiver.ItemStats
 	}
 }
@@ -214,6 +215,8 @@ func (b *Backup) CompleteItem(item string, previous, current *restic.Node, s arc
 			done:     true,
 		}
 		return
+	} else {
+		b.summary.ProcessedBytes += current.Size;
 	}
 
 	switch current.Type {
@@ -360,7 +363,7 @@ func (b *Backup) Finish(snapshotID restic.ID) {
 		TreeBlobs:           b.summary.ItemStats.TreeBlobs,
 		DataAdded:           b.summary.ItemStats.DataSize + b.summary.ItemStats.TreeSize,
 		TotalFilesProcessed: b.summary.Files.New + b.summary.Files.Changed + b.summary.Files.Unchanged,
-		TotalBytesProcessed: b.totalBytes,
+		TotalBytesProcessed: b.summary.ProcessedBytes,
 		TotalDuration:       time.Since(b.start).Seconds(),
 		SnapshotID:          snapshotID.Str(),
 	})


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

When using `backup` together with `--json` the output of total processed bytes is calculated wrong. The normal text output was already fixed with pull request #2138, but the json output wasn't touched.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2429

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
