### PR TITLE
Make FindUsedBlobs parallel

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -186,14 +186,13 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 	Verbosef("find data that is still in use for %d snapshots\n", stats.snapshots)
 
 	usedBlobs := restic.NewBlobSet()
-	seenBlobs := restic.NewBlobSet()
 
 	bar = newProgressMax(!gopts.Quiet, uint64(len(snapshots)), "snapshots")
 	bar.Start()
 	for _, sn := range snapshots {
 		debug.Log("process snapshot %v", sn.ID())
 
-		err = restic.FindUsedBlobs(ctx, repo, *sn.Tree, usedBlobs, seenBlobs)
+		err = restic.FindUsedBlobs(ctx, repo, *sn.Tree, usedBlobs)
 		if err != nil {
 			if repo.Backend().IsNotExist(err) {
 				return errors.Fatal("unable to load a tree from the repo: " + err.Error())

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -93,7 +93,6 @@ func runStats(gopts GlobalOptions, args []string) error {
 		uniqueInodes: make(map[uint64]struct{}),
 		fileBlobs:    make(map[string]restic.IDSet),
 		blobs:        restic.NewBlobSet(),
-		blobsSeen:    restic.NewBlobSet(),
 	}
 
 	if snapshotIDString != "" {
@@ -183,7 +182,7 @@ func statsWalkSnapshot(ctx context.Context, snapshot *restic.Snapshot, repo rest
 	if countMode == countModeRawData {
 		// count just the sizes of unique blobs; we don't need to walk the tree
 		// ourselves in this case, since a nifty function does it for us
-		return restic.FindUsedBlobs(ctx, repo, *snapshot.Tree, stats.blobs, stats.blobsSeen)
+		return restic.FindUsedBlobs(ctx, repo, *snapshot.Tree, stats.blobs)
 	}
 
 	err := walker.Walk(ctx, repo, *snapshot.Tree, restic.NewIDSet(), statsWalkTree(repo, stats))
@@ -318,9 +317,9 @@ type statsContainer struct {
 	// blobs that have been seen as a part of the file
 	fileBlobs map[string]restic.IDSet
 
-	// blobs and blobsSeen are used to count individual
+	// blobs are used to count individual
 	// unique blobs, independent of references to files
-	blobs, blobsSeen restic.BlobSet
+	blobs restic.BlobSet
 }
 
 // fileID is a 256-bit hash that distinguishes unique files.

--- a/internal/restic/find.go
+++ b/internal/restic/find.go
@@ -1,39 +1,103 @@
 package restic
 
-import "context"
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+)
 
 // TreeLoader loads a tree from a repository.
 type TreeLoader interface {
 	LoadTree(context.Context, ID) (*Tree, error)
 }
 
+const numUsedBlobsWorkers = 4
+
+// queue implements a concurrency-safe queue of IDs
+// It can be accessed by the channel given with queue.Items()
+type queue struct {
+	q chan ID
+	sync.WaitGroup
+}
+
+// NewQueue() gives a new empty queue
+func NewQueue() *queue {
+	return &queue{q: make(chan ID)}
+}
+
+// Add() adds the given IDs to the queue
+func (q *queue) Add(ids IDs) {
+	q.WaitGroup.Add(len(ids))
+	go func() {
+		for _, id := range ids {
+			q.q <- id
+		}
+	}()
+}
+
+// Items() give a channel to listen for IDs in the queue.
+// When an ID is processed queue.Done() should be called!
+func (q queue) Items() <-chan ID {
+	return q.q
+}
+
+// Wait() waits for all IDs to be processed and then closes the channel
+// given by Items()
+func (q *queue) Wait() {
+	q.WaitGroup.Wait()
+	close(q.q)
+}
+
 // FindUsedBlobs traverses the tree ID and adds all seen blobs (trees and data
 // blobs) to the set blobs. Already seen tree blobs will not be visited again.
 func FindUsedBlobs(ctx context.Context, repo TreeLoader, treeID ID, blobs BlobSet) error {
-	h := BlobHandle{ID: treeID, Type: TreeBlob}
-	if blobs.Has(h) {
-		return nil
-	}
-	blobs.Insert(h)
+	var m sync.Mutex
+	wg, ctx := errgroup.WithContext(ctx)
+	queue := NewQueue()
 
-	tree, err := repo.LoadTree(ctx, treeID)
-	if err != nil {
-		return err
+	queue.Add(IDs{treeID})
+	for i := 0; i < numUsedBlobsWorkers; i++ {
+		wg.Go(func() error {
+			return FindUsedBlobsWorker(queue, ctx, repo, blobs, &m)
+		})
 	}
+	queue.Wait()
+	return wg.Wait()
+}
 
-	for _, node := range tree.Nodes {
-		switch node.Type {
-		case "file":
-			for _, blob := range node.Content {
-				blobs.Insert(BlobHandle{ID: blob, Type: DataBlob})
-			}
-		case "dir":
-			err := FindUsedBlobs(ctx, repo, *node.Subtree, blobs)
-			if err != nil {
-				return err
+func FindUsedBlobsWorker(q *queue, ctx context.Context, repo TreeLoader, blobs BlobSet, m *sync.Mutex) error {
+	for treeID := range q.Items() {
+		h := BlobHandle{ID: treeID, Type: TreeBlob}
+		m.Lock()
+		if blobs.Has(h) {
+			m.Unlock()
+			q.Done()
+			continue
+		}
+		blobs.Insert(h)
+		m.Unlock()
+
+		tree, err := repo.LoadTree(ctx, treeID)
+		if err != nil {
+			q.Done()
+			return err
+		}
+		var subtrees IDs
+		for _, node := range tree.Nodes {
+			switch node.Type {
+			case "file":
+				for _, blob := range node.Content {
+					m.Lock()
+					blobs.Insert(BlobHandle{ID: blob, Type: DataBlob})
+					m.Unlock()
+				}
+			case "dir":
+				subtrees = append(subtrees, *node.Subtree)
 			}
 		}
+		q.Add(subtrees)
+		q.Done()
 	}
-
 	return nil
 }

--- a/internal/restic/find.go
+++ b/internal/restic/find.go
@@ -2,9 +2,14 @@ package restic
 
 import "context"
 
+// TreeLoader loads a tree from a repository.
+type TreeLoader interface {
+	LoadTree(context.Context, ID) (*Tree, error)
+}
+
 // FindUsedBlobs traverses the tree ID and adds all seen blobs (trees and data
 // blobs) to the set blobs. Already seen tree blobs will not be visited again.
-func FindUsedBlobs(ctx context.Context, repo Repository, treeID ID, blobs BlobSet) error {
+func FindUsedBlobs(ctx context.Context, repo TreeLoader, treeID ID, blobs BlobSet) error {
 	h := BlobHandle{ID: treeID, Type: TreeBlob}
 	if blobs.Has(h) {
 		return nil

--- a/internal/restic/find_test.go
+++ b/internal/restic/find_test.go
@@ -93,7 +93,7 @@ func TestFindUsedBlobs(t *testing.T) {
 
 	for i, sn := range snapshots {
 		usedBlobs := restic.NewBlobSet()
-		err := restic.FindUsedBlobs(context.TODO(), repo, *sn.Tree, usedBlobs, restic.NewBlobSet())
+		err := restic.FindUsedBlobs(context.TODO(), repo, *sn.Tree, usedBlobs)
 		if err != nil {
 			t.Errorf("FindUsedBlobs returned error: %v", err)
 			continue
@@ -127,9 +127,8 @@ func BenchmarkFindUsedBlobs(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		seen := restic.NewBlobSet()
 		blobs := restic.NewBlobSet()
-		err := restic.FindUsedBlobs(context.TODO(), repo, *sn.Tree, blobs, seen)
+		err := restic.FindUsedBlobs(context.TODO(), repo, *sn.Tree, blobs)
 		if err != nil {
 			b.Error(err)
 		}

--- a/internal/walker/walker.go
+++ b/internal/walker/walker.go
@@ -10,11 +10,6 @@ import (
 	"github.com/restic/restic/internal/restic"
 )
 
-// TreeLoader loads a tree from a repository.
-type TreeLoader interface {
-	LoadTree(context.Context, restic.ID) (*restic.Tree, error)
-}
-
 // SkipNode is returned by WalkFunc when a dir node should not be walked.
 var SkipNode = errors.New("skip this node")
 
@@ -38,7 +33,7 @@ type WalkFunc func(parentTreeID restic.ID, path string, node *restic.Node, nodeE
 // Walk calls walkFn recursively for each node in root. If walkFn returns an
 // error, it is passed up the call stack. The trees in ignoreTrees are not
 // walked. If walkFn ignores trees, these are added to the set.
-func Walk(ctx context.Context, repo TreeLoader, root restic.ID, ignoreTrees restic.IDSet, walkFn WalkFunc) error {
+func Walk(ctx context.Context, repo restic.TreeLoader, root restic.ID, ignoreTrees restic.IDSet, walkFn WalkFunc) error {
 	tree, err := repo.LoadTree(ctx, root)
 	_, err = walkFn(root, "/", nil, err)
 
@@ -60,7 +55,7 @@ func Walk(ctx context.Context, repo TreeLoader, root restic.ID, ignoreTrees rest
 // walk recursively traverses the tree, ignoring subtrees when the ID of the
 // subtree is in ignoreTrees. If err is nil and ignore is true, the subtree ID
 // will be added to ignoreTrees by walk.
-func walk(ctx context.Context, repo TreeLoader, prefix string, parentTreeID restic.ID, tree *restic.Tree, ignoreTrees restic.IDSet, walkFn WalkFunc) (ignore bool, err error) {
+func walk(ctx context.Context, repo restic.TreeLoader, prefix string, parentTreeID restic.ID, tree *restic.Tree, ignoreTrees restic.IDSet, walkFn WalkFunc) (ignore bool, err error) {
 	var allNodesIgnored = true
 
 	if len(tree.Nodes) == 0 {


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Make FindUsedBlobs work parallel. This can speed up `prune` and `stat --mode raw-data`.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No. However, it is based on #2599 
Performance problems with `prune` have been already discussed, see #2547.
This PR may contribute to a solution of #2126 

Actually a similar parallelization could be used for `walker.Walk` impacting much more commands.
I can propose to work on this as soon as this PR has been discussed and merged,

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
