### PR TITLE
rclone: Don't panic after unexpected subprocess exit

### DIFF
--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -173,7 +173,8 @@ func newBackend(cfg Config, lim limiter.Limiter) (*Backend, error) {
 		DialTLS: func(network, address string, cfg *tls.Config) (net.Conn, error) {
 			debug.Log("new connection requested, %v %v", network, address)
 			if dialCount > 0 {
-				panic("dial count > 0")
+				// the connection to the child process is already closed
+				return nil, errors.New("rclone stdio connection already closed")
 			}
 			dialCount++
 			return conn, nil

--- a/internal/backend/rclone/internal_test.go
+++ b/internal/backend/rclone/internal_test.go
@@ -29,9 +29,11 @@ func TestRcloneExit(t *testing.T) {
 	rtest.OK(t, err)
 	t.Log("killed rclone")
 
-	_, err = be.Stat(context.TODO(), restic.Handle{
-		Name: "foo",
-		Type: restic.DataFile,
-	})
-	rtest.Assert(t, err != nil, "expected an error")
+	for i := 0; i < 10; i++ {
+		_, err = be.Stat(context.TODO(), restic.Handle{
+			Name: "foo",
+			Type: restic.DataFile,
+		})
+		rtest.Assert(t, err != nil, "expected an error")
+	}
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
As the connection to the rclone child process is now closed after an
unexpected subprocess exit (#2855), later requests will cause the http2
transport to try to reestablish a new connection. As previously this never
should have happened, the connection called panic in that case. This
panic is now replaced with a simple error message, as it no longer
indicates an internal problem.

This crash has so far only showed up in a CI run (https://travis-ci.com/github/restic/restic/jobs/365452504) but I think it's also possible for this to happen e.g. during a backup run.

One problem not explicitly tackled by this PR, is trying to track the root cause of the flaky rclone CI runs. Previously rclone sometimes was killed with a SIGPIPE when closing the backend connection, which now seems to have been replaced by an unexpected new connection establishment. It could be possible to add something like the following code snippet, however, that snippet would have to detect which test case is running to not fail the unit test which checks the crash fix.
```
if flag.Lookup("test.v") != nil {
	// dump all active goroutines
	buf := make([]byte, 128*1024)
	ln := runtime.Stack(buf, true)
	fmt.Print(string(buf[:ln]))
	panic("reconnection")
}
```

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- No necessary ~~[ ] I have added documentation for the changes (in the manual)~~
- No, fixes a recent (unreleased) regression of #2855 ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
