### PR TITLE
Add repair command

### DIFF
--- a/changelog/unreleased/issue-1759
+++ b/changelog/unreleased/issue-1759
@@ -1,0 +1,16 @@
+Enhancement: Add new command repair
+
+We've added a new command repair which allows to repair snapshots even if needed
+parts of it are not accessable in the repository. Note that using this command
+can lead to data loss!
+
+Some corrupted repositories were reported in several issues and so far restic
+lacked a possibility to accept data loss but clean those up such that the
+repository returns to a sane state. This possibility was now added.
+
+https://github.com/restic/restic/issues/1759
+https://github.com/restic/restic/issues/1798
+https://github.com/restic/restic/issues/2334
+https://github.com/restic/restic/pull/2876
+https://forum.restic.net/t/corrupted-repo-how-to-repair/799
+https://forum.restic.net/t/recovery-options-for-damaged-repositories/1571

--- a/changelog/unreleased/issue-1759
+++ b/changelog/unreleased/issue-1759
@@ -1,14 +1,18 @@
-Enhancement: Add new command repair
+Enhancement: Add `repair index` and `repair snapshots` commands
 
-We've added a new command repair which allows to repair snapshots even if needed
-parts of it are not accessable in the repository. Note that using this command
-can lead to data loss!
+The `rebuild-index` command has been renamed to `repair index`. The old name
+will still work, but is deprecated.
 
-Some corrupted repositories were reported in several issues and so far restic
-lacked a possibility to accept data loss but clean those up such that the
-repository returns to a sane state. This possibility was now added.
+When a snapshot was damaged, the only option up to now was to completely forget
+the snapshot, even if only some unimportant file was damaged.
+
+We've added a `repair snapshots` command, which can repair snapshots by removing
+damaged directories and missing files contents. Note that using this command
+can lead to data loss! Please see the "Troubleshooting" section in the documentation
+for more details.
 
 https://github.com/restic/restic/issues/1759
+https://github.com/restic/restic/issues/1714
 https://github.com/restic/restic/issues/1798
 https://github.com/restic/restic/issues/2334
 https://github.com/restic/restic/pull/2876

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -245,7 +245,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 	}
 
 	if suggestIndexRebuild {
-		Printf("Duplicate packs/old indexes are non-critical, you can run `restic rebuild-index' to correct this.\n")
+		Printf("Duplicate packs/old indexes are non-critical, you can run `restic repair index' to correct this.\n")
 	}
 	if mixedFound {
 		Printf("Mixed packs with tree and data blobs are non-critical, you can run `restic prune` to correct this.\n")

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -488,7 +488,7 @@ func decidePackAction(ctx context.Context, opts PruneOptions, repo restic.Reposi
 			// Pack size does not fit and pack is needed => error
 			// If the pack is not needed, this is no error, the pack can
 			// and will be simply removed, see below.
-			Warnf("pack %s: calculated size %d does not match real size %d\nRun 'restic rebuild-index'.\n",
+			Warnf("pack %s: calculated size %d does not match real size %d\nRun 'restic repair index'.\n",
 				id.Str(), p.unusedSize+p.usedSize, packSize)
 			return errorSizeNotMatching
 		}

--- a/cmd/restic/cmd_repair.go
+++ b/cmd/restic/cmd_repair.go
@@ -1,0 +1,14 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var cmdRepair = &cobra.Command{
+	Use:   "repair",
+	Short: "Repair the repository",
+}
+
+func init() {
+	cmdRoot.AddCommand(cmdRepair)
+}

--- a/cmd/restic/cmd_repair.go
+++ b/cmd/restic/cmd_repair.go
@@ -84,7 +84,8 @@ func runRepair(opts RepairOptions, args []string) error {
 	}
 
 	lock, err := lockRepoExclusive(globalOptions.ctx, repo)
-	defer unlockRepo(lock)
+	// to make linter happy, as unlockRepo returns an error (which is ignored)
+	defer func() { _ = unlockRepo(lock) }()
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_repair.go
+++ b/cmd/restic/cmd_repair.go
@@ -45,7 +45,7 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 	},
 }
 
-// RestoreOptions collects all options for the restore command.
+// RepairOptions collects all options for the repair command.
 type RepairOptions struct {
 	Hosts           []string
 	Paths           []string
@@ -65,7 +65,7 @@ func init() {
 	flags.Var(&repairOptions.Tags, "tag", "only consider snapshots which include this `taglist`")
 	flags.StringArrayVar(&repairOptions.Paths, "path", nil, "only consider snapshots which include this (absolute) `path`")
 	flags.StringVar(&repairOptions.AddTag, "add-tag", "repaired", "tag to add to repaired snapshots")
-	flags.StringVar(&repairOptions.Append, "append", ".repaired", "string to append to repaired dirs/files; remove files if emtpy or impossible to repair")
+	flags.StringVar(&repairOptions.Append, "append", ".repaired", "string to append to repaired dirs/files; remove files if empty or impossible to repair")
 	flags.BoolVarP(&repairOptions.DryRun, "dry-run", "n", true, "don't do anything, only show what would be done")
 	flags.BoolVar(&repairOptions.DeleteSnapshots, "delete-snapshots", false, "delete original snapshots")
 }
@@ -75,7 +75,7 @@ func runRepair(opts RepairOptions, args []string) error {
 	case opts.DryRun:
 		Printf("\n note: --dry-run is set\n-> repair will only show what it would do.\n\n")
 	case opts.DeleteSnapshots:
-		Printf("\n note: --dry-run is not set and --delete is set\n-> this may result in data loss!\n\n")
+		Printf("\n note: --dry-run is not set and --delete-snapshots is set\n-> this may result in data loss!\n\n")
 	}
 
 	repo, err := OpenRepository(globalOptions)
@@ -168,7 +168,7 @@ func changeSnapshot(opts RepairOptions, repo restic.Repository, sn *restic.Snaps
 		}
 		Printf("snapshot repaired -> %v created.\n", newID.Str())
 	} else {
-		Printf("would have repaired snpshot %v.\n", sn.ID().Str())
+		Printf("would have repaired snapshot %v.\n", sn.ID().Str())
 	}
 	return nil
 }
