### PR TITLE
Merge in-memory indexes; use multiple maps

### DIFF
--- a/changelog/unreleased/pull-2799
+++ b/changelog/unreleased/pull-2799
@@ -1,0 +1,5 @@
+Enhancement: Optimize in-memory index
+
+We've optimized the in-memory index such that most index operations no longer depend on the repository size.
+
+https://github.com/restic/restic/pull/2799

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -190,6 +190,8 @@ func (c *Checker) LoadIndex(ctx context.Context) (hints []error, errs []error) {
 		}
 	}
 
+	c.masterIndex.MergeFinalIndexes()
+
 	err = c.repo.SetIndex(c.masterIndex)
 	if err != nil {
 		debug.Log("SetIndex returned error: %v", err)

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -86,7 +86,7 @@ func newBlobMaps() *blobMaps {
 
 func getMap(b byte) (i int) {
 	// index is chosen such that each map has (2^(1/5) - 1) = 14.87% more entries
-	// than the previous.
+	// than the following.
 	// This will ensure that only one map grows at a time.
 	// Bounds are computed by 256 * (2 - 2^(k/5)) for k=4,3,2,1
 	switch {
@@ -596,6 +596,8 @@ func (idx *Index) TreePacks() restic.IDs {
 func (idx *Index) merge(idx2 *Index) error {
 	idx.m.Lock()
 	defer idx.m.Unlock()
+	idx2.m.Lock()
+	defer idx2.m.Unlock()
 
 	if !idx2.final {
 		return errors.New("index to merge is not final!")

--- a/internal/repository/index_test.go
+++ b/internal/repository/index_test.go
@@ -134,10 +134,9 @@ func TestIndexSerialize(t *testing.T) {
 
 	id := restic.NewRandomID()
 	rtest.OK(t, idx.SetID(id))
-	id2, err := idx.ID()
+	ids, err := idx.IDs()
 	rtest.OK(t, err)
-	rtest.Assert(t, id2.Equal(id),
-		"wrong ID returned: want %v, got %v", id, id2)
+	rtest.Equals(t, restic.IDs{id}, ids)
 
 	idx3, err := repository.DecodeIndex(wr3.Bytes())
 	rtest.OK(t, err)
@@ -392,11 +391,11 @@ func NewRandomTestID(rng *rand.Rand) restic.ID {
 	return id
 }
 
-func createRandomIndex(rng *rand.Rand) (idx *repository.Index, lookupID restic.ID) {
+func createRandomIndex(rng *rand.Rand, packfiles int) (idx *repository.Index, lookupID restic.ID) {
 	idx = repository.NewIndex()
 
-	// create index with 200k pack files
-	for i := 0; i < 200000; i++ {
+	// create index with given number of pack files
+	for i := 0; i < packfiles; i++ {
 		packID := NewRandomTestID(rng)
 		var blobs []restic.Blob
 		offset := 0
@@ -423,7 +422,7 @@ func createRandomIndex(rng *rand.Rand) (idx *repository.Index, lookupID restic.I
 }
 
 func BenchmarkIndexHasUnknown(b *testing.B) {
-	idx, _ := createRandomIndex(rand.New(rand.NewSource(0)))
+	idx, _ := createRandomIndex(rand.New(rand.NewSource(0)), 200000)
 	lookupID := restic.NewRandomID()
 
 	b.ResetTimer()
@@ -434,7 +433,7 @@ func BenchmarkIndexHasUnknown(b *testing.B) {
 }
 
 func BenchmarkIndexHasKnown(b *testing.B) {
-	idx, lookupID := createRandomIndex(rand.New(rand.NewSource(0)))
+	idx, lookupID := createRandomIndex(rand.New(rand.NewSource(0)), 200000)
 
 	b.ResetTimer()
 
@@ -446,7 +445,7 @@ func BenchmarkIndexHasKnown(b *testing.B) {
 func BenchmarkIndexAlloc(b *testing.B) {
 	b.ReportAllocs()
 	for i := 0; i < b.N; i++ {
-		createRandomIndex(rand.New(rand.NewSource(0)))
+		createRandomIndex(rand.New(rand.NewSource(0)), 200000)
 	}
 }
 

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -250,18 +250,15 @@ func (mi *MasterIndex) MergeFinalIndexes() {
 	mi.idxMutex.Lock()
 	defer mi.idxMutex.Unlock()
 
-	var firstFinalIndex *Index
-	newIdx := mi.idx[:0]
-
-	for _, idx := range mi.idx {
+	// The first index is always final and the one to merge into
+	newIdx := mi.idx[:1]
+	for i := 1; i < len(mi.idx); i++ {
+		idx := mi.idx[i]
 		switch {
 		case !idx.Final():
 			newIdx = append(newIdx, idx)
-		case firstFinalIndex == nil:
-			firstFinalIndex = idx
-			newIdx = append(newIdx, idx)
 		default:
-			firstFinalIndex.merge(idx)
+			mi.idx[0].merge(idx)
 		}
 	}
 	mi.idx = newIdx


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Merge in-memory indexes when they are finalized.
This increases performance especially for large repositories with many index files.
To avoid large spikes in memory consumption when maps are resized, this PR also introduces sharded maps to save the index entries. By using 256 shards one byte of key information can be removed which also reduces the memory required for large indexes a bit.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

The idea comes from #2523.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
