### PR TITLE
internal: Fix Code and Test Dropped Errors

### DIFF
--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -822,6 +822,10 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 	}
 
 	sn, err := restic.NewSnapshot(targets, opts.Tags, opts.Hostname, opts.Time)
+	if err != nil {
+		return nil, restic.ID{}, err
+	}
+
 	sn.Excludes = opts.Excludes
 	if !opts.ParentSnapshot.IsNull() {
 		id := opts.ParentSnapshot

--- a/internal/backend/sftp/layout_test.go
+++ b/internal/backend/sftp/layout_test.go
@@ -60,6 +60,7 @@ func TestLayout(t *testing.T) {
 				datafiles[fi.Name] = false
 				return nil
 			})
+			rtest.OK(t, err)
 
 			if len(datafiles) == 0 {
 				t.Errorf("List() returned zero data files")

--- a/internal/repository/index_test.go
+++ b/internal/repository/index_test.go
@@ -134,6 +134,7 @@ func TestIndexSerialize(t *testing.T) {
 	id := restic.NewRandomID()
 	rtest.OK(t, idx.SetID(id))
 	id2, err := idx.ID()
+	rtest.OK(t, err)
 	rtest.Assert(t, id2.Equal(id),
 		"wrong ID returned: want %v, got %v", id, id2)
 

--- a/internal/restic/config_test.go
+++ b/internal/restic/config_test.go
@@ -36,6 +36,7 @@ func TestConfig(t *testing.T) {
 	rtest.OK(t, err)
 
 	_, err = saver(save).SaveJSONUnpacked(restic.ConfigFile, cfg1)
+	rtest.OK(t, err)
 
 	load := func(ctx context.Context, tpe restic.FileType, id restic.ID, arg interface{}) error {
 		rtest.Assert(t, tpe == restic.ConfigFile,


### PR DESCRIPTION
This picks off four dropped `error` variables in the `internal` package, three in tests and one in code.