### PR TITLE
Don't echo authentication passwords (rest backend)

### DIFF
--- a/changelog/unreleased/issue-2241
+++ b/changelog/unreleased/issue-2241
@@ -1,0 +1,10 @@
+Bugfix: Hide password in REST backend repository URLs
+
+When using a password in the REST backend repository URL,
+the password could in some cases be included in the output
+from restic, e.g. when initializing a repo or during an error.
+
+The password is now replaced with "***" where applicable.
+
+https://github.com/restic/restic/issues/2241
+https://github.com/restic/restic/pull/2658

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"github.com/restic/chunker"
+	"github.com/restic/restic/internal/backend/location"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
 
@@ -53,7 +54,7 @@ func runInit(opts InitOptions, gopts GlobalOptions, args []string) error {
 
 	be, err := create(gopts.Repo, gopts.extended)
 	if err != nil {
-		return errors.Fatalf("create repository at %s failed: %v\n", gopts.Repo, err)
+		return errors.Fatalf("create repository at %s failed: %v\n", location.StripPassword(gopts.Repo), err)
 	}
 
 	gopts.password, err = ReadPasswordTwice(gopts,
@@ -67,10 +68,10 @@ func runInit(opts InitOptions, gopts GlobalOptions, args []string) error {
 
 	err = s.Init(gopts.ctx, gopts.password, chunkerPolynomial)
 	if err != nil {
-		return errors.Fatalf("create key in repository at %s failed: %v\n", gopts.Repo, err)
+		return errors.Fatalf("create key in repository at %s failed: %v\n", location.StripPassword(gopts.Repo), err)
 	}
 
-	Verbosef("created restic repository %v at %s\n", s.Config().ID[:10], gopts.Repo)
+	Verbosef("created restic repository %v at %s\n", s.Config().ID[:10], location.StripPassword(gopts.Repo))
 	Verbosef("\n")
 	Verbosef("Please note that knowledge of your password is required to access\n")
 	Verbosef("the repository. Losing your password means that your data is\n")

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -631,7 +631,7 @@ func parseConfig(loc location.Location, opts options.Options) (interface{}, erro
 
 // Open the backend specified by a location config.
 func open(s string, gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
-	debug.Log("parsing location %v", s)
+	debug.Log("parsing location %v", location.StripPassword(s))
 	loc, err := location.Parse(s)
 	if err != nil {
 		return nil, errors.Fatalf("parsing repository location failed: %v", err)
@@ -686,13 +686,13 @@ func open(s string, gopts GlobalOptions, opts options.Options) (restic.Backend, 
 	}
 
 	if err != nil {
-		return nil, errors.Fatalf("unable to open repo at %v: %v", s, err)
+		return nil, errors.Fatalf("unable to open repo at %v: %v", location.StripPassword(s), err)
 	}
 
 	// check if config is there
 	fi, err := be.Stat(globalOptions.ctx, restic.Handle{Type: restic.ConfigFile})
 	if err != nil {
-		return nil, errors.Fatalf("unable to open config file: %v\nIs there a repository at the following location?\n%v", err, s)
+		return nil, errors.Fatalf("unable to open config file: %v\nIs there a repository at the following location?\n%v", err, location.StripPassword(s))
 	}
 
 	if fi.Size == 0 {

--- a/internal/backend/location/display_location_test.go
+++ b/internal/backend/location/display_location_test.go
@@ -1,0 +1,96 @@
+package location
+
+import "testing"
+
+var passwordTests = []struct {
+	input    string
+	expected string
+}{
+	{
+		"local:/srv/repo",
+		"local:/srv/repo",
+	},
+	{
+		"/dir1/dir2",
+		"/dir1/dir2",
+	},
+	{
+		`c:\dir1\foobar\dir2`,
+		`c:\dir1\foobar\dir2`,
+	},
+	{
+		"sftp:user@host:/srv/repo",
+		"sftp:user@host:/srv/repo",
+	},
+	{
+		"s3://eu-central-1/bucketname",
+		"s3://eu-central-1/bucketname",
+	},
+	{
+		"swift:container17:/prefix97",
+		"swift:container17:/prefix97",
+	},
+	{
+		"b2:bucketname:/prefix",
+		"b2:bucketname:/prefix",
+	},
+	{
+		"rest:",
+		"rest:/",
+	},
+	{
+		"rest:localhost/",
+		"rest:localhost/",
+	},
+	{
+		"rest::123/",
+		"rest::123/",
+	},
+	{
+		"rest:http://",
+		"rest:http://",
+	},
+	{
+		"rest:http://hostname.foo:1234/",
+		"rest:http://hostname.foo:1234/",
+	},
+	{
+		"rest:http://user@hostname.foo:1234/",
+		"rest:http://user@hostname.foo:1234/",
+	},
+	{
+		"rest:http://user:@hostname.foo:1234/",
+		"rest:http://user:***@hostname.foo:1234/",
+	},
+	{
+		"rest:http://user:p@hostname.foo:1234/",
+		"rest:http://user:***@hostname.foo:1234/",
+	},
+	{
+		"rest:http://user:pppppaaafhhfuuwiiehhthhghhdkjaoowpprooghjjjdhhwuuhgjsjhhfdjhruuhsjsdhhfhshhsppwufhhsjjsjs@hostname.foo:1234/",
+		"rest:http://user:***@hostname.foo:1234/",
+	},
+	{
+		"rest:http://user:password@hostname",
+		"rest:http://user:***@hostname/",
+	},
+	{
+		"rest:http://user:password@:123",
+		"rest:http://user:***@:123/",
+	},
+	{
+		"rest:http://user:password@",
+		"rest:http://user:***@/",
+	},
+}
+
+func TestStripPassword(t *testing.T) {
+	for i, test := range passwordTests {
+		t.Run(test.input, func(t *testing.T) {
+			result := StripPassword(test.input)
+			if result != test.expected {
+				t.Errorf("test %d: expected '%s' but got '%s'", i, test.expected, result)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

Bugfix: Don't echo authentication passwords

When using a password in the URL of a rest backend, in some cases
the password was displayed in the restic log:
- when creating a repository
- when restic failed to open the repository

The URL should now be displayed with "***" in place of the password.

Fixes issue https://github.com/restic/restic/issues/2241


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

closes #2241 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~I have added documentation for the changes (in the manual)~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review


Question before ticking the last box:
--------------

Do you know of any other place where the password could be displayed in the log? I cannot find any other place.
