### PR TITLE
Skip fopen for file change check to avoid network penalty

### DIFF
--- a/changelog/unreleased/issue-2969
+++ b/changelog/unreleased/issue-2969
@@ -1,0 +1,9 @@
+Enhancement: Optimize check for unchanged files during backup
+
+During a backup restic skips processing files which have not changed since the last backup run.
+Previously this required opening each file once which can be slow on network filesystems. The
+backup command now checks for file changes before opening a file. This considerably reduces
+the time to create a backup on network filesystems.
+
+https://github.com/restic/restic/issues/2969
+https://github.com/restic/restic/pull/2970

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -364,6 +364,30 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 		debug.Log("  %v regular file", target)
 		start := time.Now()
 
+		// check if the file has not changed before performing a fopen operation (more expensive, specially
+		// in network filesystems)
+		if previous != nil && !fileChanged(fi, previous, arch.IgnoreInode) {
+			if arch.allBlobsPresent(previous) {
+				debug.Log("%v hasn't changed, using old list of blobs", target)
+				arch.CompleteItem(snPath, previous, previous, ItemStats{}, time.Since(start))
+				arch.CompleteBlob(snPath, previous.Size)
+				fn.node, err = arch.nodeFromFileInfo(target, fi)
+				if err != nil {
+					return FutureNode{}, false, err
+				}
+
+				// copy list of blobs
+				fn.node.Content = previous.Content
+
+				return fn, false, nil
+			}
+
+			debug.Log("%v hasn't changed, but contents are missing!", target)
+			// There are contents missing - inform user!
+			err := errors.Errorf("parts of %v not found in the repository index; storing the file again", target)
+			arch.error(abstarget, fi, err)
+		}
+
 		// reopen file and do an fstat() on the open file to check it is still
 		// a file (and has not been exchanged for e.g. a symlink)
 		file, err := arch.FS.OpenFile(target, fs.O_RDONLY|fs.O_NOFOLLOW, 0)
@@ -396,30 +420,6 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 				return FutureNode{}, false, err
 			}
 			return FutureNode{}, true, nil
-		}
-
-		// use previous list of blobs if the file hasn't changed
-		if previous != nil && !fileChanged(fi, previous, arch.IgnoreInode) {
-			if arch.allBlobsPresent(previous) {
-				debug.Log("%v hasn't changed, using old list of blobs", target)
-				arch.CompleteItem(snPath, previous, previous, ItemStats{}, time.Since(start))
-				arch.CompleteBlob(snPath, previous.Size)
-				fn.node, err = arch.nodeFromFileInfo(target, fi)
-				if err != nil {
-					return FutureNode{}, false, err
-				}
-
-				// copy list of blobs
-				fn.node.Content = previous.Content
-
-				_ = file.Close()
-				return fn, false, nil
-			}
-
-			debug.Log("%v hasn't changed, but contents are missing!", target)
-			// There are contents missing - inform user!
-			err := errors.Errorf("parts of %v not found in the repository index; storing the file again", target)
-			arch.error(abstarget, fi, err)
 		}
 
 		fn.isFile = true


### PR DESCRIPTION
Closes https://github.com/restic/restic/issues/2969


This PR reduces drastically the time to perform a backup on top of a network filesystem. It does so by reducing the number of `fopen` calls by checking for file changes before.

On a 1 million files tree, the time to backup is reduced from 60 minutes to 22 minutes. Network filesystems are sensitive to `fopen` operations, as it often requires to open the file in the data server, while a `stat` operation does not.


Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
