### PR TITLE
Simplify cache logic

### DIFF
--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -425,10 +425,11 @@ func removePacksExcept(gopts GlobalOptions, t *testing.T, keep restic.IDSet, rem
 
 	// Get all tree packs
 	rtest.OK(t, r.LoadIndex(gopts.ctx))
+
 	treePacks := restic.NewIDSet()
-	for _, idx := range r.Index().(*repository.MasterIndex).All() {
-		for _, id := range idx.TreePacks() {
-			treePacks.Insert(id)
+	for pb := range r.Index().Each(context.TODO()) {
+		if pb.Type == restic.TreeBlob {
+			treePacks.Insert(pb.PackID)
 		}
 	}
 
@@ -487,11 +488,10 @@ func TestBackupTreeLoadError(t *testing.T) {
 	r, err := OpenRepository(env.gopts)
 	rtest.OK(t, err)
 	rtest.OK(t, r.LoadIndex(env.gopts.ctx))
-	// collect tree packs of subdirectory
-	subTreePacks := restic.NewIDSet()
-	for _, idx := range r.Index().(*repository.MasterIndex).All() {
-		for _, id := range idx.TreePacks() {
-			subTreePacks.Insert(id)
+	treePacks := restic.NewIDSet()
+	for pb := range r.Index().Each(context.TODO()) {
+		if pb.Type == restic.TreeBlob {
+			treePacks.Insert(pb.PackID)
 		}
 	}
 
@@ -499,7 +499,7 @@ func TestBackupTreeLoadError(t *testing.T) {
 	testRunCheck(t, env.gopts)
 
 	// delete the subdirectory pack first
-	for id := range subTreePacks {
+	for id := range treePacks {
 		rtest.OK(t, r.Backend().Remove(env.gopts.ctx, restic.Handle{Type: restic.PackFile, Name: id.String()}))
 	}
 	testRunRebuildIndex(t, env.gopts)

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -71,6 +71,7 @@ func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd restic.Re
 	be.m.Lock()
 	defer be.m.Unlock()
 
+	h.ContainedBlobType = restic.InvalidBlob
 	if h.Type == restic.ConfigFile {
 		h.Name = ""
 	}
@@ -122,6 +123,7 @@ func (be *MemoryBackend) openReader(ctx context.Context, h restic.Handle, length
 	be.m.Lock()
 	defer be.m.Unlock()
 
+	h.ContainedBlobType = restic.InvalidBlob
 	if h.Type == restic.ConfigFile {
 		h.Name = ""
 	}
@@ -158,6 +160,7 @@ func (be *MemoryBackend) Stat(ctx context.Context, h restic.Handle) (restic.File
 		return restic.FileInfo{}, backoff.Permanent(err)
 	}
 
+	h.ContainedBlobType = restic.InvalidBlob
 	if h.Type == restic.ConfigFile {
 		h.Name = ""
 	}
@@ -179,6 +182,7 @@ func (be *MemoryBackend) Remove(ctx context.Context, h restic.Handle) error {
 
 	debug.Log("Remove %v", h)
 
+	h.ContainedBlobType = restic.InvalidBlob
 	if _, ok := be.data[h]; !ok {
 		return errNotFound
 	}

--- a/internal/cache/backend.go
+++ b/internal/cache/backend.go
@@ -21,7 +21,7 @@ type Backend struct {
 	inProgress      map[restic.Handle]chan struct{}
 }
 
-// ensure cachedBackend implements restic.Backend
+// ensure Backend implements restic.Backend
 var _ restic.Backend = &Backend{}
 
 func newBackend(be restic.Backend, c *Cache) *Backend {
@@ -43,13 +43,19 @@ func (b *Backend) Remove(ctx context.Context, h restic.Handle) error {
 	return b.Cache.remove(h)
 }
 
-func autoCached(t restic.FileType) bool {
-	return t == restic.IndexFile || t == restic.SnapshotFile
+func autoCacheTypes(h restic.Handle) bool {
+	switch h.Type {
+	case restic.IndexFile, restic.SnapshotFile:
+		return true
+	case restic.PackFile:
+		return h.ContainedBlobType == restic.TreeBlob
+	}
+	return false
 }
 
 // Save stores a new file in the backend and the cache.
 func (b *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
-	if !autoCached(h.Type) {
+	if !autoCacheTypes(h) {
 		return b.Backend.Save(ctx, h, rd)
 	}
 
@@ -168,25 +174,8 @@ func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset 
 		debug.Log("error loading %v from cache: %v", h, err)
 	}
 
-	// partial file requested
-	if offset != 0 || length != 0 {
-		if b.Cache.PerformReadahead(h) {
-			debug.Log("performing readahead for %v", h)
-
-			err := b.cacheFile(ctx, h)
-			if err == nil {
-				return b.loadFromCacheOrDelegate(ctx, h, length, offset, consumer)
-			}
-
-			debug.Log("error caching %v: %v", h, err)
-		}
-
-		debug.Log("Load(%v, %v, %v): partial file requested, delegating to backend", h, length, offset)
-		return b.Backend.Load(ctx, h, length, offset, consumer)
-	}
-
 	// if we don't automatically cache this file type, fall back to the backend
-	if !autoCached(h.Type) {
+	if !autoCacheTypes(h) {
 		debug.Log("Load(%v, %v, %v): delegating to backend", h, length, offset)
 		return b.Backend.Load(ctx, h, length, offset, consumer)
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -17,10 +17,9 @@ import (
 
 // Cache manages a local cache.
 type Cache struct {
-	path             string
-	Base             string
-	Created          bool
-	PerformReadahead func(restic.Handle) bool
+	path    string
+	Base    string
+	Created bool
 }
 
 const dirMode = 0700
@@ -152,10 +151,6 @@ func New(id string, basedir string) (c *Cache, err error) {
 		path:    cachedir,
 		Base:    basedir,
 		Created: created,
-		PerformReadahead: func(restic.Handle) bool {
-			// do not perform readahead by default
-			return false
-		},
 	}
 
 	return c, nil

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -100,6 +100,18 @@ func (mi *MasterIndex) Has(bh restic.BlobHandle) bool {
 	return false
 }
 
+func (mi *MasterIndex) IsMixedPack(packID restic.ID) bool {
+	mi.idxMutex.RLock()
+	defer mi.idxMutex.RUnlock()
+
+	for _, idx := range mi.idx {
+		if idx.MixedPacks().Has(packID) {
+			return true
+		}
+	}
+	return false
+}
+
 // Packs returns all packs that are covered by the index.
 // If packBlacklist is given, those packs are only contained in the
 // resulting IDSet if they are contained in a non-final (newly written) index.

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -113,7 +113,8 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packe
 	}
 
 	id := restic.IDFromHash(p.hw.Sum(nil))
-	h := restic.Handle{Type: restic.PackFile, Name: id.String()}
+	h := restic.Handle{Type: restic.PackFile, Name: id.String(),
+		ContainedBlobType: t}
 	var beHash []byte
 	if p.beHw != nil {
 		beHash = p.beHw.Sum(nil)
@@ -130,20 +131,6 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packe
 	}
 
 	debug.Log("saved as %v", h)
-
-	if t == restic.TreeBlob && r.Cache != nil {
-		debug.Log("saving tree pack file in cache")
-
-		_, err = p.tmpfile.Seek(0, 0)
-		if err != nil {
-			return errors.Wrap(err, "Seek")
-		}
-
-		err := r.Cache.Save(h, p.tmpfile)
-		if err != nil {
-			return err
-		}
-	}
 
 	err = p.tmpfile.Close()
 	if err != nil {

--- a/internal/restic/file.go
+++ b/internal/restic/file.go
@@ -21,8 +21,9 @@ const (
 
 // Handle is used to store and access data in a backend.
 type Handle struct {
-	Type FileType
-	Name string
+	Type              FileType
+	ContainedBlobType BlobType
+	Name              string
 }
 
 func (h Handle) String() string {

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -243,7 +243,7 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 		return err
 	}
 
-	h := restic.Handle{Type: restic.PackFile, Name: pack.id.String()}
+	h := restic.Handle{Type: restic.PackFile, Name: pack.id.String(), ContainedBlobType: restic.DataBlob}
 	err := r.packLoader(ctx, h, int(end-start), start, func(rd io.Reader) error {
 		bufferSize := int(end - start)
 		if bufferSize > maxBufferSize {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Simplifies the cache logic: 
- Actually a "ReadAhead" closure is defined which basically keeps the information which pack is a "treepack".
This closure is used for one single purpose: If a pack file is loaded and not yet contained in the cache, it will be loaded and saved in the cache for future use.
- Actually when saving tree packs, the same pack is saved again in the cache in `packer_manager`.

I changed the logic and added `BlobType` to the handle used to access the backend. This is in fact only used by the cache to determine whether a pack file from the backend should be cached.
As a side effect no tree packs need to be determined and stored within the index implementation, but instead mixed packs are saved.

Note that this PR does change the behavior of restic with respect to these points:
- When a pack files is accessed without knowing what blob types are within, this file will not be cached if not already present in the cache. This is e.g. the case for `pack.List` which is used in some places.
- Also tests are not modified and will sometimes not use the cache

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
