### PR TITLE
Move Index.FindBlob to tests

### DIFF
--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -312,36 +312,6 @@ func (idx *Index) PacksForBlobs(blobs restic.BlobSet) (packs restic.IDSet) {
 	return packs
 }
 
-// Location describes the location of a blob in a pack.
-type Location struct {
-	PackID restic.ID
-	restic.Blob
-}
-
-// ErrBlobNotFound is return by FindBlob when the blob could not be found in
-// the index.
-var ErrBlobNotFound = errors.New("blob not found in index")
-
-// FindBlob returns a list of packs and positions the blob can be found in.
-func (idx *Index) FindBlob(h restic.BlobHandle) (result []Location, err error) {
-	for id, p := range idx.Packs {
-		for _, entry := range p.Entries {
-			if entry.ID.Equal(h.ID) && entry.Type == h.Type {
-				result = append(result, Location{
-					PackID: id,
-					Blob:   entry,
-				})
-			}
-		}
-	}
-
-	if len(result) == 0 {
-		return nil, ErrBlobNotFound
-	}
-
-	return result, nil
-}
-
 const maxEntries = 3000
 
 // Saver saves structures as JSON.


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

internal/index exported a method Index.FindBlob, an associated type and an associated error. All of these were only used in the package's tests, so I moved them there.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No, but #2701 introduces a BlobNotFoundError type that is easily confused with the error in internal/index.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
