### PR TITLE
Interrupt backup

### DIFF
--- a/cmd/restic/cleanup.go
+++ b/cmd/restic/cleanup.go
@@ -35,6 +35,19 @@ func AddCleanupHandler(f func() error) {
 	cleanupHandlers.list = append(cleanupHandlers.list, f)
 }
 
+// PrependCleanupHandler prepends the function f to the list of cleanup handlers so
+// that it is executed when all the cleanup handlers are run, e.g. when SIGINT
+// is received.
+func PrependCleanupHandler(f func() error) {
+	cleanupHandlers.Lock()
+	defer cleanupHandlers.Unlock()
+
+	// reset the done flag for integration tests
+	cleanupHandlers.done = false
+
+	cleanupHandlers.list = append([]func() error{f}, cleanupHandlers.list...)
+}
+
 // RunCleanupHandlers runs all registered cleanup handlers
 func RunCleanupHandlers() {
 	cleanupHandlers.Lock()

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -404,7 +404,7 @@ func findParentSnapshot(ctx context.Context, repo restic.Repository, opts Backup
 
 	// Find last snapshot to set it as parent, if not already set
 	if !opts.Force && parentID == nil {
-		id, err := restic.FindLatestSnapshot(ctx, repo, targets, []restic.TagList{}, []string{opts.Host})
+		id, err := restic.FindLatestSnapshot(ctx, repo, targets, []restic.TagList{}, []restic.TagList{}, []string{opts.Host})
 		if err == nil {
 			parentID = &id
 		} else if err != restic.ErrNoSnapshotFound {

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -404,7 +404,7 @@ func findParentSnapshot(ctx context.Context, repo restic.Repository, opts Backup
 
 	// Find last snapshot to set it as parent, if not already set
 	if !opts.Force && parentID == nil {
-		id, err := restic.FindLatestSnapshot(ctx, repo, targets, []restic.TagList{}, []restic.TagList{}, []string{opts.Host})
+		id, err := restic.FindLatestSnapshot(ctx, repo, targets, []restic.TagList{}, []restic.TagList{[]string{"interrupted"}}, []string{opts.Host})
 		if err == nil {
 			parentID = &id
 		} else if err != restic.ErrNoSnapshotFound {

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -600,11 +600,12 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		Hostname:       opts.Host,
 		ParentSnapshot: *parentSnapshotID,
 	}
+	fileCtx, _ := context.WithCancel(gopts.ctx)
 
 	if !gopts.JSON {
 		p.V("start backup on %v", targets)
 	}
-	_, id, err := arch.Snapshot(gopts.ctx, targets, snapshotOpts)
+	_, id, err := arch.Snapshot(gopts.ctx, fileCtx, targets, snapshotOpts)
 	if err != nil {
 		return errors.Fatalf("unable to save snapshot: %v", err)
 	}

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -155,7 +155,7 @@ func runDump(opts DumpOptions, gopts GlobalOptions, args []string) error {
 	var id restic.ID
 
 	if snapshotIDString == "latest" {
-		id, err = restic.FindLatestSnapshot(ctx, repo, opts.Paths, opts.Tags, opts.Hosts)
+		id, err = restic.FindLatestSnapshot(ctx, repo, opts.Paths, opts.Tags, []restic.TagList{}, opts.Hosts)
 		if err != nil {
 			Exitf(1, "latest snapshot for criteria not found: %v Paths:%v Hosts:%v", err, opts.Paths, opts.Hosts)
 		}

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -117,7 +117,7 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 	var id restic.ID
 
 	if snapshotIDString == "latest" {
-		id, err = restic.FindLatestSnapshot(ctx, repo, opts.Paths, opts.Tags, opts.Hosts)
+		id, err = restic.FindLatestSnapshot(ctx, repo, opts.Paths, opts.Tags, []restic.TagList{}, opts.Hosts)
 		if err != nil {
 			Exitf(1, "latest snapshot for criteria not found: %v Paths:%v Hosts:%v", err, opts.Paths, opts.Hosts)
 		}

--- a/cmd/restic/find.go
+++ b/cmd/restic/find.go
@@ -23,7 +23,7 @@ func FindFilteredSnapshots(ctx context.Context, repo *repository.Repository, hos
 			for _, s := range snapshotIDs {
 				if s == "latest" {
 					usedFilter = true
-					id, err = restic.FindLatestSnapshot(ctx, repo, paths, tags, hosts)
+					id, err = restic.FindLatestSnapshot(ctx, repo, paths, tags, []restic.TagList{}, hosts)
 					if err != nil {
 						Warnf("Ignoring %q, no snapshot matched given filter (Paths:%v Tags:%v Hosts:%v)\n", s, paths, tags, hosts)
 						continue

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -816,6 +816,12 @@ func (arch *Archiver) Snapshot(ctx, fileCtx context.Context, targets []string, o
 	}
 	sn.Tree = &rootTreeID
 
+	select {
+	case <-fileCtx.Done():
+		sn.AddTags([]string{"interrupted"})
+	default:
+	}
+
 	id, err := arch.Repo.SaveJSONUnpacked(ctx, restic.SnapshotFile, sn)
 	if err != nil {
 		return nil, restic.ID{}, err

--- a/internal/archiver/testing.go
+++ b/internal/archiver/testing.go
@@ -27,7 +27,7 @@ func TestSnapshot(t testing.TB, repo restic.Repository, path string, parent *res
 	if parent != nil {
 		opts.ParentSnapshot = *parent
 	}
-	sn, _, err := arch.Snapshot(context.TODO(), []string{path}, opts)
+	sn, _, err := arch.Snapshot(context.TODO(), context.TODO(), []string{path}, opts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/archiver/testing_test.go
+++ b/internal/archiver/testing_test.go
@@ -507,7 +507,7 @@ func TestTestEnsureSnapshot(t *testing.T) {
 				Hostname: "localhost",
 				Tags:     []string{"test"},
 			}
-			_, id, err := arch.Snapshot(ctx, []string{"."}, opts)
+			_, id, err := arch.Snapshot(ctx, ctx, []string{"."}, opts)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/archiver/tree_saver_test.go
+++ b/internal/archiver/tree_saver_test.go
@@ -27,7 +27,7 @@ func TestTreeSaver(t *testing.T) {
 		return nil
 	}
 
-	b := NewTreeSaver(ctx, tmb, uint(runtime.NumCPU()), saveFn, errFn)
+	b := NewTreeSaver(ctx, ctx, tmb, uint(runtime.NumCPU()), saveFn, errFn)
 
 	var results []FutureTree
 
@@ -88,7 +88,7 @@ func TestTreeSaverError(t *testing.T) {
 				return nil
 			}
 
-			b := NewTreeSaver(ctx, tmb, uint(runtime.NumCPU()), saveFn, errFn)
+			b := NewTreeSaver(ctx, ctx, tmb, uint(runtime.NumCPU()), saveFn, errFn)
 
 			var results []FutureTree
 

--- a/internal/dump/tar_test.go
+++ b/internal/dump/tar_test.go
@@ -82,7 +82,7 @@ func TestWriteTar(t *testing.T) {
 			back := rtest.Chdir(t, tmpdir)
 			defer back()
 
-			sn, _, err := arch.Snapshot(ctx, []string{"."}, archiver.SnapshotOptions{})
+			sn, _, err := arch.Snapshot(ctx, ctx, []string{"."}, archiver.SnapshotOptions{})
 			rtest.OK(t, err)
 
 			tree, err := repo.LoadTree(ctx, *sn.Tree)

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -14,7 +14,7 @@ import (
 var ErrNoSnapshotFound = errors.New("no snapshot found")
 
 // FindLatestSnapshot finds latest snapshot with optional target/directory, tags and hostname filters.
-func FindLatestSnapshot(ctx context.Context, repo Repository, targets []string, tagLists []TagList, hostnames []string) (ID, error) {
+func FindLatestSnapshot(ctx context.Context, repo Repository, targets []string, tagLists []TagList, ignoreTagLists []TagList, hostnames []string) (ID, error) {
 	var err error
 	absTargets := make([]string, 0, len(targets))
 	for _, target := range targets {
@@ -48,6 +48,10 @@ func FindLatestSnapshot(ctx context.Context, repo Repository, targets []string, 
 		}
 
 		if !snapshot.HasTagList(tagLists) {
+			return nil
+		}
+
+		if len(ignoreTagLists) > 0 && snapshot.HasTagList(ignoreTagLists) {
 			return nil
 		}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Add a handler to interrupt `restic backup` with saving an "interrupted" snapshot

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

closes #2960 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
