### PR TITLE
Return errors from rest.Backend.Test

### DIFF
--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -697,6 +697,13 @@ func (s *Suite) TestBackend(t *testing.T) {
 	b := s.open(t)
 	defer s.close(t, b)
 
+	// Test should return an error for an invalid type.
+	h := restic.Handle{Type: "i-am-not-a-type"}
+	_, err := b.Test(context.TODO(), h)
+	test.Assert(t, err != nil, "nil error for handle without type")
+	test.Assert(t, !b.IsNotExist(err),
+		"not-exists error for handle without type")
+
 	for _, tpe := range []restic.FileType{
 		restic.DataFile, restic.KeyFile, restic.LockFile,
 		restic.SnapshotFile, restic.IndexFile,


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

The rest backen (and by embedding, the rclone backend) ignored errors in its Test method instead of passing them on.

I also made ErrIsNotExist private and made its Error() take a pointer receiver. Not doing so causes ambiguity when testing for a type and wastes space in the binary for an autogenerated method.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Found this while working on #2797.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
