### PR TITLE
init: Add `--copy-chunker-parameters` option

### DIFF
--- a/changelog/unreleased/issue-323
+++ b/changelog/unreleased/issue-323
@@ -9,5 +9,12 @@ and destination repository. Also, the transferred files are not re-chunked,
 which may break deduplication between files already stored in the
 destination repo and files copied there using this command.
 
+To fully support deduplication between repositories when the copy command is
+used, the init command now supports the `--copy-chunker-params` option,
+which initializes the new repository with identical parameters for splitting
+files into chunks as an already existing repository. This allows copied
+snapshots to be equally deduplicated in both repositories.
+
 https://github.com/restic/restic/issues/323
 https://github.com/restic/restic/pull/2606
+https://github.com/restic/restic/pull/2928

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -18,7 +18,8 @@ The "copy" command copies one or more snapshots from one repository to another
 repository. Note that this will have to read (download) and write (upload) the
 entire snapshot(s) due to the different encryption keys on the source and
 destination, and that transferred files are not re-chunked, which may break
-their deduplication.
+their deduplication. This can be mitigated by the "--copy-chunker-params"
+option when initializing a new destination repository using the "init" command.
 `,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runCopy(copyOptions, globalOptions, args)

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -616,8 +616,10 @@ func TestBackupTags(t *testing.T) {
 
 func testRunCopy(t testing.TB, srcGopts GlobalOptions, dstGopts GlobalOptions) {
 	copyOpts := CopyOptions{
-		Repo:     dstGopts.Repo,
-		password: dstGopts.password,
+		secondaryRepoOptions: secondaryRepoOptions{
+			Repo:     dstGopts.Repo,
+			password: dstGopts.password,
+		},
 	}
 
 	rtest.OK(t, runCopy(copyOpts, srcGopts, nil))

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -51,7 +51,7 @@ func testRunInit(t testing.TB, opts GlobalOptions) {
 	restic.TestDisableCheckPolynomial(t)
 	restic.TestSetLockTimeout(t, 0)
 
-	rtest.OK(t, runInit(opts, nil))
+	rtest.OK(t, runInit(InitOptions{}, opts, nil))
 	t.Logf("repository initialized at %v", opts.Repo)
 }
 
@@ -729,6 +729,36 @@ func TestCopyIncremental(t *testing.T) {
 	snapshotIDs = testRunList(t, "snapshots", env.gopts)
 	rtest.Assert(t, len(snapshotIDs) == len(copiedSnapshotIDs), "still expected %v snapshots, found %v",
 		len(copiedSnapshotIDs), len(snapshotIDs))
+}
+
+func TestInitCopyChunkerParams(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	env2, cleanup2 := withTestEnvironment(t)
+	defer cleanup2()
+
+	testRunInit(t, env2.gopts)
+
+	initOpts := InitOptions{
+		secondaryRepoOptions: secondaryRepoOptions{
+			Repo:     env2.gopts.Repo,
+			password: env2.gopts.password,
+		},
+	}
+	rtest.Assert(t, runInit(initOpts, env.gopts, nil) != nil, "expected invalid init options to fail")
+
+	initOpts.CopyChunkerParameters = true
+	rtest.OK(t, runInit(initOpts, env.gopts, nil))
+
+	repo, err := OpenRepository(env.gopts)
+	rtest.OK(t, err)
+
+	otherRepo, err := OpenRepository(env2.gopts)
+	rtest.OK(t, err)
+
+	rtest.Assert(t, repo.Config().ChunkerPolynomial == otherRepo.Config().ChunkerPolynomial,
+		"expected equal chunker polynomials, got %v expected %v", repo.Config().ChunkerPolynomial,
+		otherRepo.Config().ChunkerPolynomial)
 }
 
 func testRunTag(t testing.TB, opts TagOptions, gopts GlobalOptions) {

--- a/cmd/restic/secondary_repo.go
+++ b/cmd/restic/secondary_repo.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"os"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/spf13/pflag"
+)
+
+type secondaryRepoOptions struct {
+	Repo            string
+	password        string
+	PasswordFile    string
+	PasswordCommand string
+	KeyHint         string
+}
+
+func initSecondaryRepoOptions(f *pflag.FlagSet, opts *secondaryRepoOptions, repoPrefix string, repoUsage string) {
+	f.StringVarP(&opts.Repo, "repo2", "", os.Getenv("RESTIC_REPOSITORY2"), repoPrefix+" repository "+repoUsage+" (default: $RESTIC_REPOSITORY2)")
+	f.StringVarP(&opts.PasswordFile, "password-file2", "", os.Getenv("RESTIC_PASSWORD_FILE2"), "`file` to read the "+repoPrefix+" repository password from (default: $RESTIC_PASSWORD_FILE2)")
+	f.StringVarP(&opts.KeyHint, "key-hint2", "", os.Getenv("RESTIC_KEY_HINT2"), "key ID of key to try decrypting the "+repoPrefix+" repository first (default: $RESTIC_KEY_HINT2)")
+	f.StringVarP(&opts.PasswordCommand, "password-command2", "", os.Getenv("RESTIC_PASSWORD_COMMAND2"), "shell `command` to obtain the "+repoPrefix+" repository password from (default: $RESTIC_PASSWORD_COMMAND2)")
+}
+
+func fillSecondaryGlobalOpts(opts secondaryRepoOptions, gopts GlobalOptions, repoPrefix string) (GlobalOptions, error) {
+	if opts.Repo == "" {
+		return GlobalOptions{}, errors.Fatal("Please specify a " + repoPrefix + " repository location (--repo2)")
+	}
+	var err error
+	dstGopts := gopts
+	dstGopts.Repo = opts.Repo
+	dstGopts.PasswordFile = opts.PasswordFile
+	dstGopts.PasswordCommand = opts.PasswordCommand
+	dstGopts.KeyHint = opts.KeyHint
+	if opts.password != "" {
+		dstGopts.password = opts.password
+	} else {
+		dstGopts.password, err = resolvePassword(dstGopts, "RESTIC_PASSWORD2")
+		if err != nil {
+			return GlobalOptions{}, err
+		}
+	}
+	dstGopts.password, err = ReadPassword(dstGopts, "enter password for "+repoPrefix+" repository: ")
+	if err != nil {
+		return GlobalOptions{}, err
+	}
+	return dstGopts, nil
+}

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -110,7 +110,8 @@ be skipped by later copy runs.
     entire snapshot(s) due to the different encryption keys used in the source and
     destination repository. Also, the transferred files are not re-chunked, which
     may break deduplication between files already stored in the destination repo
-    and files copied there using this command.
+    and files copied there using this command. See the next section for how to avoid
+    this problem.
 
 For the destination repository ``--repo2`` the password can be read from
 a file ``--password-file2`` or from a command ``--password-command2``.
@@ -140,6 +141,28 @@ which case only these instead of all snapshots will be copied:
 .. code-block:: console
 
     $ restic -r /srv/restic-repo copy --repo2 /srv/restic-repo-copy 410b18a2 4e5d5487 latest
+
+
+Ensuring deduplication for copied snapshots
+-------------------------------------------
+
+Even though the copy command can transfer snapshots between arbitrary repositories,
+deduplication between snapshots from the source and destination repository may not work.
+To ensure proper deduplication, both repositories have to use the same parameters for
+splitting large files into smaller chunks, which requires additional setup steps. With
+the same parameters restic will for both repositories split identical files into
+identical chunks and therefore deduplication also works for snapshots copied between
+these repositories.
+
+The chunker parameters are generated once when creating a new (destination) repository.
+That is for a copy destination repository we have to instruct restic to initialize it
+using the same chunker parameters as the source repository:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo-copy init --repo2 /srv/restic-repo --copy-chunker-params
+
+Note that it is not possible to change the chunker parameters of an existing repository.
 
 
 Checking integrity and consistency

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 
+	"github.com/restic/chunker"
 	"github.com/restic/restic/internal/cache"
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/debug"
@@ -614,7 +615,7 @@ func (r *Repository) SearchKey(ctx context.Context, password string, maxKeys int
 
 // Init creates a new master key with the supplied password, initializes and
 // saves the repository config.
-func (r *Repository) Init(ctx context.Context, password string) error {
+func (r *Repository) Init(ctx context.Context, password string, chunkerPolynomial *chunker.Pol) error {
 	has, err := r.be.Test(ctx, restic.Handle{Type: restic.ConfigFile})
 	if err != nil {
 		return err
@@ -626,6 +627,9 @@ func (r *Repository) Init(ctx context.Context, password string) error {
 	cfg, err := restic.CreateConfig()
 	if err != nil {
 		return err
+	}
+	if chunkerPolynomial != nil {
+		cfg.ChunkerPolynomial = *chunkerPolynomial
 	}
 
 	return r.init(ctx, password, cfg)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
It adds a `--copy-chunker-parameters` option to the init command to support copying the chunker parameters to a new repository.

This allows creating multiple repositories with identical chunker parameters which is required for working deduplication when copying snapshots between different repositories. See the documentation change for more details.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The problem was discussed in #2606 but not this solution.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- I've extended the changelog entry for the copy command ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
