### PR TITLE
Rebuild index in prune by using in-memory index

### DIFF
--- a/changelog/unreleased/pull-2718
+++ b/changelog/unreleased/pull-2718
@@ -3,6 +3,8 @@ Enhancement: Improve pruning performance and make pruning more customizable
 The `prune` command is now much faster. This is especially the case for remote
 repositories or repositories with not much data to remove.
 Also the memory usage of the `prune` command is now reduced.
+Restic used to rebuild the index from scratch after pruning. This is now
+changed and the index rebuilding uses the information already known by `prune`.
 
 By default, the `prune` command no longer removes all unused data. This
 behavior can be fine-tuned by new options, like the acceptable amount of unused space or
@@ -14,9 +16,11 @@ also shows what `prune` would do.
 
 Fixes several open issues, e.g.:
 https://github.com/restic/restic/issues/1140
+https://github.com/restic/restic/issues/1599
 https://github.com/restic/restic/issues/1985
 https://github.com/restic/restic/issues/2112
 https://github.com/restic/restic/issues/2227
 https://github.com/restic/restic/issues/2305
 
 https://github.com/restic/restic/pull/2718
+https://github.com/restic/restic/pull/2842

--- a/changelog/unreleased/pull-2718
+++ b/changelog/unreleased/pull-2718
@@ -3,8 +3,11 @@ Enhancement: Improve pruning performance and make pruning more customizable
 The `prune` command is now much faster. This is especially the case for remote
 repositories or repositories with not much data to remove.
 Also the memory usage of the `prune` command is now reduced.
-Restic used to rebuild the index from scratch after pruning. This is now
-changed and the index rebuilding uses the information already known by `prune`.
+Restic used to rebuild the index from scratch after pruning. This could lead
+to missing packs in the index in some cases for eventually consistent 
+backends, like e.g. AWS S3.
+This behavior is now changed and the index rebuilding uses the information
+already known by `prune`.
 
 By default, the `prune` command no longer removes all unused data. This
 behavior can be fine-tuned by new options, like the acceptable amount of unused space or

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -99,12 +99,10 @@ command must be run:
     
     repacking packs
     [0:00] 100.00%  2 / 2 packs repacked
-    counting files in repo
-    [0:00] 100.00%  3 / 3 packs
-    finding old index files
-    saved new indexes as [59270b3a]
-    remove 4 old index files
-    [0:00] 100.00%  4 / 4 files deleted
+    rebuilding index
+    [0:00] 100.00%  3 / 3 packs processed
+    deleting obsolete index files
+    [0:00] 100.00%  3 / 3 files deleted
     removing 3 old packs
     [0:00] 100.00%  3 / 3 files deleted
     done
@@ -147,12 +145,10 @@ to ``forget``:
     
     repacking packs
     [0:00] 100.00%  2 / 2 packs repacked
-    counting files in repo
-    [0:00] 100.00%  3 / 3 packs
-    finding old index files
-    saved new indexes as [59270b3a]
-    remove 4 old index files
-    [0:00] 100.00%  4 / 4 files deleted
+    rebuilding index
+    [0:00] 100.00%  3 / 3 packs processed
+    deleting obsolete index files
+    [0:00] 100.00%  3 / 3 files deleted
     removing 3 old packs
     [0:00] 100.00%  3 / 3 files deleted
     done

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -322,7 +322,10 @@ func (r *Repository) Flush(ctx context.Context) error {
 		return err
 	}
 
-	// Save index after flushing
+	// Save index after flushing only if noAutoIndexUpdate is not set
+	if r.noAutoIndexUpdate {
+		return nil
+	}
 	return r.SaveIndex(ctx)
 }
 

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -62,6 +62,7 @@ type MasterIndex interface {
 	Has(ID, BlobType) bool
 	Lookup(ID, BlobType) []PackedBlob
 	Count(BlobType) uint
+	Packs() IDSet
 
 	// Each returns a channel that yields all blobs known to the index. When
 	// the context is cancelled, the background goroutine terminates. This


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Optimize the rebuilding of the index during `prune` by using the in-memory index instead of reading all pack headers.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

This was a part of #2718 that has been extracted to be merged after #2718 has been merged.
To not save exact duplicates multiple times in the rebuilt index, either #2839 or #2863 should also be merged.

closes #1599 
closes #3049 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have updated the documentation for the changes (in the manual)
- [x] There's an updated file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
