### PR TITLE
Speedup exclude/include checking

### DIFF
--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -140,13 +140,15 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		return nil
 	}
 
+	excludePatterns := filter.ParsePatterns(opts.Exclude)
+	insensitiveExcludePatterns := filter.ParsePatterns(opts.InsensitiveExclude)
 	selectExcludeFilter := func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
-		matched, _, err := filter.List(opts.Exclude, item)
+		matched, _, err := filter.List(excludePatterns, item)
 		if err != nil {
 			Warnf("error for exclude pattern: %v", err)
 		}
 
-		matchedInsensitive, _, err := filter.List(opts.InsensitiveExclude, strings.ToLower(item))
+		matchedInsensitive, _, err := filter.List(insensitiveExcludePatterns, strings.ToLower(item))
 		if err != nil {
 			Warnf("error for iexclude pattern: %v", err)
 		}
@@ -161,13 +163,15 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		return selectedForRestore, childMayBeSelected
 	}
 
+	includePatterns := filter.ParsePatterns(opts.Include)
+	insensitiveIncludePatterns := filter.ParsePatterns(opts.InsensitiveInclude)
 	selectIncludeFilter := func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
-		matched, childMayMatch, err := filter.List(opts.Include, item)
+		matched, childMayMatch, err := filter.List(includePatterns, item)
 		if err != nil {
 			Warnf("error for include pattern: %v", err)
 		}
 
-		matchedInsensitive, childMayMatchInsensitive, err := filter.List(opts.InsensitiveInclude, strings.ToLower(item))
+		matchedInsensitive, childMayMatchInsensitive, err := filter.List(insensitiveIncludePatterns, strings.ToLower(item))
 		if err != nil {
 			Warnf("error for iexclude pattern: %v", err)
 		}

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -143,12 +143,12 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 	excludePatterns := filter.ParsePatterns(opts.Exclude)
 	insensitiveExcludePatterns := filter.ParsePatterns(opts.InsensitiveExclude)
 	selectExcludeFilter := func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
-		matched, _, err := filter.List(excludePatterns, item)
+		matched, err := filter.List(excludePatterns, item)
 		if err != nil {
 			Warnf("error for exclude pattern: %v", err)
 		}
 
-		matchedInsensitive, _, err := filter.List(insensitiveExcludePatterns, strings.ToLower(item))
+		matchedInsensitive, err := filter.List(insensitiveExcludePatterns, strings.ToLower(item))
 		if err != nil {
 			Warnf("error for iexclude pattern: %v", err)
 		}
@@ -166,12 +166,12 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 	includePatterns := filter.ParsePatterns(opts.Include)
 	insensitiveIncludePatterns := filter.ParsePatterns(opts.InsensitiveInclude)
 	selectIncludeFilter := func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
-		matched, childMayMatch, err := filter.List(includePatterns, item)
+		matched, childMayMatch, err := filter.ListWithChild(includePatterns, item)
 		if err != nil {
 			Warnf("error for include pattern: %v", err)
 		}
 
-		matchedInsensitive, childMayMatchInsensitive, err := filter.List(insensitiveIncludePatterns, strings.ToLower(item))
+		matchedInsensitive, childMayMatchInsensitive, err := filter.ListWithChild(insensitiveIncludePatterns, strings.ToLower(item))
 		if err != nil {
 			Warnf("error for iexclude pattern: %v", err)
 		}

