### PR TITLE
Fix shutdown hang when restic is started as background job

### DIFF
--- a/changelog/unreleased/issue-2298
+++ b/changelog/unreleased/issue-2298
@@ -1,0 +1,8 @@
+Bugfix: Do not hang when run as a background job
+
+Restic did hang on exit while restoring the terminal configuration when it was
+started as a background job, for example using `restic ... &`. This has been
+fixed by only restoring the terminal configuration when restic is interrupted
+while reading a password from the terminal.
+
+https://github.com/restic/restic/issues/2298


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
restic uses a cleanup hook to ensure that it restores the terminal configuration to a sane state, when restic is interrupted while reading a password from the terminal. However, this causes a problem, when restic runs in a background job, as reconfiguring a terminal will cause a `SIGTTOU` to be sent to restic pausing it. Therefore, restic seems to hang on shutdown when it was running in the background.

This commit changes the behavior to only restore the terminal configuration if restic was interrupted while reading a password from the terminal. As reading a password from the terminal requires that restic is in the foreground, this should avoid restic getting stopped.

See #2298 for further details on the problem. The background hang could also be addressed by another solution: `readPasswordTerminal` could temporarily register a cleanup hook and remove it afterwards. That would yield a slightly cleaner implementation, but would require much more extensive changes.

This change will result in a merge conflict with #2593, however, merging shouldn't be too complex as that PR just moves the code lines around which are modified by this PR.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The solution implemented by the PR was not discussed yet.

Closes #2298
Issue introduced in #402

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~ I've no clue how a proper test for that would look like.
- ~~[ ] I have added documentation for the changes (in the manual)~~ No new feature.
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
