### PR TITLE
prune/rebuild-index: Add warmup possibilities

### DIFF
--- a/changelog/unreleased/pull-2881
+++ b/changelog/unreleased/pull-2881
@@ -1,10 +1,11 @@
-Enhancement: Add options for warmup-possibilities to prune
+Enhancement: Add options for warmup-possibilities to prune and reabuild-index
 
 Restic `prune` did not have a good possibility to warm up pack files that need
 repacking but are stored in a cold storage backend.
-We have added the option `--warmup`` which just tries to access all needed
+We have added the option `--warm-up`` which just tries to access all needed
 files. This triggers a warmup for some cold storages.
 Also the option `--json` in combination with `--dry-run` now prints the pack
 file names in JSON format. This can be used to implement a custom warm-up.
+The `--warm-up` option is also available to `rebuild-index`.
 
 https://github.com/restic/restic/pull/2881

--- a/changelog/unreleased/pull-2881
+++ b/changelog/unreleased/pull-2881
@@ -1,0 +1,10 @@
+Enhancement: Add options for warmup-possibilities to prune
+
+Restic `prune` did not have a good possibility to warm up pack files that need
+repacking but are stored in a cold storage backend.
+We have added the option `--warmup`` which just tries to access all needed
+files. This triggers a warmup for some cold storages.
+Also the option `--json` in combination with `--dry-run` now prints the pack
+file names in JSON format. This can be used to implement a custom warm-up.
+
+https://github.com/restic/restic/pull/2881

--- a/cmd/restic/warmup.go
+++ b/cmd/restic/warmup.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"io"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/restic/restic/internal/restic"
+)
+
+const numWarmUpWorkers = 8
+
+// WarmUpFiles opens all files the given fileList in parallel in order to "warm" them up
+// This can be useful when accessing cold storage
+func WarmUpFiles(gopts GlobalOptions, fileList restic.IDSet, fileType restic.FileType) error {
+	totalCount := len(fileList)
+	fileChan := make(chan restic.ID)
+	go func() {
+		for id := range fileList {
+			fileChan <- id
+		}
+		close(fileChan)
+	}()
+
+	Verbosef("reopen repository\n")
+	// reopen the backend to get one without retries
+	be, err := open(gopts.Repo, gopts, gopts.extended)
+	if err != nil {
+		return err
+	}
+
+	bar := newProgressMax(!gopts.JSON && !gopts.Quiet, uint64(totalCount), "files warmed-up")
+	wg, ctx := errgroup.WithContext(gopts.ctx)
+	defer bar.Done()
+	for i := 0; i < numWarmUpWorkers; i++ {
+		wg.Go(func() error {
+			for id := range fileChan {
+				h := restic.Handle{Type: fileType, Name: id.String()}
+				// ignore errors, as we expect them for cold data loads
+				_ = be.Load(ctx, h, 1, 0, func(_ io.Reader) error { return nil })
+				if !gopts.JSON {
+					Verboseff("warmed up %v\n", h)
+				}
+				bar.Add(1)
+			}
+			return nil
+		})
+	}
+
+	return wg.Wait()
+}

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -359,5 +359,12 @@ The ``prune`` command accepts the following options:
   The default value is false.
 
 -  ``--dry-run`` only show what ``prune`` would do.
+   If specified in combination with ``--json``, the packs to repack and to remove are
+   printed in JSON format.
+
+-  ``--warm-up`` tries to load all needed packs for repacking, but doesn't change the
+   repository. This loading can trigger a warmup of needed backend objects, e.g. when
+   using a cold storage.
 
 -  ``--verbose`` increased verbosity shows additional statistics for ``prune``.
+


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds the possibility to access all packs which need a repack during `prune` and `rebuild.index`
This allows some cold storages to warm up these packs such that they are all accessable. This warm-up can also be done within a dry run such that the needed packs are available for the next `prune` run.
Also the `--json` option is now implemented for prune dry-run. This allows to build custom warm-up processes if the pure access to files doesn't do the warmup.

This can be easily extended to `restore`, see #2796.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

The idea comes from #2796.
For cold storage discussions see  also #2504

I didn't see a discussion about pruning cold storage, but this PR proved to be very useful for pruning my OVH Cloud Archive repositories.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
