### PR TITLE
Reimplement LookupBlobSize without loop + allocation

### DIFF
--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -261,12 +261,13 @@ func (idx *Index) Has(id restic.ID, tpe restic.BlobType) bool {
 // LookupSize returns the length of the plaintext content of the blob with the
 // given id.
 func (idx *Index) LookupSize(id restic.ID, tpe restic.BlobType) (plaintextLength uint, found bool) {
-	blobs, found := idx.Lookup(id, tpe)
-	if !found {
-		return 0, found
-	}
+	h := restic.BlobHandle{ID: id, Type: tpe}
 
-	return uint(restic.PlaintextLength(int(blobs[0].Length))), true
+	idx.m.Lock()
+	entry, ok := idx.blob[h]
+	idx.m.Unlock()
+
+	return uint(restic.PlaintextLength(int(entry.length))), ok
 }
 
 // Supersedes returns the list of indexes this index supersedes, if any.

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -209,7 +209,7 @@ func (idx *Index) indexEntryToPackedBlob(h restic.BlobHandle, entry indexEntry) 
 	}
 }
 
-// Lookup queries the index for the blob ID and returns a restic.PackedBlob.
+// Lookup queries the index for the blob ID and returns all its pack locations.
 func (idx *Index) Lookup(id restic.ID, tpe restic.BlobType) (blobs []restic.PackedBlob, found bool) {
 	idx.m.Lock()
 	defer idx.m.Unlock()

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -260,7 +260,7 @@ func (idx *Index) Has(id restic.ID, tpe restic.BlobType) bool {
 
 // LookupSize returns the length of the plaintext content of the blob with the
 // given id.
-func (idx *Index) LookupSize(id restic.ID, tpe restic.BlobType) (plaintextLength uint, found bool) {
+func (idx *Index) lookupSize(id restic.ID, tpe restic.BlobType) (plaintextLength uint, found bool) {
 	h := restic.BlobHandle{ID: id, Type: tpe}
 
 	idx.m.Lock()

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -37,12 +37,12 @@ func (mi *MasterIndex) Lookup(id restic.ID, tpe restic.BlobType) (blobs []restic
 }
 
 // LookupSize queries all known Indexes for the ID and returns the first match.
-func (mi *MasterIndex) LookupSize(id restic.ID, tpe restic.BlobType) (uint, bool) {
+func (mi *MasterIndex) lookupSize(id restic.ID, tpe restic.BlobType) (uint, bool) {
 	mi.idxMutex.RLock()
 	defer mi.idxMutex.RUnlock()
 
 	for _, idx := range mi.idx {
-		if size, found := idx.LookupSize(id, tpe); found {
+		if size, found := idx.lookupSize(id, tpe); found {
 			return size, found
 		}
 	}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -222,7 +222,7 @@ func (r *Repository) LoadJSONUnpacked(ctx context.Context, t restic.FileType, id
 
 // LookupBlobSize returns the size of blob id.
 func (r *Repository) LookupBlobSize(id restic.ID, tpe restic.BlobType) (uint, bool) {
-	return r.idx.LookupSize(id, tpe)
+	return r.idx.lookupSize(id, tpe)
 }
 
 // SaveAndEncrypt encrypts data and stores it to the backend as type t. If data

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/errors"
 
 	"github.com/restic/restic/internal/debug"
@@ -313,8 +312,7 @@ func (res *Restorer) VerifyFiles(ctx context.Context, dst string) (int, error) {
 
 			offset := int64(0)
 			for _, blobID := range node.Content {
-				blobs, _ := res.repo.Index().Lookup(blobID, restic.DataBlob)
-				length := blobs[0].Length - uint(crypto.Extension)
+				length, _ := res.repo.LookupBlobSize(blobID, restic.DataBlob)
 				buf := make([]byte, length) // TODO do I want to reuse the buffer somehow?
 				_, err = file.ReadAt(buf, offset)
 				if err != nil {


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Repository.LookupBlobSize calls Index.LookupSize, which calls Index.Lookup. That method constructs a list of all known locations for blob in a newly allocated slice, using an implicit loop in the copy function. The slice is then ignored except for the first element.

This PR changes LookupSize to just do its own lookup and return the first hit. This should speed up restic mount. The restorer can now also use LookupBlobSize instead of its own reimplementation of the size lookup, decoupling it from crypto.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

This should fix any performance regression caused by #2787.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
