### PR TITLE
Systematize documentation of environment variables

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -416,6 +416,8 @@ environment variables. The following lists these environment variables:
     RESTIC_CACHE_DIR                    Location of the cache directory
     RESTIC_PROGRESS_FPS                 Frames per second by which the progress bar is updated
 
+    TMPDIR                              Location for temporary files
+
     AWS_ACCESS_KEY_ID                   Amazon S3 access key ID
     AWS_SECRET_ACCESS_KEY               Amazon S3 secret access key
     AWS_DEFAULT_REGION                  Amazon S3 default region
@@ -453,12 +455,12 @@ environment variables. The following lists these environment variables:
 
     RCLONE_BWLIMIT                      rclone bandwidth limit
 
-In addition to restic-specific environment variables, the following system-wide environment variables
-are taken into account for various operations:
+See :ref:`caching` for the rules concerning cache locations when
+``RESTIC_CACHE_DIR`` is not set.
 
- * ``$XDG_CACHE_HOME/restic``, ``$HOME/.cache/restic``: :ref:`caching`.
- * ``$TMPDIR``: :ref:`temporary_files`.
- * ``$PATH/fusermount``: Binary for ``restic mount``.
+The external programs that restic may execute include ``rclone`` (for rclone
+backends) and ``ssh`` (for the SFTP backend). These may respond to further
+environment variables and configuration files; see their respective manuals.
 
 
 Exit status codes

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -71,10 +71,11 @@ command to serve the repository with FUSE:
     Now serving /srv/restic-repo at /mnt/restic
     When finished, quit with Ctrl-c or umount the mountpoint.
 
-Mounting repositories via FUSE is not possible on OpenBSD, Solaris/illumos
-and Windows. For Linux, the ``fuse`` kernel module needs to be loaded. For
-FreeBSD, you may need to install FUSE and load the kernel module (``kldload
-fuse``).
+Mounting repositories via FUSE is only possible on Linux, macOS and FreeBSD.
+On Linux, the ``fuse`` kernel module needs to be loaded and the ``fusermount``
+command needs to be in the ``PATH``. On macOS, you need `FUSE for macOS
+<https://osxfuse.github.io/>`__. On FreeBSD, you may need to install FUSE
+and load the kernel module (``kldload fuse``).
 
 Restic supports storage and preservation of hard links. However, since
 hard links exist in the scope of a filesystem by definition, restoring

--- a/doc/cache.rst
+++ b/doc/cache.rst
@@ -3,22 +3,12 @@ Local Cache
 ***********
 
 In order to speed up certain operations, restic manages a local cache of data.
-This document describes the data structures for the local cache with version 1.
+The location of the cache directory depends on the operating system and the
+environment; see :ref:`caching`.
 
-Versions
-========
-
-The cache directory is selected according to the `XDG base dir specification
-<https://standards.freedesktop.org/basedir-spec/basedir-spec-latest.html>`__.
 Each repository has its own cache sub-directory, consisting of the repository ID
 which is chosen at ``init``. All cache directories for different repos are
 independent of each other.
-
-The cache dir for a repo contains a file named ``version``, which contains a
-single ASCII integer line that stands for the current version of the cache. If
-a lower version number is found the cache is recreated with the current
-version. If a higher version number is found the cache is ignored and left as
-is.
 
 Snapshots, Data and Indexes
 ===========================

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -398,9 +398,13 @@ This allows faster operations, since meta data does not need to be loaded from
 a remote repository. The cache is automatically created, usually in an
 OS-specific cache folder:
 
- * Linux/other: ``~/.cache/restic`` (or ``$XDG_CACHE_HOME/restic``)
+ * Linux/other: ``$XDG_CACHE_HOME/restic``, or ``~/.cache/restic`` if
+   ``XDG_CACHE_HOME`` is not set
  * macOS: ``~/Library/Caches/restic``
  * Windows: ``%LOCALAPPDATA%/restic``
+
+If the relevant environment variables are not set, restic exits with an error
+message.
 
 The command line parameter ``--cache-dir`` or the environment variable
 ``$RESTIC_CACHE_DIR`` can be used to override the default cache location.  The


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Cleans up the documentation of restic backup's environment variables.

Cache locations were documented inconsistently in three places.

The backup docs mentioned PATH being used to find fusermount, which is never run by restic backup, while not mentioning rclone and ssh. 

The notion of a "system-wide" environment variable makes no sense, so I 
put everything in one table.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Follow-up to #2769.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added documentation for the changes (in the manual)
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
