### PR TITLE
Clarify rclone-over-SSH docs

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -567,7 +567,17 @@ rclone e.g. via SSH on a server, for example:
 
 .. code-block:: console
 
-    $ restic -o rclone.program="ssh user@host rclone" -r rclone:b2:foo/bar
+    $ restic -o rclone.program="ssh user@remotehost rclone" -r rclone:b2:foo/bar
+
+With these options, restic works with local files. It uses rclone and
+credentials stored on ``remotehost`` to communicate with B2. All data (except
+credentials) is encrypted/decrypted locally, then sent/received via
+``remotehost`` to/from B2.
+
+A more advanced version of this setup forbids specific hosts from removing
+files in a repository. See the `blog post by Simon Ruderich
+<https://ruderich.org/simon/notes/append-only-backups-with-restic-and-rclone>`_
+for details.
 
 The rclone command may also be hard-coded in the SSH configuration or the
 user's public key, in this case it may be sufficient to just start the SSH


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

This clarifies the data flow when using a restic -> SSH -> rclone -> repo pipeline. It also adds a link to [this blog post](https://ruderich.org/simon/notes/append-only-backups-with-restic-and-rclone) that explains a more advanced version of it, forbidding (hijacked?) hosts from removing files in a repo.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes #2405. The blog post was brought to my attention by @julianbrost in #2770.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added documentation for the changes (in the manual)
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
