### PR TITLE
Update usage strings to put flags before args

### DIFF
--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -14,7 +14,7 @@ import (
 )
 
 var cmdDiff = &cobra.Command{
-	Use:   "diff snapshot-ID snapshot-ID",
+	Use:   "diff [flags] snapshot-ID snapshot-ID",
 	Short: "Show differences between two snapshots",
 	Long: `
 The "diff" command shows differences from the first to the second snapshot. The

--- a/cmd/restic/cmd_generate.go
+++ b/cmd/restic/cmd_generate.go
@@ -9,7 +9,7 @@ import (
 )
 
 var cmdGenerate = &cobra.Command{
-	Use:   "generate [command]",
+	Use:   "generate [flags]",
 	Short: "Generate manual pages and auto-completion files (bash, zsh)",
 	Long: `
 The "generate" command writes automatically generated files (like the man pages

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -16,7 +16,7 @@ import (
 )
 
 var cmdKey = &cobra.Command{
-	Use:   "key [list|add|remove|passwd] [ID]",
+	Use:   "key [flags] [list|add|remove|passwd] [ID]",
 	Short: "Manage keys (passwords)",
 	Long: `
 The "key" command manages keys (passwords) for accessing the repository.

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -9,7 +9,7 @@ import (
 )
 
 var cmdList = &cobra.Command{
-	Use:   "list [blobs|packs|index|snapshots|keys|locks]",
+	Use:   "list [flags] [blobs|packs|index|snapshots|keys|locks]",
 	Short: "List objects in the repository",
 	Long: `
 The "list" command allows listing objects in the repository based on type.

--- a/cmd/restic/cmd_migrate.go
+++ b/cmd/restic/cmd_migrate.go
@@ -8,7 +8,7 @@ import (
 )
 
 var cmdMigrate = &cobra.Command{
-	Use:   "migrate [name]",
+	Use:   "migrate [flags] [name]",
 	Short: "Apply migrations",
 	Long: `
 The "migrate" command applies migrations to a repository. When no migration

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -14,7 +14,7 @@ import (
 )
 
 var cmdSnapshots = &cobra.Command{
-	Use:   "snapshots [snapshotID ...]",
+	Use:   "snapshots [flags] [snapshotID ...]",
 	Short: "List all snapshots",
 	Long: `
 The "snapshots" command lists all snapshots stored in the repository.

--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -292,7 +292,7 @@ Restic can write out man pages and bash/zsh compatible autocompletion scripts:
     and the auto-completion files for bash and zsh).
 
     Usage:
-      restic generate [command] [flags]
+      restic generate [flags] [command]
 
     Flags:
           --bash-completion file   write bash completion file


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

The standard UNIX-style ordering of command-line arguments places
optional flags before other positional arguments. All of restic's
commands support this ordering, but some of the usage strings showed the
flags after the positional arguments (which restic also parses just
fine). This change updates the doc strings to reflect the standard
ordering.

Because the `restic help` command comes directly from Cobra, there does
not appear to be a way to update the argument ordering in its usage
string, so it maintains the non-standard ordering (positional arguments
before optional flags).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2830 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review

Seeing as this is just a documentation change and restic continues to work exactly the same as before, I don't think new tests or changelog entries are necessary.