### PR TITLE
stats: Fix crash in blobs-per-file mode on missing blob

### DIFF
--- a/changelog/unreleased/pull-2668
+++ b/changelog/unreleased/pull-2668
@@ -1,0 +1,6 @@
+Bugfix: Don't abort the stats command when data blobs are missing
+
+Runing the stats command in the blobs-per-file mode on a repository with
+missing data blobs previously resulted in a crash.
+
+https://github.com/restic/restic/pull/2668

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -194,7 +194,7 @@ func statsWalkSnapshot(ctx context.Context, snapshot *restic.Snapshot, repo rest
 }
 
 func statsWalkTree(repo restic.Repository, stats *statsContainer) walker.WalkFunc {
-	return func(_ restic.ID, npath string, node *restic.Node, nodeErr error) (bool, error) {
+	return func(parentTreeID restic.ID, npath string, node *restic.Node, nodeErr error) (bool, error) {
 		if nodeErr != nil {
 			return true, nodeErr
 		}
@@ -229,7 +229,7 @@ func statsWalkTree(repo restic.Repository, stats *statsContainer) walker.WalkFun
 							// is always a data blob since we're accessing it via a file's Content array
 							blobSize, found := repo.LookupBlobSize(blobID, restic.DataBlob)
 							if !found {
-								return true, fmt.Errorf("blob %s not found for tree %s", blobID, *node.Subtree)
+								return true, fmt.Errorf("blob %s not found for tree %s", blobID, parentTreeID)
 							}
 
 							// count the blob's size, then add this blob by this


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Restic crashes when running `restic stats --mode blobs-per-file` for a damaged repository with missing blobs.

The error message tried to dereference the subtreeID field of the current node, which is a file however. Said field is set to nil for a file thus causing a segfault when dereferenced.

Fix this by using the actual parentTreeID.

We could add a changelog entry but I doubt that it's worth it, as apparently no-one ever used that command on a repository with missing blobs before.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The crash was reported in https://forum.restic.net/t/fail-restic-stats-mode-raw-data/2601/14

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review