### PR TITLE
Fix TestMetadataChanged on macOS

### DIFF
--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -2050,6 +2050,11 @@ func TestMetadataChanged(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// create want node the same way the archiver
+	// does when WithAtime is false by setting
+	// AccessTime to ModTime
+	want.AccessTime = want.ModTime
+
 	fs := &StatFS{
 		FS: fs.Local{},
 		OverrideLstat: map[string]os.FileInfo{


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This pull request fixes a test (`TestMetadataChanged`) that fails on macOS due to sub-second differences in the access time of a node after a snapshot. During my investigation I found that the access time behaviour is a bit strange on macOS Catalina with APFS. It seems to be only updated upon modification with a slight delay causing the access time and the mod time to differ a little bit. This revealed an inconsistency in the archiver's metadata test:

The `want` node is created using [`restic.NodeFromFileInfo()`](https://github.com/restic/restic/blob/66d089e23970dd34e93e87f739740bf9702f4f5c/internal/archiver/archiver_test.go#L2040). This results in a node with separate `AccessTime` and `ModTime` values that might differ. Then, `snapshot()` is called, which does not use [`restic.NodeFromFileInfo()`](https://github.com/restic/restic/blob/66d089e23970dd34e93e87f739740bf9702f4f5c/internal/archiver/archiver.go#L185-L191) directly when saving, but rather uses the wrapper method `Archiver.nodeFromFileInfo()` on an `Archiver` with `WithAtime` set to `false`. Thus, the following code causes the `AccessTime` in the resulting node to be set to the `ModTime`:
```go
func (arch *Archiver) nodeFromFileInfo(filename string, fi os.FileInfo) (*restic.Node, error) {
	node, err := restic.NodeFromFileInfo(filename, fi)
	if !arch.WithAtime {
		node.AccessTime = node.ModTime
	}
	return node, errors.Wrap(err, "NodeFromFileInfo")
}
```

As the `AccessTime` is now changed from the value present in the `want` node, the test fails if `AccessTime` was previously (in the `want` node) not equal to `ModTime` (as seems to be the case on macOS).

I fixed the test by forcing the `want` node to have an equal `AccessTime` and `ModTime` because this node configuration matches the expected result if an `Archiver` with `WithAtime` set to `false` is used to create the snapshot.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Not as far as I'm aware. I could not find any related issues and the change is so minor that I did not want to split the discussion between this PR and a new separate issue.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR (not applicable, as this PR modifies an existing test)
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review

Is a changelog file necessary in this case where the changes are not user facing and only fix an edge case? If yes, I will provide one.