### PR TITLE
b2: Add optional secondary key for locks

### DIFF
--- a/changelog/unreleased/pull-2887
+++ b/changelog/unreleased/pull-2887
@@ -1,0 +1,9 @@
+Enhancement: Secondary key for locks in B2
+
+We've added options for Backblaze B2 that can prevent restic from permanently
+deleting its data. You can now use B2_LOCK_ID and B2_LOCK_KEY, which need to be
+able to delete files with a `locks/` prefix. Then, the main B2_ACCOUNT_ID and
+B2_ACCOUNT_KEY do not need delete permissions for most operations. For details,
+please see the manual.
+
+https://github.com/restic/restic/pull/2887

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -590,6 +590,14 @@ func parseConfig(loc location.Location, opts options.Options) (interface{}, erro
 			return nil, errors.Fatalf("unable to open B2 backend: Key ($B2_ACCOUNT_KEY) is empty")
 		}
 
+		if cfg.LockID == "" {
+			cfg.LockID = os.Getenv("B2_LOCK_ID")
+		}
+
+		if cfg.LockKey == "" {
+			cfg.LockKey = os.Getenv("B2_LOCK_KEY")
+		}
+
 		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
 			return nil, err
 		}

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -407,6 +407,8 @@ environment variables. The following list of environment variables:
 
     B2_ACCOUNT_ID                       Account ID or applicationKeyId for Backblaze B2
     B2_ACCOUNT_KEY                      Account Key or applicationKey for Backblaze B2
+    B2_LOCK_ID                          Optional secondary applicationKeyId for Backblaze B2 to create and delete locks
+    B2_LOCK_KEY                         Optional secondary applicationKey for Backblaze B2 to create and delete locks
 
     AZURE_ACCOUNT_NAME                  Account name for Azure
     AZURE_ACCOUNT_KEY                   Account key for Azure

--- a/internal/backend/b2/config.go
+++ b/internal/backend/b2/config.go
@@ -14,6 +14,8 @@ import (
 type Config struct {
 	AccountID string
 	Key       string
+	LockID    string
+	LockKey   string
 	Bucket    string
 	Prefix    string
 


### PR DESCRIPTION
This enables a configuration that prevents restic from deleting its own files.
See the explanation in doc/030_preparing_a_new_repo.rst



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This enables a configuration that prevents restic on Backblaze B2 from deleting its own files (either by mistake or as the result of a key compromise). It allows the user to configure two B2 keys: one can read and write but not delete files, and the other can read+write+delete but only under the `locks/` directory.

An alternative implementation approach would be to allow two entire backends: one used for most files and the second used only for locks. This would be more general and may enable other useful configurations, but it seems significantly harder for the user to set up.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

I haven't open any discussions before. This is related to and probably conflicts with #2398.

Here's a related discussion for Wasabi, which seems to support finer-grained access policies: https://forum.restic.net/t/append-only-mode-with-s3-wasabi/845. As far as I can tell, Backblaze only allows a coarse list of permissions per key.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [X] I have added documentation for the changes (in the manual)
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
