### PR TITLE
Make cache concurrency-safe and crash-resistant

### DIFF
--- a/internal/restic/cache.go
+++ b/internal/restic/cache.go
@@ -21,10 +21,6 @@ type Cache interface {
 	// SaveIndex saves an index in the cache.
 	Save(Handle, io.Reader) error
 
-	// SaveWriter returns a writer for the to be cached object h. It must be
-	// closed after writing is finished.
-	SaveWriter(Handle) (io.WriteCloser, error)
-
 	// Remove deletes a single file from the cache. If it isn't cached, this
 	// functions must return no error.
 	Remove(Handle) error


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

The cache in internal/cache now writes files to a temporary location before moving them into their final place. This way, multiple concurrent restic processes can write the same file without stomping on each other (although they will waste time downloading) and the cache is resistant to machine crashes.

There's also some not-quite-related cleanup of the cache code here: an error was being ignored and directory creation was done multiple times in the constructor.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2345.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
