### PR TITLE
Cleanup command output code

### DIFF
--- a/cmd/restic/cleanup.go
+++ b/cmd/restic/cleanup.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 	"os/signal"
 	"sync"
@@ -16,8 +15,6 @@ var cleanupHandlers struct {
 	done bool
 	ch   chan os.Signal
 }
-
-var stderr = os.Stderr
 
 func init() {
 	cleanupHandlers.ch = make(chan os.Signal, 1)
@@ -51,7 +48,7 @@ func RunCleanupHandlers() {
 	for _, f := range cleanupHandlers.list {
 		err := f()
 		if err != nil {
-			fmt.Fprintf(stderr, "error in cleanup handler: %v\n", err)
+			Warnf("error in cleanup handler: %v\n", err)
 		}
 	}
 	cleanupHandlers.list = nil
@@ -61,7 +58,7 @@ func RunCleanupHandlers() {
 func CleanupHandler(c <-chan os.Signal) {
 	for s := range c {
 		debug.Log("signal %v received, cleaning up", s)
-		fmt.Fprintf(stderr, "%ssignal %v received, cleaning up\n", ClearLine(), s)
+		Warnf("%ssignal %v received, cleaning up\n", ClearLine(), s)
 
 		code := 0
 

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -76,7 +75,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 			return err
 		}
 
-		fmt.Println(string(buf))
+		Println(string(buf))
 		return nil
 	case "index":
 		buf, err := repo.LoadAndDecrypt(gopts.ctx, nil, restic.IndexFile, id)
@@ -99,8 +98,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 			return err
 		}
 
-		fmt.Println(string(buf))
-
+		Println(string(buf))
 		return nil
 	case "key":
 		h := restic.Handle{Type: restic.KeyFile, Name: id.String()}
@@ -120,7 +118,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 			return err
 		}
 
-		fmt.Println(string(buf))
+		Println(string(buf))
 		return nil
 	case "masterkey":
 		buf, err := json.MarshalIndent(repo.Key(), "", "  ")
@@ -128,7 +126,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 			return err
 		}
 
-		fmt.Println(string(buf))
+		Println(string(buf))
 		return nil
 	case "lock":
 		lock, err := restic.LoadLock(gopts.ctx, repo, id)
@@ -141,8 +139,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 			return err
 		}
 
-		fmt.Println(string(buf))
-
+		Println(string(buf))
 		return nil
 	}
 
@@ -162,7 +159,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 
 		hash := restic.Hash(buf)
 		if !hash.Equal(id) {
-			fmt.Fprintf(stderr, "Warning: hash of data does not match ID, want\n  %v\ngot:\n  %v\n", id.String(), hash.String())
+			Warnf("Warning: hash of data does not match ID, want\n  %v\ngot:\n  %v\n", id.String(), hash.String())
 		}
 
 		_, err = os.Stdout.Write(buf)

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"encoding/json"
-	"os"
 
 	"github.com/spf13/cobra"
 
@@ -83,9 +82,8 @@ func runCat(gopts GlobalOptions, args []string) error {
 			return err
 		}
 
-		_, err = os.Stdout.Write(append(buf, '\n'))
-		return err
-
+		Println(string(buf))
+		return nil
 	case "snapshot":
 		sn := &restic.Snapshot{}
 		err = repo.LoadJSONUnpacked(gopts.ctx, restic.SnapshotFile, id, sn)
@@ -162,7 +160,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 			Warnf("Warning: hash of data does not match ID, want\n  %v\ngot:\n  %v\n", id.String(), hash.String())
 		}
 
-		_, err = os.Stdout.Write(buf)
+		_, err = globalOptions.stdout.Write(buf)
 		return err
 
 	case "blob":
@@ -177,7 +175,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 				return err
 			}
 
-			_, err = os.Stdout.Write(buf)
+			_, err = globalOptions.stdout.Write(buf)
 			return err
 		}
 

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -3,7 +3,6 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
-	"os"
 	"strconv"
 	"strings"
 	"time"
