### PR TITLE
Dead code removal

### DIFF
--- a/cmd/restic/acl.go
+++ b/cmd/restic/acl.go
@@ -35,17 +35,6 @@ type aclElement struct {
 	Perm uint16
 }
 
-func (a *aclSID) setUID(uid uint32) {
-	*a = aclSID(uid) | (aclUser << 32)
-}
-func (a *aclSID) setGID(gid uint32) {
-	*a = aclSID(gid) | (aclGroup << 32)
-}
-
-func (a *aclSID) setType(tp int) {
-	*a = aclSID(tp) << 32
-}
-
 func (a aclSID) getType() int {
 	return int(a >> 32)
 }

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -71,7 +71,6 @@ func runList(cmd *cobra.Command, opts GlobalOptions, args []string) error {
 			return nil
 		})
 
-		return nil
 	default:
 		return errors.Fatal("invalid type")
 	}

--- a/cmd/restic/format.go
+++ b/cmd/restic/format.go
@@ -51,12 +51,6 @@ func formatPercent(numerator uint64, denominator uint64) string {
 	return fmt.Sprintf("%3.2f%%", percent)
 }
 
-func formatRate(bytes uint64, duration time.Duration) string {
-	sec := float64(duration) / float64(time.Second)
-	rate := float64(bytes) / sec / (1 << 20)
-	return fmt.Sprintf("%.2fMiB/s", rate)
-}
-
 func formatDuration(d time.Duration) string {
 	sec := uint64(d / time.Second)
 	return formatSeconds(sec)


### PR DESCRIPTION
Found by running golangci-lint on the entire code base.