### PR TITLE
Don't read password for generate, help or self-update

### DIFF
--- a/changelog/unreleased/issue-2951
+++ b/changelog/unreleased/issue-2951
@@ -1,0 +1,9 @@
+Bugfix: restic generate, help and self-update no longer check passwords
+
+The commands `restic cache`, `generate`, `help` and `self-update` don't need
+passwords, but they previously did run the RESTIC_PASSWORD_COMMAND (if set in
+the environment), prompting users to authenticate for no reason. They now skip
+running the password command.
+
+https://github.com/restic/restic/issues/2951
+https://github.com/restic/restic/pull/2987

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -51,7 +51,7 @@ directories in an encrypted repository stored on different backends.
 			return err
 		}
 		globalOptions.extended = opts
-		if c.Name() == "version" {
+		if !needsPassword(c.Name()) {
 			return nil
 		}
 		pwd, err := resolvePassword(globalOptions, "RESTIC_PASSWORD")
@@ -69,6 +69,18 @@ directories in an encrypted repository stored on different backends.
 
 		return nil
 	},
+}
+
+// Distinguish commands that need the password from those that work without,
+// so we don't run $RESTIC_PASSWORD_COMMAND for no reason (it might prompt the
+// user for authentication).
+func needsPassword(cmd string) bool {
+	switch cmd {
+	case "cache", "generate", "help", "options", "self-update", "version":
+		return false
+	default:
+		return true
+	}
 }
 
 var logBuffer = bytes.NewBuffer(nil)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

restic generate, help and self-update don't touch any repo, so they don't need to check passwords (let alone run $RESTIC_PASSWORD_COMMAND). This extends the special handling of restic version to also work for those commands.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes #2951.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
