### PR TITLE
prune: Stop progress bar after searching used blobs

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -262,13 +262,11 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 
 	var obsoletePacks restic.IDSet
 	if len(rewritePacks) != 0 {
-		bar = newProgressMax(!gopts.Quiet, uint64(len(rewritePacks)), "packs rewritten")
-		bar.Start()
+		bar := newProgressMax(!gopts.Quiet, uint64(len(rewritePacks)), "packs rewritten")
 		obsoletePacks, err = repository.Repack(ctx, repo, rewritePacks, usedBlobs, bar)
 		if err != nil {
 			return err
 		}
-		bar.Done()
 	}
 
 	removePacks.Merge(obsoletePacks)

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -295,6 +295,7 @@ func getUsedBlobs(gopts GlobalOptions, repo restic.Repository, snapshots []*rest
 
 	bar := newProgressMax(!gopts.Quiet, uint64(len(snapshots)), "snapshots")
 	bar.Start()
+	defer bar.Done()
 	for _, sn := range snapshots {
 		debug.Log("process snapshot %v", sn.ID())
 

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -17,6 +17,11 @@ import (
 // into a new pack. Returned is the list of obsolete packs which can then
 // be removed.
 func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, keepBlobs restic.BlobSet, p *restic.Progress) (obsoletePacks restic.IDSet, err error) {
+	if p != nil {
+		p.Start()
+		defer p.Done()
+	}
+
 	debug.Log("repacking %d packs while keeping %d blobs", len(packs), len(keepBlobs))
 
 	for packID := range packs {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
#2841 introduced a regression which causes the progress bar used for searching used blobs to now longer stops.
This causes prune to flicker between "[mm:ss] x / x snapshots" and "[mm:ss] x / y packs rewritten" which is rather annoying to watch for several hours ;-)

This PR fixes the regression and also ensures that the "packs rewritten" progress bar is properly stopped in case of an error.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
