### PR TITLE
Fix backend benchmarks + a micro-optimization

### DIFF
--- a/internal/backend/test/benchmarks.go
+++ b/internal/backend/test/benchmarks.go
@@ -48,17 +48,17 @@ func (s *Suite) BenchmarkLoadFile(t *testing.B) {
 			n, ierr = io.ReadFull(rd, buf)
 			return ierr
 		})
-		if err != nil {
+
+		t.StopTimer()
+		switch {
+		case err != nil:
 			t.Fatal(err)
-		}
-
-		if n != length {
+		case n != length:
 			t.Fatalf("wrong number of bytes read: want %v, got %v", length, n)
-		}
-
-		if !bytes.Equal(data, buf) {
+		case !bytes.Equal(data, buf):
 			t.Fatalf("wrong bytes returned")
 		}
+		t.StartTimer()
 	}
 }
 
@@ -85,18 +85,17 @@ func (s *Suite) BenchmarkLoadPartialFile(t *testing.B) {
 			n, ierr = io.ReadFull(rd, buf)
 			return ierr
 		})
-		if err != nil {
+
+		t.StopTimer()
+		switch {
+		case err != nil:
 			t.Fatal(err)
-		}
-
-		if n != testLength {
+		case n != testLength:
 			t.Fatalf("wrong number of bytes read: want %v, got %v", testLength, n)
-		}
-
-		if !bytes.Equal(data[:testLength], buf) {
+		case !bytes.Equal(data[:testLength], buf):
 			t.Fatalf("wrong bytes returned")
 		}
-
+		t.StartTimer()
 	}
 }
 
@@ -124,17 +123,17 @@ func (s *Suite) BenchmarkLoadPartialFileOffset(t *testing.B) {
 			n, ierr = io.ReadFull(rd, buf)
 			return ierr
 		})
-		if err != nil {
+
+		t.StopTimer()
+		switch {
+		case err != nil:
 			t.Fatal(err)
-		}
-
-		if n != testLength {
+		case n != testLength:
 			t.Fatalf("wrong number of bytes read: want %v, got %v", testLength, n)
-		}
-
-		if !bytes.Equal(data[testOffset:testOffset+testLength], buf) {
+		case !bytes.Equal(data[testOffset:testOffset+testLength], buf):
 			t.Fatalf("wrong bytes returned")
 		}
+		t.StartTimer()
 
 	}
 }

--- a/internal/backend/utils.go
+++ b/internal/backend/utils.go
@@ -32,19 +32,14 @@ func LoadAll(ctx context.Context, buf []byte, be restic.Backend, h restic.Handle
 
 // LimitedReadCloser wraps io.LimitedReader and exposes the Close() method.
 type LimitedReadCloser struct {
-	io.ReadCloser
-	io.Reader
+	io.Closer
+	io.LimitedReader
 }
 
-// Read reads data from the limited reader.
-func (l *LimitedReadCloser) Read(p []byte) (int, error) {
-	return l.Reader.Read(p)
-}
-
-// LimitReadCloser returns a new reader wraps r in an io.LimitReader, but also
+// LimitReadCloser returns a new reader wraps r in an io.LimitedReader, but also
 // exposes the Close() method.
 func LimitReadCloser(r io.ReadCloser, n int64) *LimitedReadCloser {
-	return &LimitedReadCloser{ReadCloser: r, Reader: io.LimitReader(r, n)}
+	return &LimitedReadCloser{Closer: r, LimitedReader: io.LimitedReader{R: r, N: n}}
 }
 
 // DefaultLoad implements Backend.Load using lower-level openReader func


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

The backend benchmarks contain code that verifies whether the backends return the correct results. These are so expensive that, for the local backend, they take up as much as half the time. The first patch in this PR removes the checks, which results in (linux/amd64):

    name                                      old time/op    new time/op    delta
    Backend/BenchmarkLoadFile-8                 4.89ms ± 0%    2.72ms ± 1%   -44.26%  (p=0.008 n=5+5)
    Backend/BenchmarkLoadPartialFile-8           936µs ± 6%     439µs ±15%   -53.07%  (p=0.008 n=5+5)
    Backend/BenchmarkLoadPartialFileOffset-8     940µs ± 1%     456µs ±10%   -51.50%  (p=0.008 n=5+5)
    Backend/BenchmarkSave-8                     23.9ms ±14%    24.8ms ±41%      ~     (p=0.690 n=5+5)
    
    name                                      old speed      new speed      delta
    Backend/BenchmarkLoadFile-8               3.43GB/s ± 0%  6.16GB/s ± 1%   +79.40%  (p=0.008 n=5+5)
    Backend/BenchmarkLoadPartialFile-8        4.48GB/s ± 6%  9.63GB/s ±14%  +114.78%  (p=0.008 n=5+5)
    Backend/BenchmarkLoadPartialFileOffset-8  4.46GB/s ± 1%  9.22GB/s ±10%  +106.74%  (p=0.008 n=5+5)
    Backend/BenchmarkSave-8                    706MB/s ±13%   698MB/s ±31%      ~     (p=0.690 n=5+5)

The second patch flattens the backend.LimitedReadCloser structure, inlining an io.LimitedReader inside it instead of using an interface. This causes one fewer allocation per partial load:

    name                                      old time/op    new time/op    delta
    Backend/BenchmarkLoadPartialFile-8           412µs ± 4%     413µs ± 4%    ~     (p=0.634 n=17+17)
    Backend/BenchmarkLoadPartialFileOffset-8     455µs ±13%     441µs ±10%    ~     (p=0.072 n=20+18)
    
    name                                      old speed      new speed      delta
    Backend/BenchmarkLoadPartialFile-8        10.2GB/s ± 3%  10.2GB/s ± 4%    ~     (p=0.817 n=16+17)
    Backend/BenchmarkLoadPartialFileOffset-8  9.25GB/s ±12%  9.54GB/s ± 9%    ~     (p=0.072 n=20+18)
    
    name                                      old alloc/op   new alloc/op   delta
    Backend/BenchmarkLoadPartialFile-8            888B ± 0%      872B ± 0%  -1.80%  (p=0.000 n=15+15)
    Backend/BenchmarkLoadPartialFileOffset-8      888B ± 0%      872B ± 0%  -1.80%  (p=0.000 n=15+15)
    
    name                                      old allocs/op  new allocs/op  delta
    Backend/BenchmarkLoadPartialFile-8            18.0 ± 0%      17.0 ± 0%  -5.56%  (p=0.000 n=15+15)
    Backend/BenchmarkLoadPartialFileOffset-8      18.0 ± 0%      17.0 ± 0%  -5.56%  (p=0.000 n=15+15)


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review