### PR TITLE
repository: Avoid duplicate index lookup when loading blob/tree

### DIFF
--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -194,6 +194,16 @@ func TestLoadBlob(t *testing.T) {
 			continue
 		}
 	}
+
+	// then test automatic buffer allocation
+	n, err := repo.LoadBlob(context.TODO(), restic.DataBlob, id, nil)
+	if err != nil {
+		t.Errorf("LoadBlob() failed to allocate an useable buffer: %v", err)
+	}
+
+	if n != length {
+		t.Errorf("LoadBlob() returned the wrong number of bytes: want %v, got %v", length, n)
+	}
 }
 
 func BenchmarkLoadBlob(b *testing.B) {


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
`LoadBlob` and `LoadTree` lookup the blob size in the index and use it to allocate a buffer for `loadBlob` which has to run another index lookup. Especially for large repositories index lookups are rather expensive, see #2523 .

This PR lets `loadBlob()` allocate the blob buffer itself and thus removes the duplicate index lookup.

I did not include a changelog entry as this PR only slightly improves performance.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No, the inefficiency showed up during work on #2328.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
