### PR TITLE
Don't Close in Packer.Finalize

### DIFF
--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -61,8 +61,7 @@ type headerEntry struct {
 }
 
 // Finalize writes the header for all added blobs and finalizes the pack.
-// Returned are the number of bytes written, including the header. If the
-// underlying writer implements io.Closer, it is closed.
+// Returned are the number of bytes written, including the header.
 func (p *Packer) Finalize() (uint, error) {
 	p.m.Lock()
 	defer p.m.Unlock()
@@ -101,11 +100,6 @@ func (p *Packer) Finalize() (uint, error) {
 	bytesWritten += uint(binary.Size(uint32(0)))
 
 	p.bytes = uint(bytesWritten)
-
-	if w, ok := p.wr.(io.Closer); ok {
-		return bytesWritten, w.Close()
-	}
-
 	return bytesWritten, nil
 }
 

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -25,12 +25,8 @@ type Packer struct {
 	m sync.Mutex
 }
 
-// NewPacker returns a new Packer that can be used to pack blobs
-// together. If wr is nil, a bytes.Buffer is used.
+// NewPacker returns a new Packer that can be used to pack blobs together.
 func NewPacker(k *crypto.Key, wr io.Writer) *Packer {
-	if wr == nil {
-		wr = bytes.NewBuffer(nil)
-	}
 	return &Packer{k: k, wr: wr}
 }
 

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -36,7 +36,7 @@ func newPack(t testing.TB, k *crypto.Key, lengths []int) ([]Buf, []byte, uint) {
 	}
 
 	// pack blobs
-	p := pack.NewPacker(k, nil)
+	p := pack.NewPacker(k, new(bytes.Buffer))
 	for _, b := range bufs {
 		p.Add(restic.TreeBlob, b.id, b.data)
 	}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Packer.Finalize currently tests its Writer for a Close method and calls that. There never is such a method; if one is implemented for *hashing.Writer, restic backup crashes with a "file already closed" fatal error. This PR removes the check for io.Closer.

Additionally, some testing logic was moved to the test file.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
