### PR TITLE
Add --insecure-tls flag to disable SSL cert verification

### DIFF
--- a/changelog/unreleased/issue-2656
+++ b/changelog/unreleased/issue-2656
@@ -1,0 +1,8 @@
+Enhancement: Add flag to disable TLS verification for self-signed certificates
+
+We've added a flag, `--insecure-tls`, to allow disabling
+TLS verification for self-signed certificates in order to support
+some development workflows.
+
+https://github.com/restic/restic/issues/2656
+https://github.com/restic/restic/pull/2657

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -61,6 +61,7 @@ type GlobalOptions struct {
 	CacheDir        string
 	NoCache         bool
 	CACerts         []string
+	InsecureTLS     bool
 	TLSClientCert   string
 	CleanupCache    bool
 
@@ -115,6 +116,7 @@ func init() {
 	f.BoolVar(&globalOptions.NoCache, "no-cache", false, "do not use a local cache")
 	f.StringSliceVar(&globalOptions.CACerts, "cacert", nil, "`file` to load root certificates from (default: use system certificates)")
 	f.StringVar(&globalOptions.TLSClientCert, "tls-client-cert", "", "path to a `file` containing PEM encoded TLS client certificate and private key")
+	f.BoolVar(&globalOptions.InsecureTLS, "insecure-tls", false, "skip TLS certificate verification when connecting to the repo (insecure)")
 	f.BoolVar(&globalOptions.CleanupCache, "cleanup-cache", false, "auto remove old cache directories")
 	f.IntVar(&globalOptions.LimitUploadKb, "limit-upload", 0, "limits uploads to a maximum rate in KiB/s. (default: unlimited)")
 	f.IntVar(&globalOptions.LimitDownloadKb, "limit-download", 0, "limits downloads to a maximum rate in KiB/s. (default: unlimited)")
@@ -671,6 +673,7 @@ func open(s string, gopts GlobalOptions, opts options.Options) (restic.Backend, 
 	tropts := backend.TransportOptions{
 		RootCertFilenames:        globalOptions.CACerts,
 		TLSClientCertKeyFilename: globalOptions.TLSClientCert,
+		InsecureTLS:              globalOptions.InsecureTLS,
 	}
 	rt, err := backend.Transport(tropts)
 	if err != nil {
@@ -751,6 +754,7 @@ func create(s string, opts options.Options) (restic.Backend, error) {
 	tropts := backend.TransportOptions{
 		RootCertFilenames:        globalOptions.CACerts,
 		TLSClientCertKeyFilename: globalOptions.TLSClientCert,
+		InsecureTLS:              globalOptions.InsecureTLS,
 	}
 	rt, err := backend.Transport(tropts)
 	if err != nil {

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -50,6 +50,7 @@ Usage help is available:
           --cache-dir directory        set the cache directory. (default: use system default cache directory)
           --cleanup-cache              auto remove old cache directories
       -h, --help                       help for restic
+          --insecure-tls               skip TLS certificate verification when connecting to the repo (insecure)
           --json                       set output mode to JSON for commands that support it
           --key-hint key               key ID of key to try decrypting first (default: $RESTIC_KEY_HINT)
           --limit-download int         limits downloads to a maximum rate in KiB/s. (default: unlimited)
@@ -118,6 +119,7 @@ command:
           --cacert file                file to load root certificates from (default: use system certificates)
           --cache-dir directory        set the cache directory. (default: use system default cache directory)
           --cleanup-cache              auto remove old cache directories
+          --insecure-tls               skip TLS certificate verification when connecting to the repo (insecure)
           --json                       set output mode to JSON for commands that support it
           --key-hint key               key ID of key to try decrypting first (default: $RESTIC_KEY_HINT)
           --limit-download int         limits downloads to a maximum rate in KiB/s. (default: unlimited)

--- a/internal/backend/http_transport.go
+++ b/internal/backend/http_transport.go
@@ -22,6 +22,9 @@ type TransportOptions struct {
 
 	// contains the name of a file containing the TLS client certificate and private key in PEM format
 	TLSClientCertKeyFilename string
+
+	// Skip TLS certificate verification
+	InsecureTLS bool
 }
 
 // readPEMCertKey reads a file and returns the PEM encoded certificate and key
@@ -77,6 +80,10 @@ func Transport(opts TransportOptions) (http.RoundTripper, error) {
 		TLSHandshakeTimeout:   10 * time.Second,
 		ExpectContinueTimeout: 1 * time.Second,
 		TLSClientConfig:       &tls.Config{},
+	}
+
+	if opts.InsecureTLS {
+		tr.TLSClientConfig.InsecureSkipVerify = true
 	}
 
 	if opts.TLSClientCertKeyFilename != "" {


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

This adds a flag to disable TLS certificate verification for self-signed certificates as described in https://github.com/restic/restic/issues/2656.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes https://github.com/restic/restic/issues/2656

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
