### PR TITLE
Support excluding files by size

### DIFF
--- a/changelog/unreleased/issue-2569
+++ b/changelog/unreleased/issue-2569
@@ -1,0 +1,8 @@
+Enhancement: Support excluding files by their size
+
+The `backup` command now supports the `--exclude-larger-than` option to exclude files which are
+larger than the specified maximum size. This can for example be useful to exclude unimportant
+files with a large file size.
+
+https://github.com/restic/restic/issues/2569
+https://github.com/restic/restic/pull/2914

--- a/cmd/restic/exclude_test.go
+++ b/cmd/restic/exclude_test.go
@@ -189,3 +189,113 @@ func TestMultipleIsExcludedByFile(t *testing.T) {
 		}
 	}
 }
+
+func TestParseSizeStr(t *testing.T) {
+	sizeStrTests := []struct {
+		in       string
+		expected int64
+	}{
+		{"1024", 1024},
+		{"1024b", 1024},
+		{"1024B", 1024},
+		{"1k", 1024},
+		{"100k", 102400},
+		{"100K", 102400},
+		{"10M", 10485760},
+		{"100m", 104857600},
+		{"20G", 21474836480},
+		{"10g", 10737418240},
+		{"2T", 2199023255552},
+		{"2t", 2199023255552},
+	}
+
+	for _, tt := range sizeStrTests {
+		actual, err := parseSizeStr(tt.in)
+		test.OK(t, err)
+
+		if actual != tt.expected {
+			t.Errorf("parseSizeStr(%s) = %d; expected %d", tt.in, actual, tt.expected)
+		}
+	}
+}
+
+// TestIsExcludedByFileSize is for testing the instance of
+// --exclude-larger-than parameters
+func TestIsExcludedByFileSize(t *testing.T) {
+	tempDir, cleanup := test.TempDir(t)
+	defer cleanup()
+
+	// Max size of file is set to be 1k
+	maxSizeStr := "1k"
+
+	// Create some files in a temporary directory.
+	// Files in UPPERCASE will be used as exclusion triggers later on.
+	// We will test the inclusion later, so we add the expected value as
+	// a bool.
+	files := []struct {
+		path string
+		size int64
+		incl bool
+	}{
+		{"42", 100, true},
+
+		// everything in foodir except the FOOLARGE tagfile
+		// should not be included.
+		{"foodir/FOOLARGE", 2048, false},
+		{"foodir/foo", 1002, true},
+		{"foodir/foosub/underfoo", 100, true},
+
+		// everything in bardir except the BARLARGE tagfile
+		// should not be included.
+		{"bardir/BARLARGE", 1030, false},
+		{"bardir/bar", 1000, true},
+		{"bardir/barsub/underbar", 500, true},
+
+		// everything in bazdir should be included.
+		{"bazdir/baz", 100, true},
+		{"bazdir/bazsub/underbaz", 200, true},
+	}
+	var errs []error
+	for _, f := range files {
+		// create directories first, then the file
+		p := filepath.Join(tempDir, filepath.FromSlash(f.path))
+		errs = append(errs, os.MkdirAll(filepath.Dir(p), 0700))
+		file, err := os.OpenFile(p, os.O_RDWR|os.O_CREATE|os.O_TRUNC, 0600)
+		errs = append(errs, err)
+		if err == nil {
+			// create a file with given size
+			errs = append(errs, file.Truncate(f.size))
+		}
+		errs = append(errs, file.Close())
+	}
+	test.OKs(t, errs) // see if anything went wrong during the creation
+
+	// create rejection function
+	sizeExclude, _ := rejectBySize(maxSizeStr)
+
+	// To mock the archiver scanning walk, we create filepath.WalkFn
+	// that tests against the two rejection functions and stores
+	// the result in a map against we can test later.
+	m := make(map[string]bool)
+	walk := func(p string, fi os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		excluded := sizeExclude(p, fi)
+		// the log message helps debugging in case the test fails
+		t.Logf("%q: dir:%t; size:%d; excluded:%v", p, fi.IsDir(), fi.Size(), excluded)
+		m[p] = !excluded
+		return nil
+	}
+	// walk through the temporary file and check the error
+	test.OK(t, filepath.Walk(tempDir, walk))
+
+	// compare whether the walk gave the expected values for the test cases
+	for _, f := range files {
+		p := filepath.Join(tempDir, filepath.FromSlash(f.path))
+		if m[p] != f.incl {
+			t.Errorf("inclusion status of %s is wrong: want %v, got %v", f.path, f.incl, m[p])
+		}
+	}
+}

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -144,6 +144,7 @@ the exclude options are:
 -  ``--exclude-file`` Specified one or more times to exclude items listed in a given file
 -  ``--iexclude-file`` Same as ``exclude-file`` but ignores cases like in ``--iexclude``
 -  ``--exclude-if-present foo`` Specified one or more times to exclude a folder's content if it contains a file called ``foo`` (optionally having a given header, no wildcards for the file name supported)
+-  ``--exclude-larger-than size`` Specified once to excludes files larger than the given size
 
 Please see ``restic help backup`` for more specific information about each exclude option.
 
@@ -239,6 +240,21 @@ include other filesystems like ``/sys`` and ``/proc``.
 
 .. note:: ``--one-file-system`` is currently unsupported on Windows, and will
     cause the backup to immediately fail with an error.
+
+Files larger than a given size can be excluded using the `--exclude-larger-than`
+option:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo backup ~/work --exclude-larger-than 1M
+
+This excludes files in ``~/work`` which are larger than 1 MB from the backup.
+
+The default unit for the size value is bytes, so e.g. ``--exclude-larger-than 2048``
+would exclude files larger than 2048 bytes (2 kilobytes). To specify other units,
+suffix the size value with one of ``k``/``K`` for kilobytes, ``m``/``M`` for megabytes,
+``g``/``G`` for gigabytes and ``t``/``T`` for terabytes (e.g. ``1k``, ``10K``, ``20m``,
+``20M``,  ``30g``, ``30G``, ``2t`` or ``2T``).
 
 Including Files
 ***************


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
support specifying the max size of each file to be backed up.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
#2569 
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
