### PR TITLE
rebuild_index: Report invalid packs that were ignored

### DIFF
--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -62,9 +62,15 @@ func rebuildIndex(ctx context.Context, repo restic.Repository, ignorePacks resti
 	}
 
 	bar := newProgressMax(!globalOptions.Quiet, packs-uint64(len(ignorePacks)), "packs")
-	idx, _, err := index.New(ctx, repo, ignorePacks, bar)
+	idx, invalidFiles, err := index.New(ctx, repo, ignorePacks, bar)
 	if err != nil {
 		return err
+	}
+
+	if globalOptions.verbosity >= 2 {
+		for _, id := range invalidFiles {
+			Printf("skipped incomplete pack file: %v\n", id)
+		}
 	}
 
 	Verbosef("finding old index files\n")


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
rebuild-index should print whether it ignored invalid files when run in verbose mode. This is rather useful when handling damaged repositories.

I didn't add a changelog entry as this feels like a too minor addition that would only clutter the changelog.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~  No test as this in only a minor output change
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
