### PR TITLE
Fix environment variables not being expanded when used in --files-from files

### DIFF
--- a/changelog/unreleased/issue-2825
+++ b/changelog/unreleased/issue-2825
@@ -1,0 +1,10 @@
+Bugfix: Expand environment variables when used in `--files-from` files
+
+Environment variables were not expanded when the file specified using the
+`--files-from` option contained any environment variables. This is now changed
+such that environment variables are expanded only in files specified using the
+`--exclude-file` (or `--iexclude-file`) and the `--files-from` options. The
+`--files-from-raw` and `--files-from-verbatim` options remain unaffected by
+this change.
+
+https://github.com/restic/restic/issues/2825


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Environment variables were not expanded when the file specified using the `--files-from` option contained any environment variables. 

This is now changed such that environment variables are expanded only in files specified using the `--exclude-file` (or `--iexclude-file`) and the `--files-from` options. The `--files-from-raw` and `--files-from-verbatim` options remain unaffected by this change.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Closes #2825.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
