### PR TITLE
Refactor termstatus platform-specific code

### DIFF
--- a/internal/ui/termstatus/terminal_posix.go
+++ b/internal/ui/termstatus/terminal_posix.go
@@ -15,7 +15,7 @@ const (
 
 // posixClearCurrentLine removes all characters from the current line and resets the
 // cursor position to the first column.
-func posixClearCurrentLine(wr io.Writer, fd uintptr) {
+func posixClearCurrentLine(wr io.Writer) {
 	// clear current line
 	_, err := wr.Write([]byte(posixControlMoveCursorHome + posixControlClearLine))
 	if err != nil {
@@ -25,7 +25,7 @@ func posixClearCurrentLine(wr io.Writer, fd uintptr) {
 }
 
 // posixMoveCursorUp moves the cursor to the line n lines above the current one.
-func posixMoveCursorUp(wr io.Writer, fd uintptr, n int) {
+func posixMoveCursorUp(wr io.Writer, n int) {
 	data := []byte(posixControlMoveCursorHome)
 	data = append(data, bytes.Repeat([]byte(posixControlMoveCursorUp), n)...)
 	_, err := wr.Write(data)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This refactors the internal/ui/termstatus package to get rid of some higher-order functions and some redundant checks on Windows. Code with higher-order functions is harder to navigate in an IDE and leads to awkward pseudo-method calls, e.g., `t.clearCurrentLine(t.wr, t.fd)` instead of `t.clearCurrentLine()`.

I've tried to implement this using an interface, but it wasn't better.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Not that I know.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
