### PR TITLE
Fix rclone backend not properly handling subprocess exit

### DIFF
--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -184,6 +184,7 @@ func newBackend(cfg Config, lim limiter.Limiter) (*Backend, error) {
 		debug.Log("Wait returned %v", err)
 		be.waitResult = err
 		close(waitCh)
+		stdioConn.Close()
 	}()
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -114,7 +114,7 @@ func wrapConn(c *StdioConn, lim limiter.Limiter) wrappedConn {
 }
 
 // New initializes a Backend and starts the process.
-func New(cfg Config, lim limiter.Limiter) (*Backend, error) {
+func newBackend(cfg Config, lim limiter.Limiter) (*Backend, error) {
 	var (
 		args []string
 		err  error
@@ -234,7 +234,7 @@ func New(cfg Config, lim limiter.Limiter) (*Backend, error) {
 
 // Open starts an rclone process with the given config.
 func Open(cfg Config, lim limiter.Limiter) (*Backend, error) {
-	be, err := New(cfg, lim)
+	be, err := newBackend(cfg, lim)
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +260,7 @@ func Open(cfg Config, lim limiter.Limiter) (*Backend, error) {
 
 // Create initializes a new restic repo with clone.
 func Create(cfg Config) (*Backend, error) {
-	be, err := New(cfg, nil)
+	be, err := newBackend(cfg, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/rclone/internal_test.go
+++ b/internal/backend/rclone/internal_test.go
@@ -1,0 +1,31 @@
+package rclone
+
+import (
+	"context"
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+// restic should detect rclone exiting.
+func TestRcloneExit(t *testing.T) {
+	dir, cleanup := rtest.TempDir(t)
+	defer cleanup()
+
+	cfg := NewConfig()
+	cfg.Remote = dir
+	be, err := Open(cfg, nil)
+	rtest.OK(t, err)
+	defer be.Close()
+
+	err = be.cmd.Process.Kill()
+	rtest.OK(t, err)
+	t.Log("killed rclone")
+
+	_, err = be.Stat(context.TODO(), restic.Handle{
+		Name: "foo",
+		Type: restic.DataFile,
+	})
+	rtest.Assert(t, err != nil, "expected an error")
+}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

When rclone exits unexpectedly, restic can hang. The problem occurs in the REST backend, which does not detect that its connection over stdin/stdout has stopped working.

This patch is a (hacky) fix for that problem: it simply closes stdin and stdout when the process is gone. Why this doesn't produce a SIGPIPE is beyond me. The error message is ugly, but at least it arrives instantly.

I have some ideas about how to fix this properly, but they may require quite a bit of code (if they even turn out correct). I suggest merging this as a hotfix.

I was hoping to fix the flaky rclone test, but I don't think this patch does that.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes #2381.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
