### PR TITLE
Isolate retry logic in RetryBackend

### DIFF
--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -210,13 +210,9 @@ func (wr wrapReader) Close() error {
 	return err
 }
 
-// Load runs fn with a reader that yields the contents of the file at h at the
+// Load returns a reader that yields the contents of the file at h at the
 // given offset.
-func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
-}
-
-func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/azure/azure_test.go
+++ b/internal/backend/azure/azure_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io"
 	"os"
 	"testing"
 	"time"
@@ -201,11 +200,7 @@ func TestUploadLargeFile(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			want := data[test.offset : test.offset+test.length]
 
-			buf := make([]byte, test.length)
-			err = be.Load(ctx, h, test.length, int64(test.offset), func(rd io.Reader) error {
-				_, err = io.ReadFull(rd, buf)
-				return err
-			})
+			buf, err := backend.LoadAll(ctx, nil, be, h)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -141,13 +141,9 @@ func (be *b2Backend) IsNotExist(err error) bool {
 	return b2.IsNotExist(errors.Cause(err))
 }
 
-// Load runs fn with a reader that yields the contents of the file at h at the
+// Load returns a reader that yields the contents of the file at h at the
 // given offset.
-func (be *b2Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
-}
-
-func (be *b2Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (be *b2Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/backend_error.go
+++ b/internal/backend/backend_error.go
@@ -66,12 +66,13 @@ func (be *ErrorBackend) Save(ctx context.Context, h restic.Handle, rd restic.Rew
 // given offset. If length is larger than zero, only a portion of the file
 // is returned. rd must be closed after use. If an error is returned, the
 // ReadCloser must be nil.
-func (be *ErrorBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, consumer func(rd io.Reader) error) error {
+func (be *ErrorBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	if be.fail(be.FailLoad) {
-		return errors.Errorf("Load(%v, %v, %v) random error induced", h, length, offset)
+		err := errors.Errorf("Load(%v, %v, %v) random error induced", h, length, offset)
+		return nil, err
 	}
 
-	return be.Backend.Load(ctx, h, length, offset, consumer)
+	return be.Backend.Load(ctx, h, length, offset)
 }
 
 // Stat returns information about the File identified by h.

--- a/internal/backend/backend_retry.go
+++ b/internal/backend/backend_retry.go
@@ -73,11 +73,68 @@ func (be *RetryBackend) Save(ctx context.Context, h restic.Handle, rd restic.Rew
 // given offset. If length is larger than zero, only a portion of the file
 // is returned. rd must be closed after use. If an error is returned, the
 // ReadCloser must be nil.
-func (be *RetryBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, consumer func(rd io.Reader) error) (err error) {
-	return be.retry(ctx, fmt.Sprintf("Load(%v, %v, %v)", h, length, offset),
-		func() error {
-			return be.Backend.Load(ctx, h, length, offset, consumer)
-		})
+func (be *RetryBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (r io.ReadCloser, err error) {
+	r = &retryReader{be: be, ctx: ctx, h: h, length: length, offset: offset}
+	return r, nil
+}
+
+type retryReader struct {
+	atEOF  bool
+	be     *RetryBackend
+	ctx    context.Context
+	h      restic.Handle
+	length int
+	offset int64
+}
+
+func (r *retryReader) Read(p []byte) (n int, err error) {
+	if r.atEOF {
+		return 0, io.EOF
+	}
+
+	msg := fmt.Sprintf("Load(%v, %v, %v)", r.h, r.length, r.offset)
+	err = r.be.retry(r.ctx, msg, func() (innerErr error) {
+		n, innerErr = r.read(p)
+		return innerErr
+	})
+	return n, err
+}
+
+func (r *retryReader) read(p []byte) (n int, err error) {
+	rd, err := r.be.Backend.Load(r.ctx, r.h, r.length, r.offset)
+	if err != nil {
+		return 0, err
+	}
+
+	if len(p) > r.length && r.length != 0 {
+		p = p[:r.length]
+	}
+	n, err = rd.Read(p)
+
+	switch err {
+	case nil:
+	case io.EOF:
+		r.atEOF = true
+		err = nil // Don't trigger retry.
+	default:
+		// Forget what we read, restart at current offset.
+		return 0, err
+	}
+
+	if r.length != 0 {
+		r.length -= n
+		if r.length == 0 {
+			r.atEOF = true
+		}
+	}
+	r.offset += int64(n)
+
+	return n, err
+}
+
+func (r *retryReader) Close() error {
+	*r = retryReader{}
+	return nil
 }
 
 // Stat returns information about the File identified by h.

--- a/internal/backend/backend_retry.go
+++ b/internal/backend/backend_retry.go
@@ -111,6 +111,11 @@ func (r *retryReader) read(p []byte) (n int, err error) {
 	}
 	n, err = rd.Read(p)
 
+	cerr := rd.Close()
+	if err == nil {
+		err = cerr
+	}
+
 	switch err {
 	case nil:
 	case io.EOF:

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -265,13 +265,9 @@ func (wr wrapReader) Close() error {
 	return err
 }
 
-// Load runs fn with a reader that yields the contents of the file at h at the
+// Load returns a reader that yields the contents of the file at h at the
 // given offset.
-func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
-}
-
-func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -127,13 +127,9 @@ func (b *Local) Save(ctx context.Context, h restic.Handle, rd restic.RewindReade
 	return setNewFileMode(filename, backend.Modes.File)
 }
 
-// Load runs fn with a reader that yields the contents of the file at h at the
+// Load returns a reader that yields the contents of the file at h at the
 // given offset.
-func (b *Local) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	return backend.DefaultLoad(ctx, h, length, offset, b.openReader, fn)
-}
-
-func (b *Local) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (b *Local) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -7,7 +7,6 @@ import (
 	"io/ioutil"
 	"sync"
 
-	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 
@@ -86,13 +85,9 @@ func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd restic.Re
 	return nil
 }
 
-// Load runs fn with a reader that yields the contents of the file at h at the
+// Load returns a reader that yields the contents of the file at h at the
 // given offset.
-func (be *MemoryBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
-}
-
-func (be *MemoryBackend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (be *MemoryBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	if err := h.Valid(); err != nil {
 		return nil, err
 	}

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -170,13 +170,9 @@ func (b *Backend) IsNotExist(err error) bool {
 	return ok
 }
 
-// Load runs fn with a reader that yields the contents of the file at h at the
+// Load returns a reader that yields the contents of the file at h at the
 // given offset.
-func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	return backend.DefaultLoad(ctx, h, length, offset, b.openReader, fn)
-}
-
-func (b *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -267,13 +267,9 @@ func (wr wrapReader) Close() error {
 	return err
 }
 
-// Load runs fn with a reader that yields the contents of the file at h at the
+// Load returns a reader that yields the contents of the file at h at the
 // given offset.
-func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
-}
-
-func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -300,13 +300,9 @@ func (r *SFTP) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader
 	return errors.Wrap(r.c.Chmod(filename, backend.Modes.File), "Chmod")
 }
 
-// Load runs fn with a reader that yields the contents of the file at h at the
+// Load returns a reader that yields the contents of the file at h at the
 // given offset.
-func (r *SFTP) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	return backend.DefaultLoad(ctx, h, length, offset, r.openReader, fn)
-}
-
-func (r *SFTP) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (r *SFTP) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -110,13 +110,9 @@ func (be *beSwift) Location() string {
 	return be.container
 }
 
-// Load runs fn with a reader that yields the contents of the file at h at the
+// Load returns a reader that yields the contents of the file at h at the
 // given offset.
-func (be *beSwift) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	return backend.DefaultLoad(ctx, h, length, offset, be.openReader, fn)
-}
-
-func (be *beSwift) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+func (be *beSwift) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
 		return nil, err

--- a/internal/backend/test/benchmarks.go
+++ b/internal/backend/test/benchmarks.go
@@ -3,7 +3,6 @@ package test
 import (
 	"bytes"
 	"context"
-	"io"
 	"testing"
 
 	"github.com/restic/restic/internal/restic"
@@ -43,11 +42,7 @@ func (s *Suite) BenchmarkLoadFile(t *testing.B) {
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		var n int
-		err := be.Load(context.TODO(), handle, 0, 0, func(rd io.Reader) (ierr error) {
-			n, ierr = io.ReadFull(rd, buf)
-			return ierr
-		})
+		n, err := restic.ReadAt(context.TODO(), be, handle, 0, buf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -80,11 +75,7 @@ func (s *Suite) BenchmarkLoadPartialFile(t *testing.B) {
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		var n int
-		err := be.Load(context.TODO(), handle, testLength, 0, func(rd io.Reader) (ierr error) {
-			n, ierr = io.ReadFull(rd, buf)
-			return ierr
-		})
+		n, err := restic.ReadAt(context.TODO(), be, handle, 0, buf)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -119,11 +110,7 @@ func (s *Suite) BenchmarkLoadPartialFileOffset(t *testing.B) {
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		var n int
-		err := be.Load(context.TODO(), handle, testLength, int64(testOffset), func(rd io.Reader) (ierr error) {
-			n, ierr = io.ReadFull(rd, buf)
-			return ierr
-		})
+		n, err := restic.ReadAt(context.TODO(), be, handle, int64(testOffset), buf)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/backend/utils.go
+++ b/internal/backend/utils.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"io/ioutil"
 
 	"github.com/restic/restic/internal/restic"
 )
@@ -12,22 +13,26 @@ import (
 // buffer, which is truncated. If the buffer is not large enough or nil, a new
 // one is allocated.
 func LoadAll(ctx context.Context, buf []byte, be restic.Backend, h restic.Handle) ([]byte, error) {
-	err := be.Load(ctx, h, 0, 0, func(rd io.Reader) error {
-		// make sure this is idempotent, in case an error occurs this function may be called multiple times!
-		wr := bytes.NewBuffer(buf[:0])
-		_, cerr := io.Copy(wr, rd)
-		if cerr != nil {
-			return cerr
-		}
-		buf = wr.Bytes()
-		return nil
-	})
-
+	rd, err := be.Load(ctx, h, 0, 0)
 	if err != nil {
 		return nil, err
 	}
 
-	return buf, nil
+	defer func() {
+		_, e := io.Copy(ioutil.Discard, rd)
+		if err == nil {
+			err = e
+		}
+
+		e = rd.Close()
+		if err == nil {
+			err = e
+		}
+	}()
+
+	bbuf := bytes.NewBuffer(buf[:0])
+	_, err = io.Copy(bbuf, rd)
+	return bbuf.Bytes(), err
 }
 
 // LimitedReadCloser wraps io.LimitedReader and exposes the Close() method.
@@ -45,20 +50,4 @@ func (l *LimitedReadCloser) Read(p []byte) (int, error) {
 // exposes the Close() method.
 func LimitReadCloser(r io.ReadCloser, n int64) *LimitedReadCloser {
 	return &LimitedReadCloser{ReadCloser: r, Reader: io.LimitReader(r, n)}
-}
-
-// DefaultLoad implements Backend.Load using lower-level openReader func
-func DefaultLoad(ctx context.Context, h restic.Handle, length int, offset int64,
-	openReader func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error),
-	fn func(rd io.Reader) error) error {
-	rd, err := openReader(ctx, h, length, offset)
-	if err != nil {
-		return err
-	}
-	err = fn(rd)
-	if err != nil {
-		rd.Close() // ignore secondary errors closing the reader
-		return err
-	}
-	return rd.Close()
 }

--- a/internal/backend/utils_test.go
+++ b/internal/backend/utils_test.go
@@ -3,13 +3,11 @@ package backend_test
 import (
 	"bytes"
 	"context"
-	"io"
 	"math/rand"
 	"testing"
 
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/mem"
-	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
@@ -105,55 +103,4 @@ func TestLoadAllAppend(t *testing.T) {
 			}
 		})
 	}
-}
-
-type mockReader struct {
-	closed bool
-}
-
-func (rd *mockReader) Read(p []byte) (n int, err error) {
-	return 0, nil
-}
-func (rd *mockReader) Close() error {
-	rd.closed = true
-	return nil
-}
-
-func TestDefaultLoad(t *testing.T) {
-
-	h := restic.Handle{Name: "id", Type: restic.DataFile}
-	rd := &mockReader{}
-
-	// happy case, assert correct parameters are passed around and content stream is closed
-	err := backend.DefaultLoad(context.TODO(), h, 10, 11, func(ctx context.Context, ih restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-		rtest.Equals(t, h, ih)
-		rtest.Equals(t, int(10), length)
-		rtest.Equals(t, int64(11), offset)
-
-		return rd, nil
-	}, func(ird io.Reader) error {
-		rtest.Equals(t, rd, ird)
-		return nil
-	})
-	rtest.OK(t, err)
-	rtest.Equals(t, true, rd.closed)
-
-	// unhappy case, assert producer errors are handled correctly
-	err = backend.DefaultLoad(context.TODO(), h, 10, 11, func(ctx context.Context, ih restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-		return nil, errors.Errorf("producer error")
-	}, func(ird io.Reader) error {
-		t.Fatalf("unexpected consumer invocation")
-		return nil
-	})
-	rtest.Equals(t, "producer error", err.Error())
-
-	// unhappy case, assert consumer errors are handled correctly
-	rd = &mockReader{}
-	err = backend.DefaultLoad(context.TODO(), h, 10, 11, func(ctx context.Context, ih restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-		return rd, nil
-	}, func(ird io.Reader) error {
-		return errors.Errorf("consumer error")
-	})
-	rtest.Equals(t, true, rd.closed)
-	rtest.Equals(t, "consumer error", err.Error())
 }

--- a/internal/cache/backend_test.go
+++ b/internal/cache/backend_test.go
@@ -122,9 +122,9 @@ type loadErrorBackend struct {
 	loadError error
 }
 
-func (be loadErrorBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+func (be loadErrorBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	time.Sleep(10 * time.Millisecond)
-	return be.loadError
+	return nil, be.loadError
 }
 
 func TestErrorBackend(t *testing.T) {

--- a/internal/mock/backend.go
+++ b/internal/mock/backend.go
@@ -13,7 +13,7 @@ type Backend struct {
 	CloseFn      func() error
 	IsNotExistFn func(err error) bool
 	SaveFn       func(ctx context.Context, h restic.Handle, rd restic.RewindReader) error
-	OpenReaderFn func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error)
+	LoadFn       func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error)
 	StatFn       func(ctx context.Context, h restic.Handle) (restic.FileInfo, error)
 	ListFn       func(ctx context.Context, t restic.FileType, fn func(restic.FileInfo) error) error
 	RemoveFn     func(ctx context.Context, h restic.Handle) error
@@ -64,27 +64,14 @@ func (m *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRea
 	return m.SaveFn(ctx, h, rd)
 }
 
-// Load runs fn with a reader that yields the contents of the file at h at the
+// Load returns a reader that yields the contents of the file at h at the
 // given offset.
-func (m *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	rd, err := m.openReader(ctx, h, length, offset)
-	if err != nil {
-		return err
-	}
-	err = fn(rd)
-	if err != nil {
-		rd.Close() // ignore secondary errors closing the reader
-		return err
-	}
-	return rd.Close()
-}
-
-func (m *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-	if m.OpenReaderFn == nil {
+func (m *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+	if m.LoadFn == nil {
 		return nil, errors.New("not implemented")
 	}
 
-	return m.OpenReaderFn(ctx, h, length, offset)
+	return m.LoadFn(ctx, h, length, offset)
 }
 
 // Stat an object in the backend.

--- a/internal/restic/backend.go
+++ b/internal/restic/backend.go
@@ -23,15 +23,11 @@ type Backend interface {
 	// Save stores the data from rd under the given handle.
 	Save(ctx context.Context, h Handle, rd RewindReader) error
 
-	// Load runs fn with a reader that yields the contents of the file at h at the
+	// Load returns a reader that yields the contents of the file at h at the
 	// given offset. If length is larger than zero, only a portion of the file
-	// is read.
-	//
-	// The function fn may be called multiple times during the same Load invocation
-	// and therefore must be idempotent.
-	//
-	// Implementations are encouraged to use backend.DefaultLoad
-	Load(ctx context.Context, h Handle, length int, offset int64, fn func(rd io.Reader) error) error
+	// is returned. rd must be closed after use. If an error is returned, the
+	// ReadCloser must be nil.
+	Load(ctx context.Context, h Handle, length int, offset int64) (io.ReadCloser, error)
 
 	// Stat returns information about the File identified by h.
 	Stat(ctx context.Context, h Handle) (FileInfo, error)

--- a/internal/restic/readerat.go
+++ b/internal/restic/readerat.go
@@ -25,14 +25,15 @@ func ReaderAt(be Backend, h Handle) io.ReaderAt {
 // ReadAt reads from the backend handle h at the given position.
 func ReadAt(ctx context.Context, be Backend, h Handle, offset int64, p []byte) (n int, err error) {
 	debug.Log("ReadAt(%v) at %v, len %v", h, offset, len(p))
-
-	err = be.Load(ctx, h, len(p), offset, func(rd io.Reader) (ierr error) {
-		n, ierr = io.ReadFull(rd, p)
-
-		return ierr
-	})
+	rd, err := be.Load(ctx, h, len(p), offset)
 	if err != nil {
 		return 0, err
+	}
+
+	n, err = io.ReadFull(rd, p)
+	e := rd.Close()
+	if err == nil {
+		err = e
 	}
 
 	debug.Log("ReadAt(%v) ReadFull returned %v bytes", h, n)

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -206,7 +206,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 
 	idx := restic.NewHardlinkIndex()
 
-	filerestorer := newFileRestorer(dst, res.repo.Backend().Load, res.repo.Key(), res.repo.Index().Lookup)
+	filerestorer := newFileRestorer(dst, res.repo.Backend(), res.repo.Key(), res.repo.Index().Lookup)
 
 	// first tree pass: create directories and collect all files to restore
 	err = res.traverseTree(ctx, dst, string(filepath.Separator), *res.sn.Tree, treeVisitor{


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This restores the restic.Backend.Load signature to what it was before d58ae433179dd77ec06e20c0c7cd3573dfe1b5d6: it returns a ReadCloser, rather than take a callback. The retrying logic for which the current version was implemented is now entirely contained in RetryBackend.

The main purpose of this PR is to simplify the implementation of new backends. In particular, a backend that wraps another backend has to construct a callback to call a callback. That's hard to debug.

The only functional change in this commit is in the retrying. Previously, RetryBackend.Load would retry an entire Load and its consumer, as a kind of transaction (hence the requirements on the callback). It will now retry only the Load from its underlying backend, which likely means a single API call.

Despite the addition of a stricter test for RetryBackend, the amount of backend code is reduced significantly. Performance isn't impacted. Here are benchmark results, obtained with RESTIC_TEST_TMPDIR pointing to an actual spinning disk:

```
name                                              old speed      new speed      delta
pkg:github.com/restic/restic/internal/backend/local goos:linux goarch:amd64
Backend/BenchmarkLoadFile-8                       3.53GB/s ± 3%  3.59GB/s ± 2%  +1.49%  (p=0.043 n=10+10)
Backend/BenchmarkLoadPartialFile-8                4.68GB/s ± 3%  4.76GB/s ± 4%    ~     (p=0.277 n=8+9)
Backend/BenchmarkLoadPartialFileOffset-8          4.59GB/s ± 4%  4.68GB/s ± 5%    ~     (p=0.211 n=9+10)
Backend/BenchmarkSave-8                            701MB/s ± 7%   684MB/s ± 2%    ~     (p=0.174 n=9+7)
pkg:github.com/restic/restic/internal/backend/mem goos:linux goarch:amd64
SuiteBackendMem/BenchmarkLoadFile-8               4.11GB/s ± 3%  4.12GB/s ± 2%    ~     (p=0.684 n=10+10)
SuiteBackendMem/BenchmarkLoadPartialFile-8        6.29GB/s ± 2%  6.33GB/s ± 1%    ~     (p=0.113 n=9+9)
SuiteBackendMem/BenchmarkLoadPartialFileOffset-8  6.25GB/s ± 1%  6.28GB/s ± 2%    ~     (p=0.340 n=9+9)
SuiteBackendMem/BenchmarkSave-8                   39.1TB/s ± 4%  39.1TB/s ± 2%    ~     (p=0.971 n=10+10)
pkg:github.com/restic/restic/internal/backend/rclone goos:linux goarch:amd64
BackendREST/BenchmarkLoadFile-8                   54.7MB/s ± 5%  55.2MB/s ± 5%    ~     (p=0.859 n=9+10)
BackendREST/BenchmarkLoadPartialFile-8            52.6MB/s ± 5%  53.4MB/s ± 5%    ~     (p=0.271 n=10+10)
BackendREST/BenchmarkLoadPartialFileOffset-8       219MB/s ± 1%   220MB/s ± 1%    ~     (p=0.234 n=10+9)
pkg:github.com/restic/restic/internal/backend/rest goos:linux goarch:amd64
BackendREST/BenchmarkLoadFile-8                   1.15GB/s ± 5%  1.16GB/s ± 3%    ~     (p=0.971 n=10+10)
BackendREST/BenchmarkLoadPartialFile-8             852MB/s ± 4%   867MB/s ± 3%    ~     (p=0.143 n=10+10)
BackendREST/BenchmarkLoadPartialFileOffset-8       847MB/s ± 5%   853MB/s ± 5%    ~     (p=0.739 n=10+10)
pkg:github.com/restic/restic/internal/backend/sftp goos:linux goarch:amd64
BackendSFTP/BenchmarkLoadFile-8                    993MB/s ± 3%   995MB/s ± 3%    ~     (p=0.853 n=10+10)
BackendSFTP/BenchmarkLoadPartialFile-8             895MB/s ± 4%   888MB/s ± 3%    ~     (p=0.118 n=10+10)
BackendSFTP/BenchmarkLoadPartialFileOffset-8       890MB/s ± 3%   894MB/s ± 3%    ~     (p=0.481 n=10+10)
BackendSFTP/BenchmarkSave-8                        121GB/s ± 7%   120GB/s ± 5%    ~     (p=0.684 n=10+10)
pkg:github.com/restic/restic/internal/backend/test goos:linux goarch:amd64
SuiteBackendMem/BenchmarkLoadFile-8               4.11GB/s ± 3%  4.15GB/s ± 2%    ~     (p=0.393 n=10+10)
SuiteBackendMem/BenchmarkLoadPartialFile-8        6.30GB/s ± 1%  6.33GB/s ± 1%    ~     (p=0.113 n=9+9)
SuiteBackendMem/BenchmarkLoadPartialFileOffset-8  6.28GB/s ± 1%  6.28GB/s ± 1%    ~     (p=1.000 n=9+9)
SuiteBackendMem/BenchmarkSave-8                   38.3TB/s ± 3%  38.8TB/s ± 4%    ~     (p=0.315 n=10+10)
```

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Not that I know. #1560 introduced the current Load API.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
