### PR TITLE
restic/internal/ui: fix gofmt nit that popped up in Go 1.13

### DIFF
--- a/internal/ui/jsonstatus/status.go
+++ b/internal/ui/jsonstatus/status.go
@@ -216,7 +216,7 @@ func (b *Backup) CompleteItem(item string, previous, current *restic.Node, s arc
 		}
 		return
 	} else {
-		b.summary.ProcessedBytes += current.Size;
+		b.summary.ProcessedBytes += current.Size
 	}
 
 	switch current.Type {


### PR DESCRIPTION
A stray EOL semicolon is causing Travis failures on Go 1.13, this should be a fix.