### PR TITLE
Loop over index files for 'list blobs'

### DIFF
--- a/changelog/unreleased/pull-2786
+++ b/changelog/unreleased/pull-2786
@@ -1,0 +1,6 @@
+Enhancement: Optimize `list blobs` command
+
+We've changed the implementation of `list blobs` which should be now a bit faster
+and consume almost no memory even for large repositories.
+
+https://github.com/restic/restic/pull/2786


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Do not use in-memory index for `restic list blobs`.
Instead loop over index files and process them, as discussed in #2523.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

see #2523

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-  I have not added tests for all changes in this PR
- I have not added documentation for the changes (in the manual)
- [x] There's no new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
