### PR TITLE
Add --ignore-ctime flag to backup and document change detection

### DIFF
--- a/changelog/unreleased/pull-2823
+++ b/changelog/unreleased/pull-2823
@@ -1,0 +1,26 @@
+Enhancement: Add option to let backup trust mtime without checking ctime
+
+The backup command used to require that both ctime and mtime of a file matched
+with a previously backed up version to determine that the file was unchanged.
+In other words, if either ctime or mtime of the file had changed, it would be
+considered changed and restic would read the file's content again to back up
+the relevant (changed) parts of it.
+
+The new option --ignore-ctime makes restic look at mtime only, such that ctime
+changes for a file does not cause restic to read the file's contents again.
+
+The check for both ctime and mtime was introduced in restic 0.9.6 to make
+backups more reliable in the face of programs that reset mtime (some Unix
+archivers do that), but it turned out to often be expensive because it made
+restic read file contents even if only the metadata (owner, permissions) of
+a file had changed. The new --ignore-ctime option lets the user restore the
+0.9.5 behavior when needed. The existing --ignore-inode option already turned
+off this behavior, but also removed a different check.
+
+Please note that changes in files' metadata are still recorded, regardless of
+the command line options provided to the backup command.
+
+https://github.com/restic/restic/issues/2495
+https://github.com/restic/restic/issues/2558
+https://github.com/restic/restic/issues/2819
+https://github.com/restic/restic/pull/2823

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -131,23 +131,61 @@ restic encounters:
 In fact several hosts may use the same repository to backup directories
 and files leading to a greater de-duplication.
 
-Please be aware that when you backup different directories (or the
-directories to be saved have a variable name component like a
-time/date), restic always needs to read all files and only afterwards
-can compute which parts of the files need to be saved. When you backup
-the same directory again (maybe with new or changed files) restic will
-find the old snapshot in the repo and by default only reads those files
-that are new or have been modified since the last snapshot. This is
-decided based on the following attributes of the file in the file system:
-
- * Type (file, symlink, or directory?)
- * Modification time
- * Size
- * Inode number (internal number used to reference a file in a file system)
-
 Now is a good time to run ``restic check`` to verify that all data
 is properly stored in the repository. You should run this command regularly
 to make sure the internal structure of the repository is free of errors.
+
+File change detection
+*********************
+
+When restic encounters a file that has already been backed up, whether in the
+current backup or a previous one, it makes sure the file's contents are only
+stored once in the repository. To do so, it normally has to scan the entire
+contents of every file. Because this can be very expensive, restic also uses a
+change detection rule based on file metadata to determine whether a file is
+likely unchanged since a previous backup. If it is, the file is not scanned
+again.
+
+Change detection is only performed for regular files (not special files,
+symlinks or directories) that have the exact same path as they did in a
+previous backup of the same location.  If a file or one of its containing
+directories was renamed, it is considered a different file and its entire
+contents will be scanned again.
+
+Metadata changes (permissions, ownership, etc.) are always included in the
+backup, even if file contents are considered unchanged.
+
+On **Unix** (including Linux and Mac), given that a file lives at the same
+location as a file in a previous backup, the following file metadata
+attributes have to match for its contents to be presumed unchanged:
+
+ * Modification timestamp (mtime).
+ * Metadata change timestamp (ctime).
+ * File size.
+ * Inode number (internal number used to reference a file in a filesystem).
+
+The reason for requiring both mtime and ctime to match is that Unix programs
+can freely change mtime (and some do). In such cases, a ctime change may be
+the only hint that a file did change.
+
+The following ``restic backup`` command line flags modify the change detection
+rules:
+
+ * ``--force``: turn off change detection and rescan all files.
+ * ``--ignore-ctime``: require mtime to match, but allow ctime to differ.
+ * ``--ignore-inode``: require mtime to match, but allow inode number
+   and ctime to differ.
+
+The option ``--ignore-inode`` exists to support FUSE-based filesystems and
+pCloud, which do not assign stable inodes to files.
+
+Note that the device id of the containing mount point is never taken into
+account. Device numbers are not stable for removable devices and ZFS snapshots.
+If you want to force a re-scan in such a case, you can change the mountpoint.
+
+On **Windows**, a file is considered unchanged when its path and modification
+time match, and only ``--force`` has any effect. The other options are
+recognized but ignored.
 
 Excluding Files
 ***************
@@ -371,10 +409,6 @@ restic itself. This means that for each new backup a lot of metadata is
 written, and the next backup needs to write new metadata again. If you really
 want to save the access time for files and directories, you can pass the
 ``--with-atime`` option to the ``backup`` command.
-
-In filesystems that do not support inode consistency, like FUSE-based ones and pCloud, it is
-possible to ignore inode on changed files comparison by passing ``--ignore-inode`` to
-``backup`` command.
 
 Reading data from stdin
 ***********************


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Since restic 0.9.6, restic backup has required both the ctime and mtime on a file to match with a previously backed-up version for the file to skipped on Unix. Before 0.9.6, if the mtime matched but the ctime did not, restic backup would not rehash the file.

This PR introduces a --trust-mtime flag to restore the 0.9.5 behavior. Perhaps more importantly, it documents the rules used to determine whether a file can be skipped, since the description in the manual was incomplete and out of date.

The --ignore-inode flag already turned off the ctime check, but also removed a different check; its description in the manual was also in the wrong place.

Changes in metadata are still recorded, regardless of command line options. (This seems to have confused people in previous discussions, so it's worth pointing out.)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2558. I took the flag name from [Git](https://git-scm.com/docs/git-config#Documentation/git-config.txt-guitrustmtime), because the suggested --ignore-ctime suggests that the ctime is ignored also for metadata changes.

Closes #2503.

Closes #2495. There, @fd0 suggested --use-mtime, but that's confusing because the mtime is always used. @rawtaz suggested --change-detect=mtime, but it's unclear what the other behaviors should be called (ctime+mtime? ctime+mtime+inode?).

Probably fixes #2819.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