@@ -235,10 +235,10 @@ func repairTree(opts RepairOptions, repo restic.Repository, path string, treeID 
 			if !ok {
 				changed = true
 				if opts.Append == "" || newSize == 0 {
-					Printf("removed defect file '%v'\n", path+node.Name)
+					Printf("removed defective file '%v'\n", path+node.Name)
 					continue
 				}
-				Printf("repaired defect file '%v'", path+node.Name)
+				Printf("repaired defective file '%v'", path+node.Name)
 				node.Name = node.Name + opts.Append
 				Printf(" to '%v'\n", node.Name)
 				node.Content = newContent
@@ -253,9 +253,9 @@ func repairTree(opts RepairOptions, repo restic.Repository, path string, treeID 
 			case lErr:
 				// If we get an error, we remove this subtree
 				changed = true
-				Printf("removed defect dir '%v'", path+node.Name)
+				Printf("removed defective dir '%v'", path+node.Name)
 				node.Name = node.Name + opts.Append
-				Printf("(now emtpy '%v')\n", node.Name)
+				Printf("(now empty '%v')\n", node.Name)
 				empty, err := emptyTree(opts.DryRun, repo)
 				if err != nil {
 					return newID, true, false, err

--- a/cmd/restic/cmd_repair.go
+++ b/cmd/restic/cmd_repair.go
@@ -1,0 +1,269 @@
+package main
+
+import (
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/restic"
+
+	"github.com/spf13/cobra"
+)
+
+var cmdRepair = &cobra.Command{
+	Use:   "repair [flags] [snapshot ID] [...]",
+	Short: "Repair snapshots",
+	Long: `
+The "repair" command allows to repair broken snapshots.
+It scans the given snapshots and generates new ones where
+damaged tress and file contents are removed.
+If the broken snapshots are deleted, a prune run will
+be able to refit the repository.
+
+The command depends on a good state of the index, so if
+there are inaccurancies in the index, make sure to run
+"rebuild-index" before!
+
+
+WARNING:
+========
+Repairing and deleting broken snapshots causes data loss!
+It will remove broken dirs and modify broken files in
+the modified snapshots.
+
+If the contents of directories and files are still available,
+the better option is to redo a backup which in that case is 
+able to "heal" already present snapshots.
+Only use this command if you need to recover an old and
+broken snapshot!
+
+EXIT STATUS
+===========
+
+Exit status is 0 if the command was successful, and non-zero if there was any error.
+`,
+	DisableAutoGenTag: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runRepair(repairOptions, args)
+	},
+}
+
+// RestoreOptions collects all options for the restore command.
+type RepairOptions struct {
+	Hosts           []string
+	Paths           []string
+	Tags            restic.TagLists
+	AddTag          string
+	Append          string
+	DryRun          bool
+	DeleteSnapshots bool
+}
+
+var repairOptions RepairOptions
+
+func init() {
+	cmdRoot.AddCommand(cmdRepair)
+	flags := cmdRepair.Flags()
+	flags.StringArrayVarP(&repairOptions.Hosts, "host", "H", nil, `only consider snapshots for this host (can be specified multiple times)`)
+	flags.Var(&repairOptions.Tags, "tag", "only consider snapshots which include this `taglist`")
+	flags.StringArrayVar(&repairOptions.Paths, "path", nil, "only consider snapshots which include this (absolute) `path`")
+	flags.StringVar(&repairOptions.AddTag, "add-tag", "repaired", "tag to add to repaired snapshots")
+	flags.StringVar(&repairOptions.Append, "append", ".repaired", "string to append to repaired dirs/files; remove files if emtpy or impossible to repair")
+	flags.BoolVarP(&repairOptions.DryRun, "dry-run", "n", true, "don't do anything, only show what would be done")
+	flags.BoolVar(&repairOptions.DeleteSnapshots, "delete-snapshots", false, "delete original snapshots")
+}
+
+func runRepair(opts RepairOptions, args []string) error {
+	switch {
+	case opts.DryRun:
+		Printf("\n note: --dry-run is set\n-> repair will only show what it would do.\n\n")
+	case opts.DeleteSnapshots:
+		Printf("\n note: --dry-run is not set and --delete is set\n-> this may result in data loss!\n\n")
+	}
+
+	repo, err := OpenRepository(globalOptions)
+	if err != nil {
+		return err
+	}
+
+	lock, err := lockRepoExclusive(globalOptions.ctx, repo)
+	defer unlockRepo(lock)
+	if err != nil {
+		return err
+	}
+
+	if err := repo.LoadIndex(globalOptions.ctx); err != nil {
+		return err
+	}
+
+	// get snapshots to check & repair
+	var snapshots []*restic.Snapshot
+	for sn := range FindFilteredSnapshots(globalOptions.ctx, repo.Backend(), repo, opts.Hosts, opts.Tags, opts.Paths, args) {
+		snapshots = append(snapshots, sn)
+	}
+
+	return repairSnapshots(opts, repo, snapshots)
+}
+
+func repairSnapshots(opts RepairOptions, repo restic.Repository, snapshots []*restic.Snapshot) error {
+	ctx := globalOptions.ctx
+
+	replaces := make(idMap)
+	seen := restic.NewIDSet()
+	deleteSn := restic.NewIDSet()
+
+	Verbosef("check and repair %d snapshots\n", len(snapshots))
+	bar := newProgressMax(!globalOptions.Quiet, uint64(len(snapshots)), "snapshots")
+	for _, sn := range snapshots {
+		debug.Log("process snapshot %v", sn.ID())
+		Printf("%v:\n", sn)
+		newID, changed, err := repairTree(opts, repo, "/", *sn.Tree, replaces, seen)
+		switch {
+		case err != nil:
+			Printf("the root tree is damaged -> delete snapshot.\n")
+			deleteSn.Insert(*sn.ID())
+		case changed:
+			err = changeSnapshot(opts, repo, sn, newID)
+			if err != nil {
+				return err
+			}
+			deleteSn.Insert(*sn.ID())
+		default:
+			Printf("is ok.\n")
+		}
+		debug.Log("processed snapshot %v", sn.ID())
+		bar.Add(1)
+	}
+	bar.Done()
+
+	err := repo.Flush(ctx)
+	if err != nil {
+		return err
+	}
+
+	if len(deleteSn) > 0 && opts.DeleteSnapshots {
+		Verbosef("delete %d snapshots...\n", len(deleteSn))
+		if !opts.DryRun {
+			DeleteFiles(globalOptions, repo, deleteSn, restic.SnapshotFile)
+		}
+	}
+	return nil
+}
+
+// changeSnapshot creates a modified snapshot:
+// - set the tree to newID
+// - add the rag opts.AddTag
+// - preserve original ID
+// if opts.DryRun is set, it doesn't change anything but only
+func changeSnapshot(opts RepairOptions, repo restic.Repository, sn *restic.Snapshot, newID restic.ID) error {
+	sn.AddTags([]string{opts.AddTag})
+	// Retain the original snapshot id over all tag changes.
+	if sn.Original == nil {
+		sn.Original = sn.ID()
+	}
+	sn.Tree = &newID
+	if !opts.DryRun {
+		newID, err := repo.SaveJSONUnpacked(globalOptions.ctx, restic.SnapshotFile, sn)
+		if err != nil {
+			return err
+		}
+		Printf("snapshot repaired -> %v created.\n", newID.Str())
+	} else {
+		Printf("would have repaired snpshot %v.\n", sn.ID().Str())
+	}
+	return nil
+}
+
+type idMap map[restic.ID]restic.ID
+
+// repairTree checks and repairs a tree and all its subtrees
+// Two error cases are checked:
+// - trees which cannot be loaded (-> the tree contents will be removed)
+// - files whose contents are not fully available  (-> file will be modified)
+// In case of an error, the changes made depends on:
+// - opts.Append: string to append to "repared" names; if empty files will not repaired but deleted
+// - opts.DryRun: if set to true, only print out what to but don't change anything
+func repairTree(opts RepairOptions, repo restic.Repository, path string, treeID restic.ID, replaces idMap, seen restic.IDSet) (restic.ID, bool, error) {
+	ctx := globalOptions.ctx
+
+	// check if tree was already changed
+	newID, ok := replaces[treeID]
+	if ok {
+		return newID, true, nil
+	}
+
+	// check if tree was seen but not changed
+	if seen.Has(treeID) {
+		return treeID, false, nil
+	}
+
+	tree, err := repo.LoadTree(ctx, treeID)
+	if err != nil {
+		return newID, false, err
+	}
+
+	var newNodes []*restic.Node
+	changed := false
+	for _, node := range tree.Nodes {
+		switch node.Type {
+		case "file":
+			ok := true
+			var newContent restic.IDs
+			var newSize uint64
+			// check all contents and remove if not available
+			for _, id := range node.Content {
+				if size, found := repo.LookupBlobSize(id, restic.DataBlob); !found {
+					ok = false
+				} else {
+					newContent = append(newContent, id)
+					newSize += uint64(size)
+				}
+			}
+			if !ok {
+				changed = true
+				if opts.Append == "" || newSize == 0 {
+					Printf("removed defect file '%v'\n", path+node.Name)
+					continue
+				}
+				Printf("repaired defect file '%v'", path+node.Name)
+				node.Name = node.Name + opts.Append
+				Printf(" to '%v'\n", node.Name)
+				node.Content = newContent
+				node.Size = newSize
+			}
+		case "dir":
+			// rewrite if necessary
+			newID, c, err := repairTree(opts, repo, path+node.Name+"/", *node.Subtree, replaces, seen)
+			switch {
+			case err != nil:
+				// If we get an error, we remove this subtree
+				changed = true
+				Printf("removed defect dir '%v'", path+node.Name)
+				node.Name = node.Name + opts.Append
+				Printf("(now emtpy '%v')\n", node.Name)
+				node.Subtree = nil
+			case c:
+				node.Subtree = &newID
+				changed = true
+			}
+		}
+		newNodes = append(newNodes, node)
+	}
+
+	if !changed {
+		seen.Insert(treeID)
+		return treeID, false, nil
+	}
+
+	tree.Nodes = newNodes
+
+	if !opts.DryRun {
+		newID, err = repo.SaveTree(ctx, tree)
+		if err != nil {
+			return newID, false, err
+		}
+		Printf("modified tree %v, new id: %v\n", treeID.Str(), newID.Str())
+	} else {
+		Printf("would have modified tree %v\n", treeID.Str())
+	}
+
+	replaces[treeID] = newID
+	return newID, true, nil
+}

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -15,28 +15,25 @@ var cmdRepairSnapshots = &cobra.Command{
 	Use:   "snapshots [flags] [snapshot ID] [...]",
 	Short: "Repair snapshots",
 	Long: `
-The "repair snapshots" command allows to repair broken snapshots.
-It scans the given snapshots and generates new ones where
-damaged tress and file contents are removed.
-If the broken snapshots are deleted, a prune run will
-be able to refit the repository.
+The "repair snapshots" command repairs broken snapshots. It scans the given
+snapshots and generates new ones with damaged directories and file contents
+removed. If the broken snapshots are deleted, a prune run will be able to
+clean up the repository.
 
-The command depends on a good state of the index, so if
-there are inaccurancies in the index, make sure to run
-"repair index" before!
+The command depends on a correct index, thus make sure to run "repair index"
+first!
 
 
-WARNING:
-========
-Repairing and deleting broken snapshots causes data loss!
-It will remove broken dirs and modify broken files in
-the modified snapshots.
+WARNING
+=======
 
-If the contents of directories and files are still available,
-the better option is to redo a backup which in that case is 
-able to "heal" already present snapshots.
-Only use this command if you need to recover an old and
-broken snapshot!
+Repairing and deleting broken snapshots causes data loss! It will remove broken
+directories and modify broken files in the modified snapshots.
+
+If the contents of directories and files are still available, the better option
+is to run "backup" which in that case is able to heal existing snapshots. Only
+use the "repair snapshots" command if you need to recover an old and broken
+snapshot!
 
 EXIT STATUS
 ===========

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -240,9 +240,7 @@ func repairTree(ctx context.Context, opts RepairOptions, repo restic.Repository,
 					Printf("removed defective file '%v'\n", path+node.Name)
 					continue
 				}
-				Printf("repaired defective file '%v'", path+node.Name)
-				node.Name = node.Name + ".repaired"
-				Printf(" to '%v'\n", node.Name)
+				Printf("repaired defective file '%v'\n", path+node.Name)
 				node.Content = newContent
 				node.Size = newSize
 			}
@@ -255,9 +253,7 @@ func repairTree(ctx context.Context, opts RepairOptions, repo restic.Repository,
 			case lErr:
 				// If we get an error, we remove this subtree
 				changed = true
-				Printf("removed defective dir '%v'", path+node.Name)
-				node.Name = node.Name + ".repaired"
-				Printf("(now empty '%v')\n", node.Name)
+				Printf("replaced defective dir '%v'", path+node.Name)
 				empty, err := emptyTree(ctx, repo, opts.DryRun)
 				if err != nil {
 					return newID, true, false, err

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -11,10 +11,15 @@ import (
 )
 
 var cmdRepair = &cobra.Command{
-	Use:   "repair [flags] [snapshot ID] [...]",
+	Use:   "repair",
+	Short: "Repair commands",
+}
+
+var cmdRepairSnapshots = &cobra.Command{
+	Use:   "snapshots [flags] [snapshot ID] [...]",
 	Short: "Repair snapshots",
 	Long: `
-The "repair" command allows to repair broken snapshots.
+The "repair snapshots" command allows to repair broken snapshots.
 It scans the given snapshots and generates new ones where
 damaged tress and file contents are removed.
 If the broken snapshots are deleted, a prune run will
@@ -44,7 +49,7 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 `,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runRepair(cmd.Context(), globalOptions, repairOptions, args)
+		return runRepairSnapshots(cmd.Context(), globalOptions, repairSnapshotOptions, args)
 	},
 }
 
@@ -58,21 +63,22 @@ type RepairOptions struct {
 	DeleteSnapshots bool
 }
 
-var repairOptions RepairOptions
+var repairSnapshotOptions RepairOptions
 
 func init() {
 	cmdRoot.AddCommand(cmdRepair)
-	flags := cmdRepair.Flags()
+	cmdRepair.AddCommand(cmdRepairSnapshots)
+	flags := cmdRepairSnapshots.Flags()
 
-	initMultiSnapshotFilter(flags, &repairOptions.SnapshotFilter, true)
+	initMultiSnapshotFilter(flags, &repairSnapshotOptions.SnapshotFilter, true)
 
-	flags.StringVar(&repairOptions.AddTag, "add-tag", "repaired", "tag to add to repaired snapshots")
-	flags.StringVar(&repairOptions.Append, "append", ".repaired", "string to append to repaired dirs/files; remove files if empty or impossible to repair")
-	flags.BoolVarP(&repairOptions.DryRun, "dry-run", "n", true, "don't do anything, only show what would be done")
-	flags.BoolVar(&repairOptions.DeleteSnapshots, "delete-snapshots", false, "delete original snapshots")
+	flags.StringVar(&repairSnapshotOptions.AddTag, "add-tag", "repaired", "tag to add to repaired snapshots")
+	flags.StringVar(&repairSnapshotOptions.Append, "append", ".repaired", "string to append to repaired dirs/files; remove files if empty or impossible to repair")
+	flags.BoolVarP(&repairSnapshotOptions.DryRun, "dry-run", "n", true, "don't do anything, only show what would be done")
+	flags.BoolVar(&repairSnapshotOptions.DeleteSnapshots, "delete-snapshots", false, "delete original snapshots")
 }
 
-func runRepair(ctx context.Context, gopts GlobalOptions, opts RepairOptions, args []string) error {
+func runRepairSnapshots(ctx context.Context, gopts GlobalOptions, opts RepairOptions, args []string) error {
 	switch {
 	case opts.DryRun:
 		Printf("\n note: --dry-run is set\n-> repair will only show what it would do.\n\n")

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -130,11 +130,12 @@ func runRepairSnapshots(ctx context.Context, gopts GlobalOptions, opts RepairOpt
 		},
 		RewriteFailedTree: func(nodeID restic.ID, path string, _ error) (restic.ID, error) {
 			if path == "/" {
+				Verbosef("  dir %q: not readable\n", path)
 				// remove snapshots with invalid root node
 				return restic.ID{}, nil
 			}
 			// If a subtree fails to load, remove it
-			Printf("removed defective dir '%v'", path)
+			Verbosef("  dir %q: replaced with empty directory\n", path)
 			emptyID, err := restic.SaveTree(ctx, repo, &restic.Tree{})
 			if err != nil {
 				return restic.ID{}, err

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -10,11 +10,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var cmdRepair = &cobra.Command{
-	Use:   "repair",
-	Short: "Repair commands",
-}
-
 var cmdRepairSnapshots = &cobra.Command{
 	Use:   "snapshots [flags] [snapshot ID] [...]",
 	Short: "Repair snapshots",
@@ -27,7 +22,7 @@ be able to refit the repository.
 
 The command depends on a good state of the index, so if
 there are inaccurancies in the index, make sure to run
-"rebuild-index" before!
+"repair index" before!
 
 
 WARNING:
@@ -66,12 +61,10 @@ type RepairOptions struct {
 var repairSnapshotOptions RepairOptions
 
 func init() {
-	cmdRoot.AddCommand(cmdRepair)
 	cmdRepair.AddCommand(cmdRepairSnapshots)
 	flags := cmdRepairSnapshots.Flags()
 
 	initMultiSnapshotFilter(flags, &repairSnapshotOptions.SnapshotFilter, true)
-
 	flags.StringVar(&repairSnapshotOptions.AddTag, "add-tag", "repaired", "tag to add to repaired snapshots")
 	flags.StringVar(&repairSnapshotOptions.Append, "append", ".repaired", "string to append to repaired dirs/files; remove files if empty or impossible to repair")
 	flags.BoolVarP(&repairSnapshotOptions.DryRun, "dry-run", "n", true, "don't do anything, only show what would be done")

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -107,7 +107,7 @@ func runRepairSnapshots(ctx context.Context, gopts GlobalOptions, opts RepairOpt
 			}
 
 			ok := true
-			var newContent restic.IDs
+			var newContent restic.IDs = restic.IDs{}
 			var newSize uint64
 			// check all contents and remove if not available
 			for _, id := range node.Content {
@@ -119,15 +119,13 @@ func runRepairSnapshots(ctx context.Context, gopts GlobalOptions, opts RepairOpt
 				}
 			}
 			if !ok {
-				if newSize == 0 {
-					Printf("removed defective file '%v'\n", path+node.Name)
-					node = nil
-				} else {
-					Printf("repaired defective file '%v'\n", path+node.Name)
-					node.Content = newContent
-					node.Size = newSize
-				}
+				Verbosef("  file %q: removed missing content\n", path)
+			} else if newSize != node.Size {
+				Verbosef("  file %q: fixed incorrect size\n", path)
 			}
+			// no-ops if already correct
+			node.Content = newContent
+			node.Size = newSize
 			return node
 		},
 		RewriteFailedTree: func(nodeID restic.ID, path string, _ error) (restic.ID, error) {

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -124,6 +124,20 @@ func filterAndReplaceSnapshot(ctx context.Context, repo restic.Repository, sn *r
 		return false, err
 	}
 
+	if filteredTree.IsNull() {
+		if dryRun {
+			Verbosef("would delete empty snapshot\n")
+		} else {
+			h := restic.Handle{Type: restic.SnapshotFile, Name: sn.ID().String()}
+			if err = repo.Backend().Remove(ctx, h); err != nil {
+				return false, err
+			}
+			debug.Log("removed empty snapshot %v", sn.ID())
+			Verbosef("removed empty snapshot %v\n", sn.ID().Str())
+		}
+		return true, nil
+	}
+
 	if filteredTree == *sn.Tree {
 		debug.Log("Snapshot %v not modified", sn)
 		return false, nil

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -95,6 +95,7 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *resti
 			Verbosef(fmt.Sprintf("excluding %s\n", path))
 			return nil
 		},
+		DisableNodeCache: true,
 	})
 
 	return filterAndReplaceSnapshot(ctx, repo, sn,

--- a/cmd/restic/integration_repair_snapshots_test.go
+++ b/cmd/restic/integration_repair_snapshots_test.go
@@ -1,0 +1,135 @@
+package main
+
+import (
+	"context"
+	"hash/fnv"
+	"io"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func testRunRepairSnapshot(t testing.TB, gopts GlobalOptions, forget bool) {
+	opts := RepairOptions{
+		Forget: forget,
+	}
+
+	rtest.OK(t, runRepairSnapshots(context.TODO(), gopts, opts, nil))
+}
+
+func createRandomFile(t testing.TB, env *testEnvironment, path string, size int) {
+	fn := filepath.Join(env.testdata, path)
+	rtest.OK(t, os.MkdirAll(filepath.Dir(fn), 0o755))
+
+	h := fnv.New64()
+	_, err := h.Write([]byte(path))
+	rtest.OK(t, err)
+	r := rand.New(rand.NewSource(int64(h.Sum64())))
+
+	f, err := os.OpenFile(fn, os.O_CREATE|os.O_RDWR, 0o644)
+	rtest.OK(t, err)
+	_, err = io.Copy(f, io.LimitReader(r, int64(size)))
+	rtest.OK(t, err)
+	rtest.OK(t, f.Close())
+}
+
+func TestRepairSnapshotsWithLostData(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+
+	createRandomFile(t, env, "foo/bar/file", 512*1024)
+	testRunBackup(t, "", []string{env.testdata}, BackupOptions{}, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+	// damage repository
+	removePacksExcept(env.gopts, t, restic.NewIDSet(), false)
+
+	createRandomFile(t, env, "foo/bar/file2", 256*1024)
+	testRunBackup(t, "", []string{env.testdata}, BackupOptions{}, env.gopts)
+	snapshotIDs := testListSnapshots(t, env.gopts, 2)
+	testRunCheckMustFail(t, env.gopts)
+
+	// repair but keep broken snapshots
+	testRunRebuildIndex(t, env.gopts)
+	testRunRepairSnapshot(t, env.gopts, false)
+	testListSnapshots(t, env.gopts, 4)
+	testRunCheckMustFail(t, env.gopts)
+
+	// repository must be ok after removing the broken snapshots
+	testRunForget(t, env.gopts, snapshotIDs[0].String(), snapshotIDs[1].String())
+	testListSnapshots(t, env.gopts, 2)
+	_, err := testRunCheckOutput(env.gopts)
+	rtest.OK(t, err)
+}
+
+func TestRepairSnapshotsWithLostTree(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+
+	createRandomFile(t, env, "foo/bar/file", 12345)
+	testRunBackup(t, "", []string{env.testdata}, BackupOptions{}, env.gopts)
+	oldSnapshot := testListSnapshots(t, env.gopts, 1)
+	oldPacks := testRunList(t, "packs", env.gopts)
+
+	// keep foo/bar unchanged
+	createRandomFile(t, env, "foo/bar2", 1024)
+	testRunBackup(t, "", []string{env.testdata}, BackupOptions{}, env.gopts)
+	testListSnapshots(t, env.gopts, 2)
+
+	// remove tree for foo/bar and the now completely broken first snapshot
+	removePacks(env.gopts, t, restic.NewIDSet(oldPacks...))
+	testRunForget(t, env.gopts, oldSnapshot[0].String())
+	testRunCheckMustFail(t, env.gopts)
+
+	// repair
+	testRunRebuildIndex(t, env.gopts)
+	testRunRepairSnapshot(t, env.gopts, true)
+	testListSnapshots(t, env.gopts, 1)
+	_, err := testRunCheckOutput(env.gopts)
+	rtest.OK(t, err)
+}
+
+func TestRepairSnapshotsWithLostRootTree(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+
+	createRandomFile(t, env, "foo/bar/file", 12345)
+	testRunBackup(t, "", []string{env.testdata}, BackupOptions{}, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+	oldPacks := testRunList(t, "packs", env.gopts)
+
+	// remove all trees
+	removePacks(env.gopts, t, restic.NewIDSet(oldPacks...))
+	testRunCheckMustFail(t, env.gopts)
+
+	// repair
+	testRunRebuildIndex(t, env.gopts)
+	testRunRepairSnapshot(t, env.gopts, true)
+	testListSnapshots(t, env.gopts, 0)
+	_, err := testRunCheckOutput(env.gopts)
+	rtest.OK(t, err)
+}
+
+func TestRepairSnapshotsIntact(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	testSetupBackupData(t, env)
+	testRunBackup(t, filepath.Dir(env.testdata), []string{"testdata"}, BackupOptions{}, env.gopts)
+	oldSnapshotIDs := testListSnapshots(t, env.gopts, 1)
+
+	// use an exclude that will not exclude anything
+	testRunRepairSnapshot(t, env.gopts, false)
+	snapshotIDs := testListSnapshots(t, env.gopts, 1)
+	rtest.Assert(t, reflect.DeepEqual(oldSnapshotIDs, snapshotIDs), "unexpected snapshot id mismatch %v vs. %v", oldSnapshotIDs, snapshotIDs)
+	testRunCheck(t, env.gopts)
+}

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -188,7 +188,7 @@ func testRunRebuildIndex(t testing.TB, gopts GlobalOptions) {
 		globalOptions.stdout = os.Stdout
 	}()
 
-	rtest.OK(t, runRebuildIndex(context.TODO(), RebuildIndexOptions{}, gopts))
+	rtest.OK(t, runRebuildIndex(context.TODO(), RepairIndexOptions{}, gopts))
 }
 
 func testRunLs(t testing.TB, gopts GlobalOptions, snapshotID string) []string {
@@ -1504,8 +1504,8 @@ func testRebuildIndex(t *testing.T, backendTestHook backendWrapper) {
 		t.Fatalf("expected no error from checker for test repository, got %v", err)
 	}
 
-	if !strings.Contains(out, "restic rebuild-index") {
-		t.Fatalf("did not find hint for rebuild-index command")
+	if !strings.Contains(out, "restic repair index") {
+		t.Fatalf("did not find hint for repair index command")
 	}
 
 	env.gopts.backendTestHook = backendTestHook
@@ -1518,7 +1518,7 @@ func testRebuildIndex(t *testing.T, backendTestHook backendWrapper) {
 	}
 
 	if err != nil {
-		t.Fatalf("expected no error from checker after rebuild-index, got: %v", err)
+		t.Fatalf("expected no error from checker after repair index, got: %v", err)
 	}
 }
 
@@ -1599,7 +1599,7 @@ func TestRebuildIndexFailsOnAppendOnly(t *testing.T) {
 	env.gopts.backendTestHook = func(r restic.Backend) (restic.Backend, error) {
 		return &appendOnlyBackend{r}, nil
 	}
-	err := runRebuildIndex(context.TODO(), RebuildIndexOptions{}, env.gopts)
+	err := runRebuildIndex(context.TODO(), RepairIndexOptions{}, env.gopts)
 	if err == nil {
 		t.Error("expected rebuildIndex to fail")
 	}
@@ -1887,8 +1887,8 @@ func TestListOnce(t *testing.T) {
 	testRunPrune(t, env.gopts, pruneOpts)
 	rtest.OK(t, runCheck(context.TODO(), checkOpts, env.gopts, nil))
 
-	rtest.OK(t, runRebuildIndex(context.TODO(), RebuildIndexOptions{}, env.gopts))
-	rtest.OK(t, runRebuildIndex(context.TODO(), RebuildIndexOptions{ReadAllPacks: true}, env.gopts))
+	rtest.OK(t, runRebuildIndex(context.TODO(), RepairIndexOptions{}, env.gopts))
+	rtest.OK(t, runRebuildIndex(context.TODO(), RepairIndexOptions{ReadAllPacks: true}, env.gopts))
 }
 
 func TestHardLink(t *testing.T) {

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -472,7 +472,7 @@ space. However, a **failed** ``prune`` run can cause the repository to become
 **temporarily unusable**. Therefore, make sure that you have a stable connection to the
 repository storage, before running this command. In case the command fails, it may become
 necessary to manually remove all files from the `index/` folder of the repository and
-run `rebuild-index` afterwards.
+run `repair index` afterwards.
 
 To prevent accidental usages of the ``--unsafe-recover-no-free-space`` option it is
 necessary to first run ``prune --unsafe-recover-no-free-space SOME-ID`` and then replace

--- a/doc/077_troubleshooting.rst
+++ b/doc/077_troubleshooting.rst
@@ -58,17 +58,17 @@ But make sure that your needed data is also still contained in your repository ;
 Note that `check` also prints out warning in some cases. These warnings point out that the repo may be 
 optimized but is still in perfect shape and does not need any troubleshooting. 
 
-3. Index trouble -> `rebuild-index`
+3. Index trouble -> `repair index`
 ********************************************
 
 A common problem with broken repostories is that the index does no longer correctly represent the contents
 of your pack files. This is especially the case if some pack files got lost.
-`rebuild-index` recovers this situation and ensures that the index exactly represents the pack files.
+`repair index` recovers this situation and ensures that the index exactly represents the pack files.
 
 You might even need to manually remove corrupted pack files. In this case make sure, you run 
-`restic rebuild-index` after.
+`restic repair index` after.
 
-Also if you encounter problems with the index files itselves, `rebuild-index` will solve these problems
+Also if you encounter problems with the index files itselves, `repair index` will solve these problems
 immediately.
 
 However, rebuilding the index does not solve every problem, e.g. lost pack files.
@@ -91,7 +91,7 @@ backup again and check if this did heal your repository.
 If you realize that a specific file is broken in your repository and you have this file, any run of
 `backup` which includes that file will be able to heal the situation.
 
-Note that `backup` relies on a correct index state, so make sure your index is fine or run `rebuild-index`
+Note that `backup` relies on a correct index state, so make sure your index is fine or run `repair index`
 before running `backup`.
 
 6. Unreferenced tree -> `recover`
@@ -101,7 +101,7 @@ If for some reason you have unreferenced trees in your repository but you actual
 `recover` it will generate a new snapshot which allows access to all trees that you have in your
 repository. 
 
-Note that `recover` relies on a correct index state, so make sure your index is fine or run `rebuild-index`
+Note that `recover` relies on a correct index state, so make sure your index is fine or run `repair index`
 before running `recover`.
 
 7. Repair defect snapshots using `repair`

--- a/doc/077_troubleshooting.rst
+++ b/doc/077_troubleshooting.rst
@@ -103,3 +103,9 @@ repository.
 
 Note that `recover` relies on a correct index state, so make sure your index is fine or run `rebuild-index`
 before running `recover`.
+
+7. Repair defect snapshots using `repair`
+********************************************
+
+If all other things did not help, you can repair defect snapshots with `repair`. Note that the repaired
+snapshots will miss data which was referenced in the defect snapshot.

--- a/doc/077_troubleshooting.rst
+++ b/doc/077_troubleshooting.rst
@@ -1,0 +1,105 @@
+..
+  Normally, there are no heading levels assigned to certain characters as the structure is
+  determined from the succession of headings. However, this convention is used in Python’s
+  Style Guide for documenting which you may follow:
+
+  # with overline, for parts
+  * for chapters
+  = for sections
+  - for subsections
+  ^ for subsubsections
+  " for paragraphs
+
+#########################
+Troubleshooting
+#########################
+
+Being a backup software, the repository format ensures that the data saved in the repository
+is verifiable and error-restistant. Restic even implements some self-healing functionalities.
+
+However, situations might occur where your repository gets in an incorrect state and measurements
+need to be done to get you out of this situation. These situations might be due to hardware failure,
+accidentially removing files directly from the repository or bugs in the restic implementation.
+
+This document is meant to give you some hints about how to recover from such situations.
+
+1. Stay calm and don't over-react
+********************************************
+
+The most important thing if you find yourself in the situation of a damaged repository is to
+stay calm and don't do anything you might regret later.
+
+The following point should be always considered:
+
+- Make a copy of you repository and try to recover from that copy. If you suspect a storage failure,
+  it may be even better, to make *two* copies: one to get all data out of the possibly failing storage
+  and another one to try the recovery process.
+- Pause your regular operations on the repository or let them run on a copy. You will especially make
+  sure that no `forget` or `prune` is run as these command are supposed to remove data and may result
+  in data loss.
+- Search if your issue is already known and solved. Good starting points are the restic forum and the
+  github issues.
+- Get you some help if you are unsure what to do. Find a colleage or friend to discuss what should be done.
+  Also feel free to consult the restic forum.
+- When using the commands below, make sure you read and understand the documentation. Some of the commands
+  may not be your every-day commands, so make sure you really understand what they are doing. 
+
+
+2. `check` is your friend
+********************************************
+
+Run `restic check` to find out what type of error you have. The results may be technical but can give you
+a good hint what's really wrong. 
+
+Moreover, you can always run a `check` to ensure that your repair really was sucessful and your repository
+is in a sane state again.
+But make sure that your needed data is also still contained in your repository ;-)
+ 
+Note that `check` also prints out warning in some cases. These warnings point out that the repo may be 
+optimized but is still in perfect shape and does not need any troubleshooting. 
+
+3. Index trouble -> `rebuild-index`
+********************************************
+
+A common problem with broken repostories is that the index does no longer correctly represent the contents
+of your pack files. This is especially the case if some pack files got lost.
+`rebuild-index` recovers this situation and ensures that the index exactly represents the pack files.
+
+You might even need to manually remove corrupted pack files. In this case make sure, you run 
+`restic rebuild-index` after.
+
+Also if you encounter problems with the index files itselves, `rebuild-index` will solve these problems
+immediately.
+
+However, rebuilding the index does not solve every problem, e.g. lost pack files.
+
+4. Delete unneeded defect snapshots -> `forget`
+********************************************
+
+If you encounter defect snapshots but realize you can spare them, it is often a good idea to simply
+delete them using `forget`. In case that your repository remains with just sane snapshots (including
+all trees and files) the next `prune` run will put your repository in a sane state.
+
+This can be also used if you manage to create new snapshots which can replace the defect ones, see
+below.
+
+5. No fear to `backup` again
+********************************************
+
+There are quite some self-healing mechanisms withing the `backup` command. So it is always a good idea to
+backup again and check if this did heal your repository.
+If you realize that a specific file is broken in your repository and you have this file, any run of
+`backup` which includes that file will be able to heal the situation.
+
+Note that `backup` relies on a correct index state, so make sure your index is fine or run `rebuild-index`
+before running `backup`.
+
+6. Unreferenced tree -> `recover`
+********************************************
+
+If for some reason you have unreferenced trees in your repository but you actually need them, run
+`recover` it will generate a new snapshot which allows access to all trees that you have in your
+repository. 
+
+Note that `recover` relies on a correct index state, so make sure your index is fine or run `rebuild-index`
+before running `recover`.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -14,6 +14,7 @@ Restic Documentation
    060_forget
    070_encryption
    075_scripting
+   077_troubleshooting
    080_examples
    090_participating
    100_references

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -35,8 +35,8 @@ Usage help is available:
       migrate       Apply migrations
       mount         Mount the repository
       prune         Remove unneeded data from the repository
-      rebuild-index Build a new index
       recover       Recover data from the repository not referenced by snapshots
+      repair        Repair the repository
       restore       Extract the data from a snapshot
       rewrite       Rewrite snapshots to exclude unwanted files
       self-update   Update the restic binary

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -207,7 +207,7 @@ func (arch *Archiver) wrapLoadTreeError(id restic.ID, err error) error {
 	if arch.Repo.Index().Has(restic.BlobHandle{ID: id, Type: restic.TreeBlob}) {
 		err = errors.Errorf("tree %v could not be loaded; the repository could be damaged: %v", id, err)
 	} else {
-		err = errors.Errorf("tree %v is not known; the repository could be damaged, run `rebuild-index` to try to repair it", id)
+		err = errors.Errorf("tree %v is not known; the repository could be damaged, run `repair index` to try to repair it", id)
 	}
 	return err
 }

--- a/internal/walker/rewriter.go
+++ b/internal/walker/rewriter.go
@@ -52,7 +52,7 @@ func FilterTree(ctx context.Context, repo BlobLoadSaver, nodepath string, nodeID
 			continue
 		}
 
-		if node.Subtree == nil {
+		if node.Type != "dir" {
 			err = tb.AddNode(node)
 			if err != nil {
 				return restic.ID{}, err

--- a/internal/walker/rewriter.go
+++ b/internal/walker/rewriter.go
@@ -10,24 +10,43 @@ import (
 )
 
 type NodeRewriteFunc func(node *restic.Node, path string) *restic.Node
+type FailedTreeRewriteFunc func(nodeID restic.ID, path string, err error) (restic.ID, error)
 
 type RewriteOpts struct {
 	// return nil to remove the node
 	RewriteNode NodeRewriteFunc
+	// decide what to do with a tree that could not be loaded. Return nil to remove the node. By default the load error is returned which causes the operation to fail.
+	RewriteFailedTree FailedTreeRewriteFunc
+
+	AllowUnstableSerialization bool
+	DisableNodeCache           bool
 }
+
+type idMap map[restic.ID]restic.ID
 
 type TreeRewriter struct {
 	opts RewriteOpts
+
+	replaces idMap
 }
 
 func NewTreeRewriter(opts RewriteOpts) *TreeRewriter {
 	rw := &TreeRewriter{
 		opts: opts,
 	}
+	if !opts.DisableNodeCache {
+		rw.replaces = make(idMap)
+	}
 	// setup default implementations
 	if rw.opts.RewriteNode == nil {
 		rw.opts.RewriteNode = func(node *restic.Node, path string) *restic.Node {
 			return node
+		}
+	}
+	if rw.opts.RewriteFailedTree == nil {
+		// fail with error by default
+		rw.opts.RewriteFailedTree = func(nodeID restic.ID, path string, err error) (restic.ID, error) {
+			return restic.ID{}, err
 		}
 	}
 	return rw
@@ -39,20 +58,29 @@ type BlobLoadSaver interface {
 }
 
 func (t *TreeRewriter) RewriteTree(ctx context.Context, repo BlobLoadSaver, nodepath string, nodeID restic.ID) (newNodeID restic.ID, err error) {
-	curTree, err := restic.LoadTree(ctx, repo, nodeID)
-	if err != nil {
-		return restic.ID{}, err
+	// check if tree was already changed
+	newID, ok := t.replaces[nodeID]
+	if ok {
+		return newID, nil
 	}
 
-	// check that we can properly encode this tree without losing information
-	// The alternative of using json/Decoder.DisallowUnknownFields() doesn't work as we use
-	// a custom UnmarshalJSON to decode trees, see also https://github.com/golang/go/issues/41144
-	testID, err := restic.SaveTree(ctx, repo, curTree)
+	// a nil nodeID will lead to a load error
+	curTree, err := restic.LoadTree(ctx, repo, nodeID)
 	if err != nil {
-		return restic.ID{}, err
+		return t.opts.RewriteFailedTree(nodeID, nodepath, err)
 	}
-	if nodeID != testID {
-		return restic.ID{}, fmt.Errorf("cannot encode tree at %q without losing information", nodepath)
+
+	if !t.opts.AllowUnstableSerialization {
+		// check that we can properly encode this tree without losing information
+		// The alternative of using json/Decoder.DisallowUnknownFields() doesn't work as we use
+		// a custom UnmarshalJSON to decode trees, see also https://github.com/golang/go/issues/41144
+		testID, err := restic.SaveTree(ctx, repo, curTree)
+		if err != nil {
+			return restic.ID{}, err
+		}
+		if nodeID != testID {
+			return restic.ID{}, fmt.Errorf("cannot encode tree at %q without losing information", nodepath)
+		}
 	}
 
 	debug.Log("filterTree: %s, nodeId: %s\n", nodepath, nodeID.Str())
@@ -72,7 +100,12 @@ func (t *TreeRewriter) RewriteTree(ctx context.Context, repo BlobLoadSaver, node
 			}
 			continue
 		}
-		newID, err := t.RewriteTree(ctx, repo, path, *node.Subtree)
+		// treat nil as null id
+		var subtree restic.ID
+		if node.Subtree != nil {
+			subtree = *node.Subtree
+		}
+		newID, err := t.RewriteTree(ctx, repo, path, subtree)
 		if err != nil {
 			return restic.ID{}, err
 		}
@@ -90,6 +123,9 @@ func (t *TreeRewriter) RewriteTree(ctx context.Context, repo BlobLoadSaver, node
 
 	// Save new tree
 	newTreeID, _, _, err := repo.SaveBlob(ctx, restic.TreeBlob, tree, restic.ID{}, false)
+	if t.replaces != nil {
+		t.replaces[nodeID] = newTreeID
+	}
 	if !newTreeID.Equal(nodeID) {
 		debug.Log("filterTree: save new tree for %s as %v\n", nodepath, newTreeID)
 	}

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -14,7 +14,9 @@ import (
 type TestTree map[string]interface{}
 
 // TestNode is used to test the walker.
-type TestFile struct{}
+type TestFile struct {
+	Size uint64
+}
 
 func BuildTreeMap(tree TestTree) (m TreeMap, root restic.ID) {
 	m = TreeMap{}
@@ -37,6 +39,7 @@ func buildTreeMap(tree TestTree, m TreeMap) restic.ID {
 			err := tb.AddNode(&restic.Node{
 				Name: name,
 				Type: "file",
+				Size: elem.Size,
 			})
 			if err != nil {
 				panic(err)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Allow users to recover from broken repositories/snapshots while still salvaging the sane parts of the repository/snapshot.

For given snapshots (selection identical to, e.g., `forget`) the command tries to read all trees and checks if the needed blobs are contained in the index. If blobs are missing or trees cannot be read, it will create new trees and snapshots which only miss these "defect" parts.
Those newly generated snapshots can be used to recover needed data.
Also, after removing the "defect" snapshots, `prune` is able to clean up the repo again.

While this command is able to cause data loss, special care is taken such that the default flags won't
do any harm - in fact, users have to explicitly specify `--dry-run=false --delete` to loose data.

Output looks like:
```
./restic -r /home/thinkpad/repo.index-missingblob2/repo repair 

 note: --dry-run is set
-> repair will only show what it would do.

enter password for repository: 
repository b270637f opened successfully, password is correct
check and repair 1 snapshots
<Snapshot f22c6d3a of [/home/thinkpad/data] at 2020-07-09 11:18:26.501071439 +0200 CEST by alex@thinkpad>:
removed defect file '/home/thinkpad/data/test'
would have modified tree 705adc0d
would have modified tree 1ee0d0e1
would have modified tree 98c948be
would have modified tree 9d89d7fe
would have repaired snpshot f22c6d3a.
[0:00] 100.00%  1 / 1 snapshots
```

Depends on #2878 for the troubleshooting docu update.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #1759 
Closes #1798
Closes #2334 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
