### PR TITLE
Add FAQ on whether restic can resume backups

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -3,6 +3,32 @@ FAQ
 
 This is the list of Frequently Asked Questions for restic.
 
+Will restic resume an interrupted backup?
+-----------------------------------------
+
+Yes, restic will resume interrupted backups when they are re-run.
+
+When backing up, restic periodically writes index files to keep a record of
+the uploaded data. Even if there's no snapshot created in the end (due to the
+backup being interrupted), these indexes are stored in the repository for the
+data that has been uploaded so far. Next time restic runs, it is then able to
+find the uploaded data through these indexes, and thereby reference it again
+without having to upload it a second time. This effectively makes it continue
+from where it saved the last index, which should be up to a few minutes ago.
+
+It does not matter if the backup was interrupted by the user or if it was due
+to unforeseen circumstances such as connectivity issues, power loss, etc.
+Simply re-run the backup again and restic should only upload what it needs to
+in order to complete the interrupted backup and create a snapshot.
+
+Note however that during the initial backup run and any re-tries, until there
+has been a first snapshot created for the backup set (list of files and
+directories to be backed up), restic will need to re-scan the files on disk as
+there is no parent snapshot to compare the filesystem with to determine which
+files have changed. This process should however be far quicker than the
+uploading, and it's normal to see restic scan the files again when re-running
+the backup.
+
 ``restic check`` reports packs that aren't referenced in any index, is my repository broken?
 --------------------------------------------------------------------------------------------
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This new FAQ entry explains that restic can resume interrupted backups, which previously was not clearly mentioned in the documentation.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Clarification needed as evident by discussion in #2960.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review