### PR TITLE
Optimize indexMaxBlobs for lower memory usage

### DIFF
--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -60,7 +60,7 @@ func (idx *Index) Final() bool {
 
 const (
 	indexMinBlobs = 20
-	indexMaxBlobs = 2000
+	indexMaxBlobs = 3000
 	indexMinAge   = 2 * time.Minute
 	indexMaxAge   = 15 * time.Minute
 )


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Reduce the memory required to load preliminary index files. If an preliminary index is uploaded during backup and it is considered as full because its blob count reached indexMaxBlobs, then the hashmap used to loaded this index wastes a lot of memory:

Go hashmaps use a load factor of 6.5/8 and allocate an array whose size is a power of two. For 2000 entries this requires a array with 4096 slots which wastes a lot of memory. The maximum number of entries for that array size would be 3328. However, leave some headroom as the index_uploader only runs every 30 seconds.

I'm not sure whether a changelog entry is required. The memory usage of restic should be slightly lower when running backups without calling rebuild-index inbetween, but it's hard to tell by how much.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No. I noticed the problem during the discussions in #2523.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
