### PR TITLE
Specify stdin for external password command

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -268,6 +268,7 @@ func resolvePassword(opts GlobalOptions) (string, error) {
 		}
 		cmd := exec.Command(args[0], args[1:]...)
 		cmd.Stderr = os.Stderr
+		cmd.Stdin = os.Stdin
 		output, err := cmd.Output()
 		if err != nil {
 			return "", err


### PR DESCRIPTION
This allows reading the password when terminal interaction is
required (for example, pinentry-curses).

Signed-off-by: Juergen Hoetzel <juergen@archlinux.org>


What is the purpose of this change? What does it change?
-----------------

This is just a follow up  for
[Add support for reading password from external command](https://github.com/restic/restic/commit/df7f72cdde2419937c15377d46a311e5d734a245)

currently `stdin` is connected to `/dev/null` and `pinentry-curses` fails:


```
→ export RESTIC_PASSWORD_COMMAND='pass Backup/restic@serenity'
→ restic backup ~
gpg: decryption failed: No secret key
Resolving password failed: exit status 2
```

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
