### PR TITLE
Optimize sorting blobs by cache status

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -116,6 +116,7 @@ type haver interface {
 }
 
 // sortCachedPacksFirst moves all cached pack files to the front of blobs.
+// It overwrites blobs.
 func sortCachedPacksFirst(cache haver, blobs []restic.PackedBlob) []restic.PackedBlob {
 	if cache == nil {
 		return blobs
@@ -126,7 +127,7 @@ func sortCachedPacksFirst(cache haver, blobs []restic.PackedBlob) []restic.Packe
 		return blobs
 	}
 
-	cached := make([]restic.PackedBlob, 0, len(blobs)/2)
+	cached := blobs[:0]
 	noncached := make([]restic.PackedBlob, 0, len(blobs)/2)
 
 	for _, blob := range blobs {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -116,15 +116,14 @@ type haver interface {
 }
 
 // sortCachedPacksFirst moves all cached pack files to the front of blobs.
-// It overwrites blobs.
-func sortCachedPacksFirst(cache haver, blobs []restic.PackedBlob) []restic.PackedBlob {
+func sortCachedPacksFirst(cache haver, blobs []restic.PackedBlob) {
 	if cache == nil {
-		return blobs
+		return
 	}
 
 	// no need to sort a list with one element
 	if len(blobs) == 1 {
-		return blobs
+		return
 	}
 
 	cached := blobs[:0]
@@ -138,7 +137,7 @@ func sortCachedPacksFirst(cache haver, blobs []restic.PackedBlob) []restic.Packe
 		noncached = append(noncached, blob)
 	}
 
-	return append(cached, noncached...)
+	copy(blobs[len(cached):], noncached)
 }
 
 // LoadBlob loads a blob of type t from the repository.
@@ -154,7 +153,7 @@ func (r *Repository) LoadBlob(ctx context.Context, t restic.BlobType, id restic.
 	}
 
 	// try cached pack files first
-	blobs = sortCachedPacksFirst(r.Cache, blobs)
+	sortCachedPacksFirst(r.Cache, blobs)
 
 	var lastError error
 	for _, blob := range blobs {

--- a/internal/repository/repository_internal_test.go
+++ b/internal/repository/repository_internal_test.go
@@ -1,0 +1,81 @@
+package repository
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+type mapcache map[restic.Handle]struct{}
+
+func (c mapcache) Has(h restic.Handle) bool {
+	_, ok := c[h]
+	return ok
+}
+
+func TestSortCachedPacksFirst(t *testing.T) {
+	var (
+		blobs   [100]restic.PackedBlob
+		blobset = make(map[restic.PackedBlob]struct{})
+		cache   = make(mapcache)
+		r       = rand.New(rand.NewSource(1261))
+	)
+
+	for i := 0; i < len(blobs); i++ {
+		var id restic.ID
+		r.Read(id[:])
+		blobs[i] = restic.PackedBlob{PackID: id}
+		blobset[blobs[i]] = struct{}{}
+
+		if i%3 == 0 {
+			h := restic.Handle{Name: id.String(), Type: restic.DataFile}
+			cache[h] = struct{}{}
+		}
+	}
+
+	sorted := sortCachedPacksFirst(cache, blobs[:])
+
+	rtest.Equals(t, len(blobs), len(sorted))
+	for i := 0; i < len(blobs); i++ {
+		h := restic.Handle{Type: restic.DataFile, Name: sorted[i].PackID.String()}
+		if i < len(cache) {
+			rtest.Assert(t, cache.Has(h), "non-cached blob at front of sorted output")
+		} else {
+			rtest.Assert(t, !cache.Has(h), "cached blob at end of sorted output")
+		}
+		_, ok := blobset[sorted[i]]
+		rtest.Assert(t, ok, "sortCachedPacksFirst changed blob id")
+	}
+}
+
+func BenchmarkSortCachedPacksFirst(b *testing.B) {
+	const nblobs = 512 // Corresponds to a file of ca. 2GB.
+
+	var (
+		blobs [nblobs]restic.PackedBlob
+		cache = make(mapcache)
+		r     = rand.New(rand.NewSource(1261))
+	)
+
+	for i := 0; i < nblobs; i++ {
+		var id restic.ID
+		r.Read(id[:])
+		blobs[i] = restic.PackedBlob{PackID: id}
+
+		if i%3 == 0 {
+			h := restic.Handle{Name: id.String(), Type: restic.DataFile}
+			cache[h] = struct{}{}
+		}
+	}
+
+	var cpy [nblobs]restic.PackedBlob
+	b.ReportAllocs()
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		copy(cpy[:], blobs[:])
+		sortCachedPacksFirst(cache, cpy[:])
+	}
+}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Repository.sortCachedPacks always allocates too much memory for its return value in too many calls. It can be made 10% faster (cache lookup time not included) by letting it reuse its input's space. I also gave it a unit test, which required making it a freestanding function, and renamed it for clarify while I was at it.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No. <del>But #2628 also touches this code. The changes proposed are independent and should merge easily.</del>

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
