### PR TITLE
cache/check: Clarify error message when given arguments

### DIFF
--- a/cmd/restic/cmd_cache.go
+++ b/cmd/restic/cmd_cache.go
@@ -51,7 +51,7 @@ func init() {
 
 func runCache(opts CacheOptions, gopts GlobalOptions, args []string) error {
 	if len(args) > 0 {
-		return errors.Fatal("the cache command has no arguments")
+		return errors.Fatal("the cache command expects no arguments, only options - please see `restic help cache` for usage and flags")
 	}
 
 	if gopts.NoCache {

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -142,7 +142,7 @@ func prepareCheckCache(opts CheckOptions, gopts *GlobalOptions) (cleanup func())
 
 func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	if len(args) != 0 {
-		return errors.Fatal("check has no arguments")
+		return errors.Fatal("the check command expects no arguments, only options - please see `restic help check` for usage and flags")
 	}
 
 	cleanup := prepareCheckCache(opts, &gopts)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Clarifies error message given when one invokes the `cache` and `check` commands *with* arguments (not options/flags), which neither command accept.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #1812.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
