### PR TITLE
Prevent double index lookup in restic cat

### DIFF
--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -170,13 +170,13 @@ func runCat(gopts GlobalOptions, args []string) error {
 
 	case "blob":
 		for _, t := range []restic.BlobType{restic.DataBlob, restic.TreeBlob} {
-			_, found := repo.Index().Lookup(id, t)
-			if !found {
-				continue
-			}
-
 			buf, err := repo.LoadBlob(gopts.ctx, t, id, nil)
-			if err != nil {
+
+			switch err.(type) {
+			case nil:
+			case *repository.BlobNotFoundError:
+				continue
+			default:
 				return err
 			}
 

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -178,6 +178,22 @@ func TestLoadBlob(t *testing.T) {
 	}
 }
 
+func TestLoadBlobNotFound(t *testing.T) {
+	repo, cleanup := repository.TestRepository(t)
+	defer cleanup()
+
+	for _, typ := range []restic.BlobType{restic.DataBlob, restic.TreeBlob} {
+		_, err := repo.LoadBlob(context.TODO(), typ, restic.ID{}, nil)
+		switch e := err.(type) {
+		case *repository.BlobNotFoundError:
+			rtest.Equals(t, restic.ID{}, e.ID)
+			rtest.Equals(t, typ, e.Type)
+		default:
+			t.Errorf("wrong error type %T for missing blob", err)
+		}
+	}
+}
+
 func BenchmarkLoadBlob(b *testing.B) {
 	repo, cleanup := repository.TestRepository(b)
 	defer cleanup()


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

restic cat has to do two Lookups to find a blob. This PR introduces an error type for LoadBlob to signal that a blob is not found in the index, so that cat can check for this.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

In a comment on #2640.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
