### PR TITLE
Fix race condition in Cache

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -21,6 +22,10 @@ type Cache struct {
 	Base             string
 	Created          bool
 	PerformReadahead func(restic.Handle) bool
+
+	// saving tracks files that are currently being saved.
+	savingMu sync.Mutex
+	saving   map[restic.Handle]*saveAction
 }
 
 const dirMode = 0700
@@ -158,6 +163,7 @@ func New(id string, basedir string) (c *Cache, err error) {
 			// do not perform readahead by default
 			return false
 		},
+		saving: make(map[restic.Handle]*saveAction),
 	}
 
 	return c, nil

--- a/internal/cache/file.go
+++ b/internal/cache/file.go
@@ -84,8 +84,8 @@ func (c *Cache) Load(h restic.Handle, length int, offset int64) (io.ReadCloser, 
 	return rd, nil
 }
 
-// SaveWriter returns a writer for the cache object h. It must be closed after writing is finished.
-func (c *Cache) SaveWriter(h restic.Handle) (io.WriteCloser, error) {
+// saveWriter returns a writer for the cache object h. It must be closed after writing is finished.
+func (c *Cache) saveWriter(h restic.Handle) (io.WriteCloser, error) {
 	debug.Log("Save to cache: %v", h)
 	if !c.canBeCached(h.Type) {
 		return nil, errors.New("cannot be cached")
@@ -112,7 +112,7 @@ func (c *Cache) Save(h restic.Handle, rd io.Reader) error {
 		return errors.New("Save() called with nil reader")
 	}
 
-	f, err := c.SaveWriter(h)
+	f, err := c.saveWriter(h)
 	if err != nil {
 		return err
 	}

--- a/internal/cache/file_test.go
+++ b/internal/cache/file_test.go
@@ -148,7 +148,7 @@ func TestFileSaveWriter(t *testing.T) {
 		Name: id.String(),
 	}
 
-	wr, err := c.SaveWriter(h)
+	wr, err := c.saveWriter(h)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/restic/cache.go
+++ b/internal/restic/cache.go
@@ -21,10 +21,6 @@ type Cache interface {
 	// SaveIndex saves an index in the cache.
 	Save(Handle, io.Reader) error
 
-	// SaveWriter returns a writer for the to be cached object h. It must be
-	// closed after writing is finished.
-	SaveWriter(Handle) (io.WriteCloser, error)
-
 	// Remove deletes a single file from the cache. If it isn't cached, this
 	// functions must return no error.
 	Remove(Handle) error

--- a/internal/restic/cache.go
+++ b/internal/restic/cache.go
@@ -29,5 +29,9 @@ type Cache interface {
 	Clear(FileType, IDSet) error
 
 	// Has returns true if the file is cached.
+	//
+	// In a concurrent setting, the return value may be outdated by the time
+	// the caller acts upon it, so it should only be used as an optimization
+	// hint.
 	Has(Handle) bool
 }


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

The duplicate suppression logic from cache.Backend was largely moved to cache.Cache. Saves and loads on a Cache now wait for each other to complete, instead of trying to create the same file concurrently.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes #2345.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
