### PR TITLE
Restore inconsistent timestamps permissions

### DIFF
--- a/changelog/unreleased/issue-1212
+++ b/changelog/unreleased/issue-1212
@@ -1,0 +1,11 @@
+Bugfix: Restore timestamps and permissions on intermediate directories
+
+When using the `--include` option of the restore command, restic restored
+timestamps and permissions only on directories selected by the include pattern.
+Intermediate directories, which are necessary to restore files located in sub-
+directories, were created with default permissions. We've fixed the restore
+command to restore timestamps and permissions for these directories as well.
+
+https://github.com/restic/restic/issues/1212
+https://github.com/restic/restic/issues/1402
+https://github.com/restic/restic/pull/2906

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -692,7 +692,7 @@ func TestRestorerTraverseTree(t *testing.T) {
 			// make sure we're creating a new subdir of the tempdir
 			target := filepath.Join(tempdir, "target")
 
-			err = res.traverseTree(ctx, target, string(filepath.Separator), *sn.Tree, test.Visitor(t))
+			_, err = res.traverseTree(ctx, target, string(filepath.Separator), *sn.Tree, test.Visitor(t))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -6,6 +6,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -23,14 +24,17 @@ type Snapshot struct {
 }
 
 type File struct {
-	Data  string
-	Links uint64
-	Inode uint64
+	Data    string
+	Links   uint64
+	Inode   uint64
+	Mode    os.FileMode
+	ModTime time.Time
 }
 
 type Dir struct {
-	Nodes map[string]Node
-	Mode  os.FileMode
+	Nodes   map[string]Node
+	Mode    os.FileMode
+	ModTime time.Time
 }
 
 func saveFile(t testing.TB, repo restic.Repository, node File) restic.ID {
@@ -66,9 +70,14 @@ func saveDir(t testing.TB, repo restic.Repository, nodes map[string]Node, inode 
 			if len(n.(File).Data) > 0 {
 				fc = append(fc, saveFile(t, repo, node))
 			}
+			mode := node.Mode
+			if mode == 0 {
+				mode = 0644
+			}
 			tree.Insert(&restic.Node{
 				Type:    "file",
-				Mode:    0644,
+				Mode:    mode,
+				ModTime: node.ModTime,
 				Name:    name,
 				UID:     uint32(os.Getuid()),
 				GID:     uint32(os.Getgid()),
@@ -88,6 +97,7 @@ func saveDir(t testing.TB, repo restic.Repository, nodes map[string]Node, inode 
 			tree.Insert(&restic.Node{
 				Type:    "dir",
 				Mode:    mode,
+				ModTime: node.ModTime,
 				Name:    name,
 				UID:     uint32(os.Getuid()),
 				GID:     uint32(os.Getgid()),
@@ -655,6 +665,7 @@ func TestRestorerTraverseTree(t *testing.T) {
 			},
 			Visitor: checkVisitOrder([]TreeVisit{
 				{"visitNode", "/dir/otherfile"},
+				{"leaveDir", "/dir"},
 			}),
 		},
 	}
@@ -686,5 +697,110 @@ func TestRestorerTraverseTree(t *testing.T) {
 				t.Fatal(err)
 			}
 		})
+	}
+}
+
+func normalizeFileMode(mode os.FileMode) os.FileMode {
+	if runtime.GOOS == "windows" {
+		if mode.IsDir() {
+			return 0555 | os.ModeDir
+		}
+		return os.FileMode(0444)
+	}
+	return mode
+}
+
+func checkConsistentInfo(t testing.TB, file string, fi os.FileInfo, modtime time.Time, mode os.FileMode) {
+	if fi.Mode() != mode {
+		t.Errorf("checking %q, Mode() returned wrong value, want 0%o, got 0%o", file, mode, fi.Mode())
+	}
+
+	if !fi.ModTime().Equal(modtime) {
+		t.Errorf("checking %s, ModTime() returned wrong value, want %v, got %v", file, modtime, fi.ModTime())
+	}
+}
+
+// test inspired from test case https://github.com/restic/restic/issues/1212
+func TestRestorerConsistentTimestampsAndPermissions(t *testing.T) {
+	timeForTest := time.Date(2019, time.January, 9, 1, 46, 40, 0, time.UTC)
+
+	repo, cleanup := repository.TestRepository(t)
+	defer cleanup()
+
+	_, id := saveSnapshot(t, repo, Snapshot{
+		Nodes: map[string]Node{
+			"dir": Dir{
+				Mode:    normalizeFileMode(0750 | os.ModeDir),
+				ModTime: timeForTest,
+				Nodes: map[string]Node{
+					"file1": File{
+						Mode:    normalizeFileMode(os.FileMode(0700)),
+						ModTime: timeForTest,
+						Data:    "content: file\n",
+					},
+					"anotherfile": File{
+						Data: "content: file\n",
+					},
+					"subdir": Dir{
+						Mode:    normalizeFileMode(0700 | os.ModeDir),
+						ModTime: timeForTest,
+						Nodes: map[string]Node{
+							"file2": File{
+								Mode:    normalizeFileMode(os.FileMode(0666)),
+								ModTime: timeForTest,
+								Links:   2,
+								Inode:   1,
+							},
+						},
+					},
+				},
+			},
+		},
+	})
+
+	res, err := NewRestorer(repo, id)
+	rtest.OK(t, err)
+
+	res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
+		switch filepath.ToSlash(item) {
+		case "/dir":
+			childMayBeSelected = true
+		case "/dir/file1":
+			selectedForRestore = true
+			childMayBeSelected = false
+		case "/dir/subdir":
+			selectedForRestore = true
+			childMayBeSelected = true
+		case "/dir/subdir/file2":
+			selectedForRestore = true
+			childMayBeSelected = false
+		}
+		return selectedForRestore, childMayBeSelected
+	}
+
+	tempdir, cleanup := rtest.TempDir(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
+
+	var testPatterns = []struct {
+		path    string
+		modtime time.Time
+		mode    os.FileMode
+	}{
+		{"dir", timeForTest, normalizeFileMode(0750 | os.ModeDir)},
+		{filepath.Join("dir", "file1"), timeForTest, normalizeFileMode(os.FileMode(0700))},
+		{filepath.Join("dir", "subdir"), timeForTest, normalizeFileMode(0700 | os.ModeDir)},
+		{filepath.Join("dir", "subdir", "file2"), timeForTest, normalizeFileMode(os.FileMode(0666))},
+	}
+
+	for _, test := range testPatterns {
+		f, err := os.Stat(filepath.Join(tempdir, test.path))
+		rtest.OK(t, err)
+		checkConsistentInfo(t, test.path, f, test.modtime, test.mode)
 	}
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Fix inconsistent timestamps/permissions during restore in some case

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://github.com/restic/restic/issues/1212

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review


Information
-----------

The current implementation of restore code using two pass does not restore the metadata of all elements.

I will use a simplified reproductible script to reduce the log/debug
you can find the complet reproductible script (thanks to @deviantintegral) there https://github.com/restic/restic/issues/1212#issuecomment-671553782


About the change :
- The first commit extend and add test case to check Mode and ModTime
- The second add log information because it was pretty hard to debug treeVisitor proc functions and understand what happenning.
- The fix make the simplified and complet reproductible script work, ~~but introduce a bad behaviour, trying to restore metadata on a file/dir not selected for restore.
```ignoring error for /test/bar: UtimesNano: no such file or directory```~~

The simplified script, show that metadata on the root directory isn't restored

```bash
#!/bin/bash

export DEBUG_LOG=restic-debug.log

check_equal_permission()
{
  echo "Comparing permissions on $1 to $2..."
  (test $(stat -f %p $1) -eq $(stat -f %p $2) && echo "Passed!") || (echo "#### Comparison failed." && ls -ld $1 && ls -ld $2)
  echo ""
}

check_equal_modified()
{
  echo "Comparing modified dates on $1 to $2..."
  (test $(stat -f %m $1) -eq $(stat -f %m $2) && echo "Passed!") || (echo "#### Comparison failed." && ls -ld $1 && ls -ld $2)
  echo ""
}

check_file()
{
  check_equal_permission $1 $2
  check_equal_modified $1 $2
}

rm restic-debug.log
mkdir -p test/{dir1,dir2}
mkdir -p test/dir1/dir3/
chmod 700 test/dir1
chmod 700 test/dir1/dir3
touch -t 201901010000 test/{dir1,dir2}/{file1,file2} test/{dir1,dir2} test test/dir1/dir3/file3
restic --password-command='echo pass' -r repo init
restic --password-command='echo pass' -r repo backup test

rm restic-debug.log

restic --password-command='echo pass' -r repo restore latest --include 'file1' --target restored
check_file test restored/test

rm -rf test repo restored
```

The logs show that leaveDir is never executed, this is why the metadata of the root directory and in some case isn't restored.

```go
// first tree pass: create directories and collect all files to restore
err = res.traverseTree(ctx, dst, string(filepath.Separator), *res.sn.Tree, treeVisitor{
  enterDir: func(node *restic.Node, target, location string) error {
    debug.Log("first pass, enterDir: mkdir %q, leaveDir should restore metadata", location)
    // create dir with default permissions
    // #leaveDir restores dir metadata after visiting all children
    return fs.MkdirAll(target, 0700)
  },

  visitNode: func(node *restic.Node, target, location string) error {
    debug.Log("first pass, visitNode: mkdir %q, leaveDir on second pass should restore metadata", location)
    // create parent dir with default permissions
    // second pass #leaveDir restores dir metadata after visiting/restoring all children
    err := fs.MkdirAll(filepath.Dir(target), 0700)
```

I guess, also because we use MkdirAll, so when we pass on ```"/test/dir1"``` but restoring with ```---include 'file1'``` ```childMayBeSelected``` is equal to true, but the leaveDir is only executed on ```selectedForRestore```

```bash
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false true for "/test"
```

```go
if selectedForRestore {
  err = sanitizeError(visitor.leaveDir(node, nodeTarget, nodeLocation))
  if err != nil {
    return err
  }
}
```


```bash
restorer/restorer.go:208	restorer.(*Restorer).RestoreTo	first pass for "/Users/kitone/Downloads/restic_kitone/issues_1212/restored"
restorer/restorer.go:53	  restorer.(*Restorer).traverseTree	/Users/kitone/Downloads/restic_kitone/issues_1212/restored / cfd11f1ffa1ce50693db112af06c4df85ba92ec5dd3a5a18247c81e7a067c774
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false true for "/test"
restorer/restorer.go:53	  restorer.(*Restorer).traverseTree	/Users/kitone/Downloads/restic_kitone/issues_1212/restored/test /test d6c3f48a1e21c0032e57790081a46f6aa25de05e307fae94c2859d3bc1670c33
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false true for "/test/dir1"
restorer/restorer.go:53	  restorer.(*Restorer).traverseTree	/Users/kitone/Downloads/restic_kitone/issues_1212/restored/test/dir1 /test/dir1 5adbd0033dc689a2195d61fb22b8ef6e8be43ba473528bb7e8c3fd8e0e4e2083
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false true for "/test/dir1/dir3"
restorer/restorer.go:53	  restorer.(*Restorer).traverseTree	/Users/kitone/Downloads/restic_kitone/issues_1212/restored/test/dir1/dir3 /test/dir1/dir3 ab6863baeb85cbe416e25baefd0f11622a69712323c986a027dfe4a85cf1852d
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false false for "/test/dir1/dir3/file3"
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned true false for "/test/dir1/file1"
restorer/restorer.go:220	restorer.(*Restorer).RestoreTo.func2	first pass, visitNode: mkdir "/test/dir1/file1", leaveDir on second pass should restore metadata
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false false for "/test/dir1/file2"
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false true for "/test/dir2"
restorer/restorer.go:53	  restorer.(*Restorer).traverseTree	/Users/kitone/Downloads/restic_kitone/issues_1212/restored/test/dir2 /test/dir2 81891851485d83cf6cf8e605bf3ea3487a9951cbfb2e58696db5fb326373ddd5
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned true false for "/test/dir2/file1"
restorer/restorer.go:220	restorer.(*Restorer).RestoreTo.func2	first pass, visitNode: mkdir "/test/dir2/file1", leaveDir on second pass should restore metadata
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false false for "/test/dir2/file2"

restorer/restorer.go:261	restorer.(*Restorer).RestoreTo	second pass for "/Users/kitone/Downloads/restic_kitone/issues_1212/restored"
restorer/restorer.go:53	  restorer.(*Restorer).traverseTree	/Users/kitone/Downloads/restic_kitone/issues_1212/restored / cfd11f1ffa1ce50693db112af06c4df85ba92ec5dd3a5a18247c81e7a067c774
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false true for "/test"
restorer/restorer.go:53	  restorer.(*Restorer).traverseTree	/Users/kitone/Downloads/restic_kitone/issues_1212/restored/test /test d6c3f48a1e21c0032e57790081a46f6aa25de05e307fae94c2859d3bc1670c33
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false true for "/test/dir1"
restorer/restorer.go:53	  restorer.(*Restorer).traverseTree	/Users/kitone/Downloads/restic_kitone/issues_1212/restored/test/dir1 /test/dir1 5adbd0033dc689a2195d61fb22b8ef6e8be43ba473528bb7e8c3fd8e0e4e2083
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false true for "/test/dir1/dir3"
restorer/restorer.go:53	  restorer.(*Restorer).traverseTree	/Users/kitone/Downloads/restic_kitone/issues_1212/restored/test/dir1/dir3 /test/dir1/dir3 ab6863baeb85cbe416e25baefd0f11622a69712323c986a027dfe4a85cf1852d
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false false for "/test/dir1/dir3/file3"
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned true false for "/test/dir1/file1"
restorer/restorer.go:270	restorer.(*Restorer).RestoreTo.func5	second pass, visitNode: restore node "/test/dir1/file1"
restorer/restorer.go:158	restorer.(*Restorer).restoreNodeMetadataTo	restoreNodeMetadata file1 /Users/kitone/Downloads/restic_kitone/issues_1212/restored/test/dir1/file1 /test/dir1/file1
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false false for "/test/dir1/file2"
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false true for "/test/dir2"
restorer/restorer.go:53	  restorer.(*Restorer).traverseTree	/Users/kitone/Downloads/restic_kitone/issues_1212/restored/test/dir2 /test/dir2 81891851485d83cf6cf8e605bf3ea3487a9951cbfb2e58696db5fb326373ddd5
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned true false for "/test/dir2/file1"
restorer/restorer.go:270	restorer.(*Restorer).RestoreTo.func5	second pass, visitNode: restore node "/test/dir2/file1"
restorer/restorer.go:158	restorer.(*Restorer).restoreNodeMetadataTo	restoreNodeMetadata file1 /Users/kitone/Downloads/restic_kitone/issues_1212/restored/test/dir2/file1 /test/dir2/file1
restorer/restorer.go:93	  restorer.(*Restorer).traverseTree	SelectFilter returned false false for "/test/dir2/file2"
```


The solution is to keep track of restored child status so parent and root directory not selected by filter will also restore metadata when traversing the tree.