### PR TITLE
prune: Stricter error checks

### DIFF
--- a/changelog/unreleased/pull-2674
+++ b/changelog/unreleased/pull-2674
@@ -1,0 +1,8 @@
+Bugfix: Add stricter prune error checks
+
+Additional checks were added to the prune command in order to improve
+resiliency to backend, hardware and/or networking issues. The checks now
+detect a few more cases where such outside factors could potentially cause
+data loss.
+
+https://github.com/restic/restic/pull/2674

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -191,12 +191,17 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 		return err
 	}
 
+	var missingBlobs []restic.BlobHandle
 	for h := range usedBlobs {
 		if _, ok := blobCount[h]; !ok {
-			return errors.Fatalf("At least one data blob seems to be missing, aborting prune to prevent further data loss!\n" +
-				"Please report this error (along with the output of the 'prune' run) at\n" +
-				"https://github.com/restic/restic/issues/new")
+			missingBlobs = append(missingBlobs, h)
 		}
+	}
+	if len(missingBlobs) > 0 {
+		return errors.Fatalf("%v not found in the new index\n"+
+			"Data blobs seem to be missing, aborting prune to prevent further data loss!\n"+
+			"Please report this error (along with the output of the 'prune' run) at\n"+
+			"https://github.com/restic/restic/issues/new/choose", missingBlobs)
 	}
 
 	Verbosef("found %d of %d data blobs still in use, removing %d blobs\n",

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -191,10 +191,12 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 		return err
 	}
 
-	if len(usedBlobs) > stats.blobs {
-		return errors.Fatalf("number of used blobs is larger than number of available blobs!\n" +
-			"Please report this error (along with the output of the 'prune' run) at\n" +
-			"https://github.com/restic/restic/issues/new")
+	for h := range usedBlobs {
+		if _, ok := blobCount[h]; !ok {
+			return errors.Fatalf("At least one data blob seems to be missing, aborting prune to prevent further data loss!\n" +
+				"Please report this error (along with the output of the 'prune' run) at\n" +
+				"https://github.com/restic/restic/issues/new")
+		}
 	}
 
 	Verbosef("found %d of %d data blobs still in use, removing %d blobs\n",

--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -92,7 +92,10 @@ func rebuildIndex(ctx context.Context, repo restic.Repository, ignorePacks resti
 	Verbosef("saved new indexes as %v\n", ids)
 
 	Verbosef("remove %d old index files\n", len(supersedes))
-	DeleteFiles(globalOptions, repo, restic.NewIDSet(supersedes...), restic.IndexFile)
+	err = DeleteFilesChecked(globalOptions, repo, restic.NewIDSet(supersedes...), restic.IndexFile)
+	if err != nil {
+		return errors.Fatalf("unable to remove an old index: %v\n", err)
+	}
 
 	return nil
 }

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -1277,7 +1277,7 @@ func TestPruneWithDamagedRepository(t *testing.T) {
 	if err == nil {
 		t.Fatalf("expected prune to fail")
 	}
-	if !strings.Contains(err.Error(), "blob seems to be missing") {
+	if !strings.Contains(err.Error(), "blobs seem to be missing") {
 		t.Fatalf("did not find hint for missing blobs")
 	}
 	t.Log(err)

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -57,8 +57,7 @@ func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, kee
 
 			debug.Log("  process blob %v", h)
 
-			buf = buf[:]
-			if uint(len(buf)) < entry.Length {
+			if uint(cap(buf)) < entry.Length {
 				buf = make([]byte, entry.Length)
 			}
 			buf = buf[:entry.Length]

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -2,8 +2,6 @@ package repository
 
 import (
 	"context"
-	"fmt"
-	"os"
 
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
@@ -85,7 +83,7 @@ func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, kee
 			if !id.Equal(entry.ID) {
 				debug.Log("read blob %v/%v from %v: wrong data returned, hash is %v",
 					h.Type, h.ID, tempfile.Name(), id)
-				fmt.Fprintf(os.Stderr, "read blob %v from %v: wrong data returned, hash is %v",
+				return nil, errors.Errorf("read blob %v from %v: wrong data returned, hash is %v",
 					h, tempfile.Name(), id)
 			}
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
This PR tightens the sanity checks made by prune in the following three regards:

- Prune now exactly checks that every single used blob can be found and no longer just approximately checks this condition. This is mostly an overcautious cleanup, but might help to prevent data loss if the backend temporarily returns broken packs.
- Prune aborts repacking when it finds a different blob in a pack than expected. This usually indicates that the backup has been tampered with or hardware problems on the computer running restic.
- Prune and rebuild-index fail now if an old index file cannot be removed. For rebuild-index this is problematic as that command is usually used to repair a broken index and shouldn't leave possibly invalid index files. For prune this behavior could lead to data loss, as prune would continue and remove old packs which might still be referenced by one of the old index files that were not deleted. A later backup run would the not re-upload any blobs that are listed in these index, but which might actually be missing from the repository. This could result in a snapshot that's missing data.

Most of the code in this PR implements tests and adds support for the integration tests to wrap a repository to simplify testing repository damages.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
This PRs attempts to solve possible problems in the prune implementation in the hope of possibly fixing some of the reported repository damages. The changes themselves were not discussed before.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
