### PR TITLE
Merge index (based on chaining index implementation)

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -190,6 +190,8 @@ func (c *Checker) LoadIndex(ctx context.Context) (hints []error, errs []error) {
 		}
 	}
 
+	c.masterIndex.MergeFinalIndexes()
+
 	err = c.repo.SetIndex(c.masterIndex)
 	if err != nil {
 		debug.Log("SetIndex returned error: %v", err)

--- a/internal/repository/index_test.go
+++ b/internal/repository/index_test.go
@@ -135,10 +135,9 @@ func TestIndexSerialize(t *testing.T) {
 
 	id := restic.NewRandomID()
 	rtest.OK(t, idx.SetID(id))
-	id2, err := idx.ID()
+	ids, err := idx.IDs()
 	rtest.OK(t, err)
-	rtest.Assert(t, id2.Equal(id),
-		"wrong ID returned: want %v, got %v", id, id2)
+	rtest.Equals(t, restic.IDs{id}, ids)
 
 	idx3, err := repository.DecodeIndex(wr3.Bytes())
 	rtest.OK(t, err)

--- a/internal/repository/index_test.go
+++ b/internal/repository/index_test.go
@@ -336,7 +336,7 @@ var (
 )
 
 func initBenchmarkIndexJSON() {
-	idx, _ := createRandomIndex(rand.New(rand.NewSource(0)))
+	idx, _ := createRandomIndex(rand.New(rand.NewSource(0)), 200000)
 	var buf bytes.Buffer
 	idx.Encode(&buf)
 	benchmarkIndexJSON = buf.Bytes()
@@ -418,11 +418,11 @@ func NewRandomTestID(rng *rand.Rand) restic.ID {
 	return id
 }
 
-func createRandomIndex(rng *rand.Rand) (idx *repository.Index, lookupID restic.ID) {
+func createRandomIndex(rng *rand.Rand, packfiles int) (idx *repository.Index, lookupID restic.ID) {
 	idx = repository.NewIndex()
 
-	// create index with 200k pack files
-	for i := 0; i < 200000; i++ {
+	// create index with given number of pack files
+	for i := 0; i < packfiles; i++ {
 		packID := NewRandomTestID(rng)
 		var blobs []restic.Blob
 		offset := 0
@@ -449,7 +449,7 @@ func createRandomIndex(rng *rand.Rand) (idx *repository.Index, lookupID restic.I
 }
 
 func BenchmarkIndexHasUnknown(b *testing.B) {
-	idx, _ := createRandomIndex(rand.New(rand.NewSource(0)))
+	idx, _ := createRandomIndex(rand.New(rand.NewSource(0)), 200000)
 	lookupID := restic.NewRandomID()
 
 	b.ResetTimer()
@@ -460,7 +460,7 @@ func BenchmarkIndexHasUnknown(b *testing.B) {
 }
 
 func BenchmarkIndexHasKnown(b *testing.B) {
-	idx, lookupID := createRandomIndex(rand.New(rand.NewSource(0)))
+	idx, lookupID := createRandomIndex(rand.New(rand.NewSource(0)), 200000)
 
 	b.ResetTimer()
 
@@ -474,7 +474,7 @@ func BenchmarkIndexAlloc(b *testing.B) {
 	b.ReportAllocs()
 
 	for i := 0; i < b.N; i++ {
-		createRandomIndex(rng)
+		createRandomIndex(rng, 200000)
 	}
 }
 
@@ -484,7 +484,7 @@ func BenchmarkIndexAllocParallel(b *testing.B) {
 	b.RunParallel(func(pb *testing.PB) {
 		rng := rand.New(rand.NewSource(0))
 		for pb.Next() {
-			createRandomIndex(rng)
+			createRandomIndex(rng, 200000)
 		}
 	})
 }


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Merge in-memory indexes when they are finalized.
This increases performance especially for large repositories with many index files.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

The idea comes from #2523. This is a follow-up of #2799 as the discussion in there mainly moved to index-implementation related things.

This PR is based on #2812.

closes #944
closes #1550 
closes #2799
closes #2523 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
