### PR TITLE
Fix instructions to reproduce the release binaries

### DIFF
--- a/doc/developer_information.rst
+++ b/doc/developer_information.rst
@@ -18,9 +18,9 @@ depends on the following things:
  * The environment variables (mostly ``$GOOS``, ``$GOARCH``, ``$CGO_ENABLED``)
 
 In addition, The compressed ZIP files for Windows depends on the modification
-timestamp of the binary contained in it. In order to reproduce the exact same
-ZIP file every time, we update the timestamp of the file ``VERSION`` in the
-source code archive and set the timezone to Europe/Berlin.
+timestamp and filename of the binary contained in it. In order to reproduce the
+exact same ZIP file every time, we update the timestamp of the file ``VERSION``
+in the source code archive and set the timezone to Europe/Berlin.
 
 In the following example, we'll use the file ``restic-0.10.0.tar.gz`` and Go
 1.15.2 to reproduce the released binaries.
@@ -53,9 +53,9 @@ In the following example, we'll use the file ``restic-0.10.0.tar.gz`` and Go
     $ GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -tags selfupdate -o restic_linux_amd64 ./cmd/restic
     $ bzip2 restic_linux_amd64
 
-    $ GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -tags selfupdate -o restic_windows_amd64.exe ./cmd/restic
-    $ touch --reference VERSION restic_windows_amd64.exe
-    $ TZ=Europe/Berlin zip -q -X restic_windows_amd64.zip restic_windows_amd64.exe
+    $ GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -tags selfupdate -o restic_0.10.0_windows_amd64.exe ./cmd/restic
+    $ touch --reference VERSION restic_0.10.0_windows_amd64.exe
+    $ TZ=Europe/Berlin zip -q -X restic_0.10.0_windows_amd64.zip restic_0.10.0_windows_amd64.exe
 
 Building the Official Binaries
 ******************************
@@ -98,9 +98,10 @@ The following steps are necessary to build the binaries:
     docker run --rm \
         --volume "$PWD/restic-0.10.0:/restic" \
         --volume "$PWD/output:/output" \
-        restic/builder
+        restic/builder \
+        go run helpers/build-release-binaries/main.go --version 0.10.0
 
-4. If anything goes wrong, you can enable debug output by specifying the call to ``helpers/build-release-binaries/main.go`` like this:
+4. If anything goes wrong, you can enable debug output like this:
 
 .. code::
 
@@ -108,7 +109,7 @@ The following steps are necessary to build the binaries:
         --volume "$PWD/restic-0.10.0:/restic" \
         --volume "$PWD/output:/output" \
         restic/builder \
-        go run helpers/build-release-binaries/main.go --verbose
+        go run helpers/build-release-binaries/main.go --version 0.10.0 --verbose
 
 Prepare a New Release
 *********************

--- a/doc/developer_information.rst
+++ b/doc/developer_information.rst
@@ -5,8 +5,9 @@ Reproducible Builds
 *******************
 
 This section describes how to reproduce the official released binaries for
-restic for version 0.9.3 and later. The binary produced depends on the
-following things:
+restic for version 0.10.0 and later. For restic versions down to 0.9.3 please
+refer to the documentation for the respective version. The binary produced
+depends on the following things:
 
  * The source code for the release
  * The exact version of the official `Go compiler <https://golang.org>`__ used to produce the binaries (running ``restic version`` will print this)
@@ -21,15 +22,17 @@ timestamp of the binary contained in it. In order to reproduce the exact same
 ZIP file every time, we update the timestamp of the file ``VERSION`` in the
 source code archive and set the timezone to Europe/Berlin.
 
-In the following example, we'll use the file ``restic-0.9.3.tar.gz`` and Go
-1.11.1 to reproduce the released binaries.
+In the following example, we'll use the file ``restic-0.10.0.tar.gz`` and Go
+1.15.2 to reproduce the released binaries.
 
-1. Download and extract the Go compiler into ``/usr/local/go``:
+1. Determine the Go compiler version used to build the released binaries, then download and extract the Go compiler into ``/usr/local/go``:
 
 .. code::
 
+    $ restic version
+    restic 0.10.0 compiled with go1.15.2 on linux/amd64
     $ cd /usr/local
-    $ curl -L https://dl.google.com/go/go1.11.1.linux-amd64.tar.gz | tar xz
+    $ curl -L https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz | tar xz
 
 2. Extract the restic source code into ``/restic``
 
@@ -37,7 +40,7 @@ In the following example, we'll use the file ``restic-0.9.3.tar.gz`` and Go
 
     $ mkdir /restic
     $ cd /restic
-    $ TZ=Europe/Berlin curl -L https://github.com/restic/restic/releases/download/v0.9.3/restic-0.9.3.tar.gz | tar xz --strip-components=1
+    $ TZ=Europe/Berlin curl -L https://github.com/restic/restic/releases/download/v0.10.0/restic-0.10.0.tar.gz | tar xz --strip-components=1
 
 3. Build the binaries for Windows and Linux:
 
@@ -45,7 +48,7 @@ In the following example, we'll use the file ``restic-0.9.3.tar.gz`` and Go
 
     $ export PATH=/usr/local/go/bin:$PATH
     $ go version
-    go version go1.11.1 linux/amd64
+    go version go1.15.2 linux/amd64
 
     $ GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -tags selfupdate -o restic_linux_amd64 ./cmd/restic
     $ bzip2 restic_linux_amd64
@@ -80,7 +83,7 @@ The following steps are necessary to build the binaries:
 
 .. code::
 
-    tar xvzf restic-0.9.3.tar.gz
+    tar xvzf restic-0.10.0.tar.gz
 
 3. Create a directory to place the resulting binaries in:
 
@@ -93,7 +96,7 @@ The following steps are necessary to build the binaries:
 .. code::
 
     docker run --rm \
-        --volume "$PWD/restic-0.9.3:/restic" \
+        --volume "$PWD/restic-0.10.0:/restic" \
         --volume "$PWD/output:/output" \
         restic/builder
 
@@ -102,7 +105,7 @@ The following steps are necessary to build the binaries:
 .. code::
 
     docker run --rm \
-        --volume "$PWD/restic-0.9.3:/restic" \
+        --volume "$PWD/restic-0.10.0:/restic" \
         --volume "$PWD/output:/output" \
         restic/builder \
         go run helpers/build-release-binaries/main.go --verbose
@@ -118,6 +121,6 @@ required argument is the new version number (in `Semantic Versioning
 
 .. code::
 
-    go run helpers/prepare-release/main.go 0.9.3
+    go run helpers/prepare-release/main.go 0.10.0
 
 Checks can be skipped on demand via flags, please see ``--help`` for details.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
After the false positive virus report in #2946, I've tested the reproduction instructions and noticed that these require a few small tweaks to actually arrive at the official (compressed) binaries.

The newer instructions don't work for restic 0.10.0, and therefore I've added a hint to look at the documentation of the respective version. To reproduce the zip archives of the windows binaries, it is also necessary for the filename to exactly match, which requires passing the `--version` flag to the build helper script.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~ But I've tested the instructions manually
- [x] I have added documentation for the changes (in the manual) _(sort of)_
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
