### PR TITLE
Simplify cache directory creation

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -96,7 +96,7 @@ func New(id string, basedir string) (c *Cache, err error) {
 		}
 	}
 
-	created, err := mkdirCacheDir(basedir)
+	err = fs.MkdirAll(basedir, 0700)
 	if err != nil {
 		return nil, err
 	}
@@ -119,6 +119,7 @@ func New(id string, basedir string) (c *Cache, err error) {
 	}
 
 	// create the repo cache dir if it does not exist yet
+	var created bool
 	_, err = fs.Lstat(cachedir)
 	if os.IsNotExist(err) {
 		err = fs.MkdirAll(cachedir, dirMode)

--- a/internal/cache/dir.go
+++ b/internal/cache/dir.go
@@ -4,10 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-
-	"github.com/pkg/errors"
-	"github.com/restic/restic/internal/debug"
-	"github.com/restic/restic/internal/fs"
 )
 
 // DefaultDir returns $RESTIC_CACHE_DIR, or the default cache directory
@@ -24,33 +20,4 @@ func DefaultDir() (cachedir string, err error) {
 	}
 
 	return filepath.Join(cachedir, "restic"), nil
-}
-
-// mkdirCacheDir ensures that the cache directory exists. It it didn't, created
-// is set to true.
-func mkdirCacheDir(cachedir string) (created bool, err error) {
-	var newCacheDir bool
-
-	fi, err := fs.Stat(cachedir)
-	if os.IsNotExist(errors.Cause(err)) {
-		err = fs.MkdirAll(cachedir, 0700)
-		if err != nil {
-			return true, errors.Wrap(err, "MkdirAll")
-		}
-
-		fi, err = fs.Stat(cachedir)
-		debug.Log("create cache dir %v", cachedir)
-
-		newCacheDir = true
-	}
-
-	if err != nil {
-		return newCacheDir, errors.Wrap(err, "Stat")
-	}
-
-	if !fi.IsDir() {
-		return newCacheDir, errors.Errorf("cache dir %v is not a directory", cachedir)
-	}
-
-	return newCacheDir, nil
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The package internal/cache creates a cache directory, in mkdirCacheDir, by doing a Stat to check for existence, a MkdirAll, then another Stat to check the result. Both Stats are unncessary, because MkdirAll succeeds when the directory already existed and fails (with an appropriate error message) if a non-directory existed at the given path. The only added value from mkdirCacheDir was a return value indicating whether a new directory was created, but this value wasn't always set correctly and wasn't being used anywhere in the code either, so I removed the function.

I think the only potential change in behavior might occur when symlink to an existing directory is passed to cache.New: previously, that should have failed, while now, it should succeed. I don't care enough about this corner case to write a test for it.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
