### PR TITLE
Fix rclone subprocess handling

### DIFF
--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -197,7 +197,7 @@ func newBackend(cfg Config, lim limiter.Limiter) (*Backend, error) {
 		debug.Log("Wait returned %v", err)
 		be.waitResult = err
 		// close our side of the pipes to rclone
-		stdioConn.Close()
+		stdioConn.CloseAll()
 		close(waitCh)
 	}()
 
@@ -314,7 +314,7 @@ func (be *Backend) Close() error {
 		debug.Log("rclone exited")
 	case <-time.After(waitForExit):
 		debug.Log("timeout, closing file descriptors")
-		err := be.conn.Close()
+		err := be.conn.CloseAll()
 		if err != nil {
 			return err
 		}

--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -114,7 +114,7 @@ func wrapConn(c *StdioConn, lim limiter.Limiter) wrappedConn {
 }
 
 // New initializes a Backend and starts the process.
-func New(cfg Config, lim limiter.Limiter) (*Backend, error) {
+func newBackend(cfg Config, lim limiter.Limiter) (*Backend, error) {
 	var (
 		args []string
 		err  error
@@ -234,7 +234,7 @@ func New(cfg Config, lim limiter.Limiter) (*Backend, error) {
 
 // Open starts an rclone process with the given config.
 func Open(cfg Config, lim limiter.Limiter) (*Backend, error) {
-	be, err := New(cfg, lim)
+	be, err := newBackend(cfg, lim)
 	if err != nil {
 		return nil, err
 	}
@@ -260,7 +260,7 @@ func Open(cfg Config, lim limiter.Limiter) (*Backend, error) {
 
 // Create initializes a new restic repo with clone.
 func Create(cfg Config) (*Backend, error) {
-	be, err := New(cfg, nil)
+	be, err := newBackend(cfg, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -88,9 +88,9 @@ func run(command string, args ...string) (*StdioConn, *exec.Cmd, *sync.WaitGroup
 	}
 
 	c := &StdioConn{
-		stdin:  stdout,
-		stdout: stdin,
-		cmd:    cmd,
+		receive: stdout,
+		send:    stdin,
+		cmd:     cmd,
 	}
 
 	return c, cmd, &wg, bg, nil

--- a/internal/backend/rclone/internal_test.go
+++ b/internal/backend/rclone/internal_test.go
@@ -2,8 +2,10 @@ package rclone
 
 import (
 	"context"
+	"os/exec"
 	"testing"
 
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
@@ -16,6 +18,10 @@ func TestRcloneExit(t *testing.T) {
 	cfg := NewConfig()
 	cfg.Remote = dir
 	be, err := Open(cfg, nil)
+	if e, ok := errors.Cause(err).(*exec.Error); ok && e.Err == exec.ErrNotFound {
+		t.Skipf("program %q not found", e.Name)
+		return
+	}
 	rtest.OK(t, err)
 	defer be.Close()
 

--- a/internal/backend/rclone/internal_test.go
+++ b/internal/backend/rclone/internal_test.go
@@ -1,0 +1,31 @@
+package rclone
+
+import (
+	"context"
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+// restic should detect rclone exiting.
+func TestRcloneExit(t *testing.T) {
+	dir, cleanup := rtest.TempDir(t)
+	defer cleanup()
+
+	cfg := NewConfig()
+	cfg.Remote = dir
+	be, err := Open(cfg, nil)
+	rtest.OK(t, err)
+	defer be.Close()
+
+	err = be.cmd.Process.Kill()
+	rtest.OK(t, err)
+	t.Log("killed rclone")
+
+	_, err = be.Stat(context.TODO(), restic.Handle{
+		Name: "foo",
+		Type: restic.DataFile,
+	})
+	rtest.Assert(t, err != nil, "expected an error")
+}

--- a/internal/backend/rclone/stdio_conn.go
+++ b/internal/backend/rclone/stdio_conn.go
@@ -12,28 +12,28 @@ import (
 
 // StdioConn implements a net.Conn via stdin/stdout.
 type StdioConn struct {
-	stdin    *os.File
-	stdout   *os.File
-	cmd      *exec.Cmd
-	closeIn  sync.Once
-	closeOut sync.Once
+	receive   *os.File
+	send      *os.File
+	cmd       *exec.Cmd
+	closeRecv sync.Once
+	closeSend sync.Once
 }
 
 func (s *StdioConn) Read(p []byte) (int, error) {
-	n, err := s.stdin.Read(p)
+	n, err := s.receive.Read(p)
 	return n, err
 }
 
 func (s *StdioConn) Write(p []byte) (int, error) {
-	n, err := s.stdout.Write(p)
+	n, err := s.send.Write(p)
 	return n, err
 }
 
 // Close closes the stream to the child process.
 func (s *StdioConn) Close() (err error) {
-	s.closeOut.Do(func() {
+	s.closeSend.Do(func() {
 		debug.Log("close stdio send connection")
-		err = s.stdout.Close()
+		err = s.send.Close()
 	})
 
 	return err
@@ -43,9 +43,9 @@ func (s *StdioConn) Close() (err error) {
 func (s *StdioConn) CloseAll() (err error) {
 	err = s.Close()
 
-	s.closeIn.Do(func() {
+	s.closeRecv.Do(func() {
 		debug.Log("close stdio receive connection")
-		err2 := s.stdin.Close()
+		err2 := s.receive.Close()
 		if err == nil {
 			err = err2
 		}
@@ -66,8 +66,8 @@ func (s *StdioConn) RemoteAddr() net.Addr {
 
 // SetDeadline sets the read/write deadline.
 func (s *StdioConn) SetDeadline(t time.Time) error {
-	err1 := s.stdin.SetReadDeadline(t)
-	err2 := s.stdout.SetWriteDeadline(t)
+	err1 := s.receive.SetReadDeadline(t)
+	err2 := s.send.SetWriteDeadline(t)
 	if err1 != nil {
 		return err1
 	}
@@ -76,12 +76,12 @@ func (s *StdioConn) SetDeadline(t time.Time) error {
 
 // SetReadDeadline sets the read/write deadline.
 func (s *StdioConn) SetReadDeadline(t time.Time) error {
-	return s.stdin.SetReadDeadline(t)
+	return s.receive.SetReadDeadline(t)
 }
 
 // SetWriteDeadline sets the read/write deadline.
 func (s *StdioConn) SetWriteDeadline(t time.Time) error {
-	return s.stdout.SetWriteDeadline(t)
+	return s.send.SetWriteDeadline(t)
 }
 
 // make sure StdioConn implements net.Conn


### PR DESCRIPTION
What is the purpose of this change? What does it change?
--------------------------------------------------------
restic currently does not detect when the rclone subprocess exits and hangs forever (see #2381 and #2797). We also see test failure from time to time which fail with "signal: broken pipe" while closing the rclone backend.

This PR is partially inspired by #2797 and reuses the new test.

restic currently holds on to file descriptors for both the read and write side of the stdin and stdout pipes to the rclone subprocess. That prevents the pipes from closing properly once rclone stops and is also the root cause of not noticing the subprocess exit. Calling `stdioConn.Close()` once the child process has exited is still necessary to free the file descriptors.

Failing rclone tests seems to be caused because for some reason rclone dies due to a SIGPIPE error which is then returned by `cmd.Wait()` and gets printed as `signal: broken pipe`. I have no idea what data rclone writes to the stdio_conn when `Close` is called, maybe some leftover data on the HTTP2 connection? The fix for this is to give rclone time to shut down after stdin was closed, such that stdout is not closed while rclone still write to it.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
fixes #2381 
replaces #2797 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
