### PR TITLE
Call rclone.Create to create a new repository for the rclone backend

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -742,7 +742,7 @@ func create(s string, opts options.Options) (restic.Backend, error) {
 	case "rest":
 		return rest.Create(cfg.(rest.Config), rt)
 	case "rclone":
-		return rclone.Open(cfg.(rclone.Config), nil)
+		return rclone.Create(cfg.(rclone.Config))
 	}
 
 	debug.Log("invalid repository scheme: %v", s)

--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -267,6 +267,7 @@ func Open(cfg Config, lim limiter.Limiter) (*Backend, error) {
 
 	restBackend, err := rest.Open(restConfig, debug.RoundTripper(be.tr))
 	if err != nil {
+		_ = be.Close()
 		return nil, err
 	}
 

--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -290,7 +290,7 @@ func Create(cfg Config) (*Backend, error) {
 	}
 
 	restConfig := rest.Config{
-		Connections: 20,
+		Connections: cfg.Connections,
 		URL:         url,
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
For some reason restic currently calls `rclone.Open` to create a new repository when using the rclone backend. This PR changes it to the intended `rclone.Create` method.

I've add two further small cleanups to use the configured number of backend connections and to cleanup the error handling.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #1896

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- The rclone backend itself has tests. There are no rclone specific integration tests, but I've tested the changes manually. ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- The old and new implementation work, so I doubt that anyone will notice this change. ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
