### PR TITLE
Simplify Repository.LoadBlob usage

### DIFF
--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -170,18 +170,15 @@ func runCat(gopts GlobalOptions, args []string) error {
 
 	case "blob":
 		for _, t := range []restic.BlobType{restic.DataBlob, restic.TreeBlob} {
-			list, found := repo.Index().Lookup(id, t)
+			_, found := repo.Index().Lookup(id, t)
 			if !found {
 				continue
 			}
-			blob := list[0]
 
-			buf := make([]byte, blob.Length)
-			n, err := repo.LoadBlob(gopts.ctx, t, id, buf)
+			buf, err := repo.LoadBlob(gopts.ctx, t, id, nil)
 			if err != nil {
 				return err
 			}
-			buf = buf[:n]
 
 			_, err = os.Stdout.Write(buf)
 			return err

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -171,24 +171,15 @@ func runDump(opts DumpOptions, gopts GlobalOptions, args []string) error {
 }
 
 func getNodeData(ctx context.Context, output io.Writer, repo restic.Repository, node *restic.Node) error {
-	var buf []byte
+	var (
+		buf []byte
+		err error
+	)
 	for _, id := range node.Content {
-
-		size, found := repo.LookupBlobSize(id, restic.DataBlob)
-		if !found {
-			return errors.Errorf("id %v not found in repository", id)
-		}
-
-		buf = buf[:cap(buf)]
-		if len(buf) < restic.CiphertextLength(int(size)) {
-			buf = restic.NewBlobBuffer(int(size))
-		}
-
-		n, err := repo.LoadBlob(ctx, restic.DataBlob, id, buf)
+		buf, err = repo.LoadBlob(ctx, restic.DataBlob, id, buf)
 		if err != nil {
 			return err
 		}
-		buf = buf[:n]
 
 		_, err = output.Write(buf)
 		if err != nil {

--- a/internal/archiver/testing.go
+++ b/internal/archiver/testing.go
@@ -228,13 +228,13 @@ func TestEnsureFileContent(ctx context.Context, t testing.TB, repo restic.Reposi
 	content := make([]byte, restic.CiphertextLength(len(file.Content)))
 	pos := 0
 	for _, id := range node.Content {
-		n, err := repo.LoadBlob(ctx, restic.DataBlob, id, content[pos:])
+		part, err := repo.LoadBlob(ctx, restic.DataBlob, id, content[pos:])
 		if err != nil {
 			t.Fatalf("error loading blob %v: %v", id.Str(), err)
 			return
 		}
 
-		pos += n
+		pos += len(part)
 	}
 
 	content = content[:pos]

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -96,15 +96,14 @@ func (f *file) getBlobAt(ctx context.Context, i int) (blob []byte, err error) {
 		f.blobs[j] = nil
 	}
 
-	buf := restic.NewBlobBuffer(f.sizes[i])
-	n, err := f.root.repo.LoadBlob(ctx, restic.DataBlob, f.node.Content[i], buf)
+	blob, err = f.root.repo.LoadBlob(ctx, restic.DataBlob, f.node.Content[i], nil)
 	if err != nil {
 		debug.Log("LoadBlob(%v, %v) failed: %v", f.node.Name, f.node.Content[i], err)
 		return nil, err
 	}
-	f.blobs[i] = buf[:n]
+	f.blobs[i] = blob
 
-	return buf[:n], nil
+	return blob, nil
 }
 
 func (f *file) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.ReadResponse) error {

--- a/internal/fuse/fuse_test.go
+++ b/internal/fuse/fuse_test.go
@@ -94,12 +94,11 @@ func TestFuseFile(t *testing.T) {
 		rtest.Assert(t, found, "Expected to find blob id %v", id)
 		filesize += uint64(size)
 
-		buf := restic.NewBlobBuffer(int(size))
-		n, err := repo.LoadBlob(context.TODO(), restic.DataBlob, id, buf)
+		buf, err := repo.LoadBlob(context.TODO(), restic.DataBlob, id, nil)
 		rtest.OK(t, err)
 
-		if uint(n) != size {
-			t.Fatalf("not enough bytes read for id %v: want %v, got %v", id.Str(), size, n)
+		if len(buf) != int(size) {
+			t.Fatalf("not enough bytes read for id %v: want %v, got %v", id.Str(), size, len(buf))
 		}
 
 		if uint(len(buf)) != size {

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -282,21 +282,10 @@ func (node Node) createFileAt(ctx context.Context, path string, repo Repository)
 func (node Node) writeNodeContent(ctx context.Context, repo Repository, f *os.File) error {
 	var buf []byte
 	for _, id := range node.Content {
-		size, found := repo.LookupBlobSize(id, DataBlob)
-		if !found {
-			return errors.Errorf("id %v not found in repository", id)
-		}
-
-		buf = buf[:cap(buf)]
-		if len(buf) < CiphertextLength(int(size)) {
-			buf = NewBlobBuffer(int(size))
-		}
-
-		n, err := repo.LoadBlob(ctx, DataBlob, id, buf)
+		buf, err := repo.LoadBlob(ctx, DataBlob, id, buf)
 		if err != nil {
 			return err
 		}
-		buf = buf[:n]
 
 		_, err = f.Write(buf)
 		if err != nil {

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -45,7 +45,7 @@ type Repository interface {
 	// new buffer will be allocated and returned.
 	LoadAndDecrypt(ctx context.Context, buf []byte, t FileType, id ID) (data []byte, err error)
 
-	LoadBlob(context.Context, BlobType, ID, []byte) (int, error)
+	LoadBlob(context.Context, BlobType, ID, []byte) ([]byte, error)
 	SaveBlob(context.Context, BlobType, []byte, ID) (ID, error)
 
 	LoadTree(context.Context, ID) (*Tree, error)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Repository.LoadBlob currently requires its caller to compute the size of the buffer it needs. It then checks whether the buffer has the right size, and its helper loadBlob checks again. This leads to much duplicated, yet subtly different, code for computing sizes as well as repeated index lookups.

This PR changes LoadBlob to just return a freshly allocated buffer if insufficient space was passed in. The benchmarks show that fewer allocations have to be performed. The simplified code also makes it easier to add compression, since LoadBlob callers no longer need to know how big their buffers need to be (they'd have to know about compression as well as encryption).

```
name              old time/op    new time/op    delta
LoadTree-8           479µs ± 2%     481µs ± 2%    ~     (p=0.684 n=10+10)
LoadBlob-8          11.6ms ± 2%    11.6ms ± 2%    ~     (p=0.393 n=10+10)
LoadAndDecrypt-8    13.2ms ± 2%    13.3ms ± 3%    ~     (p=0.604 n=10+9)
LoadIndex-8         33.4ms ± 2%    33.2ms ± 1%    ~     (p=0.161 n=9+9)

name              old alloc/op   new alloc/op   delta
LoadTree-8          41.2kB ± 0%    41.1kB ± 0%  -0.23%  (p=0.000 n=10+10)
LoadBlob-8          2.28kB ± 0%    2.18kB ± 0%  -4.21%  (p=0.000 n=10+10)
LoadAndDecrypt-8    2.10MB ± 0%    2.10MB ± 0%    ~     (all equal)
LoadIndex-8         5.22MB ± 0%    5.22MB ± 0%    ~     (p=0.853 n=10+10)

name              old allocs/op  new allocs/op  delta
LoadTree-8             652 ± 0%       651 ± 0%  -0.15%  (p=0.000 n=10+10)
LoadBlob-8            24.0 ± 0%      23.0 ± 0%  -4.17%  (p=0.000 n=10+10)
LoadAndDecrypt-8      30.0 ± 0%      30.0 ± 0%    ~     (all equal)
LoadIndex-8          30.2k ± 0%     30.2k ± 0%    ~     (p=0.664 n=10+10)

name              old speed      new speed      delta
LoadBlob-8        86.2MB/s ± 2%  85.9MB/s ± 2%    ~     (p=0.393 n=10+10)
LoadAndDecrypt-8  75.7MB/s ± 2%  75.4MB/s ± 3%    ~     (p=0.603 n=10+9)
```

There is one functional change, which is the error message from LoadTree will now say "id %v not found in repository" rather than "tree %v not found in repository".

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2629.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
