### PR TITLE
Add index options / make restic consume less memory for index

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -495,7 +495,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	if !gopts.JSON {
 		p.V("load index files")
 	}
-	err = repo.LoadIndex(gopts.ctx)
+	err = repo.LoadIndex(gopts.ctx, restic.IndexOptionDataIDsOnly)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -142,7 +142,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 	}
 
 	// load index, handle all the other types
-	err = repo.LoadIndex(gopts.ctx)
+	err = repo.LoadIndex(gopts.ctx, restic.IndexOptionFull)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -300,7 +300,7 @@ func runDiff(opts DiffOptions, gopts GlobalOptions, args []string) error {
 		return err
 	}
 
-	if err = repo.LoadIndex(ctx); err != nil {
+	if err = repo.LoadIndex(ctx, restic.IndexOptionFull); err != nil {
 		return err
 	}
 

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -133,7 +133,7 @@ func runDump(opts DumpOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	err = repo.LoadIndex(ctx)
+	err = repo.LoadIndex(ctx, restic.IndexOptionFull)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -536,7 +536,7 @@ func runFind(opts FindOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	if err = repo.LoadIndex(gopts.ctx); err != nil {
+	if err = repo.LoadIndex(gopts.ctx, restic.IndexOptionNoData); err != nil {
 		return err
 	}
 

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -143,7 +143,7 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 		return err
 	}
 
-	if err = repo.LoadIndex(gopts.ctx); err != nil {
+	if err = repo.LoadIndex(gopts.ctx, restic.IndexOptionNoData); err != nil {
 		return err
 	}
 

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -96,7 +96,7 @@ func mount(opts MountOptions, gopts GlobalOptions, mountpoint string) error {
 		return err
 	}
 
-	err = repo.LoadIndex(gopts.ctx)
+	err = repo.LoadIndex(gopts.ctx, restic.IndexOptionFull)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -115,7 +115,7 @@ func mixedBlobs(list []restic.Blob) bool {
 func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 	ctx := gopts.ctx
 
-	err := repo.LoadIndex(ctx)
+	err := repo.LoadIndex(ctx, restic.IndexOptionFull)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -50,7 +50,7 @@ func runRecover(gopts GlobalOptions) error {
 	}
 
 	Verbosef("load index files\n")
-	if err = repo.LoadIndex(gopts.ctx); err != nil {
+	if err = repo.LoadIndex(gopts.ctx, restic.IndexOptionNoData); err != nil {
 		return err
 	}
 
@@ -58,7 +58,11 @@ func runRecover(gopts GlobalOptions) error {
 	// tree. If it is not referenced, we have a root tree.
 	trees := make(map[restic.ID]bool)
 
-	for blob := range repo.Index().Each(gopts.ctx) {
+	blobs, err := repo.Index().Each(gopts.ctx)
+	if err != nil {
+		return err
+	}
+	for blob := range blobs {
 		if blob.Blob.Type != restic.TreeBlob {
 			continue
 		}

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -109,7 +109,7 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	err = repo.LoadIndex(ctx)
+	err = repo.LoadIndex(ctx, restic.IndexOptionFull)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -71,7 +71,7 @@ func runStats(gopts GlobalOptions, args []string) error {
 		return err
 	}
 
-	if err = repo.LoadIndex(ctx); err != nil {
+	if err = repo.LoadIndex(ctx, restic.IndexOptionNoData); err != nil {
 		return err
 	}
 

--- a/internal/archiver/blob_saver_test.go
+++ b/internal/archiver/blob_saver_test.go
@@ -40,7 +40,7 @@ func TestBlobSaver(t *testing.T) {
 
 	tmb, ctx := tomb.WithContext(ctx)
 	saver := &saveFail{
-		idx: repository.NewIndex(),
+		idx: repository.NewIndex(restic.IndexOptionDataIDsOnly),
 	}
 
 	b := NewBlobSaver(ctx, tmb, saver, uint(runtime.NumCPU()))
@@ -86,7 +86,7 @@ func TestBlobSaverError(t *testing.T) {
 
 			tmb, ctx := tomb.WithContext(ctx)
 			saver := &saveFail{
-				idx:    repository.NewIndex(),
+				idx:    repository.NewIndex(restic.IndexOptionDataIDsOnly),
 				failAt: int32(test.failAt),
 			}
 

--- a/internal/fuse/blob_size_cache.go
+++ b/internal/fuse/blob_size_cache.go
@@ -15,7 +15,8 @@ type BlobSizeCache struct {
 // NewBlobSizeCache returns a new blob size cache containing all entries from midx.
 func NewBlobSizeCache(ctx context.Context, idx restic.Index) *BlobSizeCache {
 	m := make(map[restic.ID]uint, 1000)
-	for pb := range idx.Each(ctx) {
+	blobs, _ := idx.Each(ctx)
+	for pb := range blobs {
 		m[pb.ID] = uint(restic.PlaintextLength(int(pb.Length)))
 	}
 	return &BlobSizeCache{

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -230,7 +230,7 @@ func updateSnapshots(ctx context.Context, root *Root) error {
 
 	if root.snCount != len(snapshots) {
 		root.snCount = len(snapshots)
-		root.repo.LoadIndex(ctx)
+		root.repo.LoadIndex(ctx, restic.IndexOptionFull)
 		root.snapshots = snapshots
 	}
 	root.lastCheck = time.Now()

--- a/internal/repository/index_test.go
+++ b/internal/repository/index_test.go
@@ -10,6 +10,12 @@ import (
 	rtest "github.com/restic/restic/internal/test"
 )
 
+func DecodeIndex(buf []byte) (*repository.Index, error) {
+	idx := repository.NewIndex(restic.IndexOptionFull)
+	err := repository.DecodeIndex(idx, buf)
+	return idx, err
+}
+
 func TestIndexSerialize(t *testing.T) {
 	type testEntry struct {
 		id             restic.ID
@@ -19,7 +25,7 @@ func TestIndexSerialize(t *testing.T) {
 	}
 	tests := []testEntry{}
 
-	idx := repository.NewIndex()
+	idx := repository.NewIndex(restic.IndexOptionFull)
 
 	// create 50 packs with 20 blobs each
 	for i := 0; i < 50; i++ {
@@ -55,7 +61,7 @@ func TestIndexSerialize(t *testing.T) {
 	err := idx.Encode(wr)
 	rtest.OK(t, err)
 
-	idx2, err := repository.DecodeIndex(wr.Bytes())
+	idx2, err := DecodeIndex(wr.Bytes())
 	rtest.OK(t, err)
 	rtest.Assert(t, idx2 != nil,
 		"nil returned for decoded index")
@@ -139,7 +145,7 @@ func TestIndexSerialize(t *testing.T) {
 	rtest.Assert(t, id2.Equal(id),
 		"wrong ID returned: want %v, got %v", id, id2)
 
-	idx3, err := repository.DecodeIndex(wr3.Bytes())
+	idx3, err := DecodeIndex(wr3.Bytes())
 	rtest.OK(t, err)
 	rtest.Assert(t, idx3 != nil,
 		"nil returned for decoded index")
@@ -165,7 +171,7 @@ func TestIndexSerialize(t *testing.T) {
 }
 
 func TestIndexSize(t *testing.T) {
-	idx := repository.NewIndex()
+	idx := repository.NewIndex(restic.IndexOptionFull)
 
 	packs := 200
 	blobs := 100
@@ -291,7 +297,7 @@ var exampleLookupTest = struct {
 func TestIndexUnserialize(t *testing.T) {
 	oldIdx := restic.IDs{restic.TestParseID("ed54ae36197f4745ebc4b54d10e0f623eaaaedd03013eb7ae90df881b7781452")}
 
-	idx, err := repository.DecodeIndex(docExample)
+	idx, err := DecodeIndex(docExample)
 	rtest.OK(t, err)
 
 	for _, test := range exampleTests {
@@ -333,13 +339,14 @@ func BenchmarkDecodeIndex(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		_, err := repository.DecodeIndex(docExample)
+		_, err := DecodeIndex(docExample)
 		rtest.OK(b, err)
 	}
 }
 
 func TestIndexUnserializeOld(t *testing.T) {
-	idx, err := repository.DecodeOldIndex(docOldExample)
+	idx := repository.NewIndex(restic.IndexOptionFull)
+	err := repository.DecodeOldIndex(idx, docOldExample)
 	rtest.OK(t, err)
 
 	for _, test := range exampleTests {
@@ -361,7 +368,7 @@ func TestIndexUnserializeOld(t *testing.T) {
 }
 
 func TestIndexPacks(t *testing.T) {
-	idx := repository.NewIndex()
+	idx := repository.NewIndex(restic.IndexOptionFull)
 	packs := restic.NewIDSet()
 
 	for i := 0; i < 20; i++ {
@@ -393,7 +400,7 @@ func NewRandomTestID(rng *rand.Rand) restic.ID {
 }
 
 func createRandomIndex(rng *rand.Rand) (idx *repository.Index, lookupID restic.ID) {
-	idx = repository.NewIndex()
+	idx = repository.NewIndex(restic.IndexOptionFull)
 
 	// create index with 200k pack files
 	for i := 0; i < 200000; i++ {
@@ -459,7 +466,7 @@ func TestIndexHas(t *testing.T) {
 	}
 	tests := []testEntry{}
 
-	idx := repository.NewIndex()
+	idx := repository.NewIndex(restic.IndexOptionFull)
 
 	// create 50 packs with 20 blobs each
 	for i := 0; i < 50; i++ {

--- a/internal/repository/master_index_test.go
+++ b/internal/repository/master_index_test.go
@@ -33,10 +33,10 @@ func TestMasterIndexLookup(t *testing.T) {
 		},
 	}
 
-	idx1 := repository.NewIndex()
+	idx1 := repository.NewIndex(restic.IndexOptionFull)
 	idx1.Store(blob1)
 
-	idx2 := repository.NewIndex()
+	idx2 := repository.NewIndex(restic.IndexOptionFull)
 	idx2.Store(blob2)
 
 	mIdx := repository.NewMasterIndex()

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -168,7 +168,7 @@ func rebuildIndex(t *testing.T, repo restic.Repository) {
 
 func reloadIndex(t *testing.T, repo restic.Repository) {
 	repo.SetIndex(repository.NewMasterIndex())
-	if err := repo.LoadIndex(context.TODO()); err != nil {
+	if err := repo.LoadIndex(context.TODO(), restic.IndexOptionFull); err != nil {
 		t.Fatalf("error loading new index: %v", err)
 	}
 }

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -20,7 +20,7 @@ type Repository interface {
 	Index() Index
 	SaveFullIndex(context.Context) error
 	SaveIndex(context.Context) error
-	LoadIndex(context.Context) error
+	LoadIndex(context.Context, IndexOption) error
 
 	Config() Config
 
@@ -57,6 +57,17 @@ type Lister interface {
 	List(context.Context, FileType, func(FileInfo) error) error
 }
 
+// IndexOption specifies options how loaded index is saved
+type IndexOption uint8
+
+// These are the options of how loaded index files can be saved.
+const (
+	IndexOptionFull IndexOption = iota
+	IndexOptionDataIDsOnly
+	IndexOptionNoData
+	IndexOptionNone
+)
+
 // Index keeps track of the blobs are stored within files.
 type Index interface {
 	Has(ID, BlobType) bool
@@ -66,5 +77,5 @@ type Index interface {
 	// Each returns a channel that yields all blobs known to the index. When
 	// the context is cancelled, the background goroutine terminates. This
 	// blocks any modification of the index.
-	Each(ctx context.Context) <-chan PackedBlob
+	Each(ctx context.Context) (<-chan PackedBlob, error)
 }


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Add index options to make restic consume less memory in different situations
The index option applies when reading the index from index files into memory.

The following options are added:

- IndexOptionFull:
  saves all, identical to current implemenation
- IndexOptionDataIDsOnly
  saves all except that for data blobs only the ID is saved.
  This implies that some index operations (e.g. `Lookup()` for data blobs) are
  no longer available.
  Can be used e.g. within `restic backup`
- IndexOptionNoData
  only save tree information in index
  Here even more index operations (e.g. `Has()` for data blobs) are no
  longer available.
  Can be used e.g. for `restic find`
- IndexOptionNone
  Do not store index in memory, only provide `Each()` by loading index files
  sequentially and process them.
  Can be used e.g. for `restic list blobs`

This work can also be further extended (maybe in a following PR) to give a `--lowmem` option to chosen restic commands which would then use one of the index options to trade performance or functionality for lower memory usage, see e.g. #450 

This is WIP and I haven't added tests yet. Happy to get early feedback!


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No, but I got the idea when working on #2523 and #2786.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
