### PR TITLE
Fix PackerManager benchmark and optimize hashing.Writer

### DIFF
--- a/internal/hashing/writer.go
+++ b/internal/hashing/writer.go
@@ -15,13 +15,14 @@ type Writer struct {
 func NewWriter(w io.Writer, h hash.Hash) *Writer {
 	return &Writer{
 		h: h,
-		w: io.MultiWriter(w, h),
+		w: w,
 	}
 }
 
 // Write wraps the write method of the underlying writer and also hashes all data.
 func (h *Writer) Write(p []byte) (int, error) {
 	n, err := h.w.Write(p)
+	h.h.Write(p[:n])
 	return n, err
 }
 

--- a/internal/repository/packer_manager_test.go
+++ b/internal/repository/packer_manager_test.go
@@ -14,31 +14,6 @@ import (
 	"github.com/restic/restic/internal/restic"
 )
 
-type randReader struct {
-	src  rand.Source
-	rand *rand.Rand
-}
-
-func newRandReader(src rand.Source) *randReader {
-	return &randReader{
-		src:  src,
-		rand: rand.New(src),
-	}
-}
-
-// Read generates len(p) random bytes and writes them into p. It
-// always returns len(p) and a nil error.
-func (r *randReader) Read(p []byte) (n int, err error) {
-	for i := 0; i < len(p); i += 7 {
-		val := r.src.Int63()
-		for j := 0; i+j < len(p) && j < 7; j++ {
-			p[i+j] = byte(val)
-			val >>= 8
-		}
-	}
-	return len(p), nil
-}
-
 func randomID(rd io.Reader) restic.ID {
 	id := restic.ID{}
 	_, err := io.ReadFull(rd, id[:])
@@ -73,17 +48,17 @@ func saveFile(t testing.TB, be Saver, length int, f *os.File, id restic.ID) {
 	}
 }
 
-func fillPacks(t testing.TB, rnd *randReader, be Saver, pm *packerManager, buf []byte) (bytes int) {
+func fillPacks(t testing.TB, rnd *rand.Rand, be Saver, pm *packerManager, buf []byte) (bytes int) {
 	for i := 0; i < 100; i++ {
-		l := rnd.rand.Intn(1 << 20)
-		seed := rnd.rand.Int63()
+		l := rnd.Intn(1 << 20)
+		seed := rnd.Int63()
 
 		packer, err := pm.findPacker()
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		rd := newRandReader(rand.NewSource(seed))
+		rd := rand.New(rand.NewSource(seed))
 		id := randomID(rd)
 		buf = buf[:l]
 		_, err = io.ReadFull(rd, buf)
@@ -117,7 +92,7 @@ func fillPacks(t testing.TB, rnd *randReader, be Saver, pm *packerManager, buf [
 	return bytes
 }
 
-func flushRemainingPacks(t testing.TB, rnd *randReader, be Saver, pm *packerManager) (bytes int) {
+func flushRemainingPacks(t testing.TB, be Saver, pm *packerManager) (bytes int) {
 	if pm.countPacker() > 0 {
 		for _, packer := range pm.packers {
 			n, err := packer.Finalize()
@@ -135,7 +110,7 @@ func flushRemainingPacks(t testing.TB, rnd *randReader, be Saver, pm *packerMana
 }
 
 func TestPackerManager(t *testing.T) {
-	rnd := newRandReader(rand.NewSource(23))
+	rnd := rand.New(rand.NewSource(23))
 
 	be := mem.New()
 	pm := newPackerManager(be, crypto.NewRandomKey())
@@ -143,13 +118,13 @@ func TestPackerManager(t *testing.T) {
 	blobBuf := make([]byte, maxBlobSize)
 
 	bytes := fillPacks(t, rnd, be, pm, blobBuf)
-	bytes += flushRemainingPacks(t, rnd, be, pm)
+	bytes += flushRemainingPacks(t, be, pm)
 
 	t.Logf("saved %d bytes", bytes)
 }
 
 func BenchmarkPackerManager(t *testing.B) {
-	rnd := newRandReader(rand.NewSource(23))
+	rnd := rand.New(rand.NewSource(23))
 
 	be := &mock.Backend{
 		SaveFn: func(context.Context, restic.Handle, restic.RewindReader) error { return nil },
@@ -162,7 +137,7 @@ func BenchmarkPackerManager(t *testing.B) {
 		bytes := 0
 		pm := newPackerManager(be, crypto.NewRandomKey())
 		bytes += fillPacks(t, rnd, be, pm, blobBuf)
-		bytes += flushRemainingPacks(t, rnd, be, pm)
+		bytes += flushRemainingPacks(t, be, pm)
 		t.Logf("saved %d bytes", bytes)
 	}
 }


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

I was trying to see whether a few potential optimizations to hashing.Writer would make it faster. Before I could do that, I had to fix the PackagerManager benchmark to be more realistic.

The only actual optimization that had a (very minor) effect and didn't make the code unreadable is included as the third commit.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
