### PR TITLE
Make some pack parameters public

### DIFF
--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -161,13 +161,16 @@ func (p *Packer) String() string {
 }
 
 var (
-	// size of the header-length field at the end of the file
-	headerLengthSize = binary.Size(uint32(0))
 	// we require at least one entry in the header, and one blob for a pack file
 	minFileSize = entrySize + crypto.Extension + uint(headerLengthSize)
 )
 
 const (
+	// size of the header-length field at the end of the file; it is a uint32
+	headerLengthSize = 4
+	// constant overhead of the header independent of #entries
+	HeaderSize = headerLengthSize + crypto.Extension
+
 	maxHeaderSize = 16 * 1024 * 1024
 	// number of header enries to download as part of header-length request
 	eagerEntries = 15
@@ -314,4 +317,9 @@ func List(k *crypto.Key, rd io.ReaderAt, size int64) (entries []restic.Blob, err
 	}
 
 	return entries, nil
+}
+
+// PackedSizeOfBlob returns the size a blob actually uses when saved in a pack
+func PackedSizeOfBlob(blobLength uint) uint {
+	return blobLength + entrySize
 }

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -37,7 +37,7 @@ type packerManager struct {
 	packers []*Packer
 }
 
-const minPackSize = 4 * 1024 * 1024
+const MinPackSize = 4 * 1024 * 1024
 
 // newPackerManager returns an new packer manager which writes temporary files
 // to a temporary directory

--- a/internal/repository/packer_manager_test.go
+++ b/internal/repository/packer_manager_test.go
@@ -79,7 +79,7 @@ func fillPacks(t testing.TB, rnd *rand.Rand, be Saver, pm *packerManager, buf []
 		}
 		bytes += l
 
-		if packer.Size() < minPackSize {
+		if packer.Size() < MinPackSize {
 			pm.insertPacker(packer)
 			continue
 		}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -263,7 +263,7 @@ func (r *Repository) SaveAndEncrypt(ctx context.Context, t restic.BlobType, data
 	}
 
 	// if the pack is not full enough, put back to the list
-	if packer.Size() < minPackSize {
+	if packer.Size() < MinPackSize {
 		debug.Log("pack is not full enough (%d bytes)", packer.Size())
 		pm.insertPacker(packer)
 		return nil


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

Make some pack parameters public that are needed, e.g. by #2718 

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

see #2718

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- I have not added tests for all changes in this PR
- I have not added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
