### PR TITLE
Use low memory map for in-memory index - about 45% less memory for index

### DIFF
--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -49,7 +49,7 @@ import (
 // Index holds lookup tables for id -> pack.
 type Index struct {
 	m         sync.Mutex
-	byType    map[restic.BlobType]*lowMemMap
+	byType    []*linkedMemMap
 	packs     restic.IDs
 	treePacks restic.IDs
 	// only used by Store, StorePacks does not check for already saved packIDs
@@ -73,12 +73,12 @@ type indexEntry struct {
 // NewIndex returns a new index.
 func NewIndex() *Index {
 	ind := Index{
-		byType:        make(map[restic.BlobType]*lowMemMap),
+		byType:        make([]*linkedMemMap, len(allBlobTypes)+1),
 		packIDToIndex: make(map[restic.ID]int),
 		created:       time.Now(),
 	}
 	for _, t := range allBlobTypes {
-		ind.byType[t] = newLowMemMap()
+		ind.byType[t] = newLinkedMemMap()
 	}
 
 	return &ind

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -84,12 +84,6 @@ func NewIndex() *Index {
 	return &ind
 }
 
-func (idx *Index) Stats() {
-	for _, t := range allBlobTypes {
-		idx.byType[t].Stats()
-	}
-}
-
 // addToPacks saves the given pack ID and return the index.
 // This procedere allows to use pack IDs which can be easily garbage collected after.
 func (idx *Index) addToPacks(id restic.ID) int {

--- a/internal/repository/index_inmem.go
+++ b/internal/repository/index_inmem.go
@@ -1,0 +1,322 @@
+package repository
+
+import (
+	"sort"
+
+	"github.com/restic/restic/internal/restic"
+)
+
+// Low Memory Map
+//
+// is a low memory replacement for the standard map[key]value.
+// In order to get low memory consumption, we use large buckets which have in
+// average about 1000 to 2000 entries.
+// The entries of bucket are saved in a paged array, that is an array of "pages"
+// which each contain up to 32 entries.
+// As each bucket usually consists of 32 to 64 pages this gives an average
+// unsed page space of only 1/2 page out of 48 pages. The organizational overhead
+// is 8 bytes per page and 48 bytes per bucket on 64bit architectures.
+// Hence the organizational overhead per entry is less than 1/2 byte per map entry.
+//
+// Note that duplicate keys are allowed and stored separately.
+// This low memory map must be sorted using the sort method before it can be
+// accessed.
+//
+//
+// As there are no generics in go, we use the types mapKey and mapValue
+// which have to be defined in order to use a generic implementation.
+
+// Define type of key and values of the map
+// please ensure that mapKey implements Hash, Less, LessEqual and Equal
+type mapKey restic.ID
+type mapValue indexEntry
+
+func (key mapKey) Hash() int {
+	var x int
+	var s uint
+	id := restic.ID(key)
+	for _, b := range id[:8] {
+		x |= int(b) << s
+		s += 8
+	}
+
+	return x
+}
+
+func (key mapKey) Less(other mapKey) bool {
+	return restic.ID(key).Less(restic.ID(other))
+}
+
+func (key mapKey) LessEqual(other mapKey) bool {
+	return restic.ID(key).LessEqual(restic.ID(other))
+}
+
+func (key mapKey) Equal(other mapKey) bool {
+	return restic.ID(key).Equal(restic.ID(other))
+}
+
+// --- start of generic implementation
+
+// grow when each bucket has in average 64 pages
+const GrowFactor = 64
+
+// Make pages of 2^5 = 32 blobEntries by default
+const shiftBits = 5
+const pageSize = 1 << shiftBits
+const maskBits = pageSize - 1
+
+// lowMemMap - actually behaves like map[mapKey]mapEntry, but uses much less memory
+type lowMemMap struct {
+	cnt       int
+	bucketCnt int
+	mask      int
+
+	buckets []*bucket
+}
+
+// newLowMemMap creates a new low memory hashmap
+func newLowMemMap() *lowMemMap {
+	buckets := make([]*bucket, 1)
+	buckets[0] = newBucket()
+	return &lowMemMap{
+		mask:      0,
+		buckets:   buckets,
+		bucketCnt: 0,
+	}
+}
+
+// get(k) returns the value for the given key k
+// entry, found := sm.get(k) works like entry, found := map[k]
+func (m *lowMemMap) get(key mapKey) (mapValue, bool) {
+	bucket := m.buckets[key.Hash()&m.mask]
+	return bucket.getKey(key)
+}
+
+// getAll(k) returns all values (including duplicates) for the given key k
+func (m *lowMemMap) getAll(key mapKey) []mapValue {
+	bucket := m.buckets[key.Hash()&m.mask]
+	return bucket.getAllKey(key)
+}
+
+// len returns the number of entries in the hashmap
+func (m *lowMemMap) len() int {
+	return m.cnt
+}
+
+// forEach calls the given func for all entries of the hashmap
+func (m *lowMemMap) forEach(fn func(mapKey, mapValue)) {
+	for _, b := range m.buckets {
+		b.forEach(fn)
+	}
+}
+
+// clear frees all memory used for the hashmap
+func (m *lowMemMap) clear() {
+	for i := range m.buckets {
+		m.buckets[i].clear()
+		m.buckets[i] = nil
+	}
+	m.buckets = nil
+}
+
+// sort sorts all buckets in the hashmap
+func (m *lowMemMap) sort() {
+	// TODO: this can be done concurrently
+	for _, b := range m.buckets {
+		b.sort()
+	}
+}
+
+// add adds an entry to the hashmap
+func (m *lowMemMap) add(key mapKey, entry mapValue) {
+	bucket := m.buckets[key.Hash()&m.mask]
+	m.cnt++
+	if bucket.append(bucketEntry{key: key, value: entry}) {
+		m.bucketCnt++
+		if m.bucketCnt >= GrowFactor*len(m.buckets) {
+			m.grow()
+		}
+	}
+}
+
+// grow grows the hashmap and thus doubles the number of buckets
+func (m *lowMemMap) grow() {
+	oldLen := len(m.buckets)
+	newBuckets := make([]*bucket, 2*oldLen)
+	m.mask = 2*m.mask + 1
+	// TODO: this can be done concurrently
+	for i, b := range m.buckets {
+		newBuckets[i] = b
+		newBucket, delta := b.split(func(key mapKey) bool {
+			return (key.Hash() & m.mask) == i+oldLen
+		})
+		newBuckets[i+oldLen] = newBucket
+		m.bucketCnt += delta
+	}
+	m.buckets = newBuckets
+}
+
+// bucket implements a "paged" array of bucketEntry.
+// It is a replacement for []bucketEntry.
+// The difference to a simple array is that it uses fix "pages" of a
+// given length.
+//
+// Using a paged array makes bucket faster for append as no existing elements
+// need to be copied but instead only new "pages" are added.
+// Also the memory overhead is at most one "page" and hence significantly
+// smaller than of a standard array for big arrays.
+// The cost is a more expensive access to elements.
+type bucket struct {
+	page   []bucketPage
+	length int
+	sorted bool
+}
+
+type bucketPage *[pageSize]bucketEntry
+
+type bucketEntry struct {
+	key   mapKey
+	value mapValue
+}
+
+// newBucket creates a new bucket
+func newBucket() *bucket {
+	return &bucket{}
+}
+
+// newPage creates a new page for a bucket
+func newPage() bucketPage {
+	return &[pageSize]bucketEntry{}
+}
+
+func (b *bucket) clear() {
+	b.page = nil
+}
+
+// splitIndex is a helper function to split i into inner and outer index
+func splitIndex(i int) (int, int) {
+	return i >> shiftBits, i & maskBits
+}
+
+// Let bucket implement sort.Interface
+func (b *bucket) Len() int {
+	return b.length
+}
+func (b *bucket) Less(i, j int) bool {
+	return b.get(i).key.Less(b.get(j).key)
+}
+func (b *bucket) Swap(i, j int) {
+	// calculate outer and inner indices
+	outI, inI := splitIndex(i)
+	outJ, inJ := splitIndex(j)
+
+	b.page[outI][inI], b.page[outJ][inJ] =
+		b.page[outJ][inJ], b.page[outI][inI]
+}
+
+func (b *bucket) sort() {
+	if b.sorted {
+		return
+	}
+	sort.Sort(b)
+	b.sorted = true
+}
+
+// get accesses an element of the bucket; entry = b.get(i) is the eqivalent of entry = b[i]
+func (b *bucket) get(i int) bucketEntry {
+	outI, inI := splitIndex(i)
+	return b.page[outI][inI]
+}
+
+// append appends an entry; b.append(entry) is the equivalent of b = append(b, entry)
+// it returns whether we needed to add a page to the bucket
+func (b *bucket) append(blob bucketEntry) (pageAdded bool) {
+	outI, inI := splitIndex(b.length)
+	// if page is full, create a new page
+	if inI == 0 {
+		b.page = append(b.page, newPage())
+		pageAdded = true
+	}
+	b.page[outI][inI] = blob
+	b.length++
+	b.sorted = false
+
+	return pageAdded
+}
+
+// forEach calls the given function for all entries in the bucket
+func (bt *bucket) forEach(fn func(mapKey, mapValue)) {
+	for k := 0; k < bt.length; k++ {
+		be := bt.get(k)
+		fn(be.key, be.value)
+	}
+}
+
+// getKey searches for an elements with given key; bucket must be sorted!
+// returns the first found entry and wheter found or not
+func (b *bucket) getKey(key mapKey) (mapValue, bool) {
+	if !b.sorted {
+		panic("bucket is not sorted!")
+	}
+	if k := sort.Search(b.length, func(i int) bool {
+		return key.LessEqual(b.get(i).key)
+	}); k < b.length {
+		if be := b.get(k); be.key.Equal(key) {
+			return be.value, true
+		}
+	}
+	return mapValue{}, false
+}
+
+// getAllKey returns all elements with given ID; bucket must be sorted!
+func (bt *bucket) getAllKey(key mapKey) (entries []mapValue) {
+	if !bt.sorted {
+		panic("bucket is not sorted!")
+	}
+	for k := sort.Search(bt.length, func(i int) bool {
+		return key.LessEqual(bt.get(i).key)
+	}); k < bt.length; k++ {
+		be := bt.get(k)
+		if !be.key.Equal(key) {
+			break
+		}
+		entries = append(entries, be.value)
+	}
+	return entries
+}
+
+// split splits a bucket into two depending on a given split function
+// if splitFn is true for a key, the entry will be moved to a newly created bucket
+// returns the newly created bucket and the number of pages which have been added
+func (bt *bucket) split(splitFn func(mapKey) bool) (newbucket *bucket, pagesAdded int) {
+	newbucket = newBucket()
+	newbucket.sorted = bt.sorted
+	var outJ, inJ, newLength int
+
+	for i := 0; i < bt.length; i++ {
+		entry := bt.get(i)
+		if splitFn(entry.key) {
+			if newbucket.append(entry) {
+				pagesAdded++
+			}
+		} else {
+			if inJ >= pageSize {
+				outJ++
+				inJ = 0
+			}
+			bt.page[outJ][inJ] = entry
+			inJ++
+			newLength++
+		}
+	}
+	bt.length = newLength
+
+	// remove unneeded pages
+	for i := outJ + 1; i < len(bt.page); i++ {
+		bt.page[i] = nil
+		pagesAdded--
+	}
+	bt.page = bt.page[:outJ+1]
+
+	return newbucket, pagesAdded
+}

--- a/internal/repository/index_linkedlist.go
+++ b/internal/repository/index_linkedlist.go
@@ -1,0 +1,119 @@
+package repository
+
+// Linked List Map
+//
+// Note that duplicate keys are allowed and stored separately.
+//
+//
+// As there are no generics in go, we use the types mapKey and mapValue
+// which have to be defined in order to use a generic implementation.
+
+// --- start of generic implementation
+
+const maxEntriesPerBucket = 8
+
+// linkedMemMap - actually behaves like map[mapKey]mapEntry, but uses much less memory
+type linkedMemMap struct {
+	cnt  int
+	mask int
+
+	buckets []*linkedBucket
+}
+
+type linkedBucket struct {
+	key   mapKey
+	value mapValue
+	next  *linkedBucket
+}
+
+// newLinkedMemMap creates a new low memory hashmap
+func newLinkedMemMap() *linkedMemMap {
+	buckets := make([]*linkedBucket, 1)
+	return &linkedMemMap{
+		mask:    0,
+		buckets: buckets,
+	}
+}
+
+// get(k) returns the value for the given key k
+// entry, found := sm.get(k) works like entry, found := map[k]
+func (m *linkedMemMap) get(key mapKey) (mapValue, bool) {
+	bucket := m.buckets[key.Hash()&m.mask]
+	for bucket != nil {
+		if bucket.key.Compare(key) == 0 {
+			return bucket.value, true
+		}
+		bucket = bucket.next
+	}
+	return mapValue{}, false
+}
+
+// getAll(k) returns all values (including duplicates) for the given key k
+func (m *linkedMemMap) getAll(key mapKey) (values []mapValue) {
+	bucket := m.buckets[key.Hash()&m.mask]
+	for bucket != nil {
+		if bucket.key.Compare(key) == 0 {
+			values = append(values, bucket.value)
+		}
+		bucket = bucket.next
+	}
+	return values
+}
+
+// len returns the number of entries in the hashmap
+func (m *linkedMemMap) len() int {
+	return m.cnt
+}
+
+// forEach calls the given func for all entries of the hashmap
+func (m *linkedMemMap) forEach(fn func(mapKey, mapValue)) {
+	for _, b := range m.buckets {
+		for b != nil {
+			fn(b.key, b.value)
+			b = b.next
+		}
+	}
+}
+
+func (m *linkedMemMap) sort() {
+}
+
+// clear frees all memory used for the hashmap
+func (m *linkedMemMap) clear() {
+	for i := range m.buckets {
+		m.buckets[i] = nil
+	}
+	m.buckets = nil
+}
+
+// add adds an entry to the hashmap
+func (m *linkedMemMap) add(key mapKey, entry mapValue) {
+	index := key.Hash() & m.mask
+	b := &linkedBucket{key: key,
+		value: entry,
+		next:  m.buckets[index],
+	}
+	m.buckets[index] = b
+
+	m.cnt++
+	if m.cnt >= maxEntriesPerBucket*len(m.buckets) {
+		m.grow()
+	}
+}
+
+// grow grows the hashmap and thus doubles the number of buckets
+func (m *linkedMemMap) grow() {
+	newBuckets := make([]*linkedBucket, 2*len(m.buckets))
+	m.mask = 2*m.mask + 1
+	// TODO: this can be done concurrently
+	for _, b := range m.buckets {
+		for b != nil {
+			index := b.key.Hash() & m.mask
+			next := b.next
+			b.next = newBuckets[index]
+			newBuckets[index] = b
+			b = next
+		}
+	}
+	m.buckets = newBuckets
+}

--- a/internal/repository/index_test.go
+++ b/internal/repository/index_test.go
@@ -50,6 +50,7 @@ func TestIndexSerialize(t *testing.T) {
 			pos += length
 		}
 	}
+	idx.Sort()
 
 	wr := bytes.NewBuffer(nil)
 	err := idx.Encode(wr)
@@ -418,6 +419,7 @@ func createRandomIndex(rng *rand.Rand) (idx *repository.Index, lookupID restic.I
 		}
 		idx.StorePack(packID, blobs)
 	}
+	idx.Sort()
 
 	return idx, lookupID
 }
@@ -490,6 +492,7 @@ func TestIndexHas(t *testing.T) {
 			pos += length
 		}
 	}
+	idx.Sort()
 
 	for _, testBlob := range tests {
 		rtest.Assert(t, idx.Has(testBlob.id, testBlob.tpe), "Index reports not having data blob added to it")

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -62,7 +62,6 @@ func (mi *MasterIndex) ListPack(id restic.ID) (list []restic.PackedBlob) {
 			return list
 		}
 	}
-
 	return nil
 }
 
