### PR TITLE
Support IPv6 in SFTP backend

### DIFF
--- a/changelog/unreleased/pull-2592
+++ b/changelog/unreleased/pull-2592
@@ -1,0 +1,6 @@
+Bugfix: SFTP backend supports IPv6 addresses
+
+The SFTP backend now supports IPv6 addresses natively, without relying on
+aliases in the external SSH configuration.
+
+https://github.com/restic/restic/pull/2592

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -86,10 +86,21 @@ specify the user this way: ``user@domain@host``.
           want to specify a path relative to the user's home directory, pass a
           relative path to the sftp backend.
 
-The backend config string does not allow specifying a port. If you need
-to contact an sftp server on a different port, you can create an entry
-in the ``ssh`` file, usually located in your user's home directory at
-``~/.ssh/config`` or in ``/etc/ssh/ssh_config``:
+If you need to specify a port number or IPv6 address, you'll need to use
+URL syntax. E.g., the repository ``/srv/restic-repo`` on ``[::1]`` (localhost)
+at port 2222 with username ``user`` can be specified as
+
+::
+
+    sftp://user@[::1]:2222//srv/restic-repo
+
+Note the double slash: the first slash separates the connection settings from
+the path, while the second is the start of the path. To specify a relative
+path, use one slash.
+
+Alternatively, you can create an entry in the ``ssh`` configuration file,
+usually located in your home directory at ``~/.ssh/config`` or in
+``/etc/ssh/ssh_config``:
 
 ::
 

