### PR TITLE
Fix nil check in rejectBySize

### DIFF
--- a/changelog/unreleased/issue-2942
+++ b/changelog/unreleased/issue-2942
@@ -1,0 +1,7 @@
+Bugfix: Make --exclude-larger-than handle disappearing files
+
+There was a small bug in the backup command's --exclude-larger-than
+option where files that disappeared between scanning and actually
+backing them up to the repository caused a panic. This is now fixed.
+
+https://github.com/restic/restic/issues/2942

--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -301,6 +301,10 @@ func rejectBySize(maxSizeStr string) (RejectFunc, error) {
 	}
 
 	return func(item string, fi os.FileInfo) bool {
+		if fi == nil {
+			return false
+		}
+
 		// directory will be ignored
 		if fi.IsDir() {
 			return false


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

`rejectBySize` function did not check if the `fileInfo` is nil, which may lead to panic if already scanned file quickly disappearing.
This PR fixes this bug like `rejectByDevice` did.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

#2942 and [forum](https://forum.restic.net/t/panic-in-the-exclude-larger-than-filter-function/3074)
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
