### PR TITLE
Remove Solaris build workaround in integration tests

### DIFF
--- a/run_integration_tests.go
+++ b/run_integration_tests.go
@@ -230,13 +230,7 @@ func (env *TravisEnvironment) Prepare() error {
 				"openbsd/386", "openbsd/amd64",
 				"netbsd/386", "netbsd/amd64",
 				"linux/arm", "freebsd/arm",
-				"linux/ppc64le",
-			}
-
-			if os.Getenv("RESTIC_BUILD_SOLARIS") == "0" {
-				msg("Skipping Solaris build\n")
-			} else {
-				env.goxOSArch = append(env.goxOSArch, "solaris/amd64")
+				"linux/ppc64le", "solaris/amd64",
 			}
 		} else {
 			env.goxOSArch = []string{runtime.GOOS + "/" + runtime.GOARCH}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This removes a workaround for Solaris builds introduced in #1821 because of issues with Go 1.9, but that compiler version is no longer supported.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Go 1.9 compatibility was removed in #2600 with some additional cleanup in later PRs.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
