### PR TITLE
cmd/restic: Fix Dropped Error

### DIFF
--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -233,7 +233,7 @@ func tarTree(ctx context.Context, repo restic.Repository, rootNode *restic.Node,
 
 		if node.Type == "file" || node.Type == "symlink" || node.Type == "dir" {
 			err := tarNode(ctx, tw, node, repo)
-			if err != err {
+			if err != nil {
 				return false, err
 			}
 		}


### PR DESCRIPTION
This bug reads as if `err` was supposed to be compared to `nil`, instead of itself.