### PR TITLE
Concurrent restore --verify

### DIFF
--- a/changelog/unreleased/pull-2594
+++ b/changelog/unreleased/pull-2594
@@ -1,7 +1,6 @@
 Enhancement: Speed up restic restore --verify
 
-The --verify option causes restic restore to do some verification after it
-has restored from a snapshot. This verification now runs up to 52% faster,
-depending on the exact setup.
+The --verify option lets restic restore verify the file content after it has
+restored a snapshot. We've sped up the verification by up to a factor of two.
 
 https://github.com/restic/restic/pull/2594

--- a/changelog/unreleased/pull-2594
+++ b/changelog/unreleased/pull-2594
@@ -1,0 +1,7 @@
+Enhancement: Speed up restic restore --verify
+
+The --verify option causes restic restore to do some verification after it
+has restored from a snapshot. This verification now runs up to 52% faster,
+depending on the exact setup.
+
+https://github.com/restic/restic/pull/2594

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"strings"
+	"time"
 
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
@@ -202,6 +203,7 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 	if opts.Verify {
 		Verbosef("verifying files in %s\n", opts.Target)
 		var count int
+		t0 := time.Now()
 		count, err = res.VerifyFiles(ctx, opts.Target)
 		if err != nil {
 			return err
@@ -209,7 +211,8 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		if totalErrors > 0 {
 			return errors.Fatalf("There were %d errors\n", totalErrors)
 		}
-		Verbosef("finished verifying %d files in %s\n", count, opts.Target)
+		Verbosef("finished verifying %d files in %s (took %s)\n", count, opts.Target,
+			time.Since(t0).Round(time.Millisecond))
 	}
 
 	return nil

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -317,8 +317,8 @@ const nVerifyWorkers = 8
 
 // VerifyFiles checks whether all regular files in the snapshot res.sn
 // have been successfully written to dst. It stops when it encounters an
-// error. It returns that error and the number of files it has checked,
-// including the file(s) that caused errors.
+// error. It returns that error and the number of files it has successfully
+// verified.
 func (res *Restorer) VerifyFiles(ctx context.Context, dst string) (int, error) {
 	type mustCheck struct {
 		node *restic.Node
@@ -358,11 +358,11 @@ func (res *Restorer) VerifyFiles(ctx context.Context, dst string) (int, error) {
 		g.Go(func() (err error) {
 			var buf []byte
 			for job := range work {
-				atomic.AddUint64(&nchecked, 1)
 				buf, err = res.verifyFile(job.path, job.node, buf)
 				if err != nil {
 					break
 				}
+				atomic.AddUint64(&nchecked, 1)
 			}
 			return
 		})

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -351,6 +351,9 @@ func (res *Restorer) VerifyFiles(ctx context.Context, dst string) (int, error) {
 			for job := range work {
 				buf, err = res.verifyFile(job.path, job.node, buf)
 				if err != nil {
+					err = res.Error(job.path, err)
+				}
+				if err != nil || ctx.Err() != nil {
 					break
 				}
 				atomic.AddUint64(&nchecked, 1)

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -397,11 +397,7 @@ func (res *Restorer) verifyFile(target string, node *restic.Node, buf []byte) ([
 		}
 
 		if length > uint(cap(buf)) {
-			newcap := uint(2 * cap(buf))
-			if newcap < length {
-				newcap = length
-			}
-			buf = make([]byte, newcap)
+			buf = make([]byte, 2*length)
 		}
 		buf = buf[:length]
 

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -99,10 +99,13 @@ func (res *Restorer) traverseTree(ctx context.Context, target, location string, 
 		}
 
 		sanitizeError := func(err error) error {
-			if err != nil {
-				err = res.Error(nodeLocation, err)
+			switch err {
+			case nil, context.Canceled, context.DeadlineExceeded:
+				// Context errors are permanent.
+				return err
+			default:
+				return res.Error(nodeLocation, err)
 			}
-			return err
 		}
 
 		if node.Type == "dir" {
@@ -364,7 +367,7 @@ func (res *Restorer) VerifyFiles(ctx context.Context, dst string) (int, error) {
 				}
 				atomic.AddUint64(&nchecked, 1)
 			}
-			return
+			return err
 		})
 	}
 

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -310,7 +310,10 @@ func (res *Restorer) Snapshot() *restic.Snapshot {
 	return res.sn
 }
 
-// VerifyFiles reads all snapshot files and verifies their contents
+// VerifyFiles checks whether all regular files in the snapshot res.sn
+// have been successfully written to dst. It stops when it encounters an
+// error. It returns that error and the number of files it has checked,
+// including the file(s) that caused errors.
 func (res *Restorer) VerifyFiles(ctx context.Context, dst string) (int, error) {
 	// TODO multithreaded?
 

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -375,7 +375,9 @@ func (res *Restorer) verifyFile(target string, node *restic.Node, buf []byte) ([
 	if err != nil {
 		return buf, err
 	}
-	defer f.Close()
+	defer func() {
+		_ = f.Close()
+	}()
 
 	fi, err := f.Stat()
 	switch {

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -4,13 +4,14 @@ import (
 	"context"
 	"os"
 	"path/filepath"
-
-	"github.com/restic/chunker"
-	"github.com/restic/restic/internal/errors"
+	"sync/atomic"
 
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/restic"
+
+	"golang.org/x/sync/errgroup"
 )
 
 // Restorer is used to restore a snapshot to a directory.
@@ -311,58 +312,110 @@ func (res *Restorer) Snapshot() *restic.Snapshot {
 	return res.sn
 }
 
+// Number of workers in VerifyFiles.
+const nVerifyWorkers = 8
+
 // VerifyFiles checks whether all regular files in the snapshot res.sn
 // have been successfully written to dst. It stops when it encounters an
 // error. It returns that error and the number of files it has checked,
 // including the file(s) that caused errors.
 func (res *Restorer) VerifyFiles(ctx context.Context, dst string) (int, error) {
-	// TODO multithreaded?
+	type mustCheck struct {
+		node *restic.Node
+		path string
+	}
+
 	var (
-		buf   = make([]byte, 0, chunker.MaxSize)
-		count = 0
+		nchecked uint64
+		work     = make(chan mustCheck, 2*nVerifyWorkers)
 	)
 
-	_, err := res.traverseTree(ctx, dst, string(filepath.Separator), *res.sn.Tree, treeVisitor{
-		enterDir: func(node *restic.Node, target, location string) error { return nil },
-		visitNode: func(node *restic.Node, target, location string) error {
-			if node.Type != "file" {
-				return nil
-			}
+	g, ctx := errgroup.WithContext(ctx)
 
-			count++
-			stat, err := os.Stat(target)
-			if err != nil {
-				return err
-			}
-			if int64(node.Size) != stat.Size() {
-				return errors.Errorf("Invalid file size: expected %d got %d", node.Size, stat.Size())
-			}
+	// Traverse tree and send jobs to work.
+	g.Go(func() error {
+		defer close(work)
 
-			file, err := os.Open(target)
-			if err != nil {
-				return err
-			}
-
-			offset := int64(0)
-			for _, blobID := range node.Content {
-				length, _ := res.repo.LookupBlobSize(blobID, restic.DataBlob)
-				buf = buf[:length]
-				_, err = file.ReadAt(buf, offset)
-				if err != nil {
-					_ = file.Close()
-					return err
+		_, err := res.traverseTree(ctx, dst, string(filepath.Separator), *res.sn.Tree, treeVisitor{
+			enterDir: func(node *restic.Node, target, location string) error { return nil },
+			visitNode: func(node *restic.Node, target, location string) error {
+				if node.Type != "file" {
+					return nil
 				}
-				if !blobID.Equal(restic.Hash(buf)) {
-					_ = file.Close()
-					return errors.Errorf("Unexpected contents starting at offset %d", offset)
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case work <- mustCheck{node, target}:
+					return nil
 				}
-				offset += int64(length)
-			}
-
-			return file.Close()
-		},
-		leaveDir: func(node *restic.Node, target, location string) error { return nil },
+			},
+			leaveDir: func(node *restic.Node, target, location string) error { return nil },
+		})
+		return err
 	})
 
-	return count, err
+	for i := 0; i < nVerifyWorkers; i++ {
+		g.Go(func() (err error) {
+			var buf []byte
+			for job := range work {
+				atomic.AddUint64(&nchecked, 1)
+				buf, err = res.verifyFile(job.path, job.node, buf)
+				if err != nil {
+					break
+				}
+			}
+			return
+		})
+	}
+
+	return int(nchecked), g.Wait()
+}
+
+// Verify that the file target has the contents of node.
+// buf and the first return value are scratch space, passed around for reuse.
+func (res *Restorer) verifyFile(target string, node *restic.Node, buf []byte) ([]byte, error) {
+	f, err := os.Open(target)
+	if err != nil {
+		return buf, err
+	}
+	defer f.Close()
+
+	fi, err := f.Stat()
+	switch {
+	case err != nil:
+		return nil, err
+	case int64(node.Size) != fi.Size():
+		return buf, errors.Errorf("Invalid file size for %s: expected %d, got %d",
+			target, node.Size, fi.Size())
+	}
+
+	var offset int64
+	for _, blobID := range node.Content {
+		length, found := res.repo.LookupBlobSize(blobID, restic.DataBlob)
+		if !found {
+			return buf, errors.Errorf("Unable to fetch blob %s", blobID)
+		}
+
+		if length > uint(cap(buf)) {
+			newcap := uint(2 * cap(buf))
+			if newcap < length {
+				newcap = length
+			}
+			buf = make([]byte, newcap)
+		}
+		buf = buf[:length]
+
+		_, err = f.ReadAt(buf, offset)
+		if err != nil {
+			return buf, err
+		}
+		if !blobID.Equal(restic.Hash(buf)) {
+			return buf, errors.Errorf(
+				"Unexpected content in %s, starting at offset %d",
+				target, offset)
+		}
+		offset += int64(length)
+	}
+
+	return buf, nil
 }

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -844,5 +844,6 @@ func TestVerifyCancel(t *testing.T) {
 	nverified, err := res.VerifyFiles(ctx, tempdir)
 	rtest.Equals(t, 0, nverified)
 	rtest.Assert(t, err != nil, "nil error from VerifyFiles")
-	rtest.Equals(t, []error(nil), errs)
+	rtest.Equals(t, 1, len(errs))
+	rtest.Assert(t, strings.Contains(errs[0].Error(), "Invalid file size for"), "wrong error %q", errs[0].Error())
 }

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -367,6 +367,11 @@ func TestRestorer(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			if len(test.ErrorsMust)+len(test.ErrorsMay) == 0 {
+				_, err = res.VerifyFiles(ctx, tempdir)
+				rtest.OK(t, err)
+			}
+
 			for location, expectedErrors := range test.ErrorsMust {
 				actualErrors, ok := errors[location]
 				if !ok {
@@ -465,6 +470,9 @@ func TestRestorerRelative(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
+			nverified, err := res.VerifyFiles(ctx, "restore")
+			rtest.OK(t, err)
+			rtest.Equals(t, len(test.Files), nverified)
 
 			for filename, err := range errors {
 				t.Errorf("unexpected error for %v found: %v", filename, err)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

restic restore --verify is now concurrent. When restoring a 2GB snapshot, the time to verify goes down by 60%.

The PR makes two optimizations in separate commits:

* Cache a large buffer for reuse. That saves about 16% wallclock time.
* Verify files in multiple concurrent goroutines, with one more goroutine walking the snapshot tree. That saves 52% compared to only reusing the buffer.

The number of goroutines is currently fixed at eight. I have ideas about how to make it scale to the available CPUs/memory, but the patch is big enough already.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Not that I know, but the code contained TODO items indicating an intent to implement this.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
