### PR TITLE
diff command: custom root paths

### DIFF
--- a/changelog/unreleased/pull-2873
+++ b/changelog/unreleased/pull-2873
@@ -1,0 +1,10 @@
+Enhancement: Option for root paths in diff command
+
+The diff command now has new `--from-root` and `--to-root` flags that allow you
+to compare specific subpaths within snapshots.
+
+This allows you to compare a specific subset of a snapshots, and to compare files in 
+snapshots that were taken with different root paths.
+
+https://github.com/restic/restic/issues/2872
+https://github.com/restic/restic/pull/2873

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -281,6 +281,17 @@ and displays a small statistic, just pass the command two snapshot IDs:
       Added:   16.403 MiB
       Removed: 16.402 MiB
 
+To compare specific subpaths in the two snapshots, you can use the
+``--from-root`` and ``--to-root`` flags. This is especially useful if
+the snapshots were created with different root paths, or when the folders
+you want to compare have been moved around in the filesystem.
+
+Example:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo diff 5845b002 2ab627a6 --from-root=Pictures/Library/2020 --to-root=Photos/2020
+
 
 Backing up special items and metadata
 *************************************


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Allow specifying different root paths in the diff command with new `--from-root` and `--to-root` flags.

See #2872 for more info. 

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2872.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
