### PR TITLE
Make self-healing work when backing up with parent snapshot

### DIFF
--- a/changelog/unreleased/issue-2571
+++ b/changelog/unreleased/issue-2571
@@ -1,0 +1,16 @@
+Enhancement: Self-heal missing file parts during backup of unchanged files
+
+We've improved the resilience of restic to certain types of repository corruption.
+
+For files that are unchanged since the parent snapshot, the backup command now
+verifies that all parts of the files still exist in the repository. Parts that are
+missing, e.g. from a damaged repository, are backed up again. This verification
+was already run for files that were modified since the parent snapshot, but is
+now also done for unchanged files.
+
+Note that restic will not backup file parts that are referenced in the index but
+where the actual data is not present on disk, as this situation can only be
+detected by restic check. Please ensure that you run `restic check` regularly.
+
+https://github.com/restic/restic/issues/2571
+https://github.com/restic/restic/pull/2827


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

When using backup with a parent snapshot, the blob list for file contents of an unchanged file is taken without any checks.
This PR adds a check if those blobs are really contained in the index. If not, the file will be saved like a changed file.

This allows backups to "heal" damaged repositories with missing data (of course only if the missing data still exists and is chosen to backup)

As this PR adds lot's of `Index.Has()` calls to `restic backup`, maybe should be postponed after #2818 
An alternative would be to make this optional by an additional flag within `backup` but I would argue against it if there is no notable performance decrease.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

The problem is discussed e.g. in #2334 
closes #2571 

To solve the problem without loosing data, users are supposed to run `backup --force` which may heal the repo.

With this PR a standard backup run will also heal the repo, if a `backup --force` would.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
