### PR TITLE
Fix repository_test.BenchmarkSaveAndEncrypt

### DIFF
--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -107,8 +107,7 @@ func BenchmarkSaveAndEncrypt(t *testing.B) {
 	t.SetBytes(int64(size))
 
 	for i := 0; i < t.N; i++ {
-		// save
-		_, _, err = repo.SaveBlob(context.TODO(), restic.DataBlob, data, id, false)
+		_, _, err = repo.SaveBlob(context.TODO(), restic.DataBlob, data, id, true)
 		rtest.OK(t, err)
 	}
 }


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

The SaveAndEncrypt benchmark was actually testing the speed of index lookups, rather than encryption, because its result was cached after the first call in every run. Benchmark results are the most dramatic I've seen so far:

```
name              old time/op    new time/op        delta
SaveAndEncrypt-8     101ns ± 2%    31077757ns ± 1%    +30886161.78%  (p=0.001 n=10+5)

name              old speed      new speed          delta
SaveAndEncrypt-8  41.7TB/s ± 2%       0.0TB/s ± 1%         -100.00%  (p=0.001 n=10+5)

name              old alloc/op   new alloc/op       delta
SaveAndEncrypt-8     1.00B ± 0%  20989534.60B ± 0%  +2098953360.00%  (p=0.001 n=10+5)

name              old allocs/op  new allocs/op      delta
SaveAndEncrypt-8      0.00             123.00 ± 0%            +Inf%  (p=0.001 n=10+5)
```

(The actual speed is ca. 135MiB/s.)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
