### PR TITLE
local: mark repository files as read-only and handle chmod errors

### DIFF
--- a/changelog/unreleased/issue-1756
+++ b/changelog/unreleased/issue-1756
@@ -1,0 +1,15 @@
+Bugfix: Mark repository files as read-only when using the local backend
+
+Files stored in a local repository were marked as writeable on the
+filesystem for non-Windows systems, which did not prevent accidental file
+modifications outside of restic. In addition, the local backend did not work
+with certain filesystems and network mounts which do not permit modifications
+of file permissions.
+
+restic now marks files stored in a local repository as read-only on the
+filesystem on non-Windows systems. The error handling is improved to support
+more filesystems.
+
+https://github.com/restic/restic/issues/1756
+https://github.com/restic/restic/issues/2157
+https://github.com/restic/restic/pull/2989

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -130,7 +130,14 @@ func (b *Local) Save(ctx context.Context, h restic.Handle, rd restic.RewindReade
 		return errors.Wrap(err, "Close")
 	}
 
-	return setNewFileMode(filename, backend.Modes.File)
+	// ignore if the operation fails as some filesystems don't allow the chmod call
+	// e.g. exfat and network file systems with certain mount options
+	err = setNewFileMode(filename, backend.Modes.File)
+	if err != nil && !os.IsPermission(err) {
+		return errors.Wrap(err, "Chmod")
+	}
+
+	return nil
 }
 
 // Load runs fn with a reader that yields the contents of the file at h at the
@@ -205,7 +212,7 @@ func (b *Local) Remove(ctx context.Context, h restic.Handle) error {
 
 	// reset read-only flag
 	err := fs.Chmod(fn, 0666)
-	if err != nil {
+	if err != nil && !os.IsPermission(err) {
 		return errors.Wrap(err, "Chmod")
 	}
 

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -130,9 +130,10 @@ func (b *Local) Save(ctx context.Context, h restic.Handle, rd restic.RewindReade
 		return errors.Wrap(err, "Close")
 	}
 
+	// try to mark file as read-only to avoid accidential modifications
 	// ignore if the operation fails as some filesystems don't allow the chmod call
 	// e.g. exfat and network file systems with certain mount options
-	err = setNewFileMode(filename, backend.Modes.File)
+	err = setFileReadonly(filename, backend.Modes.File)
 	if err != nil && !os.IsPermission(err) {
 		return errors.Wrap(err, "Chmod")
 	}

--- a/internal/backend/local/local_unix.go
+++ b/internal/backend/local/local_unix.go
@@ -9,6 +9,6 @@ import (
 )
 
 // set file to readonly
-func setNewFileMode(f string, mode os.FileMode) error {
-	return fs.Chmod(f, mode)
+func setFileReadonly(f string, mode os.FileMode) error {
+	return fs.Chmod(f, mode&^0222)
 }

--- a/internal/backend/local/local_windows.go
+++ b/internal/backend/local/local_windows.go
@@ -7,6 +7,6 @@ import (
 // We don't modify read-only on windows,
 // since it will make us unable to delete the file,
 // and this isn't common practice on this platform.
-func setNewFileMode(f string, mode os.FileMode) error {
+func setFileReadonly(f string, mode os.FileMode) error {
 	return nil
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Files stored by the local backend in a repository should be marked as readonly to prevent accidental modifications. However this was accidentally removed in #1258. This PR reintroduces this behavior. In addition permissions errors for the `chmod` calls are now ignored. These could cause problems with certain mounted filesystems, see #1756 and #2157.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
closes #1756
closes #2157

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
