### PR TITLE
Fix running tests on a SELinux enabled system

### DIFF
--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -2071,7 +2071,9 @@ func TestMetadataChanged(t *testing.T) {
 	// set some values so we can then compare the nodes
 	want.Content = node2.Content
 	want.Path = ""
-	want.ExtendedAttributes = nil
+	if len(want.ExtendedAttributes) == 0 {
+		want.ExtendedAttributes = nil
+	}
 
 	want.AccessTime = want.ModTime
 


### PR DESCRIPTION
Archivers TestMetadataChanged incorrectly clears the Extended Attributes
from the expected metadata of the temporary file. This is incorrect as on
SELinux enabled filesystem, the kernel will automatically add a SElinux
label. In fact the code make no sense here, as when SELinux is not enabled,
there are no extended attributes and nothing needs to be cleared.



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
Allow tests to run on a SELinux enabled system.

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
closes #2604

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
