### PR TITLE
Fix examples of --verbose with argument

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -72,7 +72,7 @@ type GlobalOptions struct {
 	//  0 means: don't print any messages except errors, this is used when --quiet is specified
 	//  1 is the default: print essential messages
 	//  2 means: print more messages, report minor things, this is used when --verbose is specified
-	//  3 means: print very detailed debug messages, this is used when --verbose 2 is specified
+	//  3 means: print very detailed debug messages, this is used when --verbose=2 is specified
 	verbosity uint
 
 	Options []string

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -83,7 +83,7 @@ You can even backup individual files in the same repository (not passing
     snapshot 249d0210 saved
 
 If you're interested in what restic does, pass ``--verbose`` twice (or
-``--verbose 2``) to display detailed information about each file and directory
+``--verbose=2``) to display detailed information about each file and directory
 restic encounters:
 
 .. code-block:: console


### PR DESCRIPTION
`--verbose` has a default value, so `--verbose 2` doesn't work; only `--verbose=2` does.

BTW, there's the same mistake in the help message. But I don't speak Go, so I'll let someone else fix it. :-)