### PR TITLE
issue2699: restore symlinks on windows when run as admin user

### DIFF
--- a/changelog/unreleased/issue-2699
+++ b/changelog/unreleased/issue-2699
@@ -1,0 +1,9 @@
+Bugfix: Restore symbolic links on windows
+
+We've added support to restore symbolic links on windows.
+Because of windows specific restrictions this is only possible when running
+restic having SeCreateSymbolicLinkPrivilege privilege or when running as admin.
+
+https://github.com/restic/restic/issues/1078
+https://github.com/restic/restic/issues/2699
+https://github.com/restic/restic/pull/2875

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -56,6 +56,10 @@ There are case insensitive variants of ``--exclude`` and ``--include`` called
 ``--iexclude`` and ``--iinclude``. These options will behave the same way but
 ignore the casing of paths.
 
+Restoring symbolic links on windows is only possible when the user has
+``SeCreateSymbolicLinkPrivilege`` privilege or is running as admin. This is a
+restriction of windows not restic.
+
 Restore using mount
 ===================
 

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -51,7 +51,7 @@ func Rename(oldpath, newpath string) error {
 // Symlink creates newname as a symbolic link to oldname.
 // If there is an error, it will be of type *LinkError.
 func Symlink(oldname, newname string) error {
-	return os.Symlink(fixpath(oldname), fixpath(newname))
+	return os.Symlink(oldname, fixpath(newname))
 }
 
 // Link creates newname as a hard link to oldname.

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -14,7 +14,6 @@ import (
 	"github.com/restic/restic/internal/errors"
 
 	"bytes"
-	"runtime"
 
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/fs"
@@ -295,10 +294,6 @@ func (node Node) writeNodeContent(ctx context.Context, repo Repository, f *os.Fi
 }
 
 func (node Node) createSymlinkAt(path string) error {
-	// Windows does not allow non-admins to create soft links.
-	if runtime.GOOS == "windows" {
-		return nil
-	}
 
 	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return errors.Wrap(err, "Symlink")

--- a/internal/restic/node_test.go
+++ b/internal/restic/node_test.go
@@ -183,9 +183,6 @@ func TestNodeRestoreAt(t *testing.T) {
 		rtest.OK(t, test.CreateAt(context.TODO(), nodePath, nil))
 		rtest.OK(t, test.RestoreMetadata(nodePath))
 
-		if test.Type == "symlink" && runtime.GOOS == "windows" {
-			continue
-		}
 		if test.Type == "dir" {
 			rtest.OK(t, test.RestoreTimestamps(nodePath))
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Currently symlinks on windows are backed up but not restored. Because of windows restrictions this is only possible with admin privileges. This patch checks if the user running restic has sufficient privileges to restore symlinks and restores them if possible.

For testing the feature you may use the attached demo script: [issue2699.zip](https://github.com/restic/restic/files/5030502/issue2699.zip)

Running demo.bat will do the following:

1. call init.bat: create a demo repository and demo data in the current directory
2. call backup.bat: backup the created data
2. call restore.bat: restore the data to a new folder

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2699
Closes #1078

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
