### PR TITLE
Add base URL option to Google Storage

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -474,6 +474,10 @@ The number of concurrent connections to the GCS service can be set with the
 ``-o gs.connections=10`` switch. By default, at most five parallel connections are
 established.
 
+The base URL to the GCS service can be set with the ``-o gs.baseurl=http://myhost/my/path/``
+switch. By default, the value is https://storage.googleapis.com/storage/v1/. This should not
+be confused with a full proxy like the ``HTTPS_PROXY`` environment variable.
+
 .. _service account: https://cloud.google.com/storage/docs/authentication#service_accounts
 .. _create a service account key: https://cloud.google.com/storage/docs/authentication#generating-a-private-key
 .. _default authentication material: https://developers.google.com/identity/protocols/application-default-credentials

--- a/internal/backend/gs/config.go
+++ b/internal/backend/gs/config.go
@@ -16,7 +16,8 @@ type Config struct {
 	Bucket    string
 	Prefix    string
 
-	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 20)"`
+	Connections uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 20)"`
+	BaseURL     string `option:"baseurl" help:"override the base URL"`
 }
 
 // NewConfig returns a new Config with the default values filled in.

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -73,6 +73,9 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 	if err != nil {
 		return nil, errors.Wrap(err, "getStorageService")
 	}
+	if cfg.BaseURL != "" {
+		service.BasePath = cfg.BaseURL
+	}
 
 	sem, err := backend.NewSemaphore(cfg.Connections)
 	if err != nil {


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Adds `-o gs.baseurl=http://somehost/some/path` option to GCS.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

fixes #2676

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR **(did not seem warranted for scope of change)**
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)) **(does not seem warranted for scope of change)**
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
