### PR TITLE
restorer: Preallocate files

### DIFF
--- a/changelog/unreleased/pull-2195
+++ b/changelog/unreleased/pull-2195
@@ -14,4 +14,10 @@ file can be written to the file before any of the preceeding file blobs.
 It is therefore possible to have gaps in the data written to the target
 files if restore fails or interrupted by the user.
 
+The implementation will try to preallocate space for the restored files
+on the filesystem to prevent file fragmentation. This ensures good read
+performance for large files, like for example VM images. If preallocating
+space is not supported by the filesystem, then this step is silently skipped.
+
 https://github.com/restic/restic/pull/2195
+https://github.com/restic/restic/pull/2893

--- a/internal/restorer/fileswriter_test.go
+++ b/internal/restorer/fileswriter_test.go
@@ -16,19 +16,19 @@ func TestFilesWriterBasic(t *testing.T) {
 	f1 := dir + "/f1"
 	f2 := dir + "/f2"
 
-	rtest.OK(t, w.writeToFile(f1, []byte{1}, 0, true))
+	rtest.OK(t, w.writeToFile(f1, []byte{1}, 0, 2))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 	rtest.Equals(t, 0, len(w.buckets[0].users))
 
-	rtest.OK(t, w.writeToFile(f2, []byte{2}, 0, true))
+	rtest.OK(t, w.writeToFile(f2, []byte{2}, 0, 2))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 	rtest.Equals(t, 0, len(w.buckets[0].users))
 
-	rtest.OK(t, w.writeToFile(f1, []byte{1}, 1, false))
+	rtest.OK(t, w.writeToFile(f1, []byte{1}, 1, -1))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 	rtest.Equals(t, 0, len(w.buckets[0].users))
 
-	rtest.OK(t, w.writeToFile(f2, []byte{2}, 1, false))
+	rtest.OK(t, w.writeToFile(f2, []byte{2}, 1, -1))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 	rtest.Equals(t, 0, len(w.buckets[0].users))
 

--- a/internal/restorer/preallocate_darwin.go
+++ b/internal/restorer/preallocate_darwin.go
@@ -1,0 +1,33 @@
+package restorer
+
+import (
+	"os"
+	"runtime"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func preallocateFile(wr *os.File, size int64) error {
+	// try contiguous first
+	fst := unix.Fstore_t{
+		Flags:   unix.F_ALLOCATECONTIG | unix.F_ALLOCATEALL,
+		Posmode: unix.F_PEOFPOSMODE,
+		Offset:  0,
+		Length:  size,
+	}
+	_, err := unix.FcntlInt(wr.Fd(), unix.F_PREALLOCATE, int(uintptr(unsafe.Pointer(&fst))))
+
+	if err == nil {
+		return nil
+	}
+
+	// just take preallocation in any form, but still ask for everything
+	fst.Flags = unix.F_ALLOCATEALL
+	_, err = unix.FcntlInt(wr.Fd(), unix.F_PREALLOCATE, int(uintptr(unsafe.Pointer(&fst))))
+
+	// Keep struct alive until fcntl has returned
+	runtime.KeepAlive(fst)
+
+	return err
+}

--- a/internal/restorer/preallocate_linux.go
+++ b/internal/restorer/preallocate_linux.go
@@ -1,0 +1,16 @@
+package restorer
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func preallocateFile(wr *os.File, size int64) error {
+	if size <= 0 {
+		return nil
+	}
+	// int fallocate(int fd, int mode, off_t offset, off_t len)
+	// use mode = 0 to also change the file size
+	return unix.Fallocate(int(wr.Fd()), 0, 0, size)
+}

--- a/internal/restorer/preallocate_other.go
+++ b/internal/restorer/preallocate_other.go
@@ -1,0 +1,11 @@
+// +build !linux,!darwin
+
+package restorer
+
+import "os"
+
+func preallocateFile(wr *os.File, size int64) error {
+	// Maybe truncate can help?
+	// Windows: This calls SetEndOfFile which preallocates space on disk
+	return wr.Truncate(size)
+}

--- a/internal/restorer/preallocate_test.go
+++ b/internal/restorer/preallocate_test.go
@@ -1,0 +1,34 @@
+package restorer
+
+import (
+	"os"
+	"path"
+	"strconv"
+	"testing"
+
+	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/test"
+)
+
+func TestPreallocate(t *testing.T) {
+	for _, i := range []int64{0, 1, 4096, 1024 * 1024} {
+		t.Run(strconv.FormatInt(i, 10), func(t *testing.T) {
+			dirpath, cleanup := test.TempDir(t)
+			defer cleanup()
+
+			flags := os.O_CREATE | os.O_TRUNC | os.O_WRONLY
+			wr, err := os.OpenFile(path.Join(dirpath, "test"), flags, 0600)
+			test.OK(t, err)
+			defer wr.Close()
+
+			err = preallocateFile(wr, i)
+			test.OK(t, err)
+
+			fi, err := wr.Stat()
+			test.OK(t, err)
+
+			efi := fs.ExtendedStat(fi)
+			test.Assert(t, efi.Size == i || efi.Blocks > 0, "Preallocated size of %v, got size %v block %v", i, efi.Size, efi.Blocks)
+		})
+	}
+}

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -238,7 +238,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 				idx.Add(node.Inode, node.DeviceID, location)
 			}
 
-			filerestorer.addFile(location, node.Content)
+			filerestorer.addFile(location, node.Content, int64(node.Size))
 
 			return nil
 		},


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The new restorer implementation writes data blobs in a random order to the destinations. On filesystems which implicitly create sparse files (probably on most unixoid systems) when writing to a location somewhere after the file end this can lead to a very large amount of file fragments. Even without sparse files (e.g. the default on Windows) the file will grow in multiple increments which can cause fragmentation.

The restore loop itself now queues pack files for download in to order of their first reference in one of the restored files. For a large file this should usually mean that the pack download order closely resembles the order in which data blobs are referenced. That way the access pattern more closely resembles that of a file which grows over time.

In addition, after a file is created, the fileswriter will issue a call to preallocate the full file size. This allows the filesystem to allocate space with as little fragmentation as possible.

There's currently a preallocate implementation for Linux and macOS. For Windows the generic implementation with `Truncate` calls `SetEndOfFile` which is supposed to preallocate disk space. On Linux the file system is able to track not yet initialized file extents, whereas on Windows there's only an offset up to which the file content was initialized. This means that a write into the middle of a file has to zero everything up to then.

The preallocate implementation is currently located in `internal/restorer` which is probably not the ideal place, but `internal/restic` is already overcrowded. There's also a test in `internal/restorer/preallocate_test.go`, which tests something, but I'm not really sure how fragile it is.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Closes #2675

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- No user visible changes. ~~[ ] I have added documentation for the changes (in the manual)~~
- Not necessary, as the new restorer implementation is not yet released. ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
