### PR TITLE
Improve wording for --password-file and related options

### DIFF
--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -46,7 +46,7 @@ func init() {
 
 	f := cmdCopy.Flags()
 	f.StringVarP(&copyOptions.Repo, "repo2", "", os.Getenv("RESTIC_REPOSITORY2"), "destination repository to copy snapshots to (default: $RESTIC_REPOSITORY2)")
-	f.StringVarP(&copyOptions.PasswordFile, "password-file2", "", os.Getenv("RESTIC_PASSWORD_FILE2"), "read the destination repository password from a file (default: $RESTIC_PASSWORD_FILE2)")
+	f.StringVarP(&copyOptions.PasswordFile, "password-file2", "", os.Getenv("RESTIC_PASSWORD_FILE2"), "`file` to read the destination repository password from (default: $RESTIC_PASSWORD_FILE2)")
 	f.StringVarP(&copyOptions.KeyHint, "key-hint2", "", os.Getenv("RESTIC_KEY_HINT2"), "key ID of key to try decrypting the destination repository first (default: $RESTIC_KEY_HINT2)")
 	f.StringVarP(&copyOptions.PasswordCommand, "password-command2", "", os.Getenv("RESTIC_PASSWORD_COMMAND2"), "shell `command` to obtain the destination repository password from (default: $RESTIC_PASSWORD_COMMAND2)")
 

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -42,7 +42,7 @@ func init() {
 	cmdRoot.AddCommand(cmdKey)
 
 	flags := cmdKey.Flags()
-	flags.StringVarP(&newPasswordFile, "new-password-file", "", "", "the file from which to load a new password")
+	flags.StringVarP(&newPasswordFile, "new-password-file", "", "", "`file` from which to read the new password")
 	flags.StringVarP(&keyUsername, "user", "", "", "the username for new keys")
 	flags.StringVarP(&keyHostname, "host", "", "", "the hostname for new keys")
 }

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -101,7 +101,7 @@ func init() {
 
 	f := cmdRoot.PersistentFlags()
 	f.StringVarP(&globalOptions.Repo, "repo", "r", os.Getenv("RESTIC_REPOSITORY"), "`repository` to backup to or restore from (default: $RESTIC_REPOSITORY)")
-	f.StringVarP(&globalOptions.PasswordFile, "password-file", "p", os.Getenv("RESTIC_PASSWORD_FILE"), "read the repository password from a `file` (default: $RESTIC_PASSWORD_FILE)")
+	f.StringVarP(&globalOptions.PasswordFile, "password-file", "p", os.Getenv("RESTIC_PASSWORD_FILE"), "`file` to read the repository password from (default: $RESTIC_PASSWORD_FILE)")
 	f.StringVarP(&globalOptions.KeyHint, "key-hint", "", os.Getenv("RESTIC_KEY_HINT"), "`key` ID of key to try decrypting first (default: $RESTIC_KEY_HINT)")
 	f.StringVarP(&globalOptions.PasswordCommand, "password-command", "", os.Getenv("RESTIC_PASSWORD_COMMAND"), "shell `command` to obtain the repository password from (default: $RESTIC_PASSWORD_COMMAND)")
 	f.BoolVarP(&globalOptions.Quiet, "quiet", "q", false, "do not output comprehensive progress report")

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -57,7 +57,7 @@ Usage help is available:
           --no-lock                    do not lock the repo, this allows some operations on read-only repos
       -o, --option key=value           set extended option (key=value, can be specified multiple times)
           --password-command command   shell command to obtain the repository password from (default: $RESTIC_PASSWORD_COMMAND)
-      -p, --password-file file         read the repository password from a file (default: $RESTIC_PASSWORD_FILE)
+      -p, --password-file file         file to read the repository password from (default: $RESTIC_PASSWORD_FILE)
       -q, --quiet                      do not output comprehensive progress report
       -r, --repo repository            repository to backup to or restore from (default: $RESTIC_REPOSITORY)
           --tls-client-cert file       path to a file containing PEM encoded TLS client certificate and private key
@@ -119,7 +119,7 @@ command:
           --no-lock                    do not lock the repo, this allows some operations on read-only repos
       -o, --option key=value           set extended option (key=value, can be specified multiple times)
           --password-command command   shell command to obtain the repository password from (default: $RESTIC_PASSWORD_COMMAND)
-      -p, --password-file file         read the repository password from a file (default: $RESTIC_PASSWORD_FILE)
+      -p, --password-file file         file to read the repository password from (default: $RESTIC_PASSWORD_FILE)
       -q, --quiet                      do not output comprehensive progress report
       -r, --repo repository            repository to backup to or restore from (default: $RESTIC_REPOSITORY)
           --tls-client-cert file       path to a file containing PEM encoded TLS client certificate and private key


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Improve wording for --password-file and related options

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Nein.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review