### PR TITLE
Update documentation for environment variables

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -379,6 +379,7 @@ environment variables. The following list of environment variables:
     RESTIC_PASSWORD_FILE                Location of password file (replaces --password-file)
     RESTIC_PASSWORD                     The actual password for the repository
     RESTIC_PASSWORD_COMMAND             Command printing the password for the repository to stdout
+    RESTIC_CACHE_DIR                    Location of the cache directory
 
     AWS_ACCESS_KEY_ID                   Amazon S3 access key ID
     AWS_SECRET_ACCESS_KEY               Amazon S3 secret access key
@@ -417,4 +418,9 @@ environment variables. The following list of environment variables:
     RCLONE_BWLIMIT                      rclone bandwidth limit
 
 
+In addition to restic-specific environment variables, the following system-wide environment variables
+are taken into account for various operations:
 
+ * ``$XDG_CACHE_HOME/restic``, ``$HOME/.cache/restic``: :ref:`caching`.
+ * ``$TMPDIR``: :ref:`temporary_files`.
+ * ``$PATH/fusermount``: Binary for ``restic mount``.

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -361,6 +361,8 @@ lists all snapshots as JSON and uses ``jq`` to pretty-print the result:
       }
     ]
 
+.. _temporary_files:
+
 Temporary files
 ---------------
 
@@ -377,6 +379,8 @@ instead of the default, set the environment variable like this:
     $ restic -r /srv/restic-repo backup ~/work
 
 
+
+.. _caching:
 
 Caching
 -------


### PR DESCRIPTION
Changes proposed in #2763:

- Adding `RESTIC_CACHE_DIR` environment variables (introduced in #2425 for Unix and #2607 for Mac, Win).
- Adding used system-wide environment variables with links to the corresponding section.

What is the purpose of this change? What does it change?
--------------------------------------------------------
Documentation

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Closes #2763


Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
