### PR TITLE
Don't require `self-update --output` placeholder file

### DIFF
--- a/changelog/unreleased/issue-2491
+++ b/changelog/unreleased/issue-2491
@@ -1,0 +1,9 @@
+Bugfix: Don't require `self-update --output` placeholder file
+
+`restic self-update --output /path/to/new-restic` used to require that
+new-restic was an existing file, to be overwritten. Now it's possible
+to download an updated restic binary to a new path, without first
+having to create a placeholder file.
+
+https://github.com/restic/restic/issues/2491
+https://github.com/restic/restic/pull/2937

--- a/cmd/restic/cmd_self_update.go
+++ b/cmd/restic/cmd_self_update.go
@@ -4,6 +4,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/selfupdate"
@@ -56,11 +57,18 @@ func runSelfUpdate(opts SelfUpdateOptions, gopts GlobalOptions, args []string) e
 
 	fi, err := os.Lstat(opts.Output)
 	if err != nil {
-		return err
-	}
-
-	if !fi.Mode().IsRegular() {
-		return errors.Errorf("output file %v is not a normal file, use --output to specify a different file", opts.Output)
+		dirname := filepath.Dir(opts.Output)
+		di, err := os.Lstat(dirname)
+		if err != nil {
+			return err
+		}
+		if !di.Mode().IsDir() {
+			return errors.Fatalf("output parent path %v is not a directory, use --output to specify a different file path", dirname)
+		}
+	} else {
+		if !fi.Mode().IsRegular() {
+			return errors.Fatalf("output path %v is not a normal file, use --output to specify a different file path", opts.Output)
+		}
 	}
 
 	Printf("writing restic to %v\n", opts.Output)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This removes the requirement on `restic self-update --output` to point
to a path of an existing file, to overwrite. In case the specified
path does exist we still want to verify that it's a regular file,
rather than a directory or a device, which gets overwritten.

We also want to verify that a path to a new file exists within an
existing directory. The alternative being running into that issue
after the actual download, etc has completed.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Resolves #2491


Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
