### PR TITLE
Fix unsafe sync.WaitGroup usage in restorer.fileRestorer

### DIFF
--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -152,8 +152,8 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 		}
 	}
 	for i := 0; i < workerCount; i++ {
-		go worker()
 		wg.Add(1)
+		go worker()
 	}
 
 	// the main restore loop


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

The new fileRestorer.restoreFiles called sync.WaitGroup.Add after launching a goroutine. Depending on the order of execution, a goroutine may call WaitGroup.Done before the first Add, causing

```
panic: sync: negative WaitGroup counter
```

To see this in action, put a `time.Sleep(time.Second)` between `go worker()` and `wg.Add(1)`, then run the tests (maybe a few times).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
