### PR TITLE
Revive hint to the unlock command if a repository is locked

### DIFF
--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -36,7 +36,7 @@ func lockRepository(repo *repository.Repository, exclusive bool) (*restic.Lock, 
 
 	lock, err := lockFn(context.TODO(), repo)
 	if err != nil {
-		return nil, errors.Fatalf("unable to create lock in backend: %v", err)
+		return nil, errors.WithMessage(err, "unable to create lock in backend")
 	}
 	debug.Log("create lock %p (exclusive %v)", lock, exclusive)
 


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
The hint to the unlock command wasn't shown when a command failed due to a locked repository.

`errors.Fatalf` wraps a error and just keeps an error message as a string. This prevents the `restic.IsAlreadyLocked(err)` check from working as the error is no longer an ErrAlreadyLocked.

This PR uses `errors.WithMessage` instead which properly adds an additional remark to the error.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
closes #2751

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
