### PR TITLE
Cache uid and gid for top directories in internal/fuse

### DIFF
--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -98,8 +98,6 @@ func newDirFromSnapshot(ctx context.Context, root *Root, inode uint64, snapshot 
 	return &dir{
 		root: root,
 		node: &restic.Node{
-			UID:        uint32(os.Getuid()),
-			GID:        uint32(os.Getgid()),
 			AccessTime: snapshot.Time,
 			ModTime:    snapshot.Time,
 			ChangeTime: snapshot.Time,
@@ -114,11 +112,8 @@ func (d *dir) Attr(ctx context.Context, a *fuse.Attr) error {
 	debug.Log("called")
 	a.Inode = d.inode
 	a.Mode = os.ModeDir | d.node.Mode
-
-	if !d.root.cfg.OwnerIsRoot {
-		a.Uid = d.node.UID
-		a.Gid = d.node.GID
-	}
+	a.Uid = d.root.uid
+	a.Gid = d.root.gid
 	a.Atime = d.node.AccessTime
 	a.Ctime = d.node.ChangeTime
 	a.Mtime = d.node.ModTime

--- a/internal/fuse/meta_dir.go
+++ b/internal/fuse/meta_dir.go
@@ -42,11 +42,9 @@ func NewMetaDir(root *Root, inode uint64, entries map[string]fs.Node) *MetaDir {
 func (d *MetaDir) Attr(ctx context.Context, attr *fuse.Attr) error {
 	attr.Inode = d.inode
 	attr.Mode = os.ModeDir | 0555
+	attr.Uid = d.root.uid
+	attr.Gid = d.root.gid
 
-	if !d.root.cfg.OwnerIsRoot {
-		attr.Uid = uint32(os.Getuid())
-		attr.Gid = uint32(os.Getgid())
-	}
 	debug.Log("attr: %v", attr)
 	return nil
 }

--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -6,6 +6,7 @@
 package fuse
 
 import (
+	"os"
 	"time"
 
 	"github.com/restic/restic/internal/debug"
@@ -37,6 +38,8 @@ type Root struct {
 	lastCheck time.Time
 
 	*MetaDir
+
+	uid, gid uint32
 }
 
 // ensure that *Root implements these interfaces
@@ -54,6 +57,11 @@ func NewRoot(ctx context.Context, repo restic.Repository, cfg Config) (*Root, er
 		inode:         rootInode,
 		cfg:           cfg,
 		blobSizeCache: NewBlobSizeCache(ctx, repo.Index()),
+	}
+
+	if !cfg.OwnerIsRoot {
+		root.uid = uint32(os.Getuid())
+		root.gid = uint32(os.Getgid())
 	}
 
 	entries := map[string]fs.Node{

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -168,11 +168,9 @@ func NewTagsDir(root *Root, inode uint64) *TagsDir {
 func (d *SnapshotsDir) Attr(ctx context.Context, attr *fuse.Attr) error {
 	attr.Inode = d.inode
 	attr.Mode = os.ModeDir | 0555
+	attr.Uid = d.root.uid
+	attr.Gid = d.root.gid
 
-	if !d.root.cfg.OwnerIsRoot {
-		attr.Uid = uint32(os.Getuid())
-		attr.Gid = uint32(os.Getgid())
-	}
 	debug.Log("attr: %v", attr)
 	return nil
 }
@@ -181,11 +179,9 @@ func (d *SnapshotsDir) Attr(ctx context.Context, attr *fuse.Attr) error {
 func (d *SnapshotsIDSDir) Attr(ctx context.Context, attr *fuse.Attr) error {
 	attr.Inode = d.inode
 	attr.Mode = os.ModeDir | 0555
+	attr.Uid = d.root.uid
+	attr.Gid = d.root.gid
 
-	if !d.root.cfg.OwnerIsRoot {
-		attr.Uid = uint32(os.Getuid())
-		attr.Gid = uint32(os.Getgid())
-	}
 	debug.Log("attr: %v", attr)
 	return nil
 }
@@ -194,11 +190,9 @@ func (d *SnapshotsIDSDir) Attr(ctx context.Context, attr *fuse.Attr) error {
 func (d *HostsDir) Attr(ctx context.Context, attr *fuse.Attr) error {
 	attr.Inode = d.inode
 	attr.Mode = os.ModeDir | 0555
+	attr.Uid = d.root.uid
+	attr.Gid = d.root.gid
 
-	if !d.root.cfg.OwnerIsRoot {
-		attr.Uid = uint32(os.Getuid())
-		attr.Gid = uint32(os.Getgid())
-	}
 	debug.Log("attr: %v", attr)
 	return nil
 }
@@ -207,11 +201,9 @@ func (d *HostsDir) Attr(ctx context.Context, attr *fuse.Attr) error {
 func (d *TagsDir) Attr(ctx context.Context, attr *fuse.Attr) error {
 	attr.Inode = d.inode
 	attr.Mode = os.ModeDir | 0555
+	attr.Uid = d.root.uid
+	attr.Gid = d.root.gid
 
-	if !d.root.cfg.OwnerIsRoot {
-		attr.Uid = uint32(os.Getuid())
-		attr.Gid = uint32(os.Getgid())
-	}
 	debug.Log("attr: %v", attr)
 	return nil
 }
@@ -437,11 +429,8 @@ func (l *snapshotLink) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) 
 func (l *snapshotLink) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Inode = l.inode
 	a.Mode = os.ModeSymlink | 0777
-
-	if !l.root.cfg.OwnerIsRoot {
-		a.Uid = uint32(os.Getuid())
-		a.Gid = uint32(os.Getgid())
-	}
+	a.Uid = l.root.uid
+	a.Gid = l.root.gid
 	a.Atime = l.snapshot.Time
 	a.Ctime = l.snapshot.Time
 	a.Mtime = l.snapshot.Time


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Restic mount now caches the uid and gid for use in its top-level directories (mountpoint, mountpoint/ids, etc.). Previously, it performed two system calls per Attr call.

Also, the test coverage in internal/fuse goes up from 16.7% to 38.8%.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
