### PR TITLE
Revert "Put host last in SSH command line"

### DIFF
--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -189,8 +189,11 @@ func buildSSHCommand(cfg Config) (cmd string, args []string, err error) {
 
 	cmd = "ssh"
 
-	if cfg.Port != "" {
-		args = append(args, "-p", cfg.Port)
+	host, port := cfg.Host, cfg.Port
+
+	args = []string{host}
+	if port != "" {
+		args = append(args, "-p", port)
 	}
 	if cfg.User != "" {
 		args = append(args, "-l")
@@ -198,8 +201,6 @@ func buildSSHCommand(cfg Config) (cmd string, args []string, err error) {
 	}
 	args = append(args, "-s")
 	args = append(args, "sftp")
-
-	args = append(args, "--", cfg.Host)
 	return cmd, args, nil
 }
 

--- a/internal/backend/sftp/sshcmd_test.go
+++ b/internal/backend/sftp/sshcmd_test.go
@@ -13,34 +13,34 @@ var sshcmdTests = []struct {
 	{
 		Config{User: "user", Host: "host", Path: "dir/subdir"},
 		"ssh",
-		[]string{"-l", "user", "-s", "sftp", "--", "host"},
+		[]string{"host", "-l", "user", "-s", "sftp"},
 	},
 	{
 		Config{Host: "host", Path: "dir/subdir"},
 		"ssh",
-		[]string{"-s", "sftp", "--", "host"},
+		[]string{"host", "-s", "sftp"},
 	},
 	{
 		Config{Host: "host", Port: "10022", Path: "/dir/subdir"},
 		"ssh",
-		[]string{"-p", "10022", "-s", "sftp", "--", "host"},
+		[]string{"host", "-p", "10022", "-s", "sftp"},
 	},
 	{
 		Config{User: "user", Host: "host", Port: "10022", Path: "/dir/subdir"},
 		"ssh",
-		[]string{"-p", "10022", "-l", "user", "-s", "sftp", "--", "host"},
+		[]string{"host", "-p", "10022", "-l", "user", "-s", "sftp"},
 	},
 	{
 		// IPv6 address.
 		Config{User: "user", Host: "::1", Path: "dir"},
 		"ssh",
-		[]string{"-l", "user", "-s", "sftp", "--", "::1"},
+		[]string{"::1", "-l", "user", "-s", "sftp"},
 	},
 	{
 		// IPv6 address with zone and port.
 		Config{User: "user", Host: "::1%lo0", Port: "22", Path: "dir"},
 		"ssh",
-		[]string{"-p", "22", "-l", "user", "-s", "sftp", "--", "::1%lo0"},
+		[]string{"::1%lo0", "-p", "22", "-l", "user", "-s", "sftp"},
 	},
 }
 


### PR DESCRIPTION
This reverts commit e1969d1e3360fd268184b810b5f08ad327725c66.

Closes #2627. The new order of options doesn't work on all (Open)SSH versions.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
