### PR TITLE
gs: support authentication with access token

### DIFF
--- a/changelog/unreleased/pull-2848
+++ b/changelog/unreleased/pull-2848
@@ -1,0 +1,7 @@
+Enhancement: Authenticate to Google Cloud Storage with access token
+
+When using the GCS backend, it is now possible to authenticate with OAuth2
+access tokens instead of a credentials file by setting the GOOGLE_ACCESS_TOKEN
+environment variable.
+
+https://github.com/restic/restic/pull/2848

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -458,6 +458,18 @@ which means if you're running in Google Container Engine or are otherwise
 located on an instance with default service accounts then these should work out of 
 the box.
 
+Alternatively, you can specify an existing access token directly:
+
+.. code-block:: console
+
+    $ export GOOGLE_ACCESS_TOKEN=ya29.a0AfH6SMC78...
+
+If ``GOOGLE_ACCESS_TOKEN`` is set all other authentication mechanisms are
+disabled. The access token must have at least the
+``https://www.googleapis.com/auth/devstorage.read_write`` scope. Keep in mind
+that access tokens are short-lived (usually one hour), so they are not suitable
+if creating a backup takes longer than that, for instance.
+
 Once authenticated, you can use the ``gs:`` backend type to create a new
 repository in the bucket ``foo`` at the root path:
 

--- a/internal/backend/gs/gs_test.go
+++ b/internal/backend/gs/gs_test.go
@@ -87,7 +87,6 @@ func TestBackendGS(t *testing.T) {
 	}()
 
 	vars := []string{
-		"GOOGLE_APPLICATION_CREDENTIALS",
 		"RESTIC_TEST_GS_PROJECT_ID",
 		"RESTIC_TEST_GS_REPOSITORY",
 	}
@@ -97,6 +96,10 @@ func TestBackendGS(t *testing.T) {
 			t.Skipf("environment variable %v not set", v)
 			return
 		}
+	}
+	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")+os.Getenv("GOOGLE_ACCESS_TOKEN") == "" {
+		t.Skipf("environment variable GOOGLE_APPLICATION_CREDENTIALS not set, nor GOOGLE_ACCESS_TOKEN")
+		return
 	}
 
 	t.Logf("run tests")
@@ -105,7 +108,6 @@ func TestBackendGS(t *testing.T) {
 
 func BenchmarkBackendGS(t *testing.B) {
 	vars := []string{
-		"GOOGLE_APPLICATION_CREDENTIALS",
 		"RESTIC_TEST_GS_PROJECT_ID",
 		"RESTIC_TEST_GS_REPOSITORY",
 	}
@@ -115,6 +117,10 @@ func BenchmarkBackendGS(t *testing.B) {
 			t.Skipf("environment variable %v not set", v)
 			return
 		}
+	}
+	if os.Getenv("GOOGLE_APPLICATION_CREDENTIALS")+os.Getenv("GOOGLE_ACCESS_TOKEN") == "" {
+		t.Skipf("environment variable GOOGLE_APPLICATION_CREDENTIALS not set, nor GOOGLE_ACCESS_TOKEN")
+		return
 	}
 
 	t.Logf("run tests")


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------

In the Google Cloud Storage backend, support specifying access tokens
directly, as an alternative to a credentials file. This is useful when
restic is used non-interactively by some other program that is already
authenticated and eliminates the need to store long lived credentials.

The access token is specified in the GOOGLE_ACCESS_TOKEN environment
variable and takes precedence over GOOGLE_APPLICATION_CREDENTIALS.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR 
  - Not necessary; the existing tests cover this feature already
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
