### PR TITLE
snapshots: Make --json output [] instead of null when no snapshots

### DIFF
--- a/changelog/unreleased/issue-2979
+++ b/changelog/unreleased/issue-2979
@@ -1,0 +1,9 @@
+Bugfix: Make snapshots --json output [] instead of null when no snapshots
+
+Restic previously output `null` instead of `[]` for the `--json snapshots`
+command, when there were no snapshots in the repository. This caused some
+minor problems when parsing the output, but is now fixed such that `[]` is
+output when the list of snapshots is empty.
+
+https://github.com/restic/restic/issues/2979
+https://github.com/restic/restic/pull/2984

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -298,7 +298,7 @@ type SnapshotGroup struct {
 // printSnapshotsJSON writes the JSON representation of list to stdout.
 func printSnapshotGroupJSON(stdout io.Writer, snGroups map[string]restic.Snapshots, grouped bool) error {
 	if grouped {
-		var snapshotGroups []SnapshotGroup
+		snapshotGroups := []SnapshotGroup{}
 
 		for k, list := range snGroups {
 			var key restic.SnapshotGroupKey
@@ -330,7 +330,7 @@ func printSnapshotGroupJSON(stdout io.Writer, snGroups map[string]restic.Snapsho
 	}
 
 	// Old behavior
-	var snapshots []Snapshot
+	snapshots := []Snapshot{}
 
 	for _, list := range snGroups {
 		for _, sn := range list {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Makes `--json snapshots` (both with and without `--group-by`) output `[]` instead of `null` when the list of snapshots is empty. This solves some minor parsing issues as in #2979.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2979.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review