### PR TITLE
Don't save exact duplicates in merged index

### DIFF
--- a/internal/repository/master_index_test.go
+++ b/internal/repository/master_index_test.go
@@ -193,6 +193,15 @@ func createRandomMasterIndex(rng *rand.Rand, num, size int) (*repository.MasterI
 	return mIdx, lookupID
 }
 
+func BenchmarkMasterIndexAlloc(b *testing.B) {
+	rng := rand.New(rand.NewSource(0))
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		createRandomMasterIndex(rng, 10000, 5)
+	}
+}
+
 func BenchmarkMasterIndexLookupSingleIndex(b *testing.B) {
 	mIdx, lookupID := createRandomMasterIndex(rand.New(rand.NewSource(0)), 1, 200000)
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Don't save exact duplicates (i.e. same blob ID, same pack, same offset and same length) in index. This situation can happen in rare cases where superseded index files are not deleted. Saving exact duplicates doesn't help anywhere but may pose some problems (more memory usage; and possible trouble within #2842) 

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

see #2839 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
