### PR TITLE
backup: Correct keep policy text

### DIFF
--- a/internal/restic/snapshot_policy.go
+++ b/internal/restic/snapshot_policy.go
@@ -25,7 +25,7 @@ type ExpirePolicy struct {
 func (e ExpirePolicy) String() (s string) {
 	var keeps []string
 	if e.Last > 0 {
-		keeps = append(keeps, fmt.Sprintf("%d snapshots", e.Last))
+		keeps = append(keeps, fmt.Sprintf("%d latest", e.Last))
 	}
 	if e.Hourly > 0 {
 		keeps = append(keeps, fmt.Sprintf("%d hourly", e.Hourly))
@@ -44,7 +44,7 @@ func (e ExpirePolicy) String() (s string) {
 	}
 
 	if len(keeps) > 0 {
-		s = fmt.Sprintf("keep the last %s snapshots", strings.Join(keeps, ", "))
+		s = fmt.Sprintf("keep %s snapshots", strings.Join(keeps, ", "))
 	}
 
 	if len(e.Tags) > 0 {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Makes the following corrections to the "Applying Policy:" output from `restic backup`:

- keep the last 1 snapshots snapshots => keep 1 latest snapshots
- keep the last 1 snapshots, 3 hourly, 5 yearly snapshots => keep 1 latest, 3 hourly, 5 yearly snapshots

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
