### PR TITLE
Check error in archiver before calling Select

### DIFF
--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -234,10 +234,6 @@ func rejectByDevice(samples []string) (RejectFunc, error) {
 	debug.Log("allowed devices: %v\n", allowed)
 
 	return func(item string, fi os.FileInfo) bool {
-		if fi == nil {
-			return false
-		}
-
 		item = filepath.Clean(item)
 
 		id, err := fs.DeviceID(fi)
@@ -301,10 +297,6 @@ func rejectBySize(maxSizeStr string) (RejectFunc, error) {
 	}
 
 	return func(item string, fi os.FileInfo) bool {
-		if fi == nil {
-			return false
-		}
-
 		// directory will be ignored
 		if fi.IsDir() {
 			return false

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -345,17 +345,16 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 
 	// get file info and run remaining select functions that require file information
 	fi, err := arch.FS.Lstat(target)
-	if !arch.Select(abstarget, fi) {
-		debug.Log("%v is excluded", target)
-		return FutureNode{}, true, nil
-	}
-
 	if err != nil {
 		debug.Log("lstat() for %v returned error: %v", target, err)
 		err = arch.error(abstarget, fi, err)
 		if err != nil {
 			return FutureNode{}, false, errors.Wrap(err, "Lstat")
 		}
+		return FutureNode{}, true, nil
+	}
+	if !arch.Select(abstarget, fi) {
+		debug.Log("%v is excluded", target)
 		return FutureNode{}, true, nil
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The archiver first called the Select function for a path before checking whether the Lstat on that path actually worked. The RejectFuncs in exclude.go worked around this by checking whether they received a nil os.FileInfo. Checking first is more obvious and requires less code.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
