### PR TITLE
Clarify: message applies to storage encryption (not transport mechanism)

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -343,7 +343,7 @@ func ReadPassword(opts GlobalOptions, prompt string) (string, error) {
 		password, err = readPasswordTerminal(os.Stdin, os.Stderr, prompt)
 	} else {
 		password, err = readPassword(os.Stdin)
-		Verbosef("read password from stdin\n")
+		Verbosef("reading repository encryption password from stdin\n")
 	}
 
 	if err != nil {


### PR DESCRIPTION
Previous message "read password from stdin" is ambiguous with respect to
whether the password being read refers to the respository encryption
password (passphrase), or to a password required for a non-local access
method for a remote repository.





What does this PR change? What problem does it solve?
-----------------------------------------------------

Aide failure debugging by clarifying that at this point restic is attempting to aquire the repository encryption passphrase, as opposed to a transport (e.g. https / sftp) password.

Would have saved me ~30 mins wondering why an ssh auth key wasn't being used (when in fact it was, but the script was failing to inherit the RESTIC_PASSWORD_FILE env var under some execution paths).

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [N/A] I have added tests for all changes in this PR
- [N/A] I have added documentation for the changes (in the manual)
- [N/A] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
