### PR TITLE
prune: Point bug report link to the bug issue template

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -210,7 +210,7 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 	if len(usedBlobs) > stats.blobs {
 		return errors.Fatalf("number of used blobs is larger than number of available blobs!\n" +
 			"Please report this error (along with the output of the 'prune' run) at\n" +
-			"https://github.com/restic/restic/issues/new")
+			"https://github.com/restic/restic/issues/new?template=Bug.md")
 	}
 
 	Verbosef("found %d of %d data blobs still in use, removing %d blobs\n",


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
When prune failed with the "dreaded" `number of used blobs is larger than number of available blobs` error it showed a link pointing to a blank issue. Direct the restic user to the bug template instead.

As an alternative it would also be possible to point users to the issue template chooser. However, that would mean one extra step to take in addition to filling out the issue template.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The change was suggested in https://github.com/restic/restic/issues/2663#issuecomment-604138591 .

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
