### PR TITLE
Store *[]byte in internal/repository.bufPool, not []byte

### DIFF
--- a/internal/repository/pool.go
+++ b/internal/repository/pool.go
@@ -6,16 +6,19 @@ import (
 	"github.com/restic/chunker"
 )
 
+// This pool stores pointers to []byte, for use in Repository.SaveAndEncrypt.
+// See the example in the sync package docs for why pointers are used.
 var bufPool = sync.Pool{
 	New: func() interface{} {
-		return make([]byte, chunker.MaxSize/3)
+		buf := make([]byte, 0, chunker.MaxSize/3)
+		return &buf
 	},
 }
 
-func getBuf() []byte {
-	return bufPool.Get().([]byte)
+func getBuf() *[]byte {
+	return bufPool.Get().(*[]byte)
 }
 
-func freeBuf(data []byte) {
+func freeBuf(data *[]byte) {
 	bufPool.Put(data)
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -228,13 +228,13 @@ func (r *Repository) SaveAndEncrypt(ctx context.Context, t restic.BlobType, data
 	// get buf from the pool
 	ciphertext := getBuf()
 
-	ciphertext = ciphertext[:0]
+	*ciphertext = (*ciphertext)[:0]
 	nonce := crypto.NewRandomNonce()
-	ciphertext = append(ciphertext, nonce...)
+	*ciphertext = append(*ciphertext, nonce...)
 	defer freeBuf(ciphertext)
 
 	// encrypt blob
-	ciphertext = r.key.Seal(ciphertext, nonce, data, nil)
+	*ciphertext = r.key.Seal(*ciphertext, nonce, data, nil)
 
 	// find suitable packer and add blob
 	var pm *packerManager
@@ -254,7 +254,7 @@ func (r *Repository) SaveAndEncrypt(ctx context.Context, t restic.BlobType, data
 	}
 
 	// save ciphertext
-	_, err = packer.Add(t, *id, ciphertext)
+	_, err = packer.Add(t, *id, *ciphertext)
 	if err != nil {
 		return restic.ID{}, err
 	}

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -93,6 +93,8 @@ func TestSaveFrom(t *testing.T) {
 }
 
 func BenchmarkSaveAndEncrypt(t *testing.B) {
+	t.ReportAllocs()
+
 	repo, cleanup := repository.TestRepository(t)
 	defer cleanup()
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

internal/repository uses a sync.Pool to cache allocations. The following benchstat output shows what happens when I remove this pool:

```
name              old time/op    new time/op    delta
SaveAndEncrypt-8    36.1ms ± 2%    36.5ms ± 2%    ~     (p=0.123 n=10+10)

name              old speed      new speed      delta
SaveAndEncrypt-8   116MB/s ± 2%   115MB/s ± 2%    ~     (p=0.128 n=10+10)

name              old alloc/op   new alloc/op   delta
SaveAndEncrypt-8    21.1MB ± 0%    21.0MB ± 0%  -0.42%  (p=0.000 n=10+10)

name              old allocs/op  new allocs/op  delta
SaveAndEncrypt-8      82.0 ± 0%      81.0 ± 0%  -1.22%  (p=0.000 n=10+10)
```

No significant drop in speed, but the number of allocations actually goes down when the pool is removed. The code in this PR uses the pool as intended, storing pointers instead of slices. The result is a tiny, but significant, speedup, as well as reduced allocation:

```
name              old time/op    new time/op    delta
SaveAndEncrypt-8    36.1ms ± 2%    35.4ms ± 1%   -2.17%  (p=0.000 n=10+7)

name              old speed      new speed      delta
SaveAndEncrypt-8   116MB/s ± 2%   119MB/s ± 1%   +2.20%  (p=0.000 n=10+7)

name              old alloc/op   new alloc/op   delta
SaveAndEncrypt-8    21.1MB ± 0%    17.0MB ± 0%  -19.34%  (p=0.000 n=10+10)

name              old allocs/op  new allocs/op  delta
SaveAndEncrypt-8      82.0 ± 0%      80.0 ± 0%   -2.44%  (p=0.000 n=10+10)
```

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
