### PR TITLE
Remove repetitive error wrapping from internal/cache

### DIFF
--- a/internal/cache/file.go
+++ b/internal/cache/file.go
@@ -48,13 +48,13 @@ func (c *Cache) load(h restic.Handle, length int, offset int64) (io.ReadCloser, 
 
 	f, err := fs.Open(c.filename(h))
 	if err != nil {
-		return nil, errors.Wrap(err, "Open")
+		return nil, errors.WithStack(err)
 	}
 
 	fi, err := f.Stat()
 	if err != nil {
 		_ = f.Close()
-		return nil, errors.Wrap(err, "Stat")
+		return nil, errors.WithStack(err)
 	}
 
 	if fi.Size() <= crypto.Extension {
@@ -94,15 +94,11 @@ func (c *Cache) saveWriter(h restic.Handle) (io.WriteCloser, error) {
 	p := c.filename(h)
 	err := fs.MkdirAll(filepath.Dir(p), 0700)
 	if err != nil {
-		return nil, errors.Wrap(err, "MkdirAll")
+		return nil, errors.WithStack(err)
 	}
 
 	f, err := fs.OpenFile(p, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0400)
-	if err != nil {
-		return nil, errors.Wrap(err, "Create")
-	}
-
-	return f, err
+	return f, errors.WithStack(err)
 }
 
 // Save saves a file in the cache.
@@ -133,7 +129,7 @@ func (c *Cache) Save(h restic.Handle, rd io.Reader) error {
 
 	if err = f.Close(); err != nil {
 		_ = c.remove(h)
-		return errors.Wrap(err, "Close")
+		return errors.WithStack(err)
 	}
 
 	return nil


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Many instances of errors.Wrap in this package would produce messages like "Open: open <filename>: no such file or directory"; those now omit the first "Open:" (or "Stat:", or "MkdirAll"). The function readVersion now appends its own name to the error message, rather than the function that failed, to make it easier to spot. Other function names (e.g., Load) are already added further up in the call chain.

I tested this by writing small test programs that trigger errors in os functions.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

I considered opening an issue for this, as this pattern occurs in several places throughout the codebase, but I decided against it because the issue would be very open-ended. I'll submit separate PRs if and when I find more occurrences.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
