### PR TITLE
Don’t print excessively detailed debug messages on object deletion when —verbose is used

### DIFF
--- a/cmd/restic/delete.go
+++ b/cmd/restic/delete.go
@@ -48,7 +48,7 @@ func deleteFiles(gopts GlobalOptions, ignoreError bool, repo restic.Repository, 
 						return err
 					}
 				}
-				if !gopts.JSON && gopts.verbosity >= 2 {
+				if !gopts.JSON && gopts.verbosity > 2 {
 					Verbosef("removed %v\n", h)
 				}
 				bar.Report(restic.Stat{Blobs: 1})


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

PR #2840 added a new debug message printed for each deleted object to the --verbose output level. This means that the output for any operation with -v enabled, which was detailed but manageable, now can include thousands of not very informative lines (removed <index/41df4139f1>, removed <data/b62da41602>, removed <snapshot/54cda69f1a>, etc) obscuring the important information.

This PR hides the new debug messages under --verbose=2, which I think is a more appropriate level.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
