### PR TITLE
Call enterDir/leaveDir if a directory's child may be selected

### DIFF
--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -104,7 +104,7 @@ func (res *Restorer) traverseTree(ctx context.Context, target, location string, 
 				return errors.Errorf("Dir without subtree in tree %v", treeID.Str())
 			}
 
-			if selectedForRestore {
+			if selectedForRestore || childMayBeSelected {
 				err = sanitizeError(visitor.enterDir(node, nodeTarget, nodeLocation))
 				if err != nil {
 					return err
@@ -118,7 +118,7 @@ func (res *Restorer) traverseTree(ctx context.Context, target, location string, 
 				}
 			}
 
-			if selectedForRestore {
+			if selectedForRestore || childMayBeSelected {
 				err = sanitizeError(visitor.leaveDir(node, nodeTarget, nodeLocation))
 				if err != nil {
 					return err
@@ -209,11 +209,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 
 	// first tree pass: create directories and collect all files to restore
 	err = res.traverseTree(ctx, dst, string(filepath.Separator), *res.sn.Tree, treeVisitor{
-		enterDir: func(node *restic.Node, target, location string) error {
-			// create dir with default permissions
-			// #leaveDir restores dir metadata after visiting all children
-			return fs.MkdirAll(target, 0700)
-		},
+		enterDir: noop,
 
 		visitNode: func(node *restic.Node, target, location string) error {
 			// create parent dir with default permissions


### PR DESCRIPTION
This allows leaveDir to set metadata properly for directories
with descendants that are selected by an include filter, even
if the directory in question isn't selected by that filter.

For example, let's say you have the following file in your repo:

    /home/user/nested/data/values.txt

...and / and /home are owned by root, but /home/user and below are owned
by user.

If you run "restic restore -i /home/user/nested/data -t /tmp/restore $SNAPSHOT" as root,
/home/user/nested/ will currently be restored with root as the owner,
even though it's supposed to be owned by user.

This change makes sure that leaveDir is called to restore metadata to
nodes like /home/user/nested - enterDir is also called under the same
circumstances for purposes of symmetry.

This fixes GH #1402 and (I think) GH #2563



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR changes directory traversal logic when restoring a snapshot, and it fixes a bug around restoration of metadata.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

This PR closes #1402 and closes #2563 

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
