### PR TITLE
Don't print a stacktrace if some files could not be read

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -98,8 +98,8 @@ type BackupOptions struct {
 
 var backupOptions BackupOptions
 
-// Error sentinel for invalid source data
-var InvalidSourceData = errors.New("Failed to read all source data during backup.")
+// ErrInvalidSourceData is used to report an incomplete backup
+var ErrInvalidSourceData = errors.New("failed to read all source data during backup")
 
 func init() {
 	cmdRoot.AddCommand(cmdBackup)
@@ -601,7 +601,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		p.P("snapshot %s saved\n", id.Str())
 	}
 	if !success {
-		return InvalidSourceData
+		return ErrInvalidSourceData
 	}
 
 	// Return error if any

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -515,7 +515,7 @@ func TestBackupErrors(t *testing.T) {
 	gopts.stderr = ioutil.Discard
 	err := testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"testdata"}, opts, gopts)
 	rtest.Assert(t, err != nil, "Assumed failure, but no error occured.")
-	rtest.Assert(t, err == InvalidSourceData, "Wrong error returned")
+	rtest.Assert(t, err == ErrInvalidSourceData, "Wrong error returned")
 	snapshotIDs := testRunList(t, "snapshots", env.gopts)
 	rtest.Assert(t, len(snapshotIDs) == 1,
 		"expected one snapshot, got %v", snapshotIDs)

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -88,6 +88,8 @@ func main() {
 	switch {
 	case restic.IsAlreadyLocked(errors.Cause(err)):
 		fmt.Fprintf(os.Stderr, "%v\nthe `unlock` command can be used to remove stale locks\n", err)
+	case err == ErrInvalidSourceData:
+		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
 	case errors.IsFatal(errors.Cause(err)):
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 	case err != nil:
@@ -106,7 +108,7 @@ func main() {
 	switch err {
 	case nil:
 		exitCode = 0
-	case InvalidSourceData:
+	case ErrInvalidSourceData:
 		exitCode = 3
 	default:
 		exitCode = 1


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The error message added by #2546 which is printed when restic fails to read all backup source files, currently also includes a stacktrace. While this will catch a users eye, it rather looks like restic crashed and distracts from the warning itself. This changes the output to
```
[...]
snapshot a6e0269c saved
Warning: failed to read all source data during backup
```
instead of the previous
```
[...]
snapshot 9d4501a7 saved
backup is incomplete, could not read all source data
main.init
	restic/cmd/restic/cmd_backup.go:102
runtime.doInit
	libexec/src/runtime/proc.go:5414
runtime.main
	libexec/src/runtime/proc.go:190
runtime.goexit
	libexec/src/runtime/asm_amd64.s:1373
```

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR``
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
