### PR TITLE
Add flag `--read-data-sample` to `restic check`

### DIFF
--- a/changelog/unreleased/issue-2186
+++ b/changelog/unreleased/issue-2186
@@ -1,0 +1,7 @@
+Enhancement: Add flag `--read-data-sample` to restich check
+
+We've added a new flag to restic check which allows to read only a random sample of data files.
+
+https://github.com/restic/restic/issues/2186
+https://github.com/restic/restic/pull/2801
+https://forum.restic.net/t/rsync-net-how-do-you-run-repo-maintanenance

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -169,3 +169,10 @@ check all repository data files over 5 separate invocations:
     $ restic -r /srv/restic-repo check --read-data-subset=3/5
     $ restic -r /srv/restic-repo check --read-data-subset=4/5
     $ restic -r /srv/restic-repo check --read-data-subset=5/5
+
+If only testing a sample subset of all data files, use the ``--read-data-sample=s``
+parameter which randomly picks ``s`` data files to check:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo check --read-data-sample=100


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Add a new flag to `restic check` to allow test a random sample of given sample size of pack files
instead of all pack files (with `--read-data`) or a very specific subset (with `--read-data-subset`)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

See [forum discussion](https://forum.restic.net/t/rsync-net-how-do-you-run-repo-maintanenance/2845) where I got the idea.

closes #2186 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- I have not added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
