### PR TITLE
Update Go version to 1.14.6 in Docker build script

### DIFF
--- a/docker/build.sh
+++ b/docker/build.sh
@@ -5,7 +5,7 @@ set -e
 echo "Build binary using golang docker image"
 docker run --rm -ti \
     -v "`pwd`":/go/src/github.com/restic/restic \
-    -w /go/src/github.com/restic/restic golang:1.13.6-alpine go run build.go
+    -w /go/src/github.com/restic/restic golang:1.14.6-alpine go run build.go
 
 echo "Build docker image restic/restic:latest"
 docker build --rm -t restic/restic:latest -f docker/Dockerfile .


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
This updates Go to the latest 1.13 point release. Go has received some security fixes since 1.13.6, namely CVE-2020-7919, CVE-2020-9283 and CVE-2020-15586.

The current image uses an ancient base image version:
```
$ docker run --rm --entrypoint='' restic/restic cat /etc/issue
Welcome to Alpine Linux 3.10
Kernel \r on an \m (\l)
```

Rebuilding the image will also bump Alpine to 3.12 and therefore update `ca-certificates` etc.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] ~~I have added tests for all changes in this PR~~
- [x] ~~I have added documentation for the changes (in the manual)~~
- [x] ~~There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] ~~I have run `gofmt` on the code in all commits~~
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
