### PR TITLE
Building restic + rclone as a library

### DIFF
--- a/cmd/global/api.go
+++ b/cmd/global/api.go
@@ -1,0 +1,29 @@
+package global
+
+import (
+	"github.com/restic/restic/internal/cache"
+	"github.com/restic/restic/internal/options"
+	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
+)
+
+const (
+	DataBlob = restic.DataBlob
+	TreeBlob = restic.TreeBlob
+)
+
+// types
+type Repository = restic.Repository
+type Node = restic.Node
+type Tree = restic.Tree
+type TagList = restic.TagList
+type Cache = cache.Cache
+type Options = options.Options
+
+// functions
+var FindLatestSnapshot = restic.FindLatestSnapshot
+var LoadSnapshot = restic.LoadSnapshot
+var NewBlobBuffer = restic.NewBlobBuffer
+var CiphertextLength = restic.CiphertextLength
+var NewRepository = repository.New
+var NewCache = cache.New

--- a/cmd/global/global.go
+++ b/cmd/global/global.go
@@ -1,0 +1,315 @@
+package global
+
+import (
+	"context"
+	"os"
+
+	"github.com/restic/restic/internal/backend"
+	"github.com/restic/restic/internal/backend/azure"
+	"github.com/restic/restic/internal/backend/b2"
+	"github.com/restic/restic/internal/backend/gs"
+	"github.com/restic/restic/internal/backend/inproc"
+	"github.com/restic/restic/internal/backend/local"
+	"github.com/restic/restic/internal/backend/location"
+	"github.com/restic/restic/internal/backend/rclone"
+	"github.com/restic/restic/internal/backend/rest"
+	"github.com/restic/restic/internal/backend/s3"
+	"github.com/restic/restic/internal/backend/sftp"
+	"github.com/restic/restic/internal/backend/swift"
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/limiter"
+	"github.com/restic/restic/internal/options"
+	"github.com/restic/restic/internal/restic"
+
+	"github.com/restic/restic/internal/errors"
+)
+
+// GlobalOptions hold all global options for restic.
+type GlobalOptions struct {
+	Repo            string
+	PasswordFile    string
+	PasswordCommand string
+	KeyHint         string
+	Quiet           bool
+	Verbose         int
+	NoLock          bool
+	JSON            bool
+	CacheDir        string
+	NoCache         bool
+	CACerts         []string
+	TLSClientCert   string
+	CleanupCache    bool
+
+	LimitUploadKb   int
+	LimitDownloadKb int
+
+	Ctx context.Context
+}
+
+func parseConfig(loc location.Location, opts options.Options) (interface{}, error) {
+	// only apply options for a particular backend here
+	opts = opts.Extract(loc.Scheme)
+
+	switch loc.Scheme {
+	case "local":
+		cfg := loc.Config.(local.Config)
+		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
+			return nil, err
+		}
+
+		debug.Log("opening local repository at %#v", cfg)
+		return cfg, nil
+
+	case "sftp":
+		cfg := loc.Config.(sftp.Config)
+		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
+			return nil, err
+		}
+
+		debug.Log("opening sftp repository at %#v", cfg)
+		return cfg, nil
+
+	case "s3":
+		cfg := loc.Config.(s3.Config)
+		if cfg.KeyID == "" {
+			cfg.KeyID = os.Getenv("AWS_ACCESS_KEY_ID")
+		}
+
+		if cfg.Secret == "" {
+			cfg.Secret = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		}
+
+		if cfg.Region == "" {
+			cfg.Region = os.Getenv("AWS_DEFAULT_REGION")
+		}
+
+		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
+			return nil, err
+		}
+
+		debug.Log("opening s3 repository at %#v", cfg)
+		return cfg, nil
+
+	case "gs":
+		cfg := loc.Config.(gs.Config)
+		if cfg.ProjectID == "" {
+			cfg.ProjectID = os.Getenv("GOOGLE_PROJECT_ID")
+		}
+
+		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
+			return nil, err
+		}
+
+		debug.Log("opening gs repository at %#v", cfg)
+		return cfg, nil
+
+	case "azure":
+		cfg := loc.Config.(azure.Config)
+		if cfg.AccountName == "" {
+			cfg.AccountName = os.Getenv("AZURE_ACCOUNT_NAME")
+		}
+
+		if cfg.AccountKey == "" {
+			cfg.AccountKey = os.Getenv("AZURE_ACCOUNT_KEY")
+		}
+
+		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
+			return nil, err
+		}
+
+		debug.Log("opening gs repository at %#v", cfg)
+		return cfg, nil
+
+	case "swift":
+		cfg := loc.Config.(swift.Config)
+
+		if err := swift.ApplyEnvironment("", &cfg); err != nil {
+			return nil, err
+		}
+
+		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
+			return nil, err
+		}
+
+		debug.Log("opening swift repository at %#v", cfg)
+		return cfg, nil
+
+	case "b2":
+		cfg := loc.Config.(b2.Config)
+
+		if cfg.AccountID == "" {
+			cfg.AccountID = os.Getenv("B2_ACCOUNT_ID")
+		}
+
+		if cfg.AccountID == "" {
+			return nil, errors.Fatalf("unable to open B2 backend: Account ID ($B2_ACCOUNT_ID) is empty")
+		}
+
+		if cfg.Key == "" {
+			cfg.Key = os.Getenv("B2_ACCOUNT_KEY")
+		}
+
+		if cfg.Key == "" {
+			return nil, errors.Fatalf("unable to open B2 backend: Key ($B2_ACCOUNT_KEY) is empty")
+		}
+
+		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
+			return nil, err
+		}
+
+		debug.Log("opening b2 repository at %#v", cfg)
+		return cfg, nil
+	case "rest":
+		cfg := loc.Config.(rest.Config)
+		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
+			return nil, err
+		}
+
+		debug.Log("opening rest repository at %#v", cfg)
+		return cfg, nil
+	case "rclone":
+		cfg := loc.Config.(rclone.Config)
+		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
+			return nil, err
+		}
+
+		debug.Log("opening rest repository at %#v", cfg)
+		return cfg, nil
+	case "inproc":
+		cfg := loc.Config.(inproc.Config)
+		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
+			return nil, err
+		}
+
+		debug.Log("opening rest repository at %#v", cfg)
+		return cfg, nil
+
+	}
+
+	return nil, errors.Fatalf("invalid backend: %q", loc.Scheme)
+}
+
+// Open the backend specified by a location config.
+func Open(gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
+	s := gopts.Repo
+	debug.Log("parsing location %v", s)
+	loc, err := location.Parse(s)
+	if err != nil {
+		return nil, errors.Fatalf("parsing repository location failed: %v", err)
+	}
+
+	var be restic.Backend
+	cfg, err := parseConfig(loc, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	tropts := backend.TransportOptions{
+		RootCertFilenames:        gopts.CACerts,
+		TLSClientCertKeyFilename: gopts.TLSClientCert,
+	}
+	rt, err := backend.Transport(tropts)
+	if err != nil {
+		return nil, err
+	}
+
+	// wrap the transport so that the throughput via HTTP is limited
+	lim := limiter.NewStaticLimiter(gopts.LimitUploadKb, gopts.LimitDownloadKb)
+	rt = lim.Transport(rt)
+
+	switch loc.Scheme {
+	case "local":
+		be, err = local.Open(cfg.(local.Config))
+		// wrap the backend in a LimitBackend so that the throughput is limited
+		be = limiter.LimitBackend(be, lim)
+	case "sftp":
+		be, err = sftp.Open(cfg.(sftp.Config))
+		// wrap the backend in a LimitBackend so that the throughput is limited
+		be = limiter.LimitBackend(be, lim)
+	case "s3":
+		be, err = s3.Open(cfg.(s3.Config), rt)
+	case "gs":
+		be, err = gs.Open(cfg.(gs.Config), rt)
+	case "azure":
+		be, err = azure.Open(cfg.(azure.Config), rt)
+	case "swift":
+		be, err = swift.Open(cfg.(swift.Config), rt)
+	case "b2":
+		be, err = b2.Open(gopts.Ctx, cfg.(b2.Config), rt)
+	case "rest":
+		be, err = rest.Open(cfg.(rest.Config), rt)
+	case "rclone":
+		be, err = rclone.Open(cfg.(rclone.Config), lim)
+	case "inproc":
+		be, err = inproc.Open(cfg.(inproc.Config), lim)
+
+	default:
+		return nil, errors.Fatalf("invalid backend: %q", loc.Scheme)
+	}
+
+	if err != nil {
+		return nil, errors.Fatalf("unable to open repo at %v: %v", s, err)
+	}
+
+	// check if config is there
+	fi, err := be.Stat(gopts.Ctx, restic.Handle{Type: restic.ConfigFile})
+	if err != nil {
+		return nil, errors.Fatalf("unable to open config file: %v\nIs there a repository at the following location?\n%v", err, s)
+	}
+
+	if fi.Size == 0 {
+		return nil, errors.New("config file has zero size, invalid repository?")
+	}
+
+	return be, nil
+}
+
+// Create the backend specified by URI.
+func Create(gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
+	s := gopts.Repo
+	debug.Log("parsing location %v", s)
+	loc, err := location.Parse(s)
+	if err != nil {
+		return nil, err
+	}
+
+	cfg, err := parseConfig(loc, opts)
+	if err != nil {
+		return nil, err
+	}
+
+	tropts := backend.TransportOptions{
+		RootCertFilenames:        gopts.CACerts,
+		TLSClientCertKeyFilename: gopts.TLSClientCert,
+	}
+	rt, err := backend.Transport(tropts)
+	if err != nil {
+		return nil, err
+	}
+
+	switch loc.Scheme {
+	case "local":
+		return local.Create(cfg.(local.Config))
+	case "sftp":
+		return sftp.Create(cfg.(sftp.Config))
+	case "s3":
+		return s3.Create(cfg.(s3.Config), rt)
+	case "gs":
+		return gs.Create(cfg.(gs.Config), rt)
+	case "azure":
+		return azure.Create(cfg.(azure.Config), rt)
+	case "swift":
+		return swift.Open(cfg.(swift.Config), rt)
+	case "b2":
+		return b2.Create(gopts.Ctx, cfg.(b2.Config), rt)
+	case "rest":
+		return rest.Create(cfg.(rest.Config), rt)
+	case "rclone":
+		return rclone.Open(cfg.(rclone.Config), nil)
+	case "inproc":
+		return inproc.Open(cfg.(inproc.Config), nil)
+	}
+
+	debug.Log("invalid repository scheme: %v", s)
+	return nil, errors.Fatalf("invalid scheme %q", loc.Scheme)
+}

--- a/cmd/global/global.go
+++ b/cmd/global/global.go
@@ -42,8 +42,6 @@ type GlobalOptions struct {
 
 	LimitUploadKb   int
 	LimitDownloadKb int
-
-	Ctx context.Context
 }
 
 func parseConfig(loc location.Location, opts options.Options) (interface{}, error) {
@@ -190,7 +188,7 @@ func parseConfig(loc location.Location, opts options.Options) (interface{}, erro
 }
 
 // Open the backend specified by a location config.
-func Open(gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
+func Open(ctx context.Context, gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
 	s := gopts.Repo
 	debug.Log("parsing location %v", s)
 	loc, err := location.Parse(s)
@@ -235,7 +233,7 @@ func Open(gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
 	case "swift":
 		be, err = swift.Open(cfg.(swift.Config), rt)
 	case "b2":
-		be, err = b2.Open(gopts.Ctx, cfg.(b2.Config), rt)
+		be, err = b2.Open(ctx, cfg.(b2.Config), rt)
 	case "rest":
 		be, err = rest.Open(cfg.(rest.Config), rt)
 	case "rclone":
@@ -252,7 +250,7 @@ func Open(gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
 	}
 
 	// check if config is there
-	fi, err := be.Stat(gopts.Ctx, restic.Handle{Type: restic.ConfigFile})
+	fi, err := be.Stat(ctx, restic.Handle{Type: restic.ConfigFile})
 	if err != nil {
 		return nil, errors.Fatalf("unable to open config file: %v\nIs there a repository at the following location?\n%v", err, s)
 	}
@@ -265,7 +263,7 @@ func Open(gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
 }
 
 // Create the backend specified by URI.
-func Create(gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
+func Create(ctx context.Context, gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
 	s := gopts.Repo
 	debug.Log("parsing location %v", s)
 	loc, err := location.Parse(s)
@@ -301,7 +299,7 @@ func Create(gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
 	case "swift":
 		return swift.Open(cfg.(swift.Config), rt)
 	case "b2":
-		return b2.Create(gopts.Ctx, cfg.(b2.Config), rt)
+		return b2.Create(ctx, cfg.(b2.Config), rt)
 	case "rest":
 		return rest.Create(cfg.(rest.Config), rt)
 	case "rclone":

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -34,7 +34,7 @@ func runInit(gopts GlobalOptions, args []string) error {
 		return errors.Fatal("Please specify repository location (-r)")
 	}
 
-	be, err := global.Create(gopts.GlobalOptions, gopts.extended)
+	be, err := global.Create(gopts.ctx, gopts.GlobalOptions, gopts.extended)
 	if err != nil {
 		return errors.Fatalf("create repository at %s failed: %v\n", gopts.Repo, err)
 	}

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"github.com/restic/restic/cmd/global"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
 
@@ -33,7 +34,7 @@ func runInit(gopts GlobalOptions, args []string) error {
 		return errors.Fatal("Please specify repository location (-r)")
 	}
 
-	be, err := create(gopts.Repo, gopts.extended)
+	be, err := global.Create(gopts.GlobalOptions, gopts.extended)
 	if err != nil {
 		return errors.Fatalf("create repository at %s failed: %v\n", gopts.Repo, err)
 	}

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -12,27 +12,14 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/restic/restic/cmd/global"
 	"github.com/restic/restic/internal/backend"
-	"github.com/restic/restic/internal/backend/azure"
-	"github.com/restic/restic/internal/backend/b2"
-	"github.com/restic/restic/internal/backend/gs"
-	"github.com/restic/restic/internal/backend/local"
-	"github.com/restic/restic/internal/backend/location"
-	"github.com/restic/restic/internal/backend/rclone"
-	"github.com/restic/restic/internal/backend/rest"
-	"github.com/restic/restic/internal/backend/s3"
-	"github.com/restic/restic/internal/backend/sftp"
-	"github.com/restic/restic/internal/backend/swift"
 	"github.com/restic/restic/internal/cache"
-	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
-	"github.com/restic/restic/internal/limiter"
 	"github.com/restic/restic/internal/options"
 	"github.com/restic/restic/internal/repository"
-	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/textfile"
-
-	"github.com/restic/restic/internal/errors"
 
 	"os/exec"
 
@@ -46,22 +33,7 @@ const TimeFormat = "2006-01-02 15:04:05"
 
 // GlobalOptions hold all global options for restic.
 type GlobalOptions struct {
-	Repo            string
-	PasswordFile    string
-	PasswordCommand string
-	KeyHint         string
-	Quiet           bool
-	Verbose         int
-	NoLock          bool
-	JSON            bool
-	CacheDir        string
-	NoCache         bool
-	CACerts         []string
-	TLSClientCert   string
-	CleanupCache    bool
-
-	LimitUploadKb   int
-	LimitDownloadKb int
+	global.GlobalOptions
 
 	ctx      context.Context
 	password string
@@ -90,6 +62,7 @@ var isReadingPassword bool
 func init() {
 	var cancel context.CancelFunc
 	globalOptions.ctx, cancel = context.WithCancel(context.Background())
+	globalOptions.Ctx = globalOptions.ctx
 	AddCleanupHandler(func() error {
 		cancel()
 		return nil
@@ -386,7 +359,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		return nil, errors.Fatal("Please specify repository location (-r)")
 	}
 
-	be, err := open(opts.Repo, opts, opts.extended)
+	be, err := global.Open(opts.GlobalOptions, opts.extended)
 	if err != nil {
 		return nil, err
 	}
@@ -481,258 +454,4 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 	}
 
 	return s, nil
-}
-
-func parseConfig(loc location.Location, opts options.Options) (interface{}, error) {
-	// only apply options for a particular backend here
-	opts = opts.Extract(loc.Scheme)
-
-	switch loc.Scheme {
-	case "local":
-		cfg := loc.Config.(local.Config)
-		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
-			return nil, err
-		}
-
-		debug.Log("opening local repository at %#v", cfg)
-		return cfg, nil
-
-	case "sftp":
-		cfg := loc.Config.(sftp.Config)
-		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
-			return nil, err
-		}
-
-		debug.Log("opening sftp repository at %#v", cfg)
-		return cfg, nil
-
-	case "s3":
-		cfg := loc.Config.(s3.Config)
-		if cfg.KeyID == "" {
-			cfg.KeyID = os.Getenv("AWS_ACCESS_KEY_ID")
-		}
-
-		if cfg.Secret == "" {
-			cfg.Secret = os.Getenv("AWS_SECRET_ACCESS_KEY")
-		}
-
-		if cfg.Region == "" {
-			cfg.Region = os.Getenv("AWS_DEFAULT_REGION")
-		}
-
-		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
-			return nil, err
-		}
-
-		debug.Log("opening s3 repository at %#v", cfg)
-		return cfg, nil
-
-	case "gs":
-		cfg := loc.Config.(gs.Config)
-		if cfg.ProjectID == "" {
-			cfg.ProjectID = os.Getenv("GOOGLE_PROJECT_ID")
-		}
-
-		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
-			return nil, err
-		}
-
-		debug.Log("opening gs repository at %#v", cfg)
-		return cfg, nil
-
-	case "azure":
-		cfg := loc.Config.(azure.Config)
-		if cfg.AccountName == "" {
-			cfg.AccountName = os.Getenv("AZURE_ACCOUNT_NAME")
-		}
-
-		if cfg.AccountKey == "" {
-			cfg.AccountKey = os.Getenv("AZURE_ACCOUNT_KEY")
-		}
-
-		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
-			return nil, err
-		}
-
-		debug.Log("opening gs repository at %#v", cfg)
-		return cfg, nil
-
-	case "swift":
-		cfg := loc.Config.(swift.Config)
-
-		if err := swift.ApplyEnvironment("", &cfg); err != nil {
-			return nil, err
-		}
-
-		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
-			return nil, err
-		}
-
-		debug.Log("opening swift repository at %#v", cfg)
-		return cfg, nil
-
-	case "b2":
-		cfg := loc.Config.(b2.Config)
-
-		if cfg.AccountID == "" {
-			cfg.AccountID = os.Getenv("B2_ACCOUNT_ID")
-		}
-
-		if cfg.AccountID == "" {
-			return nil, errors.Fatalf("unable to open B2 backend: Account ID ($B2_ACCOUNT_ID) is empty")
-		}
-
-		if cfg.Key == "" {
-			cfg.Key = os.Getenv("B2_ACCOUNT_KEY")
-		}
-
-		if cfg.Key == "" {
-			return nil, errors.Fatalf("unable to open B2 backend: Key ($B2_ACCOUNT_KEY) is empty")
-		}
-
-		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
-			return nil, err
-		}
-
-		debug.Log("opening b2 repository at %#v", cfg)
-		return cfg, nil
-	case "rest":
-		cfg := loc.Config.(rest.Config)
-		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
-			return nil, err
-		}
-
-		debug.Log("opening rest repository at %#v", cfg)
-		return cfg, nil
-	case "rclone":
-		cfg := loc.Config.(rclone.Config)
-		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
-			return nil, err
-		}
-
-		debug.Log("opening rest repository at %#v", cfg)
-		return cfg, nil
-	}
-
-	return nil, errors.Fatalf("invalid backend: %q", loc.Scheme)
-}
-
-// Open the backend specified by a location config.
-func open(s string, gopts GlobalOptions, opts options.Options) (restic.Backend, error) {
-	debug.Log("parsing location %v", s)
-	loc, err := location.Parse(s)
-	if err != nil {
-		return nil, errors.Fatalf("parsing repository location failed: %v", err)
-	}
-
-	var be restic.Backend
-
-	cfg, err := parseConfig(loc, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	tropts := backend.TransportOptions{
-		RootCertFilenames:        globalOptions.CACerts,
-		TLSClientCertKeyFilename: globalOptions.TLSClientCert,
-	}
-	rt, err := backend.Transport(tropts)
-	if err != nil {
-		return nil, err
-	}
-
-	// wrap the transport so that the throughput via HTTP is limited
-	lim := limiter.NewStaticLimiter(gopts.LimitUploadKb, gopts.LimitDownloadKb)
-	rt = lim.Transport(rt)
-
-	switch loc.Scheme {
-	case "local":
-		be, err = local.Open(cfg.(local.Config))
-		// wrap the backend in a LimitBackend so that the throughput is limited
-		be = limiter.LimitBackend(be, lim)
-	case "sftp":
-		be, err = sftp.Open(cfg.(sftp.Config))
-		// wrap the backend in a LimitBackend so that the throughput is limited
-		be = limiter.LimitBackend(be, lim)
-	case "s3":
-		be, err = s3.Open(cfg.(s3.Config), rt)
-	case "gs":
-		be, err = gs.Open(cfg.(gs.Config), rt)
-	case "azure":
-		be, err = azure.Open(cfg.(azure.Config), rt)
-	case "swift":
-		be, err = swift.Open(cfg.(swift.Config), rt)
-	case "b2":
-		be, err = b2.Open(globalOptions.ctx, cfg.(b2.Config), rt)
-	case "rest":
-		be, err = rest.Open(cfg.(rest.Config), rt)
-	case "rclone":
-		be, err = rclone.Open(cfg.(rclone.Config), lim)
-
-	default:
-		return nil, errors.Fatalf("invalid backend: %q", loc.Scheme)
-	}
-
-	if err != nil {
-		return nil, errors.Fatalf("unable to open repo at %v: %v", s, err)
-	}
-
-	// check if config is there
-	fi, err := be.Stat(globalOptions.ctx, restic.Handle{Type: restic.ConfigFile})
-	if err != nil {
-		return nil, errors.Fatalf("unable to open config file: %v\nIs there a repository at the following location?\n%v", err, s)
-	}
-
-	if fi.Size == 0 {
-		return nil, errors.New("config file has zero size, invalid repository?")
-	}
-
-	return be, nil
-}
-
-// Create the backend specified by URI.
-func create(s string, opts options.Options) (restic.Backend, error) {
-	debug.Log("parsing location %v", s)
-	loc, err := location.Parse(s)
-	if err != nil {
-		return nil, err
-	}
-
-	cfg, err := parseConfig(loc, opts)
-	if err != nil {
-		return nil, err
-	}
-
-	tropts := backend.TransportOptions{
-		RootCertFilenames:        globalOptions.CACerts,
-		TLSClientCertKeyFilename: globalOptions.TLSClientCert,
-	}
-	rt, err := backend.Transport(tropts)
-	if err != nil {
-		return nil, err
-	}
-
-	switch loc.Scheme {
-	case "local":
-		return local.Create(cfg.(local.Config))
-	case "sftp":
-		return sftp.Create(cfg.(sftp.Config))
-	case "s3":
-		return s3.Create(cfg.(s3.Config), rt)
-	case "gs":
-		return gs.Create(cfg.(gs.Config), rt)
-	case "azure":
-		return azure.Create(cfg.(azure.Config), rt)
-	case "swift":
-		return swift.Open(cfg.(swift.Config), rt)
-	case "b2":
-		return b2.Create(globalOptions.ctx, cfg.(b2.Config), rt)
-	case "rest":
-		return rest.Create(cfg.(rest.Config), rt)
-	case "rclone":
-		return rclone.Open(cfg.(rclone.Config), nil)
-	}
-
-	debug.Log("invalid repository scheme: %v", s)
-	return nil, errors.Fatalf("invalid scheme %q", loc.Scheme)
 }

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -62,7 +62,6 @@ var isReadingPassword bool
 func init() {
 	var cancel context.CancelFunc
 	globalOptions.ctx, cancel = context.WithCancel(context.Background())
-	globalOptions.Ctx = globalOptions.ctx
 	AddCleanupHandler(func() error {
 		cancel()
 		return nil
@@ -359,7 +358,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		return nil, errors.Fatal("Please specify repository location (-r)")
 	}
 
-	be, err := global.Open(opts.GlobalOptions, opts.extended)
+	be, err := global.Open(opts.ctx, opts.GlobalOptions, opts.extended)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"testing"
 
+	"github.com/restic/restic/cmd/global"
 	"github.com/restic/restic/internal/options"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
@@ -199,9 +200,10 @@ func withTestEnvironment(t testing.TB) (env *testEnvironment, cleanup func()) {
 	rtest.OK(t, os.MkdirAll(env.repo, 0700))
 
 	env.gopts = GlobalOptions{
-		Repo:     env.repo,
-		Quiet:    true,
-		CacheDir: env.cache,
+		GlobalOptions: global.GlobalOptions{
+			Repo:     env.repo,
+			Quiet:    true,
+			CacheDir: env.cache},
 		ctx:      context.Background(),
 		password: rtest.TestPassword,
 		stdout:   os.Stdout,

--- a/internal/backend/inproc/backend.go
+++ b/internal/backend/inproc/backend.go
@@ -55,11 +55,6 @@ func Open(cfg Config, lim limiter.Limiter) (*Backend, error) {
 	return be, nil
 }
 
-// Create initializes a new restic repo
-func Create(cfg Config) (*Backend, error) {
-	return Open(cfg, nil)
-}
-
 type ServiceProvider interface {
 	NewService(args string) (http.RoundTripper, error)
 }

--- a/internal/backend/inproc/backend.go
+++ b/internal/backend/inproc/backend.go
@@ -60,11 +60,6 @@ func Create(cfg Config) (*Backend, error) {
 	return Open(cfg, nil)
 }
 
-// Close does nothing
-func (be *Backend) Close() error {
-	return nil
-}
-
 type ServiceProvider interface {
 	NewService(args string) (http.RoundTripper, error)
 }

--- a/internal/backend/inproc/backend.go
+++ b/internal/backend/inproc/backend.go
@@ -18,7 +18,7 @@ type Backend struct {
 
 // New initializes a Backend and starts the process.
 func New(cfg Config, lim limiter.Limiter) (*Backend, error) {
-	service, err := cfg.Provider.NewService(cfg.Remote)
+	service, err := cfg.provider.NewService(cfg.Remote)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/inproc/backend.go
+++ b/internal/backend/inproc/backend.go
@@ -1,0 +1,84 @@
+package inproc
+
+import (
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/restic/restic/internal/backend/rest"
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/limiter"
+)
+
+// Backend is used to access data stored somewhere via rclone.
+type Backend struct {
+	*rest.Backend
+	tr http.RoundTripper
+}
+
+// New initializes a Backend and starts the process.
+func New(cfg Config, lim limiter.Limiter) (*Backend, error) {
+	service, err := cfg.Provider.NewService(cfg.Remote)
+	if err != nil {
+		return nil, err
+	}
+
+	be := &Backend{
+		tr: service,
+	}
+	return be, nil
+}
+
+// Open starts an rclone process with the given config.
+func Open(cfg Config, lim limiter.Limiter) (*Backend, error) {
+	be, err := New(cfg, lim)
+	if err != nil {
+		return nil, err
+	}
+
+	url, err := url.Parse("http://localhost/")
+	if err != nil {
+		return nil, err
+	}
+
+	restConfig := rest.Config{
+		Connections: cfg.Connections,
+		URL:         url,
+	}
+
+	restBackend, err := rest.Open(restConfig, debug.RoundTripper(be.tr))
+	if err != nil {
+		return nil, err
+	}
+
+	be.Backend = restBackend
+	return be, nil
+}
+
+// Create initializes a new restic repo
+func Create(cfg Config) (*Backend, error) {
+	return Open(cfg, nil)
+}
+
+// Close does nothing
+func (be *Backend) Close() error {
+	return nil
+}
+
+type ServiceProvider interface {
+	NewService(args string) (http.RoundTripper, error)
+}
+
+var providers = make(map[string]ServiceProvider)
+
+// RegisterServiceProvider register a provider that can create an http.RoundTripper
+func RegisterServiceProvider(name string, provider ServiceProvider) {
+	providers[name] = provider
+}
+
+func findServiceProvider(name string) (ServiceProvider, error) {
+	if p, ok := providers[name]; ok {
+		return p, nil
+	}
+	return nil, fmt.Errorf("service %s not found", name)
+}

--- a/internal/backend/inproc/config.go
+++ b/internal/backend/inproc/config.go
@@ -10,7 +10,7 @@ import (
 type Config struct {
 	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
 	Remote      string
-	Provider    ServiceProvider
+	provider    ServiceProvider
 }
 
 var defaultConfig = Config{
@@ -44,6 +44,6 @@ func ParseConfig(s string) (interface{}, error) {
 
 	cfg := NewConfig()
 	cfg.Remote = items[2]
-	cfg.Provider = provider
+	cfg.provider = provider
 	return cfg, nil
 }

--- a/internal/backend/inproc/config.go
+++ b/internal/backend/inproc/config.go
@@ -1,0 +1,49 @@
+package inproc
+
+import (
+	"strings"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/options"
+)
+
+type Config struct {
+	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	Remote      string
+	Provider    ServiceProvider
+}
+
+var defaultConfig = Config{
+	Connections: 5,
+}
+
+func init() {
+	options.Register("inproc", Config{})
+}
+
+// NewConfig returns a new Config with the default values filled in.
+func NewConfig() Config {
+	return defaultConfig
+}
+
+// ParseConfig parses the string s and extracts the remote server URL.
+func ParseConfig(s string) (interface{}, error) {
+	if !strings.HasPrefix(s, "inproc:") {
+		return nil, errors.New("invalid inproc backend specification")
+	}
+
+	items := strings.SplitN(s, ":", 3)
+	if len(items) != 3 {
+		return nil, errors.New("invalid URL")
+	}
+
+	provider, err := findServiceProvider(items[1])
+	if err != nil {
+		return nil, err
+	}
+
+	cfg := NewConfig()
+	cfg.Remote = items[2]
+	cfg.Provider = provider
+	return cfg, nil
+}

--- a/internal/backend/inproc/rclone.go
+++ b/internal/backend/inproc/rclone.go
@@ -4,17 +4,31 @@ package inproc
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"strings"
 
 	_ "github.com/rclone/rclone/backend/all"
+	"github.com/rclone/rclone/cmd"
+	"github.com/rclone/rclone/cmd/serve/httplib/httpflags"
 	"github.com/rclone/rclone/cmd/serve/restic"
 )
 
 type rcloneProvider struct {
 }
 
+type server struct {
+	*restic.Server
+}
+
 func (rp *rcloneProvider) NewService(args string) (http.RoundTripper, error) {
-	return restic.NewServer(strings.Fields(args))
+	f := cmd.NewFsSrc(strings.Fields(args))
+	return &server{restic.NewServer(f, &httpflags.Opt)}, nil
+}
+
+func (s *server) RoundTrip(r *http.Request) (*http.Response, error) {
+	w := httptest.NewRecorder()
+	s.ServeHTTP(w, r)
+	return w.Result(), nil
 }
 
 func init() {

--- a/internal/backend/inproc/rclone.go
+++ b/internal/backend/inproc/rclone.go
@@ -1,0 +1,22 @@
+// +build rclone
+
+package inproc
+
+import (
+	"net/http"
+	"strings"
+
+	_ "github.com/rclone/rclone/backend/all"
+	"github.com/rclone/rclone/cmd/serve/restic"
+)
+
+type rcloneProvider struct {
+}
+
+func (rp *rcloneProvider) NewService(args string) (http.RoundTripper, error) {
+	return restic.NewServer(strings.Fields(args))
+}
+
+func init() {
+	RegisterServiceProvider("rclone", &rcloneProvider{})
+}

--- a/internal/backend/location/location.go
+++ b/internal/backend/location/location.go
@@ -7,6 +7,7 @@ import (
 	"github.com/restic/restic/internal/backend/azure"
 	"github.com/restic/restic/internal/backend/b2"
 	"github.com/restic/restic/internal/backend/gs"
+	"github.com/restic/restic/internal/backend/inproc"
 	"github.com/restic/restic/internal/backend/local"
 	"github.com/restic/restic/internal/backend/rclone"
 	"github.com/restic/restic/internal/backend/rest"
@@ -40,6 +41,7 @@ var parsers = []parser{
 	{"swift", swift.ParseConfig},
 	{"rest", rest.ParseConfig},
 	{"rclone", rclone.ParseConfig},
+	{"inproc", inproc.ParseConfig},
 }
 
 func isPath(s string) bool {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What is the purpose of this change? What does it change?
--------------------------------------------------------
Building restic + rclone as a library will allow developers to build applications to access files stored in the Cloud via restic + rclone natively on multiple platforms including mobile.

There are 3 parts in the change: a new backend `inproc` to embed rclone as an http.RoundTripper via the rest backend which is only additional, moving 3 functions in `cmd/restic/global.go` to `cmd/global/global.go` so that they can be reused, and exposing some types and functions in `cmd/global/api.go`.

This requires some small change in rclone. See https://github.com/rclone/rclone/pull/4460/files
 
A code example can be found here: https://gist.github.com/jdeng/81f64666c61d143d5d3d9fb88f1f64dd

<!--
Describe the changes here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No. The code change is relatively small (except for global.go reorganization) and mostly glue code, so I hope this can be upstreamed. 

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "closes #1234" so that the issue is
closed automatically when this PR is merged.
-->

Checklist
---------

- [ ] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
