### PR TITLE
Change condition for full index

### DIFF
--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -59,10 +59,8 @@ func (idx *Index) Final() bool {
 }
 
 const (
-	indexMinBlobs = 20
-	indexMaxBlobs = 2000
-	indexMinAge   = 2 * time.Minute
-	indexMaxAge   = 15 * time.Minute
+	indexMaxBlobs = 50000
+	indexMaxAge   = 10 * time.Minute
 )
 
 // IndexFull returns true iff the index is "full enough" to be saved as a preliminary index.
@@ -72,26 +70,21 @@ var IndexFull = func(idx *Index) bool {
 
 	debug.Log("checking whether index %p is full", idx)
 
-	packs := len(idx.pack)
+	blobs := len(idx.pack)
 	age := time.Now().Sub(idx.created)
 
-	if age > indexMaxAge {
+	switch {
+	case age >= indexMaxAge:
 		debug.Log("index %p is old enough", idx, age)
 		return true
-	}
-
-	if packs < indexMinBlobs || age < indexMinAge {
-		debug.Log("index %p only has %d packs or is too young (%v)", idx, packs, age)
-		return false
-	}
-
-	if packs > indexMaxBlobs {
-		debug.Log("index %p has %d packs", idx, packs)
+	case blobs >= indexMaxBlobs:
+		debug.Log("index %p has %d blobs", idx, blobs)
 		return true
 	}
 
-	debug.Log("index %p is not full", idx)
+	debug.Log("index %p only has %d blobs and is too young (%v)", idx, blobs, age)
 	return false
+
 }
 
 // Store remembers the id and pack in the index. An existing entry will be


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Index files are saved when they are "full". This is determined by the number of blobs within and the age of the index. The current coding translates to the following decision table:

|   | age < MinAge | age in [MinAge, MaxAge] | age > MaxAge |
| --- | --- | --- | --- |
| **#blobs < MinBlobs** | not full | not full | full |
| **#blobs in [MinBlobs, MaxBlobs]** | not full | not full | full |
| **#blobs > MaxBlobs** | not full | full | full |

This is a bit counter-intuitive and has the following shortcomings:

- MinBlobs is specified, but effectively not used as it does not change the behavior
- an index is never full if it has not reached the age MinAge - despite it can can possible contain millions of index entries.

This PR changes the decision table to:

**EDIT: condition has been even more simplified, see below in the comments**

|   | age < MinAge | age in [MinAge, MaxAge] | age > MaxAge |
| --- | --- | --- | --- |
| **#blobs < MinBlobs** | not full | not full | full |
| **#blobs in [MinBlobs, MaxBlobs]** | not full | full | full |
| **#blobs > MaxBlobs** | full | full | full |

Moreover it changes the value of MinBlobs to 50 and MaxBlobs to 50.000 (was 2.000)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No, but the discussion came up in #2718. 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have **not** added tests for all changes in this PR - no extra tests needed.
- [x] I have **not** added documentation for the changes (in the manual) - no extra docu needed.
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)) - do we really need one for this minor change?
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
