### PR TITLE
Reduce debug log overhead

### DIFF
--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -17,9 +17,10 @@ import (
 )
 
 var opts struct {
-	logger *log.Logger
-	funcs  map[string]bool
-	files  map[string]bool
+	isEnabled bool
+	logger    *log.Logger
+	funcs     map[string]bool
+	files     map[string]bool
 }
 
 // make sure that all the initialization happens before the init() functions
@@ -30,6 +31,12 @@ func initDebug() bool {
 	initDebugLogger()
 	initDebugTags()
 
+	if opts.logger == nil && len(opts.funcs) == 0 && len(opts.files) == 0 {
+		opts.isEnabled = false
+		return false
+	}
+
+	opts.isEnabled = true
 	fmt.Fprintf(os.Stderr, "debug enabled\n")
 
 	return true
@@ -173,6 +180,10 @@ func checkFilter(filter map[string]bool, key string) bool {
 
 // Log prints a message to the debug log (if debug is enabled).
 func Log(f string, args ...interface{}) {
+	if !opts.isEnabled {
+		return
+	}
+
 	fn, dir, file, line := getPosition()
 	goroutine := goroutineNum()
 

--- a/internal/debug/round_tripper_debug.go
+++ b/internal/debug/round_tripper_debug.go
@@ -66,7 +66,12 @@ type loggingRoundTripper struct {
 // RoundTripper returns a new http.RoundTripper which logs all requests (if
 // debug is enabled). When debug is not enabled, upstream is returned.
 func RoundTripper(upstream http.RoundTripper) http.RoundTripper {
-	return loggingRoundTripper{eofDetectRoundTripper{upstream}}
+	eofRoundTripper := eofDetectRoundTripper{upstream}
+	if opts.isEnabled {
+		// only use loggingRoundTripper if the debug log is configured
+		return loggingRoundTripper{eofRoundTripper}
+	}
+	return eofRoundTripper
 }
 
 func (tr loggingRoundTripper) RoundTrip(req *http.Request) (res *http.Response, err error) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
While profiling a debug build I've noticed that `debug.Log` spends a lot of time determining the goroutine number and formatting the log message. This also happens when no debug log is configured and thus the log message is just thrown away once it's formatted. This PR introduces a simple flag which indicates whether a debug log is configured and leaves the logging function immediately if there is none.

In addition the "debug enabled" message is now only printed, if there's actually a configured debug log.

Logging of http requests is now also skipped if no debug log is enabled.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
This PR can be seen as a prerequisite to implement #1842. However, we probably also have to disable the `eofDetectRoundTripper` for regular release builds and restic should try to mask sensitive data.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- I've tested the changes manually ~~[ ] I have added tests for all changes in this PR~~
-  ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] **The change is right now only interesting for developers. So I don't think there's a need for a changelog entry** There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
