### PR TITLE
Make all signal.Notify channels buffered

### DIFF
--- a/cmd/restic/cleanup.go
+++ b/cmd/restic/cleanup.go
@@ -20,7 +20,7 @@ var cleanupHandlers struct {
 var stderr = os.Stderr
 
 func init() {
-	cleanupHandlers.ch = make(chan os.Signal)
+	cleanupHandlers.ch = make(chan os.Signal, 1)
 	go CleanupHandler(cleanupHandlers.ch)
 	signal.Notify(cleanupHandlers.ch, syscall.SIGINT)
 }

--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -253,7 +253,7 @@ var ignoreSIGHUP sync.Once
 func init() {
 	ignoreSIGHUP.Do(func() {
 		go func() {
-			c := make(chan os.Signal)
+			c := make(chan os.Signal, 1)
 			signal.Notify(c, syscall.SIGHUP)
 			for s := range c {
 				debug.Log("Signal received: %v\n", s)

--- a/internal/restic/progress_unix.go
+++ b/internal/restic/progress_unix.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	c := make(chan os.Signal)
+	c := make(chan os.Signal, 1)
 	signal.Notify(c, syscall.SIGUSR1)
 	go func() {
 		for s := range c {

--- a/internal/restic/progress_unix_with_siginfo.go
+++ b/internal/restic/progress_unix_with_siginfo.go
@@ -11,9 +11,8 @@ import (
 )
 
 func init() {
-	c := make(chan os.Signal)
-	signal.Notify(c, syscall.SIGUSR1)
-	signal.Notify(c, syscall.SIGINFO)
+	c := make(chan os.Signal, 1)
+	signal.Notify(c, syscall.SIGINFO, syscall.SIGUSR1)
 	go func() {
 		for s := range c {
 			debug.Log("Signal received: %v\n", s)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

It makes all channels passed to signal.Notify buffered, as its documentation recommends.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

I think this solves part of #2618 (segfault on ARM), at least by making it easier to diagnose the problem. #2630 includes one of these cases, but should merge cleanly, since the change is exactly the same.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
