### PR TITLE
Lighter init and buffered channels for signals

### DIFF
--- a/cmd/restic/cleanup.go
+++ b/cmd/restic/cleanup.go
@@ -20,7 +20,7 @@ var cleanupHandlers struct {
 var stderr = os.Stderr
 
 func init() {
-	cleanupHandlers.ch = make(chan os.Signal)
+	cleanupHandlers.ch = make(chan os.Signal, 1)
 	go CleanupHandler(cleanupHandlers.ch)
 	signal.Notify(cleanupHandlers.ch, syscall.SIGINT)
 }

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -196,7 +196,7 @@ func uniqueNodeNames(tree1, tree2 *restic.Tree) (tree1Nodes, tree2Nodes map[stri
 		uniqueNames = append(uniqueNames, name)
 	}
 
-	sort.Sort(sort.StringSlice(uniqueNames))
+	sort.Strings(uniqueNames)
 	return tree1Nodes, tree2Nodes, uniqueNames
 }
 

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -251,9 +251,8 @@ func PrintSnapshots(stdout io.Writer, list restic.Snapshots, reasons []restic.Ke
 // Prints nothing, if we did not group at all.
 func PrintSnapshotGroupHeader(stdout io.Writer, groupKeyJSON string) error {
 	var key restic.SnapshotGroupKey
-	var err error
 
-	err = json.Unmarshal([]byte(groupKeyJSON), &key)
+	err := json.Unmarshal([]byte(groupKeyJSON), &key)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -126,7 +126,7 @@ func runStats(gopts GlobalOptions, args []string) error {
 		err = repo.List(ctx, restic.SnapshotFile, func(snapshotID restic.ID, size int64) error {
 			snapshot, err := restic.LoadSnapshot(ctx, repo, snapshotID)
 			if err != nil {
-				return fmt.Errorf("Error loading snapshot %s: %v", snapshotID.Str(), err)
+				return fmt.Errorf("error loading snapshot %s: %v", snapshotID.Str(), err)
 			}
 			return statsWalkSnapshot(ctx, snapshot, repo, stats)
 		})

--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -190,7 +190,7 @@ func isDirExcludedByFile(dir, tagFilename, header string) bool {
 		Warnf("could not read signature from exclusion tagfile %q: %v\n", tf, err)
 		return false
 	}
-	if bytes.Compare(buf, []byte(header)) != 0 {
+	if !bytes.Equal(buf, []byte(header)) {
 		Warnf("invalid signature in exclusion tagfile %q\n", tf)
 		return false
 	}

--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -54,7 +54,7 @@ func walkDir(dir string) <-chan *dirEntry {
 	}()
 
 	// first element is root
-	_ = <-ch
+	<-ch
 
 	return ch
 }

--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -141,11 +141,7 @@ func directoriesEqualContents(dir1, dir2 string) bool {
 		a, b = nil, nil
 	}
 
-	if changes {
-		return false
-	}
-
-	return true
+	return !changes
 }
 
 type dirStat struct {

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -143,7 +143,7 @@ func testRunCheckOutput(gopts GlobalOptions) (string, error) {
 	}
 
 	err := runCheck(opts, gopts, nil)
-	return string(buf.Bytes()), err
+	return buf.String(), err
 }
 
 func testRunRebuildIndex(t testing.TB, gopts GlobalOptions) {
@@ -169,7 +169,7 @@ func testRunLs(t testing.TB, gopts GlobalOptions, snapshotID string) []string {
 
 	rtest.OK(t, runLs(opts, gopts, []string{snapshotID}))
 
-	return strings.Split(string(buf.Bytes()), "\n")
+	return strings.Split(buf.String(), "\n")
 }
 
 func testRunFind(t testing.TB, wantJSON bool, gopts GlobalOptions, pattern string) []byte {

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -1147,11 +1147,7 @@ func linksEqual(source, dest map[uint64][]string) bool {
 		}
 	}
 
-	if len(dest) != 0 {
-		return false
-	}
-
-	return true
+	return len(dest) == 0
 }
 
 func linkEqual(source, dest []string) bool {

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -901,14 +901,14 @@ func TestRestoreNoMetadataOnIgnoredIntermediateDirs(t *testing.T) {
 	testRunRestoreIncludes(t, env.gopts, filepath.Join(env.base, "restore0"), snapshotID, []string{"*.ext"})
 
 	f1 := filepath.Join(env.base, "restore0", "testdata", "subdir1", "subdir2")
-	fi, err := os.Stat(f1)
+	_, err := os.Stat(f1)
 	rtest.OK(t, err)
 
 	// restore with filter "*", this should restore meta data on everything.
 	testRunRestoreIncludes(t, env.gopts, filepath.Join(env.base, "restore1"), snapshotID, []string{"*"})
 
 	f2 := filepath.Join(env.base, "restore1", "testdata", "subdir1", "subdir2")
-	fi, err = os.Stat(f2)
+	fi, err := os.Stat(f2)
 	rtest.OK(t, err)
 
 	rtest.Assert(t, fi.ModTime() == time.Unix(0, 0),

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1448,10 +1448,7 @@ func TestArchiverSnapshotSelect(t *testing.T) {
 				"other": TestFile{Content: "another file"},
 			},
 			selFn: func(item string, fi os.FileInfo) bool {
-				if filepath.Ext(item) == ".txt" {
-					return false
-				}
-				return true
+				return filepath.Ext(item) != ".txt"
 			},
 		},
 		{
@@ -1475,10 +1472,7 @@ func TestArchiverSnapshotSelect(t *testing.T) {
 				"other": TestFile{Content: "another file"},
 			},
 			selFn: func(item string, fi os.FileInfo) bool {
-				if filepath.Base(item) == "subdir" {
-					return false
-				}
-				return true
+				return filepath.Base(item) != "subdir"
 			},
 		},
 		{

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -131,8 +131,7 @@ func (d *dir) Attr(ctx context.Context, a *fuse.Attr) error {
 func (d *dir) calcNumberOfLinks() uint32 {
 	// a directory d has 2 hardlinks + the number
 	// of directories contained by d
-	var count uint32
-	count = 2
+	count := uint32(2)
 	for _, node := range d.items {
 		if node.Type == "dir" {
 			count++

--- a/internal/repository/worker_group.go
+++ b/internal/repository/worker_group.go
@@ -11,7 +11,7 @@ import (
 // one of the workers, it is returned. FinalFunc is always run, regardless of
 // any other previous errors.
 func RunWorkers(ctx context.Context, count int, workerFunc func() error, finalFunc func()) error {
-	wg, ctx := errgroup.WithContext(ctx)
+	wg, _ := errgroup.WithContext(ctx)
 
 	// run workers
 	for i := 0; i < count; i++ {

--- a/internal/restic/hardlinks_index_test.go
+++ b/internal/restic/hardlinks_index_test.go
@@ -15,15 +15,13 @@ func TestHardLinks(t *testing.T) {
 	idx.Add(1, 2, "inode1-file1-on-device2")
 	idx.Add(2, 3, "inode2-file2-on-device3")
 
-	var sresult string
-	sresult = idx.GetFilename(1, 2)
+	sresult := idx.GetFilename(1, 2)
 	rtest.Equals(t, sresult, "inode1-file1-on-device2")
 
 	sresult = idx.GetFilename(2, 3)
 	rtest.Equals(t, sresult, "inode2-file2-on-device3")
 
-	var bresult bool
-	bresult = idx.Has(1, 2)
+	bresult := idx.Has(1, 2)
 	rtest.Equals(t, bresult, true)
 
 	bresult = idx.Has(1, 3)

--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -253,7 +253,7 @@ var ignoreSIGHUP sync.Once
 func init() {
 	ignoreSIGHUP.Do(func() {
 		go func() {
-			c := make(chan os.Signal)
+			c := make(chan os.Signal, 1)
 			signal.Notify(c, syscall.SIGHUP)
 			for s := range c {
 				debug.Log("Signal received: %v\n", s)

--- a/internal/restic/progress.go
+++ b/internal/restic/progress.go
@@ -40,7 +40,7 @@ type Progress struct {
 	start      time.Time
 	c          *time.Ticker
 	cancel     chan struct{}
-	o          *sync.Once
+	o          sync.Once
 	d          time.Duration
 	lastUpdate time.Time
 
@@ -79,7 +79,6 @@ func (p *Progress) Start() {
 		return
 	}
 
-	p.o = &sync.Once{}
 	p.cancel = make(chan struct{})
 	p.running = true
 	p.Reset()

--- a/internal/restic/progress_unix.go
+++ b/internal/restic/progress_unix.go
@@ -10,8 +10,8 @@ import (
 	"github.com/restic/restic/internal/debug"
 )
 
-func init() {
-	c := make(chan os.Signal)
+func progressSignalInit() {
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGUSR1)
 	go func() {
 		for s := range c {

--- a/internal/restic/progress_unix_with_siginfo.go
+++ b/internal/restic/progress_unix_with_siginfo.go
@@ -10,8 +10,8 @@ import (
 	"github.com/restic/restic/internal/debug"
 )
 
-func init() {
-	c := make(chan os.Signal)
+func progressSignalInit() {
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGUSR1)
 	signal.Notify(c, syscall.SIGINFO)
 	go func() {

--- a/internal/restic/progress_windows.go
+++ b/internal/restic/progress_windows.go
@@ -1,0 +1,5 @@
+// +build windows
+
+package restic
+
+func progressSignalInit() {}

--- a/internal/restic/rand_reader.go
+++ b/internal/restic/rand_reader.go
@@ -64,7 +64,7 @@ func (rd *RandReader) Read(p []byte) (int, error) {
 
 	// load 7 byte to temp buffer
 	rd.buf = rd.buf[:7]
-	n, err = rd.read(rd.buf)
+	_, err = rd.read(rd.buf)
 	if err != nil {
 		return pos, errors.Wrap(err, "Read")
 	}

--- a/internal/restic/snapshot_group.go
+++ b/internal/restic/snapshot_group.go
@@ -51,7 +51,7 @@ func GroupSnapshots(snapshots Snapshots, options string) (map[string]Snapshots, 
 
 		if GroupByTag {
 			tags = sn.Tags
-			sort.StringSlice(tags).Sort()
+			sort.Strings(tags)
 		}
 		if GroupByHost {
 			hostname = sn.Hostname
@@ -60,7 +60,7 @@ func GroupSnapshots(snapshots Snapshots, options string) (map[string]Snapshots, 
 			paths = sn.Paths
 		}
 
-		sort.StringSlice(sn.Paths).Sort()
+		sort.Strings(sn.Paths)
 		var k []byte
 		var err error
 

--- a/internal/restic/snapshot_group.go
+++ b/internal/restic/snapshot_group.go
@@ -25,9 +25,7 @@ func GroupSnapshots(snapshots Snapshots, options string) (map[string]Snapshots, 
 	var GroupByTag bool
 	var GroupByHost bool
 	var GroupByPath bool
-	var GroupOptionList []string
-
-	GroupOptionList = strings.Split(options, ",")
+	GroupOptionList := strings.Split(options, ",")
 
 	for _, option := range GroupOptionList {
 		switch option {

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -224,7 +224,7 @@ func (t *Terminal) runWithoutStatus(ctx context.Context) {
 				fmt.Fprintf(os.Stderr, "flush failed: %v\n", err)
 			}
 
-		case _ = <-t.status:
+		case <-t.status:
 			// discard status lines
 		}
 	}

--- a/internal/walker/walker.go
+++ b/internal/walker/walker.go
@@ -89,7 +89,7 @@ func walk(ctx context.Context, repo TreeLoader, prefix string, parentTreeID rest
 				return false, err
 			}
 
-			if ignore == false {
+			if !ignore {
 				allNodesIgnored = false
 			}
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

It makes restic's startup lighter by not postponing restic.Progress initialization. It also makes all channels passed to signal.Notify buffered.

The number of commits in this PR is large because it includes part of #2630, which I deemed uncontroversial, and which already fixed part of the problem. The reason that lighter initialization is part of it at all is that I first tried getting right of init functions, then figured out that signal handling is the actual problem.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

The segfault reported at #2618 is very likely the result of improper signal.Notify use. This does not fix the issue entirely, but reduces it to the well-known "restic uses much memory" problem.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
