### PR TITLE
Warn if backup failed to read tree blob

### DIFF
--- a/changelog/unreleased/pull-2978
+++ b/changelog/unreleased/pull-2978
@@ -1,0 +1,8 @@
+Enhancement: Warn if parent snapshot cannot be loaded during backup
+
+During a backup restic uses the parent snapshot to check whether a file was
+changed and has to be backed up again. For this check the backup has to read
+the directories contained in the old snapshot. If a tree blob cannot be
+loaded, restic now warns about this problem with the backup repository.
+
+https://github.com/restic/restic/pull/2978

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -357,7 +357,7 @@ func TestBackupNonExistingFile(t *testing.T) {
 	testRunBackup(t, "", dirs, opts, env.gopts)
 }
 
-func removeDataPacksExcept(gopts GlobalOptions, t *testing.T, keep restic.IDSet) {
+func removePacksExcept(gopts GlobalOptions, t *testing.T, keep restic.IDSet, removeTreePacks bool) {
 	r, err := OpenRepository(gopts)
 	rtest.OK(t, err)
 
@@ -372,7 +372,7 @@ func removeDataPacksExcept(gopts GlobalOptions, t *testing.T, keep restic.IDSet)
 
 	// remove all packs containing data blobs
 	rtest.OK(t, r.List(gopts.ctx, restic.PackFile, func(id restic.ID, size int64) error {
-		if treePacks.Has(id) || keep.Has(id) {
+		if treePacks.Has(id) != removeTreePacks || keep.Has(id) {
 			return nil
 		}
 		return r.Backend().Remove(gopts.ctx, restic.Handle{Type: restic.PackFile, Name: id.String()})
@@ -395,7 +395,7 @@ func TestBackupSelfHealing(t *testing.T) {
 	testRunCheck(t, env.gopts)
 
 	// remove all data packs
-	removeDataPacksExcept(env.gopts, t, restic.NewIDSet())
+	removePacksExcept(env.gopts, t, restic.NewIDSet(), false)
 
 	testRunRebuildIndex(t, env.gopts)
 	// now the repo is also missing the data blob in the index; check should report this
@@ -406,6 +406,56 @@ func TestBackupSelfHealing(t *testing.T) {
 	err := testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{filepath.Base(env.testdata)}, opts, env.gopts)
 	rtest.Assert(t, err != nil,
 		"backup should have reported an error")
+	testRunCheck(t, env.gopts)
+}
+
+func TestBackupTreeLoadError(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+	p := filepath.Join(env.testdata, "test/test")
+	rtest.OK(t, os.MkdirAll(filepath.Dir(p), 0755))
+	rtest.OK(t, appendRandomData(p, 5))
+
+	opts := BackupOptions{}
+	// Backup a subdirectory first, such that we can remove the tree pack for the subdirectory
+	testRunBackup(t, env.testdata, []string{"test"}, opts, env.gopts)
+
+	r, err := OpenRepository(env.gopts)
+	rtest.OK(t, err)
+	rtest.OK(t, r.LoadIndex(env.gopts.ctx))
+	// collect tree packs of subdirectory
+	subTreePacks := restic.NewIDSet()
+	for _, idx := range r.Index().(*repository.MasterIndex).All() {
+		for _, id := range idx.TreePacks() {
+			subTreePacks.Insert(id)
+		}
+	}
+
+	testRunBackup(t, filepath.Dir(env.testdata), []string{filepath.Base(env.testdata)}, opts, env.gopts)
+	testRunCheck(t, env.gopts)
+
+	// delete the subdirectory pack first
+	for id := range subTreePacks {
+		rtest.OK(t, r.Backend().Remove(env.gopts.ctx, restic.Handle{Type: restic.PackFile, Name: id.String()}))
+	}
+	testRunRebuildIndex(t, env.gopts)
+	// now the repo is missing the tree blob in the index; check should report this
+	rtest.Assert(t, runCheck(CheckOptions{}, env.gopts, nil) != nil, "check should have reported an error")
+	// second backup should report an error but "heal" this situation
+	err = testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{filepath.Base(env.testdata)}, opts, env.gopts)
+	rtest.Assert(t, err != nil, "backup should have reported an error for the subdirectory")
+	testRunCheck(t, env.gopts)
+
+	// remove all tree packs
+	removePacksExcept(env.gopts, t, restic.NewIDSet(), true)
+	testRunRebuildIndex(t, env.gopts)
+	// now the repo is also missing the data blob in the index; check should report this
+	rtest.Assert(t, runCheck(CheckOptions{}, env.gopts, nil) != nil, "check should have reported an error")
+	// second backup should report an error but "heal" this situation
+	err = testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{filepath.Base(env.testdata)}, opts, env.gopts)
+	rtest.Assert(t, err != nil, "backup should have reported an error")
 	testRunCheck(t, env.gopts)
 }
 
@@ -1385,7 +1435,7 @@ func TestPruneWithDamagedRepository(t *testing.T) {
 	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "3")}, opts, env.gopts)
 	snapshotIDs := testRunList(t, "snapshots", env.gopts)
 
-	removeDataPacksExcept(env.gopts, t, oldPacks)
+	removePacksExcept(env.gopts, t, oldPacks, false)
 
 	rtest.Assert(t, len(snapshotIDs) == 1,
 		"expected one snapshot, got %v", snapshotIDs)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
When `backup` uses a parent snapshot it has to load the tree blobs of that snapshot. Previously a load failure was silently ignored, although a such a failure to load a tree blob indicates repository damage. This PR adds the missing warning message. Depending on whether the tree blob is contained in the index the warning message is either `tree 01234567 could not be loaded; the repository could be damaged: <error from backend>` or `tree 01234567 is not known; the repository could be damaged, run `rebuild-index` to try to repair it`.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No that I know.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
