### PR TITLE
Fix #1681 mount: change behavior of `restic mount` when path doesn't exist

### DIFF
--- a/changelog/unreleased/issue-1681
+++ b/changelog/unreleased/issue-1681
@@ -1,0 +1,9 @@
+Bugfix: Make mount not create missing mount point
+
+When specifying a non-existent directory as mount point for the mount
+command, restic used to create the directory automatically. This has now
+changed such that restic instead gives an error when the directory for the
+mount point doesn't exist.
+
+https://github.com/restic/restic/issues/1681
+https://github.com/restic/restic/pull/3008

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -104,11 +104,8 @@ func mount(opts MountOptions, gopts GlobalOptions, mountpoint string) error {
 	}
 
 	if _, err := resticfs.Stat(mountpoint); os.IsNotExist(errors.Cause(err)) {
-		Verbosef("Mountpoint %s doesn't exist, creating it\n", mountpoint)
-		err = resticfs.Mkdir(mountpoint, os.ModeDir|0700)
-		if err != nil {
-			return err
-		}
+		Verbosef("Mountpoint %s doesn't exist\n", mountpoint)
+		return err
 	}
 
 	mountOptions := []systemFuse.MountOption{

--- a/cmd/restic/integration_fuse_test.go
+++ b/cmd/restic/integration_fuse_test.go
@@ -163,9 +163,6 @@ func TestMount(t *testing.T) {
 	repo, err := OpenRepository(env.gopts)
 	rtest.OK(t, err)
 
-	// We remove the mountpoint now to check that cmdMount creates it
-	rtest.RemoveAll(t, env.mountpoint)
-
 	checkSnapshots(t, env.gopts, repo, env.mountpoint, env.repo, []restic.ID{}, 0)
 
 	rtest.SetupTarTestFixture(t, env.testdata, filepath.Join("testdata", "backup-data.tar.gz"))


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

The `restic mount` command will not try to create any directory and just fail if the mount point does not exist with explicit messages. The checks of the validity of the mount point (exist and permission) will be done sooner.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
#1681
~~#1724~~
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~I have added tests for all changes in this PR~~
- ~~I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
