### PR TITLE
Set O_NOATIME flag on Linux

### DIFF
--- a/changelog/unreleased/pull-2816
+++ b/changelog/unreleased/pull-2816
@@ -1,0 +1,10 @@
+Enhancement: backup no longer updates file access times on Linux
+
+When reading files during backup, restic caused the operating system to update
+the file access times. Note that this does not apply to filesystems with
+disabled file access times.
+
+Restic now instructs the operation system not to update the file access time,
+if the user running restic is the file owner or has root permissions.
+
+https://github.com/restic/restic/pull/2816

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -85,7 +85,12 @@ func Create(name string) (*os.File, error) {
 
 // Open opens a file for reading.
 func Open(name string) (File, error) {
-	return os.Open(fixpath(name))
+	f, err := os.Open(fixpath(name))
+	if err != nil {
+		return nil, err
+	}
+	setFlags(f)
+	return f, err
 }
 
 // OpenFile is the generalized open call; most users will use Open
@@ -94,7 +99,12 @@ func Open(name string) (File, error) {
 // methods on the returned File can be used for I/O.
 // If there is an error, it will be of type *PathError.
 func OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
-	return os.OpenFile(fixpath(name), flag, perm)
+	f, err := os.OpenFile(fixpath(name), flag, perm)
+	if err != nil {
+		return nil, err
+	}
+	setFlags(f)
+	return f, err
 }
 
 // Walk walks the file tree rooted at root, calling walkFn for each file or

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -85,12 +85,7 @@ func Create(name string) (*os.File, error) {
 
 // Open opens a file for reading.
 func Open(name string) (File, error) {
-	f, err := os.Open(fixpath(name))
-	if err != nil {
-		return nil, err
-	}
-	setFlags(f)
-	return f, err
+	return os.Open(fixpath(name))
 }
 
 // OpenFile is the generalized open call; most users will use Open
@@ -99,12 +94,7 @@ func Open(name string) (File, error) {
 // methods on the returned File can be used for I/O.
 // If there is an error, it will be of type *PathError.
 func OpenFile(name string, flag int, perm os.FileMode) (*os.File, error) {
-	f, err := os.OpenFile(fixpath(name), flag, perm)
-	if err != nil {
-		return nil, err
-	}
-	setFlags(f)
-	return f, err
+	return os.OpenFile(fixpath(name), flag, perm)
 }
 
 // Walk walks the file tree rooted at root, calling walkFn for each file or

--- a/internal/fs/fs_local.go
+++ b/internal/fs/fs_local.go
@@ -24,6 +24,7 @@ func (fs Local) Open(name string) (File, error) {
 	if err != nil {
 		return nil, err
 	}
+	_ = setFlags(f)
 	return f, nil
 }
 
@@ -37,6 +38,7 @@ func (fs Local) OpenFile(name string, flag int, perm os.FileMode) (File, error) 
 	if err != nil {
 		return nil, err
 	}
+	_ = setFlags(f)
 	return f, nil
 }
 

--- a/internal/fs/setflags_linux.go
+++ b/internal/fs/setflags_linux.go
@@ -1,0 +1,21 @@
+package fs
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// SetFlags tries to set the O_NOATIME flag on f, which prevents the kernel
+// from updating the atime on a read call.
+//
+// The call fails when we're not the owner of the file or root. The caller
+// should ignore the error, which is returned for testing only.
+func setFlags(f *os.File) error {
+	fd := f.Fd()
+	flags, err := unix.FcntlInt(fd, unix.F_GETFL, 0)
+	if err == nil {
+		_, err = unix.FcntlInt(fd, unix.F_SETFL, flags|unix.O_NOATIME)
+	}
+	return err
+}

--- a/internal/fs/setflags_linux_test.go
+++ b/internal/fs/setflags_linux_test.go
@@ -1,0 +1,67 @@
+package fs
+
+import (
+	"io"
+	"io/ioutil"
+	"os"
+	"testing"
+	"time"
+
+	rtest "github.com/restic/restic/internal/test"
+
+	"golang.org/x/sys/unix"
+)
+
+func TestNoatime(t *testing.T) {
+	f, err := ioutil.TempFile("", "restic-test-noatime")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer func() {
+		_ = f.Close()
+		err = Remove(f.Name())
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	// Only run this test on common filesystems that support O_NOATIME.
+	// On others, we may not get an error.
+	if !supportsNoatime(t, f) {
+		t.Skip("temp directory may not support O_NOATIME, skipping")
+	}
+	// From this point on, we own the file, so we should not get EPERM.
+
+	_, err = io.WriteString(f, "Hello!")
+	rtest.OK(t, err)
+	_, err = f.Seek(0, io.SeekStart)
+	rtest.OK(t, err)
+
+	getAtime := func() time.Time {
+		info, err := f.Stat()
+		rtest.OK(t, err)
+		return ExtendedStat(info).AccessTime
+	}
+
+	atime := getAtime()
+
+	err = setFlags(f)
+	rtest.OK(t, err)
+
+	_, err = f.Read(make([]byte, 1))
+	rtest.OK(t, err)
+	rtest.Equals(t, atime, getAtime())
+}
+
+func supportsNoatime(t *testing.T, f *os.File) bool {
+	var fsinfo unix.Statfs_t
+	err := unix.Fstatfs(int(f.Fd()), &fsinfo)
+	rtest.OK(t, err)
+
+	return fsinfo.Type == unix.BTRFS_SUPER_MAGIC ||
+		fsinfo.Type == unix.EXT2_SUPER_MAGIC ||
+		fsinfo.Type == unix.EXT3_SUPER_MAGIC ||
+		fsinfo.Type == unix.EXT4_SUPER_MAGIC ||
+		fsinfo.Type == unix.TMPFS_MAGIC
+}

--- a/internal/fs/setflags_other.go
+++ b/internal/fs/setflags_other.go
@@ -1,0 +1,12 @@
+//go:build !linux
+// +build !linux
+
+package fs
+
+import "os"
+
+// OS-specific replacements of setFlags can set file status flags
+// that improve I/O performance.
+func setFlags(*os.File) error {
+	return nil
+}


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

The O_NOATIME flag is set when opening a file on Linux, which prevents the access time from being updated on every read.

Citing Kerrisk, The Linux Programming Interface:

> The O_NOATIME flag is intended for use by indexing and backup programs. Its use can significantly reduce the amount of disk activity, because repeated disk seeks back and forth across the disk are not required to read the contents of a file and to update the last access time in the file’s i-node[.]

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

restic used to do this, but the functionality was removed along with the fadvise call in #670. That solved #666, which is unrelated to O_NOATIME.

The implementation here is different: it uses fcntl, so we don't need to open the file twice when an error occurs (leading to duplicate path traversals). Errors are expected to be common, as O_NOATIME is only available to the owner of a file or root. Also, fcntl can set O_DIRECT on FreeBSD and is needed to set F_NOCACHE on MacOS, in case we ever want to do that.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