@@ -235,7 +234,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 			continue
 		}
 		errorsFound = true
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		Warnf("%v\n", err)
 	}
 
 	if orphanedPacks > 0 {
@@ -249,12 +248,12 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	for err := range errChan {
 		errorsFound = true
 		if e, ok := err.(checker.TreeError); ok {
-			fmt.Fprintf(os.Stderr, "error for tree %v:\n", e.ID.Str())
+			Warnf("error for tree %v:\n", e.ID.Str())
 			for _, treeErr := range e.Errors {
-				fmt.Fprintf(os.Stderr, "  %v\n", treeErr)
+				Warnf("  %v\n", treeErr)
 			}
 		} else {
-			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			Warnf("error: %v\n", err)
 		}
 	}
 
@@ -289,7 +288,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 
 		for err := range errChan {
 			errorsFound = true
-			fmt.Fprintf(os.Stderr, "%v\n", err)
+			Warnf("%v\n", err)
 		}
 	}
 

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -89,7 +89,7 @@ func printPacks(repo *repository.Repository, wr io.Writer) error {
 
 		blobs, err := pack.List(repo.Key(), restic.ReaderAt(repo.Backend(), h), size)
 		if err != nil {
-			fmt.Fprintf(globalOptions.stderr, "error for pack %v: %v\n", id.Str(), err)
+			Warnf("error for pack %v: %v\n", id.Str(), err)
 			return nil
 		}
 
@@ -112,7 +112,7 @@ func printPacks(repo *repository.Repository, wr io.Writer) error {
 
 func dumpIndexes(repo restic.Repository, wr io.Writer) error {
 	return repo.List(context.TODO(), restic.IndexFile, func(id restic.ID, size int64) error {
-		fmt.Printf("index_id: %v\n", id)
+		Printf("index_id: %v\n", id)
 
 		idx, err := repository.LoadIndex(context.TODO(), repo, id)
 		if err != nil {
@@ -151,13 +151,13 @@ func runDebugDump(gopts GlobalOptions, args []string) error {
 	case "packs":
 		return printPacks(repo, gopts.stdout)
 	case "all":
-		fmt.Printf("snapshots:\n")
+		Printf("snapshots:\n")
 		err := debugPrintSnapshots(repo, gopts.stdout)
 		if err != nil {
 			return err
 		}
 
-		fmt.Printf("\nindexes:\n")
+		Printf("\nindexes:\n")
 		err = dumpIndexes(repo, gopts.stdout)
 		if err != nil {
 			return err

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"fmt"
-
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/index"
 	"github.com/restic/restic/internal/restic"
@@ -69,7 +67,7 @@ func runList(cmd *cobra.Command, opts GlobalOptions, args []string) error {
 
 		for _, pack := range idx.Packs {
 			for _, entry := range pack.Entries {
-				fmt.Printf("%v %v\n", entry.Type, entry.ID)
+				Printf("%v %v\n", entry.Type, entry.ID)
 			}
 		}
 

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
 	"path/filepath"
 
 	"github.com/restic/restic/internal/errors"
@@ -149,7 +148,7 @@ func runStats(gopts GlobalOptions, args []string) error {
 	}
 
 	if gopts.JSON {
-		err = json.NewEncoder(os.Stdout).Encode(stats)
+		err = json.NewEncoder(globalOptions.stdout).Encode(stats)
 		if err != nil {
 			return fmt.Errorf("encoding output: %v", err)
 		}

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -2,8 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"os"
 	"sync"
 	"time"
 
@@ -79,7 +77,7 @@ func refreshLocks(wg *sync.WaitGroup, done <-chan struct{}) {
 			for _, lock := range globalLocks.locks {
 				err := lock.Refresh(context.TODO())
 				if err != nil {
-					fmt.Fprintf(os.Stderr, "unable to refresh lock: %v\n", err)
+					Warnf("unable to refresh lock: %v\n", err)
 				}
 			}
 			globalLocks.Unlock()


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Many commands directly print to `os.Stdout/Stderr` instead of using the wrappers defined in `cmd/restic/global.go`. This changes converts most uses of the former output stream to use the wrapper functions. This could be useful for test cases which can then capture more of the command outputs.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No. This is a follow-up to #2681.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~ I've tested most of the modified commands manually
- ~~[ ] I have added documentation for the changes (in the manual)~~ Not user visible
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~ Not user visible
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
