### PR TITLE
Fix interactive password reading

### DIFF
--- a/changelog/unreleased/issue-2591
+++ b/changelog/unreleased/issue-2591
@@ -1,0 +1,15 @@
+Bugfix: Fix reading passwords when standard input is redirected
+
+Passwords are now read from the controlling terminal (on Unix) or the console
+(on Windows), instead of from standard input. This means that commands that
+read from a pipe, notably
+
+    mysqldump my_database | restic backup --stdin
+
+now no longer confuse the input for the password.
+
+This means that reading the password from a file using shell redirection
+syntax is no longer possible. Use the option `--password-file` instead.
+
+https://github.com/restic/restic/issues/2591
+https://github.com/restic/restic/pull/2593

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -38,11 +38,12 @@ func runInit(gopts GlobalOptions, args []string) error {
 		return errors.Fatalf("create repository at %s failed: %v\n", gopts.Repo, err)
 	}
 
-	gopts.password, err = ReadPasswordTwice(gopts,
-		"enter password for new repository: ",
-		"enter password again: ")
-	if err != nil {
-		return err
+	if gopts.password == "" {
+		gopts.password, err = ReadPasswordTerminal(
+			"enter password for new repository: ", true)
+		if err != nil {
+			return err
+		}
 	}
 
 	s := repository.New(be)

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -104,14 +104,7 @@ func getNewPassword(gopts GlobalOptions) (string, error) {
 		return loadPasswordFromFile(newPasswordFile)
 	}
 
-	// Since we already have an open repository, temporary remove the password
-	// to prompt the user for the passwd.
-	newopts := gopts
-	newopts.password = ""
-
-	return ReadPasswordTwice(newopts,
-		"enter password for new key: ",
-		"enter password again: ")
+	return ReadPasswordTerminal("enter password for new key: ", true)
 }
 
 func addKey(gopts GlobalOptions, repo *repository.Repository) error {

--- a/cmd/restic/global_unix_test.go
+++ b/cmd/restic/global_unix_test.go
@@ -1,0 +1,25 @@
+// +build !windows
+
+package main
+
+import (
+	"os"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestReadPasswordTerminalNotATTY(t *testing.T) {
+	f, err := os.Open("/dev/zero")
+	rtest.OK(t, err)
+	defer f.Close()
+
+	oldtty := devtty
+	devtty = f.Name()
+	defer func() { devtty = oldtty }()
+
+	password, err := ReadPasswordTerminal("please enter password: ", false)
+	rtest.Assert(t, err != nil,
+		"ReadPasswordTerminal should refuse to read from a non-terminal")
+	rtest.Equals(t, "", password)
+}

--- a/cmd/restic/open_terminal_unix.go
+++ b/cmd/restic/open_terminal_unix.go
@@ -1,0 +1,14 @@
+// +build !windows
+
+package main
+
+import "os"
+
+var devtty = "/dev/tty" // Variable so that the test can reset it.
+
+// openTerminal opens the controlling terminal.
+func openTerminal() (*controllingTerminal, error) {
+	return os.OpenFile(devtty, os.O_RDWR, 0)
+}
+
+type controllingTerminal = os.File

--- a/cmd/restic/open_terminal_windows.go
+++ b/cmd/restic/open_terminal_windows.go
@@ -1,0 +1,49 @@
+// +build windows
+
+package main
+
+import "os"
+
+// openTerminal opens the console input and screen buffers.
+func openTerminal() (t *controllingTerminal, err error) {
+	// https://docs.microsoft.com/en-us/windows/console/console-handles
+
+	// If we open CONIN$ in read-only mode, windows.SetConsoleMode in
+	// terminal.ReadPassword fails with Access denied. Opening it in
+	// read-write mode adds the flag GENERIC_WRITE, which the standard
+	// handles have, too.
+	conin, err := os.OpenFile("CONIN$", os.O_RDWR, 0)
+	if err != nil {
+		return nil, err
+	}
+
+	conout, err := os.OpenFile("CONOUT$", os.O_WRONLY, 0)
+	if err != nil {
+		conin.Close()
+		return nil, err
+	}
+
+	return &controllingTerminal{conin, conout}, nil
+}
+
+type controllingTerminal struct {
+	conin, conout *os.File
+}
+
+// Returns the input buffer's Handle for reading passwords.
+func (t *controllingTerminal) Fd() uintptr {
+	return t.conin.Fd()
+}
+
+func (t *controllingTerminal) Write(p []byte) (int, error) {
+	return t.conout.Write(p)
+}
+
+func (t *controllingTerminal) Close() error {
+	err1 := t.conin.Close()
+	err2 := t.conout.Close()
+	if err1 != nil {
+		return err1
+	}
+	return err2
+}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

restic no longer tries to read passwords from stdin. Instead, it tries to open the controlling terminal and fails when there is none.

This changes some surprising behavior when reading passwords interactively, most notably in restic backup --stdin:

	$ echo 'Hello, world!' | restic -r t backup --stdin
	read password from stdin
	Fatal: wrong password or no key found

Absence of a controlling terminal would lead to even stranger behavior:

	$ setsid restic -r t snapshots
	$ enter password for repository:
	tFatal: wrong password or no key found

The 't' in tFatal is part of the password echoing.

As a side-effect, the code has been simplified. The former ReadPasswordTwice would read the password once when stdin was not a terminal, breaking its own contract.

Unit-testing this kind of code is hard, but here's some terminal output from the new version:

```
$ export RESTIC_REPOSITORY=/tmp/testrepo
$ restic init < /dev/null
enter password for new repository: 
enter password again: 
created restic repository b0d8ab44c5 at t

Please note that knowledge of your password is required to access
the repository. Losing your password means that your data is
irrecoverably lost.
```

```
$ setsid restic init
get terminal for password: open /dev/tty: no such device or address
```

```
$ echo 'Hello, world!' | restic backup --stdin
enter password for repository:
repository 51d19e93 opened successfully, password is correct
created new cache in /home/me/.cache/restic

Files:           1 new,     0 changed,     0 unmodified
Dirs:            0 new,     0 changed,     0 unmodified
Added to the repo: 317 B

processed 1 files, 14 B in 0:00
snapshot 0618542f saved
$ restic dump 0618542f stdin
enter password for repository: 
repository 51d19e93 opened successfully, password is correct
Hello, world!
```

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

closes #2591

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
