### PR TITLE
Write sparse files in restorer

### DIFF
--- a/changelog/unreleased/pull-2601
+++ b/changelog/unreleased/pull-2601
@@ -1,0 +1,12 @@
+Enhancement: Restore files with many zeros as sparse files
+
+On all platforms except Windows, the restorer may now write files containing
+long runs of zeros as sparse files (also called files with holes): the zeros
+are not actually written to disk.
+
+How much space is saved by writing sparse files depends on the operating
+system, file system and the distribution of zeros in the file.
+
+https://github.com/restic/restic/issues/79
+https://github.com/restic/restic/pull/2601
+https://forum.restic.net/t/sparse-file-support/1264

--- a/internal/restorer/fileswriter_test.go
+++ b/internal/restorer/fileswriter_test.go
@@ -18,19 +18,15 @@ func TestFilesWriterBasic(t *testing.T) {
 
 	rtest.OK(t, w.writeToFile(f1, []byte{1}, 0, true))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
-	rtest.Equals(t, 0, len(w.buckets[0].users))
 
 	rtest.OK(t, w.writeToFile(f2, []byte{2}, 0, true))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
-	rtest.Equals(t, 0, len(w.buckets[0].users))
 
 	rtest.OK(t, w.writeToFile(f1, []byte{1}, 1, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
-	rtest.Equals(t, 0, len(w.buckets[0].users))
 
 	rtest.OK(t, w.writeToFile(f2, []byte{2}, 1, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
-	rtest.Equals(t, 0, len(w.buckets[0].users))
 
 	buf, err := ioutil.ReadFile(f1)
 	rtest.OK(t, err)

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -3,12 +3,17 @@
 package restorer
 
 import (
+	"bytes"
 	"context"
+	"io/ioutil"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
 
+	"github.com/restic/restic/internal/archiver"
+	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
@@ -58,4 +63,84 @@ func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
 	if ok1 && ok2 {
 		rtest.Equals(t, s1.Ino, s2.Ino)
 	}
+}
+
+func TestRestorerSparseFiles(t *testing.T) {
+	repo, cleanup := repository.TestRepository(t)
+	defer cleanup()
+
+	var zeros [1<<20 + 13]byte // 1MB + a bit to get a corner case
+
+	target := &fs.Reader{
+		Mode:       0600,
+		Name:       "/zeros",
+		ReadCloser: ioutil.NopCloser(bytes.NewReader(zeros[:])),
+	}
+	sc := archiver.NewScanner(target)
+	err := sc.Scan(context.TODO(), []string{"/zeros"})
+	rtest.OK(t, err)
+
+	arch := archiver.New(repo, target, archiver.Options{})
+	_, id, err := arch.Snapshot(context.Background(), []string{"/zeros"},
+		archiver.SnapshotOptions{})
+
+	res, err := NewRestorer(repo, id)
+	rtest.OK(t, err)
+
+	tempdir, cleanup := rtest.TempDir(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
+
+	filename := filepath.Join(tempdir, "zeros")
+	content, err := ioutil.ReadFile(filename)
+	rtest.OK(t, err)
+
+	rtest.Equals(t, zeros[:], content)
+
+	fi, err := os.Stat(filename)
+	rtest.OK(t, err)
+	st := fi.Sys().(*syscall.Stat_t)
+	if st == nil {
+		return
+	}
+
+	// This reports 0 blocks on a supporting filesystem.
+	// We can't assert that, though, since we don't know to what type
+	// of filesystem we're writing.
+	t.Logf("wrote %d zeros as %d blocks", len(zeros), st.Blocks)
+}
+
+func BenchmarkAllZero(b *testing.B) {
+	// Only benchmark the case were the blocks are not all zeros,
+	// to ensure that the common case doesn't suffer a performance hit
+	// from sparse file support.
+
+	var (
+		buf   [4<<20 + 37]byte
+		r     = rand.New(rand.NewSource(0x618732))
+		zeros int
+	)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(buf)))
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		j := r.Intn(len(buf))
+		buf[j] = 0xff
+
+		z := allZero(buf[:])
+		if z {
+			zeros++
+		}
+
+		buf[j] = 0
+	}
+
+	// Make sure the compiler doesn't optimize away the call to allZeros.
+	rtest.Equals(b, zeros, 0)
 }

--- a/internal/restorer/sparsewrite.go
+++ b/internal/restorer/sparsewrite.go
@@ -1,0 +1,59 @@
+// +build !windows
+
+package restorer
+
+import "bytes"
+
+// WriteAt writes p to f.File at offset. It tries to do a sparse write
+// and updates f.size.
+func (f *partialFile) WriteAt(p []byte, offset int64) (n int, err error) {
+	n = len(p)
+	end := offset + int64(n)
+
+	// Skip the longest all-zero prefix of p.
+	// If it's long enough, we can punch a hole in the file.
+	skipped := zeroPrefixLen(p)
+	p = p[skipped:]
+	offset += int64(skipped)
+
+	switch {
+	case len(p) == 0 && end > f.size:
+		// We need to do a Truncate, as WriteAt with length-0 input
+		// doesn't actually extend the file.
+		err = f.Truncate(end)
+		if err != nil {
+			return 0, err
+		}
+
+	case len(p) == 0:
+		// All zeros, file already big enough. A previous WriteAt or
+		// Truncate will have produced the zeros in f.File.
+
+	default:
+		n, err = f.File.WriteAt(p, offset)
+	}
+
+	end = offset + int64(n)
+	if end > f.size {
+		f.size = end
+	}
+	return n, err
+}
+
+// zeroPrefixLen returns the length of the longest all-zero prefix of p.
+func zeroPrefixLen(p []byte) (n int) {
+	// First skip 1kB-sized blocks, for speed.
+	var zeros [1024]byte
+
+	for len(p) >= len(zeros) && bytes.Equal(p[:len(zeros)], zeros[:]) {
+		p = p[len(zeros):]
+		n += len(zeros)
+	}
+
+	for len(p) > 0 && p[0] == 0 {
+		p = p[1:]
+		n++
+	}
+
+	return n
+}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

The capacity to write sparse files has been added to the restorer. Files aren't necessarily as sparse as they can be, since the code for detecting runs of zeros isn't exhaustive, but long runs of zeros have a good chance of being detected.

In a short test, I restored a pair of disk images and found that one only took up half the disk space that it used to. The other one was 13% smaller. Restoring it took the same wall-clock time that it took with current master.

See the commit message for some benchmark results.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #79. Closes #2378, which tried to do the same thing in a different way. I redid the work since the restorer was just rewritten and I came up with a different heuristic for detecting zero blocks.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
