### PR TITLE
Simplify and optimize validNonce

### DIFF
--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -237,11 +237,12 @@ var ErrInvalidCiphertext = errors.New("invalid ciphertext, same slice used for p
 
 // validNonce checks that nonce is not all zero.
 func validNonce(nonce []byte) bool {
-	var sum byte
 	for _, b := range nonce {
-		sum |= b
+		if b != 0 {
+			return true
+		}
 	}
-	return sum > 0
+	return false
 }
 
 // statically ensure that *Key implements crypto/cipher.AEAD

--- a/internal/crypto/crypto_int_test.go
+++ b/internal/crypto/crypto_int_test.go
@@ -164,7 +164,7 @@ func TestCrypto(t *testing.T) {
 	}
 }
 
-func TestNonceVadlid(t *testing.T) {
+func TestNonceValid(t *testing.T) {
 	nonce := make([]byte, ivSize)
 
 	if validNonce(nonce) {


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

<del>crypto.validNonce was optimized for older Go versions, but Go 1.14 is smart enough to optimize the obvious implementation to 4x the speed of the current version.</del>

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
