### PR TITLE
Revert "Darwin test fix: allow 1μs timestamp difference"

### DIFF
--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -72,17 +72,7 @@ func sameModTime(fi1, fi2 os.FileInfo) bool {
 		}
 	}
 
-	same := fi1.ModTime().Equal(fi2.ModTime())
-	if !same && (runtime.GOOS == "darwin" || runtime.GOOS == "openbsd") {
-		// Allow up to 1μs difference, because macOS <10.13 cannot restore
-		// with nanosecond precision and the current version of Go (1.9.2)
-		// does not yet support the new syscall. (#1087)
-		mt1 := fi1.ModTime()
-		mt2 := fi2.ModTime()
-		usecDiff := (mt1.Nanosecond()-mt2.Nanosecond())/1000 + (mt1.Second()-mt2.Second())*1000000
-		same = usecDiff <= 1 && usecDiff >= -1
-	}
-	return same
+	return fi1.ModTime().Equal(fi2.ModTime())
 }
 
 // directoriesEqualContents checks if both directories contain exactly the same


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
This PR reverts the workaround for reading node timestamps with nanoseconds precision, but go only being able to restore microseconds on macOS and OpenBSD. 
The go changes to fix #1087 and #1307 are included in Go 1.10. Restic by now requires at least Go 1.11 and therefore the workaround is no longer necessary.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #1087 .

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
