### PR TITLE
prune: Better handling of eventually consistent backend

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -276,18 +276,16 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 	Verbosef("will delete %d packs and rewrite %d packs, this frees %s\n",
 		len(removePacks), len(rewritePacks), formatBytes(uint64(removeBytes)))
 
-	var obsoletePacks restic.IDSet
 	if len(rewritePacks) != 0 {
+		var obsoletePacks restic.IDSet
 		bar = newProgressMax(!gopts.Quiet, uint64(len(rewritePacks)), "packs rewritten")
-		bar.Start()
 		obsoletePacks, err = repository.Repack(ctx, repo, rewritePacks, usedBlobs, bar)
 		if err != nil {
 			return err
 		}
-		bar.Done()
+		removePacks.Merge(obsoletePacks)
 	}
 
-	removePacks.Merge(obsoletePacks)
 
 	if err = rebuildIndex(ctx, repo, removePacks); err != nil {
 		return err

--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -46,10 +46,10 @@ func runRebuildIndex(gopts GlobalOptions) error {
 
 	ctx, cancel := context.WithCancel(gopts.ctx)
 	defer cancel()
-	return rebuildIndex(ctx, repo, restic.NewIDSet())
+	return rebuildIndex(ctx, repo)
 }
 
-func rebuildIndex(ctx context.Context, repo restic.Repository, ignorePacks restic.IDSet) error {
+func rebuildIndex(ctx context.Context, repo restic.Repository) error {
 	Verbosef("counting files in repo\n")
 
 	var packs uint64
@@ -61,8 +61,8 @@ func rebuildIndex(ctx context.Context, repo restic.Repository, ignorePacks resti
 		return err
 	}
 
-	bar := newProgressMax(!globalOptions.Quiet, packs-uint64(len(ignorePacks)), "packs")
-	idx, _, err := index.New(ctx, repo, ignorePacks, bar)
+	bar := newProgressMax(!globalOptions.Quiet, packs, "packs")
+	idx, _, err := index.New(ctx, repo, bar)
 	if err != nil {
 		return err
 	}

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -48,7 +48,7 @@ type Lister interface {
 
 // New creates a new index for repo from scratch. InvalidFiles contains all IDs
 // of files  that cannot be listed successfully.
-func New(ctx context.Context, repo Lister, ignorePacks restic.IDSet, p *restic.Progress) (idx *Index, invalidFiles restic.IDs, err error) {
+func New(ctx context.Context, repo Lister, p *restic.Progress) (idx *Index, invalidFiles restic.IDs, err error) {
 	p.Start()
 	defer p.Done()
 
@@ -72,10 +72,6 @@ func New(ctx context.Context, repo Lister, ignorePacks restic.IDSet, p *restic.P
 	wg.Go(func() error {
 		defer close(inputCh)
 		return repo.List(ctx, restic.DataFile, func(id restic.ID, size int64) error {
-			if ignorePacks.Has(id) {
-				return nil
-			}
-
 			job := Job{
 				PackID: id,
 				Size:   size,

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -50,7 +50,7 @@ func TestIndexNew(t *testing.T) {
 	repo, cleanup := createFilledRepo(t, 3, 0)
 	defer cleanup()
 
-	idx, invalid, err := New(context.TODO(), repo, restic.NewIDSet(), nil)
+	idx, invalid, err := New(context.TODO(), repo, nil)
 	if err != nil {
 		t.Fatalf("New() returned error %v", err)
 	}
@@ -116,7 +116,7 @@ func TestIndexNewListErrors(t *testing.T) {
 			Repository:   repo,
 			MaxListFiles: max,
 		}
-		idx, invalid, err := New(context.TODO(), errRepo, restic.NewIDSet(), nil)
+		idx, invalid, err := New(context.TODO(), errRepo, nil)
 		if err == nil {
 			t.Errorf("expected error not found, got nil")
 		}
@@ -140,7 +140,7 @@ func TestIndexNewPackErrors(t *testing.T) {
 			Repository: repo,
 			MaxPacks:   max,
 		}
-		idx, invalid, err := New(context.TODO(), errRepo, restic.NewIDSet(), nil)
+		idx, invalid, err := New(context.TODO(), errRepo, nil)
 		if err == nil {
 			t.Errorf("expected error not found, got nil")
 		}
@@ -170,7 +170,7 @@ func TestIndexLoad(t *testing.T) {
 
 	validateIndex(t, repo, loadIdx)
 
-	newIdx, _, err := New(context.TODO(), repo, restic.NewIDSet(), nil)
+	newIdx, _, err := New(context.TODO(), repo, nil)
 	if err != nil {
 		t.Fatalf("New() returned error %v", err)
 	}
@@ -234,7 +234,7 @@ func BenchmarkIndexNew(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		idx, _, err := New(context.TODO(), repo, restic.NewIDSet(), nil)
+		idx, _, err := New(context.TODO(), repo, nil)
 
 		if err != nil {
 			b.Fatalf("New() returned error %v", err)
@@ -251,7 +251,7 @@ func BenchmarkIndexSave(b *testing.B) {
 	repo, cleanup := repository.TestRepository(b)
 	defer cleanup()
 
-	idx, _, err := New(context.TODO(), repo, restic.NewIDSet(), nil)
+	idx, _, err := New(context.TODO(), repo, nil)
 	test.OK(b, err)
 
 	for i := 0; i < 8000; i++ {
@@ -284,7 +284,7 @@ func TestIndexDuplicateBlobs(t *testing.T) {
 	repo, cleanup := createFilledRepo(t, 3, 0.05)
 	defer cleanup()
 
-	idx, _, err := New(context.TODO(), repo, restic.NewIDSet(), nil)
+	idx, _, err := New(context.TODO(), repo, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -18,6 +18,8 @@ import (
 // be removed.
 func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, keepBlobs restic.BlobSet, p *restic.Progress) (obsoletePacks restic.IDSet, err error) {
 	debug.Log("repacking %d packs while keeping %d blobs", len(packs), len(keepBlobs))
+	p.Start()
+	defer p.Done()
 
 	for packID := range packs {
 		// load the complete pack into a temp file

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+type packListener func(id restic.ID, size uint)
+
 // Repository is used to access a repository in a backend.
 type Repository struct {
 	be      restic.Backend
@@ -29,8 +31,9 @@ type Repository struct {
 	idx     *MasterIndex
 	restic.Cache
 
-	treePM *packerManager
-	dataPM *packerManager
+	treePM   *packerManager
+	dataPM   *packerManager
+	packHook packListener
 }
 
 // New returns a new repository with backend be.


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
The prune command rebuilds the repository index immediately after repacking unused packs. Rebuilding the index currently requires listing all packs in the repository. For an eventually consistent backend this can be a problem, as files may show up with some delay.

This PR lets the prune command itself keep track of all packs that should be contained in the rebuilt index. This side-steps the problems associated with listing the pack files.

Remaining design issues:
- The `selectedPacksRepo`, which wraps a normal repository object but just returns the packs to be included in the new index, feels a bit like a hack. I've also made an attempt to explicitly pass in the list of packs to include in the index, however that resulted in special cases all the way between `runPrune` and `index/index.New`.
- Tracking newly created packs involves a `packHook` which directly reaches into the `packer_manager.savePacker`. While this works it seems rather hacky, to directly reach into the repository object like that.
- The datatype `map[restic.ID]int64` used to map packs to their size, could probably use a proper type definition.

#2674 is a prerequisite to use this PR safely.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No, but there have been some reports in the forum e.g. in https://forum.restic.net/t/fail-restic-stats-mode-raw-data/2601/16 .

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review