### PR TITLE
Reduce memory usage and startup time of debug command

### DIFF
--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -141,11 +141,6 @@ func runDebugDump(gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	err = repo.LoadIndex(gopts.ctx)
-	if err != nil {
-		return err
-	}
-
 	tpe := args[0]
 
 	switch tpe {

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -7,7 +7,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -90,7 +89,7 @@ func printPacks(repo *repository.Repository, wr io.Writer) error {
 
 		blobs, err := pack.List(repo.Key(), restic.ReaderAt(repo.Backend(), h), size)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error for pack %v: %v\n", id.Str(), err)
+			fmt.Fprintf(globalOptions.stderr, "error for pack %v: %v\n", id.Str(), err)
 			return nil
 		}
 
@@ -151,20 +150,20 @@ func runDebugDump(gopts GlobalOptions, args []string) error {
 
 	switch tpe {
 	case "indexes":
-		return dumpIndexes(repo, os.Stdout)
+		return dumpIndexes(repo, gopts.stdout)
 	case "snapshots":
-		return debugPrintSnapshots(repo, os.Stdout)
+		return debugPrintSnapshots(repo, gopts.stdout)
 	case "packs":
-		return printPacks(repo, os.Stdout)
+		return printPacks(repo, gopts.stdout)
 	case "all":
 		fmt.Printf("snapshots:\n")
-		err := debugPrintSnapshots(repo, os.Stdout)
+		err := debugPrintSnapshots(repo, gopts.stdout)
 		if err != nil {
 			return err
 		}
 
 		fmt.Printf("\nindexes:\n")
-		err = dumpIndexes(repo, os.Stdout)
+		err = dumpIndexes(repo, gopts.stdout)
 		if err != nil {
 			return err
 		}

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -107,13 +107,11 @@ func printPacks(repo *repository.Repository, wr io.Writer) error {
 			}
 		}
 
-		return prettyPrintJSON(os.Stdout, p)
+		return prettyPrintJSON(wr, p)
 	})
-
-	return nil
 }
 
-func dumpIndexes(repo restic.Repository) error {
+func dumpIndexes(repo restic.Repository, wr io.Writer) error {
 	return repo.List(context.TODO(), restic.IndexFile, func(id restic.ID, size int64) error {
 		fmt.Printf("index_id: %v\n", id)
 
@@ -122,7 +120,7 @@ func dumpIndexes(repo restic.Repository) error {
 			return err
 		}
 
-		return idx.Dump(os.Stdout)
+		return idx.Dump(wr)
 	})
 }
 
@@ -153,7 +151,7 @@ func runDebugDump(gopts GlobalOptions, args []string) error {
 
 	switch tpe {
 	case "indexes":
-		return dumpIndexes(repo)
+		return dumpIndexes(repo, os.Stdout)
 	case "snapshots":
 		return debugPrintSnapshots(repo, os.Stdout)
 	case "packs":
@@ -166,7 +164,7 @@ func runDebugDump(gopts GlobalOptions, args []string) error {
 		}
 
 		fmt.Printf("\nindexes:\n")
-		err = dumpIndexes(repo)
+		err = dumpIndexes(repo, os.Stdout)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
The `debug` command currently loads the repository index, but none of the commands use the index. This can cause long, unnecessary delays when working with large repositories.

In addition this PR, passes in `gopts.stdout` from the toplevel functions instead of directly accessing `os.Stdout`.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review