### PR TITLE
`--verbose 2` to `--verbose=2`

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -83,7 +83,7 @@ You can even backup individual files in the same repository (not passing
     snapshot 249d0210 saved
 
 If you're interested in what restic does, pass ``--verbose`` twice (or
-``--verbose 2``) to display detailed information about each file and directory
+``--verbose=2``) to display detailed information about each file and directory
 restic encounters:
 
 .. code-block:: console


### PR DESCRIPTION
`--verbose 2` seems to be incorrect here - it gives an error/warning that "the `2` directory does not exist, skipping".


What does this PR change? What problem does it solve?
-----------------------------------------------------
Fixes a small typo in the docs.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Not that I know of.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review

(I checked all of the above boxes, but many don't apply.)