--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -74,8 +74,9 @@ type RejectFunc func(path string, fi os.FileInfo) bool
 // rejectByPattern returns a RejectByNameFunc which rejects files that match
 // one of the patterns.
 func rejectByPattern(patterns []string) RejectByNameFunc {
+	parsedPatterns := filter.ParsePatterns(patterns)
 	return func(item string) bool {
-		matched, _, err := filter.List(patterns, item)
+		matched, _, err := filter.List(parsedPatterns, item)
 		if err != nil {
 			Warnf("error for exclude pattern: %v", err)
 		}

--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -76,7 +76,7 @@ type RejectFunc func(path string, fi os.FileInfo) bool
 func rejectByPattern(patterns []string) RejectByNameFunc {
 	parsedPatterns := filter.ParsePatterns(patterns)
 	return func(item string) bool {
-		matched, _, err := filter.List(parsedPatterns, item)
+		matched, err := filter.List(parsedPatterns, item)
 		if err != nil {
 			Warnf("error for exclude pattern: %v", err)
 		}

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -149,8 +149,13 @@ func match(patterns Pattern, strs []string) (matched bool, err error) {
 	}
 
 	if len(patterns) <= len(strs) {
+		maxOffset := len(strs) - len(patterns)
+		// special case absolute patterns
+		if patterns[0] == "" {
+			maxOffset = 0
+		}
 	outer:
-		for offset := len(strs) - len(patterns); offset >= 0; offset-- {
+		for offset := maxOffset; offset >= 0; offset-- {
 
 			for i := len(patterns) - 1; i >= 0; i-- {
 				ok, err := filepath.Match(patterns[i], strs[offset+i])

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -194,7 +194,18 @@ func ParsePatterns(patterns []string) []Pattern {
 }
 
 // List returns true if str matches one of the patterns. Empty patterns are ignored.
-func List(patterns []Pattern, str string) (matched bool, childMayMatch bool, err error) {
+func List(patterns []Pattern, str string) (matched bool, err error) {
+	matched, _, err = list(patterns, false, str)
+	return matched, err
+}
+
+// ListWithChild returns true if str matches one of the patterns. Empty patterns are ignored.
+func ListWithChild(patterns []Pattern, str string) (matched bool, childMayMatch bool, err error) {
+	return list(patterns, true, str)
+}
+
+// List returns true if str matches one of the patterns. Empty patterns are ignored.
+func list(patterns []Pattern, checkChildMatches bool, str string) (matched bool, childMayMatch bool, err error) {
 	if len(patterns) == 0 {
 		return false, false, nil
 	}
@@ -209,9 +220,14 @@ func List(patterns []Pattern, str string) (matched bool, childMayMatch bool, err
 			return false, false, err
 		}
 
-		c, err := childMatch(pat, strs)
-		if err != nil {
-			return false, false, err
+		var c bool
+		if checkChildMatches {
+			c, err = childMatch(pat, strs)
+			if err != nil {
+				return false, false, err
+			}
+		} else {
+			c = true
 		}
 
 		matched = matched || m

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -123,11 +123,15 @@ func hasDoubleWildcard(list Pattern) (ok bool, pos int) {
 func match(patterns Pattern, strs []string) (matched bool, err error) {
 	if ok, pos := hasDoubleWildcard(patterns); ok {
 		// gradually expand '**' into separate wildcards
+		newPat := make(Pattern, len(strs))
+		// copy static prefix once
+		copy(newPat, patterns[:pos])
 		for i := 0; i <= len(strs)-len(patterns)+1; i++ {
-			newPat := make(Pattern, pos)
-			copy(newPat, patterns[:pos])
-			for k := 0; k < i; k++ {
-				newPat = append(newPat, "*")
+			// limit to static prefix and already appended '*'
+			newPat := newPat[:pos+i]
+			// in the first iteration the wildcard expands to nothing
+			if i > 0 {
+				newPat[pos+i-1] = "*"
 			}
 			newPat = append(newPat, patterns[pos+1:]...)
 

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -24,21 +24,13 @@ func prepareStr(str string) ([]string, error) {
 		return nil, ErrBadString
 	}
 
-	// convert file path separator to '/'
-	if filepath.Separator != '/' {
-		str = strings.Replace(str, string(filepath.Separator), "/", -1)
-	}
-
+	str = filepath.ToSlash(str)
 	return strings.Split(str, "/"), nil
 }
 
 func preparePattern(pattern string) Pattern {
 	pattern = filepath.Clean(pattern)
-
-	// convert file path separator to '/'
-	if filepath.Separator != '/' {
-		pattern = strings.Replace(pattern, string(filepath.Separator), "/", -1)
-	}
+	pattern = filepath.ToSlash(pattern)
 
 	parts := strings.Split(pattern, "/")
 	patterns := make([]patternPart, len(parts))

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -167,13 +167,17 @@ func match(patterns Pattern, strs []string) (matched bool, err error) {
 	}
 
 	if len(patterns) <= len(strs) {
+		minOffset := 0
 		maxOffset := len(strs) - len(patterns)
 		// special case absolute patterns
 		if patterns[0].pattern == "/" {
 			maxOffset = 0
+		} else if strs[0] == "/" {
+			// skip absolute path marker if pattern is not rooted
+			minOffset = 1
 		}
 	outer:
-		for offset := maxOffset; offset >= 0; offset-- {
+		for offset := maxOffset; offset >= minOffset; offset-- {
 
 			for i := len(patterns) - 1; i >= 0; i-- {
 				var ok bool

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -240,21 +240,22 @@ func ExampleMatch_wildcards() {
 }
 
 var filterListTests = []struct {
-	patterns []string
-	path     string
-	match    bool
+	patterns   []string
+	path       string
+	match      bool
+	childMatch bool
 }{
-	{[]string{}, "/foo/bar/test.go", false},
-	{[]string{"*.go"}, "/foo/bar/test.go", true},
-	{[]string{"*.c"}, "/foo/bar/test.go", false},
-	{[]string{"*.go", "*.c"}, "/foo/bar/test.go", true},
-	{[]string{"*"}, "/foo/bar/test.go", true},
-	{[]string{"x"}, "/foo/bar/test.go", false},
-	{[]string{"?"}, "/foo/bar/test.go", false},
-	{[]string{"?", "x"}, "/foo/bar/x", true},
-	{[]string{"/*/*/bar/test.*"}, "/foo/bar/test.go", false},
-	{[]string{"/*/*/bar/test.*", "*.go"}, "/foo/bar/test.go", true},
-	{[]string{"", "*.c"}, "/foo/bar/test.go", false},
+	{[]string{}, "/foo/bar/test.go", false, false},
+	{[]string{"*.go"}, "/foo/bar/test.go", true, true},
+	{[]string{"*.c"}, "/foo/bar/test.go", false, true},
+	{[]string{"*.go", "*.c"}, "/foo/bar/test.go", true, true},
+	{[]string{"*"}, "/foo/bar/test.go", true, true},
+	{[]string{"x"}, "/foo/bar/test.go", false, true},
+	{[]string{"?"}, "/foo/bar/test.go", false, true},
+	{[]string{"?", "x"}, "/foo/bar/x", true, true},
+	{[]string{"/*/*/bar/test.*"}, "/foo/bar/test.go", false, false},
+	{[]string{"/*/*/bar/test.*", "*.go"}, "/foo/bar/test.go", true, true},
+	{[]string{"", "*.c"}, "/foo/bar/test.go", false, true},
 }
 
 func TestList(t *testing.T) {
@@ -268,8 +269,20 @@ func TestList(t *testing.T) {
 		}
 
 		if match != test.match {
-			t.Errorf("test %d: filter.MatchList(%q, %q): expected %v, got %v",
+			t.Errorf("test %d: filter.List(%q, %q): expected %v, got %v",
 				i, test.patterns, test.path, test.match, match)
+		}
+
+		match, childMatch, err := filter.ListWithChild(patterns, test.path)
+		if err != nil {
+			t.Errorf("test %d failed: expected no error for patterns %q, but error returned: %v",
+				i, test.patterns, err)
+			continue
+		}
+
+		if match != test.match || childMatch != test.childMatch {
+			t.Errorf("test %d: filter.ListWithChild(%q, %q): expected %v, %v, got %v, %v",
+				i, test.patterns, test.path, test.match, test.childMatch, match, childMatch)
 		}
 	}
 }

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -244,6 +244,7 @@ var filterListTests = []struct {
 	path     string
 	match    bool
 }{
+	{[]string{}, "/foo/bar/test.go", false},
 	{[]string{"*.go"}, "/foo/bar/test.go", true},
 	{[]string{"*.c"}, "/foo/bar/test.go", false},
 	{[]string{"*.go", "*.c"}, "/foo/bar/test.go", true},
@@ -277,6 +278,38 @@ func ExampleList() {
 	fmt.Printf("match: %v\n", match)
 	// Output:
 	// match: true
+}
+
+func TestInvalidStrs(t *testing.T) {
+	_, err := filter.Match("test", "")
+	if err == nil {
+		t.Error("Match accepted invalid path")
+	}
+
+	_, err = filter.ChildMatch("test", "")
+	if err == nil {
+		t.Error("ChildMatch accepted invalid path")
+	}
+
+	patterns := []string{"test"}
+	_, _, err = filter.List(patterns, "")
+	if err == nil {
+		t.Error("List accepted invalid path")
+	}
+}
+
+func TestInvalidPattern(t *testing.T) {
+	patterns := []string{"test/["}
+	_, _, err := filter.List(patterns, "test/example")
+	if err == nil {
+		t.Error("List accepted invalid pattern")
+	}
+
+	patterns = []string{"test/**/["}
+	_, _, err = filter.List(patterns, "test/example")
+	if err == nil {
+		t.Error("List accepted invalid pattern")
+	}
 }
 
 func extractTestLines(t testing.TB) (lines []string) {

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -260,7 +260,7 @@ var filterListTests = []struct {
 func TestList(t *testing.T) {
 	for i, test := range filterListTests {
 		patterns := filter.ParsePatterns(test.patterns)
-		match, _, err := filter.List(patterns, test.path)
+		match, err := filter.List(patterns, test.path)
 		if err != nil {
 			t.Errorf("test %d failed: expected no error for patterns %q, but error returned: %v",
 				i, test.patterns, err)
@@ -276,7 +276,7 @@ func TestList(t *testing.T) {
 
 func ExampleList() {
 	patterns := filter.ParsePatterns([]string{"*.c", "*.go"})
-	match, _, _ := filter.List(patterns, "/home/user/file.go")
+	match, _ := filter.List(patterns, "/home/user/file.go")
 	fmt.Printf("match: %v\n", match)
 	// Output:
 	// match: true
@@ -294,7 +294,7 @@ func TestInvalidStrs(t *testing.T) {
 	}
 
 	patterns := []string{"test"}
-	_, _, err = filter.List(filter.ParsePatterns(patterns), "")
+	_, err = filter.List(filter.ParsePatterns(patterns), "")
 	if err == nil {
 		t.Error("List accepted invalid path")
 	}
@@ -302,13 +302,13 @@ func TestInvalidStrs(t *testing.T) {
 
 func TestInvalidPattern(t *testing.T) {
 	patterns := []string{"test/["}
-	_, _, err := filter.List(filter.ParsePatterns(patterns), "test/example")
+	_, err := filter.List(filter.ParsePatterns(patterns), "test/example")
 	if err == nil {
 		t.Error("List accepted invalid pattern")
 	}
 
 	patterns = []string{"test/**/["}
-	_, _, err = filter.List(filter.ParsePatterns(patterns), "test/example")
+	_, err = filter.List(filter.ParsePatterns(patterns), "test/example")
 	if err == nil {
 		t.Error("List accepted invalid pattern")
 	}
@@ -435,7 +435,7 @@ func BenchmarkFilterPatterns(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				c = 0
 				for _, line := range lines {
-					match, _, err := filter.List(test.patterns, line)
+					match, err := filter.List(test.patterns, line)
 					if err != nil {
 						b.Fatal(err)
 					}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Backup (and restore) slow down a lot if a large number of excludes is used, see e.g. #2694. This PR optimizes the pattern processing to reduce the number and size of memory allocations. In total this speeds up the benchmarks by a factor between 5 and 100:

```
name                          old time/op    new time/op    delta
FilterPatterns/Relative-4       62.1ms ±15%    11.0ms ± 2%  -82.25%  (p=0.000 n=9+10)
FilterPatterns/Absolute-4        111ms ±10%       9ms ± 3%  -92.24%  (p=0.000 n=10+10)
FilterPatterns/Wildcard-4        393ms ±15%      36ms ± 2%  -90.73%  (p=0.000 n=10+9)
FilterPatterns/ManyNoMatch-4     10.0s ± 3%      0.1s ± 6%  -98.98%  (p=0.000 n=10+9)

name                          old alloc/op   new alloc/op   delta
FilterPatterns/Relative-4       16.4MB ± 0%     3.6MB ± 0%  -78.25%  (p=0.000 n=10+9)
FilterPatterns/Absolute-4       31.4MB ± 0%     3.6MB ± 0%  -88.62%  (p=0.000 n=9+10)
FilterPatterns/Wildcard-4        168MB ± 0%      20MB ± 0%  -88.25%  (p=0.000 n=10+10)
FilterPatterns/ManyNoMatch-4    3.23GB ± 0%    0.00GB ± 0%  -99.89%  (p=0.000 n=10+10)

name                          old allocs/op  new allocs/op  delta
FilterPatterns/Relative-4         178k ± 0%       22k ± 0%  -87.50%  (p=0.000 n=10+10)
FilterPatterns/Absolute-4         266k ± 0%       22k ± 0%  -91.67%  (p=0.000 n=10+10)
FilterPatterns/Wildcard-4        1.87M ± 0%     0.09M ± 0%  -95.27%  (p=0.000 n=10+10)
FilterPatterns/ManyNoMatch-4     17.7M ± 0%      0.0M ± 0%  -99.88%  (p=0.000 n=9+10)
```

The`ManyNoMatch` test uses 200 exclude patterns which are suffixed such that these do not match any filenames, but require matching against the full pattern which is the worst-case performance wise. Originally I've tried to add all 22k tested filepaths to the filter patterns, however that was way too slow.

Assuming restic should be able to check 20k excludes per second (i.e., 1.2 million excludes per minute), one "op" of the `ManyNoMatch` benchmark shouldn't take much more than one seconds. With the optimizations I'm currently able to increase the number of exclude pattern to 2000.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The exclude performance problems were in parts discussed in #2694.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR **The code already had a lot of tests, I've added some special case tests to increase coverage to 95%**
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