--- a/internal/backend/sftp/config.go
+++ b/internal/backend/sftp/config.go
@@ -11,9 +11,10 @@ import (
 
 // Config collects all information required to connect to an sftp server.
 type Config struct {
-	User, Host, Path string
-	Layout           string `option:"layout" help:"use this backend directory layout (default: auto-detect)"`
-	Command          string `option:"command" help:"specify command to create sftp connection"`
+	User, Host, Port, Path string
+
+	Layout  string `option:"layout" help:"use this backend directory layout (default: auto-detect)"`
+	Command string `option:"command" help:"specify command to create sftp connection"`
 }
 
 func init() {
@@ -21,12 +22,12 @@ func init() {
 }
 
 // ParseConfig parses the string s and extracts the sftp config. The
-// supported configuration formats are sftp://user@host/directory
+// supported configuration formats are sftp://user@host[:port]/directory
 //  and sftp:user@host:directory.  The directory will be path Cleaned and can
 //  be an absolute path if it starts with a '/' (e.g.
 //  sftp://user@host//absolute and sftp:user@host:/absolute).
 func ParseConfig(s string) (interface{}, error) {
-	var user, host, dir string
+	var user, host, port, dir string
 	switch {
 	case strings.HasPrefix(s, "sftp://"):
 		// parse the "sftp://user@host/path" url format
@@ -37,7 +38,8 @@ func ParseConfig(s string) (interface{}, error) {
 		if url.User != nil {
 			user = url.User.Username()
 		}
-		host = url.Host
+		host = url.Hostname()
+		port = url.Port()
 		dir = url.Path
 		if dir == "" {
 			return nil, errors.Errorf("invalid backend %q, no directory specified", s)
@@ -76,6 +78,7 @@ func ParseConfig(s string) (interface{}, error) {
 	return Config{
 		User: user,
 		Host: host,
+		Port: port,
 		Path: p,
 	}, nil
 }

--- a/internal/backend/sftp/config_test.go
+++ b/internal/backend/sftp/config_test.go
@@ -23,11 +23,11 @@ var configTests = []struct {
 	},
 	{
 		"sftp://host:10022//dir/subdir",
-		Config{Host: "host:10022", Path: "/dir/subdir"},
+		Config{Host: "host", Port: "10022", Path: "/dir/subdir"},
 	},
 	{
 		"sftp://user@host:10022//dir/subdir",
-		Config{User: "user", Host: "host:10022", Path: "/dir/subdir"},
+		Config{User: "user", Host: "host", Port: "10022", Path: "/dir/subdir"},
 	},
 	{
 		"sftp://user@host/dir/subdir/../other",
@@ -36,6 +36,17 @@ var configTests = []struct {
 	{
 		"sftp://user@host/dir///subdir",
 		Config{User: "user", Host: "host", Path: "dir/subdir"},
+	},
+
+	// IPv6 address.
+	{
+		"sftp://user@[::1]/dir",
+		Config{User: "user", Host: "::1", Path: "dir"},
+	},
+	// IPv6 address with port.
+	{
+		"sftp://user@[::1]:22/dir",
+		Config{User: "user", Host: "::1", Port: "22", Path: "dir"},
 	},
 
 	// second form, user specified sftp:user@host:/dir

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -8,7 +8,6 @@ import (
 	"os"
 	"os/exec"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/restic/restic/internal/errors"
@@ -190,10 +189,11 @@ func buildSSHCommand(cfg Config) (cmd string, args []string, err error) {
 
 	cmd = "ssh"
 
-	hostport := strings.Split(cfg.Host, ":")
-	args = []string{hostport[0]}
-	if len(hostport) > 1 {
-		args = append(args, "-p", hostport[1])
+	host, port := cfg.Host, cfg.Port
+
+	args = []string{host}
+	if port != "" {
+		args = append(args, "-p", port)
 	}
 	if cfg.User != "" {
 		args = append(args, "-l")

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -189,11 +189,8 @@ func buildSSHCommand(cfg Config) (cmd string, args []string, err error) {
 
 	cmd = "ssh"
 
-	host, port := cfg.Host, cfg.Port
-
-	args = []string{host}
-	if port != "" {
-		args = append(args, "-p", port)
+	if cfg.Port != "" {
+		args = append(args, "-p", cfg.Port)
 	}
 	if cfg.User != "" {
 		args = append(args, "-l")
@@ -201,6 +198,8 @@ func buildSSHCommand(cfg Config) (cmd string, args []string, err error) {
 	}
 	args = append(args, "-s")
 	args = append(args, "sftp")
+
+	args = append(args, "--", cfg.Host)
 	return cmd, args, nil
 }
 

--- a/internal/backend/sftp/sshcmd_test.go
+++ b/internal/backend/sftp/sshcmd_test.go
@@ -13,34 +13,34 @@ var sshcmdTests = []struct {
 	{
 		Config{User: "user", Host: "host", Path: "dir/subdir"},
 		"ssh",
-		[]string{"host", "-l", "user", "-s", "sftp"},
+		[]string{"-l", "user", "-s", "sftp", "--", "host"},
 	},
 	{
 		Config{Host: "host", Path: "dir/subdir"},
 		"ssh",
-		[]string{"host", "-s", "sftp"},
+		[]string{"-s", "sftp", "--", "host"},
 	},
 	{
 		Config{Host: "host", Port: "10022", Path: "/dir/subdir"},
 		"ssh",
-		[]string{"host", "-p", "10022", "-s", "sftp"},
+		[]string{"-p", "10022", "-s", "sftp", "--", "host"},
 	},
 	{
 		Config{User: "user", Host: "host", Port: "10022", Path: "/dir/subdir"},
 		"ssh",
-		[]string{"host", "-p", "10022", "-l", "user", "-s", "sftp"},
+		[]string{"-p", "10022", "-l", "user", "-s", "sftp", "--", "host"},
 	},
 	{
 		// IPv6 address.
 		Config{User: "user", Host: "::1", Path: "dir"},
 		"ssh",
-		[]string{"::1", "-l", "user", "-s", "sftp"},
+		[]string{"-l", "user", "-s", "sftp", "--", "::1"},
 	},
 	{
 		// IPv6 address with zone and port.
 		Config{User: "user", Host: "::1%lo0", Port: "22", Path: "dir"},
 		"ssh",
-		[]string{"::1%lo0", "-p", "22", "-l", "user", "-s", "sftp"},
+		[]string{"-p", "22", "-l", "user", "-s", "sftp", "--", "::1%lo0"},
 	},
 }
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

IPv6 addresses can now be used in sftp backend specifiers. Also, setting port numbers for sftp is documented and ssh command lines are more in line with the OpenSSH manual.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

#1952 tried to achieve the same, but in a more complicated way.


Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
