### PR TITLE
Unify progress bar of check and prune commands

### DIFF
--- a/changelog/unreleased/pull-2899
+++ b/changelog/unreleased/pull-2899
@@ -1,0 +1,9 @@
+Bugfix: Fix possible crash in the progress bar of check --read-data
+
+We've fixed a possible crash while displaying the progress bar for the
+check --read-data command. The crash occurred when the length of the
+progress bar status exceeded the terminal width, which only happened for
+very narrow terminal windows.
+
+https://github.com/restic/restic/pull/2899
+https://forum.restic.net/t/restic-rclone-pcloud-connection-issues/2963/15

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -1,9 +1,6 @@
 package main
 
 import (
-	"fmt"
-	"time"
-
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/index"
@@ -45,34 +42,6 @@ func shortenStatus(maxLength int, s string) string {
 	}
 
 	return s[:maxLength-3] + "..."
-}
-
-// newProgressMax returns a progress that counts blobs.
-func newProgressMax(show bool, max uint64, description string) *restic.Progress {
-	if !show {
-		return nil
-	}
-
-	p := restic.NewProgress()
-
-	p.OnUpdate = func(s restic.Stat, d time.Duration, ticker bool) {
-		status := fmt.Sprintf("[%s] %s  %d / %d %s",
-			formatDuration(d),
-			formatPercent(s.Blobs, max),
-			s.Blobs, max, description)
-
-		if w := stdoutTerminalWidth(); w > 0 {
-			status = shortenStatus(w, status)
-		}
-
-		PrintProgress("%s", status)
-	}
-
-	p.OnDone = func(s restic.Stat, d time.Duration, ticker bool) {
-		fmt.Printf("\n")
-	}
-
-	return p
 }
 
 func runPrune(gopts GlobalOptions) error {

--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/restic/restic/internal/restic"
+)
+
+// newProgressMax returns a progress that counts blobs.
+func newProgressMax(show bool, max uint64, description string) *restic.Progress {
+	if !show {
+		return nil
+	}
+
+	p := restic.NewProgress()
+
+	p.OnUpdate = func(s restic.Stat, d time.Duration, ticker bool) {
+		status := fmt.Sprintf("[%s] %s  %d / %d %s",
+			formatDuration(d),
+			formatPercent(s.Blobs, max),
+			s.Blobs, max, description)
+
+		if w := stdoutTerminalWidth(); w > 0 {
+			status = shortenStatus(w, status)
+		}
+
+		PrintProgress("%s", status)
+	}
+
+	p.OnDone = func(s restic.Stat, d time.Duration, ticker bool) {
+		fmt.Printf("\n")
+	}
+
+	return p
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR unifies the progress bar implementation used by the check and prune commands. In essence, it drops the implementation used by `check` and uses the one from `prune` instead.

This also implicitly fixes a crash in the check command, if the terminal is quite narrow.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes a crash reported at https://forum.restic.net/t/restic-rclone-pcloud-connection-issues/2963/15

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- I've manually tested the progress bars instead.  ~~[] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
