### PR TITLE
Add content_hash to ls --json output

### DIFF
--- a/changelog/unreleased/pull-2871
+++ b/changelog/unreleased/pull-2871
@@ -1,0 +1,8 @@
+Enhancement: Add content hash to `ls --json` output
+
+Added a new `content_hash` field to the `ls --json` output.
+
+These content hashes can only be compared within a single backup repository.
+
+https://github.com/restic/restic/issues/2870
+https://github.com/restic/restic/pull/2871

--- a/cmd/restic/cmd_ls_test.go
+++ b/cmd/restic/cmd_ls_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/hex"
+	"encoding/json"
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+)
+
+func TestContentHash_MarshalText(t *testing.T) {
+	table := []struct {
+		name    string
+		content []string
+		want    string
+	}{
+		{
+			name:    "empty",
+			content: nil,
+			want:    `""`,
+		},
+		{
+			name: "single",
+			content: []string{
+				"77c2a7ef1cb99b134e64b33752834e76e76ae487a1fa7e82c044d9c82df7d304",
+			},
+			want: `"sha256:77c2a7ef1cb99b134e64b33752834e76e76ae487a1fa7e82c044d9c82df7d304"`,
+		},
+		{
+			name: "multi",
+			content: []string{
+				"77c2a7ef1cb99b134e64b33752834e76e76ae487a1fa7e82c044d9c82df7d304",
+				"8d02bb72e9a86e37a16219cfa43d996ce5751f4eee19c0e27b4b627ddf6b40fc",
+			},
+			want: `"multi:d252c57fe80290ad98c37e16b1728b70292f346098fe045fc805032033c23d63"`,
+		},
+	}
+
+	for _, row := range table {
+		t.Run(row.name, func(t *testing.T) {
+			var ch contentHash
+			for _, h := range row.content {
+				testHash, err := hex.DecodeString(h)
+				if err != nil {
+					t.Fatalf("hex decode error: %v", err)
+				}
+				testID := restic.IDFromHash(testHash)
+				ch = append(ch, testID)
+			}
+			// We test MarshalText indirectly through the json modules, because
+			// that is what we are actually interested in.
+			jsonBytes, err := json.Marshal(ch)
+			if err != nil {
+				t.Fatalf("json marshal error: %v", err)
+			}
+			jsonString := string(jsonBytes)
+			if jsonString != row.want {
+				t.Fatalf("error: got %s, want %s", jsonString, row.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION

What does this PR change? What problem does it solve?
-----------------------------------------------------

Add a new content_hash field to every file in the `ls --json` output.

For small files, this will usually be their sha256 hash.

For larger files, we only have the hashes of the content blocks, so we construct a single hash out of those hashes.

See #2870.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2870 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
