### PR TITLE
Treat superseded indexes correctly

### DIFF
--- a/changelog/unreleased/issue-2824
+++ b/changelog/unreleased/issue-2824
@@ -1,0 +1,11 @@
+Bugfix: Treat superseded index files correctly
+
+We've fixed the treatment of still existing superseded index files.
+
+Index files that have been superseded are usually removed directly. However, if this
+wasn't the case, restic used them like normal index files without warning.
+This could result in data loss in special circumstances.
+The treatment of this special situation has been fixed and restic check was changed
+to warn if "obsolete" index files are present in the repo.
+
+https://github.com/restic/restic/issues/2824

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -512,6 +512,13 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 		DeleteFiles(gopts, repo, removePacksFirst, restic.PackFile)
 	}
 
+	// delete obsolete index files (index files that have already been superseded)
+	obsoleteIndexes := (repo.Index()).(*repository.MasterIndex).Obsolete()
+	if len(obsoleteIndexes) != 0 {
+		Verbosef("deleting unused index files...\n")
+		DeleteFiles(gopts, repo, obsoleteIndexes, restic.IndexFile)
+	}
+
 	if len(repackPacks) != 0 {
 		Verbosef("repacking packs\n")
 		bar := newProgressMax(!gopts.Quiet, uint64(len(repackPacks)), "packs repacked")

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -471,6 +471,9 @@ func (r *Repository) LoadIndex(ctx context.Context) error {
 		return err
 	}
 
+	// remove obsolete indexes
+	validIndex.Sub(r.idx.Obsolete())
+
 	// remove index files from the cache which have been removed in the repo
 	return r.PrepareCache(validIndex)
 }


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Treat superseded index files correctly, if they still exist.
This means, they are now ignored for most commands and check prints a hint if they exist.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

closes #2824 

Is also used within #2718.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR - tests are added within #2718 
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review