### PR TITLE
cmd/mount: honour --no-lock flag

### DIFF
--- a/changelog/unreleased/pull-2821
+++ b/changelog/unreleased/pull-2821
@@ -1,0 +1,8 @@
+Change: Honor the --no-lock flag in the mount command
+
+The mount command now does not lock the repository if given the
+--no-lock flag. This allows to mount repositories which are archived
+on a read only backend/filesystem.
+
+https://github.com/restic/restic/issues/1597
+https://github.com/restic/restic/pull/2821

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -90,10 +90,12 @@ func mount(opts MountOptions, gopts GlobalOptions, mountpoint string) error {
 		return err
 	}
 
-	lock, err := lockRepo(repo)
-	defer unlockRepo(lock)
-	if err != nil {
-		return err
+	if !gopts.NoLock {
+		lock, err := lockRepo(repo)
+		defer unlockRepo(lock)
+		if err != nil {
+			return err
+		}
 	}
 
 	err = repo.LoadIndex(gopts.ctx)


### PR DESCRIPTION
Do not lock the repository if --no-lock flag is set. This allows to
mount repositories which are archived on a read only system.

Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------

<!--
Describe the changes here, as detailed as needed.
-->

If remote repository is on a read-only partition no lock can be acquired making the repo un-mountable.

This small patch fixes this by honouring the `--no-lock` global flag.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://forum.restic.net/t/mount-without-locking/2887

Fixes #1597

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
