### PR TITLE
Replace sort.Stable by sort.Strings

### DIFF
--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -515,7 +515,7 @@ func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, 
 	for name := range atree.Nodes {
 		names = append(names, name)
 	}
-	sort.Stable(sort.StringSlice(names))
+	sort.Strings(names)
 
 	for _, name := range names {
 		subatree := atree.Nodes[name]


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

archiver.SaveTree calls the slow, O(n lg² n) sort.Stable. But in context, it's equivalent to the more simple sort.Strings. This is meant to simplify, not optimize, but the code does get asymptotically faster.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Not that I know of.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
