### PR TITLE
ls: Explicitly enforce that the user specifies a snapshot ID

### DIFF
--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -16,7 +16,7 @@ import (
 )
 
 var cmdLs = &cobra.Command{
-	Use:   "ls [flags] [snapshotID] [dir...]",
+	Use:   "ls [flags] snapshotID [dir...]",
 	Short: "List files in a snapshot",
 	Long: `
 The "ls" command lists files and directories in a snapshot.
@@ -89,8 +89,8 @@ type lsNode struct {
 }
 
 func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
-	if len(args) == 0 && len(opts.Hosts) == 0 && len(opts.Tags) == 0 && len(opts.Paths) == 0 {
-		return errors.Fatal("Invalid arguments, either give one or more snapshot IDs or set filters.")
+	if len(args) == 0 {
+		return errors.Fatal("no snapshot ID specified")
 	}
 
 	// extract any specific directories to walk


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
As reported in #2299 the help message of the `ls` command suggests that the snapshotID is optional but falls when call like this. This PR changes the help message and parameter check to always require a snapshotID.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #2299

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review