### PR TITLE
Diff speedup

### DIFF
--- a/changelog/unreleased/pull-2598
+++ b/changelog/unreleased/pull-2598
@@ -1,0 +1,6 @@
+Enhancement: Improve speed of diff command
+
+We've improved the performance of the diff command when comparing snapshots
+with similar content. It should run up to twice as fast as before.
+
+https://github.com/restic/restic/pull/2598


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Optimize diff calculation for shared subtrees.

When the diff calculation compares two trees with identical id then no
differences between them can ever show up. Optimize for that case by
simply traversing the tree only once to collect all referenced blobs for
a proper calculation of added and removed blobs.

Just skipping the common subtrees is not possible as this would skew the
results if the added or removed blobs are shared with one of the
subtrees.

This change can speed-up the diff calculation by up to a factor two. I'm not sure whether that's worth a changelog entry or not.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