@@ -145,12 +144,14 @@ func (mi *MasterIndex) StorePack(id restic.ID, blobs []restic.Blob) {
 	for _, idx := range mi.idx {
 		if !idx.Final() {
 			idx.StorePack(id, blobs)
+			idx.Sort()
 			return
 		}
 	}
 
 	newIdx := NewIndex()
 	newIdx.StorePack(id, blobs)
+	newIdx.Sort()
 	mi.idx = append(mi.idx, newIdx)
 }
 

--- a/internal/repository/master_index_test.go
+++ b/internal/repository/master_index_test.go
@@ -35,9 +35,11 @@ func TestMasterIndexLookup(t *testing.T) {
 
 	idx1 := repository.NewIndex()
 	idx1.Store(blob1)
+	idx1.Sort()
 
 	idx2 := repository.NewIndex()
 	idx2.Store(blob2)
+	idx2.Sort()
 
 	mIdx := repository.NewMasterIndex()
 	mIdx.Insert(idx1)

--- a/internal/restic/id.go
+++ b/internal/restic/id.go
@@ -83,6 +83,28 @@ func (id ID) Equal(other ID) bool {
 	return id == other
 }
 
+func (id ID) Less(other ID) bool {
+	if len(id) < len(other) {
+		return true
+	}
+
+	for k, b := range id {
+		if b == other[k] {
+			continue
+		}
+
+		if b < other[k] {
+			return true
+		}
+		return false
+	}
+	return false
+}
+
+func (id ID) LessEqual(other ID) bool {
+	return !other.Less(id)
+}
+
 // EqualString compares this ID to another one, given as a string.
 func (id ID) EqualString(other string) (bool, error) {
 	s, err := hex.DecodeString(other)

--- a/internal/restic/id.go
+++ b/internal/restic/id.go
@@ -1,6 +1,7 @@
 package restic
 
 import (
+	"bytes"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -83,26 +84,16 @@ func (id ID) Equal(other ID) bool {
 	return id == other
 }
 
+func (id ID) Compare(other ID) int {
+	return bytes.Compare(id[:], other[:])
+}
+
 func (id ID) Less(other ID) bool {
-	if len(id) < len(other) {
-		return true
-	}
-
-	for k, b := range id {
-		if b == other[k] {
-			continue
-		}
-
-		if b < other[k] {
-			return true
-		}
-		return false
-	}
-	return false
+	return bytes.Compare(id[:], other[:]) < 0
 }
 
 func (id ID) LessEqual(other ID) bool {
-	return !other.Less(id)
+	return bytes.Compare(id[:], other[:]) <= 0
 }
 
 // EqualString compares this ID to another one, given as a string.

--- a/internal/restic/ids.go
+++ b/internal/restic/ids.go
@@ -13,23 +13,7 @@ func (ids IDs) Len() int {
 }
 
 func (ids IDs) Less(i, j int) bool {
-	if len(ids[i]) < len(ids[j]) {
-		return true
-	}
-
-	for k, b := range ids[i] {
-		if b == ids[j][k] {
-			continue
-		}
-
-		if b < ids[j][k] {
-			return true
-		}
-
-		return false
-	}
-
-	return false
+	return ids[i].Less(ids[j])
 }
 
 func (ids IDs) Swap(i, j int) {


### PR DESCRIPTION
UPDATE: This PR is only left for reference; IMO #2812 should be followed which gives slightly worse memory results but much better handling and performance.

What is the purpose of this change? What does it change?
--------------------------------------------------------

Use a low memory map for the in-memory index.

In fact there are a few changes which come with this PR:

- Use a separate map for treeBlobs and dataBlobs as this saves 1 byte per index entry.
- Use a complete replacement for go's map which uses much less memory and doesn't show worst-case behavior on memory usage. The tradeoff is that this map is slower, needs an extra sorting step and there are performance spikes when inserting (growing is done all at once). IMO these drawbacks are acceptable within restic.
- Remove the extra handling of duplicate blobs as this "feature" is now integrated within the map.

For more details about the low-memory map, see `internal/repository/index_inmem.go`.

Here is the comparison to master (where #2781 is already merged!) of the repository benchmarks:
```
name                                     old time/op    new time/op    delta
PackerManager-4                             288ms ± 5%     262ms ± 0%    -8.94%  (p=0.000 n=10+8)
DecodeIndex-4                              18.4µs ± 4%    23.6µs ± 2%   +28.55%  (p=0.000 n=10+10)
IndexHasUnknown-4                          61.7ns ± 8%   247.0ns ± 2%  +300.19%  (p=0.000 n=10+8)
IndexHasKnown-4                            63.3ns ± 2%   279.8ns ± 2%  +341.68%  (p=0.000 n=9+9)
IndexAlloc-4                                1.08s ± 3%     1.23s ± 2%   +14.51%  (p=0.000 n=10+10)
MasterIndexLookupSingleIndex-4              173ns ± 5%     430ns ± 1%  +148.97%  (p=0.000 n=10+9)
MasterIndexLookupMultipleIndex-4            515ns ± 8%    1855ns ± 6%  +260.19%  (p=0.000 n=9+10)
MasterIndexLookupSingleIndexUnknown-4      90.9ns ± 6%   268.4ns ± 5%  +195.24%  (p=0.000 n=10+10)
MasterIndexLookupMultipleIndexUnknown-4     435ns ± 5%    1643ns ± 5%  +277.42%  (p=0.002 n=4+10)
LoadTree-4                                  459µs ± 1%     460µs ± 2%      ~     (p=0.481 n=10+10)
LoadBlob-4                                 8.19ms ± 1%    8.18ms ± 0%      ~     (p=0.549 n=10+9)
LoadAndDecrypt-4                           10.2ms ± 4%    10.1ms ± 3%      ~     (p=0.190 n=10+10)
LoadIndex-4                                41.6ms ± 2%    42.8ms ± 3%    +2.94%  (p=0.000 n=10+10)
SaveAndEncrypt-4                            127ns ± 1%     204ns ± 2%   +60.66%  (p=0.000 n=9+10)

name                                     old speed      new speed      delta
PackerManager-4                           183MB/s ± 5%   201MB/s ± 0%    +9.74%  (p=0.000 n=10+8)
LoadBlob-4                                122MB/s ± 1%   122MB/s ± 0%      ~     (p=0.534 n=10+9)
LoadAndDecrypt-4                         97.9MB/s ± 4%  99.3MB/s ± 3%      ~     (p=0.190 n=10+10)
SaveAndEncrypt-4                         33.0TB/s ± 1%  20.6TB/s ± 1%   -37.54%  (p=0.000 n=10+9)

name                                     old alloc/op   new alloc/op   delta
PackerManager-4                            91.0kB ± 0%    91.0kB ± 0%      ~     (p=1.117 n=9+10)
IndexAlloc-4                                786MB ± 0%     430MB ± 0%   -45.28%  (p=0.000 n=10+10)
SaveAndEncrypt-4                            2.00B ± 0%     3.00B ± 0%   +50.00%  (p=0.000 n=10+10)

name                                     old allocs/op  new allocs/op  delta
PackerManager-4                             1.41k ± 0%     1.41k ± 0%      ~     (p=0.917 n=9+10)
IndexAlloc-4                                 977k ± 0%      995k ± 0%    +1.90%  (p=0.000 n=10+10)
SaveAndEncrypt-4                             0.00           0.00           ~     (all equal)
```

As expected, some timings are getting worse, but these are internal timings and I didn't see impacts with restic commands (but didn't measure these, either). Note the `-45.28%` on memory usage.

Also note, that with this PR huge index speed improvements are possible when merging the indexes, see #2799 . 


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

The ideas come from #2523 and #2799.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
