### PR TITLE
Use restic.Repository interface, not *repository.Repository

### DIFF
--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
-	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/spf13/cobra"
 )
@@ -52,7 +51,7 @@ func init() {
 	f.BoolVar(&diffOptions.ShowMetadata, "metadata", false, "print changes in metadata")
 }
 
-func loadSnapshot(ctx context.Context, repo *repository.Repository, desc string) (*restic.Snapshot, error) {
+func loadSnapshot(ctx context.Context, repo restic.Repository, desc string) (*restic.Snapshot, error) {
 	id, err := restic.FindSnapshot(repo, desc)
 	if err != nil {
 		return nil, err

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -41,7 +41,7 @@ func init() {
 	flags.StringVarP(&newPasswordFile, "new-password-file", "", "", "the file from which to load a new password")
 }
 
-func listKeys(ctx context.Context, s *repository.Repository, gopts GlobalOptions) error {
+func listKeys(ctx context.Context, s restic.Repository, gopts GlobalOptions) error {
 	type keyInfo struct {
 		Current  bool   `json:"current"`
 		ID       string `json:"id"`
@@ -114,7 +114,7 @@ func getNewPassword(gopts GlobalOptions) (string, error) {
 		"enter password again: ")
 }
 
-func addKey(gopts GlobalOptions, repo *repository.Repository) error {
+func addKey(gopts GlobalOptions, repo restic.Repository) error {
 	pw, err := getNewPassword(gopts)
 	if err != nil {
 		return err
@@ -130,7 +130,7 @@ func addKey(gopts GlobalOptions, repo *repository.Repository) error {
 	return nil
 }
 
-func deleteKey(ctx context.Context, repo *repository.Repository, name string) error {
+func deleteKey(ctx context.Context, repo restic.Repository, name string) error {
 	if name == repo.KeyName() {
 		return errors.Fatal("refusing to remove key currently used to access repository")
 	}
@@ -145,7 +145,7 @@ func deleteKey(ctx context.Context, repo *repository.Repository, name string) er
 	return nil
 }
 
-func changePassword(gopts GlobalOptions, repo *repository.Repository) error {
+func changePassword(gopts GlobalOptions, repo restic.Repository) error {
 	pw, err := getNewPassword(gopts)
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
-	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 )
 
@@ -58,7 +57,7 @@ func init() {
 	tagFlags.StringArrayVar(&tagOptions.Paths, "path", nil, "only consider snapshots which include this (absolute) `path`, when no snapshot-ID is given")
 }
 
-func changeTags(ctx context.Context, repo *repository.Repository, sn *restic.Snapshot, setTags, addTags, removeTags []string) (bool, error) {
+func changeTags(ctx context.Context, repo restic.Repository, sn *restic.Snapshot, setTags, addTags, removeTags []string) (bool, error) {
 	var changed bool
 
 	if len(setTags) != 0 {

--- a/cmd/restic/find.go
+++ b/cmd/restic/find.go
@@ -3,12 +3,11 @@ package main
 import (
 	"context"
 
-	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 )
 
 // FindFilteredSnapshots yields Snapshots, either given explicitly by `snapshotIDs` or filtered from the list of all snapshots.
-func FindFilteredSnapshots(ctx context.Context, repo *repository.Repository, hosts []string, tags []restic.TagList, paths []string, snapshotIDs []string) <-chan *restic.Snapshot {
+func FindFilteredSnapshots(ctx context.Context, repo restic.Repository, hosts []string, tags []restic.TagList, paths []string, snapshotIDs []string) <-chan *restic.Snapshot {
 	out := make(chan *restic.Snapshot)
 	go func() {
 		defer close(out)

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
-	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 )
 
@@ -20,15 +19,15 @@ var globalLocks struct {
 	sync.Mutex
 }
 
-func lockRepo(repo *repository.Repository) (*restic.Lock, error) {
+func lockRepo(repo restic.Repository) (*restic.Lock, error) {
 	return lockRepository(repo, false)
 }
 
-func lockRepoExclusive(repo *repository.Repository) (*restic.Lock, error) {
+func lockRepoExclusive(repo restic.Repository) (*restic.Lock, error) {
 	return lockRepository(repo, true)
 }
 
-func lockRepository(repo *repository.Repository, exclusive bool) (*restic.Lock, error) {
+func lockRepository(repo restic.Repository, exclusive bool) (*restic.Lock, error) {
 	lockFn := restic.NewLock
 	if exclusive {
 		lockFn = restic.NewExclusiveLock

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -14,6 +14,7 @@ type Repository interface {
 	Backend() Backend
 
 	Key() *crypto.Key
+	KeyName() string
 
 	SetIndex(Index) error
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

I was trying to implement a custom implementation of restic.Repository, but found that some parts of restic (especially the commands) specifically require a *repository.Repository. This PR fixes the easy cases. cmd_backup.go needs work, but if and when I finish that, I'll send a separate PR.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Not that I know.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
