### PR TITLE
backup: Avoid race between password prompt and open repository message

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -415,7 +415,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	var t tomb.Tomb
 
 	if gopts.verbosity >= 2 && !gopts.JSON {
-		term.Print("open repository\n")
+		Verbosef("open repository\n")
 	}
 
 	repo, err := OpenRepository(gopts)


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
`term.Print` sends the output via a channel to a goroutine which actually prints the message. This may race with the password prompt printed by `OpenRepository` resulting in a missing prompt.

This PR prints the initial "open repository" message now directly using `Verbosef`. 

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #2225

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review