### PR TITLE
cache: Don't sort one element pack lists

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -111,6 +111,11 @@ func (r *Repository) sortCachedPacks(blobs []restic.PackedBlob) []restic.PackedB
 		return blobs
 	}
 
+	// no need to sort a list with one element
+	if len(blobs) == 1 {
+		return blobs
+	}
+
 	cached := make([]restic.PackedBlob, 0, len(blobs)/2)
 	noncached := make([]restic.PackedBlob, 0, len(blobs)/2)
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Avoid unnecessary checks on whether a pack file is already cached, that is it reduces the number of `stat` syscalls. The cache still checks later on whether the pack file is stored in the cache.

When loading a blob, restic first looks up pack files containing the
blob. To avoid unnecessary work an already cached pack file is preferred.
However, if there is only a single pack file to choose from (which is
the normal case) sorting the one-element list won't change anything.
Therefore avoid the unnecessary cache check in that case.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No. I came across this inefficiency during work on #2328.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- Just a minor optimization ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- No user facing changes ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
