### PR TITLE
--hostname flag is deprecated

### DIFF
--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -176,7 +176,7 @@ Multiple policies will be ORed together so as to be as inclusive as possible
 for keeping snapshots.
 
 Additionally, you can restrict removing snapshots to those which have a
-particular hostname with the ``--hostname`` parameter, or tags with the
+particular hostname with the ``--host`` parameter, or tags with the
 ``--tag`` option. When multiple tags are specified, only the snapshots
 which have all the tags are considered. For example, the following command
 removes all but the latest snapshot of all snapshots that have the tag ``foo``:


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
Update documentation to follow the deprecation warning "Flag --hostname has been deprecated, use --host" that is given on the latest build(s).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
no

Checklist
---------
- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [N/A] I have added tests for all changes in this PR
- [X] I have added documentation for the changes (in the manual)
- [N/A] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [N/A] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
