### PR TITLE
Rework print functions to better match verbosity levels 

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -436,7 +436,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 
 	var t tomb.Tomb
 
-	if gopts.verbosity >= 2 && !gopts.JSON {
+	if !gopts.JSON {
 		Verbosef("open repository\n")
 	}
 

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -436,9 +436,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 
 	var t tomb.Tomb
 
-	if !gopts.JSON {
-		Verbosef("open repository\n")
-	}
+	Verbosef("open repository\n")
 
 	repo, err := OpenRepository(gopts)
 	if err != nil {

--- a/cmd/restic/cmd_cache.go
+++ b/cmd/restic/cmd_cache.go
@@ -77,11 +77,11 @@ func runCache(opts CacheOptions, gopts GlobalOptions, args []string) error {
 		}
 
 		if len(oldDirs) == 0 {
-			Verbosef("no old cache dirs found\n")
+			PrintDef("no old cache dirs found\n")
 			return nil
 		}
 
-		Verbosef("remove %d old cache directories\n", len(oldDirs))
+		PrintDef("remove %d old cache directories\n", len(oldDirs))
 
 		for _, item := range oldDirs {
 			dir := filepath.Join(cachedir, item.Name())

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -128,7 +128,7 @@ func prepareCheckCache(opts CheckOptions, gopts *GlobalOptions) (cleanup func())
 	}
 
 	gopts.CacheDir = tempdir
-	Verbosef("using temporary cache in %v\n", tempdir)
+	PrintDef("using temporary cache in %v\n", tempdir)
 
 	cleanup = func() {
 		err := fs.RemoveAll(tempdir)
@@ -157,7 +157,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	}
 
 	if !gopts.NoLock {
-		Verbosef("create exclusive lock for repository\n")
+		PrintDef("create exclusive lock for repository\n")
 		lock, err := lockRepoExclusive(gopts.ctx, repo)
 		defer unlockRepo(lock)
 		if err != nil {
@@ -167,7 +167,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 
 	chkr := checker.New(repo)
 
-	Verbosef("load indexes\n")
+	PrintDef("load indexes\n")
 	hints, errs := chkr.LoadIndex(gopts.ctx)
 
 	dupFound := false
@@ -193,13 +193,13 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	orphanedPacks := 0
 	errChan := make(chan error)
 
-	Verbosef("check all packs\n")
+	PrintDef("check all packs\n")
 	go chkr.Packs(gopts.ctx, errChan)
 
 	for err := range errChan {
 		if checker.IsOrphanedPack(err) {
 			orphanedPacks++
-			Verbosef("%v\n", err)
+			PrintDef("%v\n", err)
 			continue
 		}
 		errorsFound = true
@@ -207,10 +207,10 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	}
 
 	if orphanedPacks > 0 {
-		Verbosef("%d additional files were found in the repo, which likely contain duplicate data.\nYou can run `restic prune` to correct this.\n", orphanedPacks)
+		PrintDef("%d additional files were found in the repo, which likely contain duplicate data.\nYou can run `restic prune` to correct this.\n", orphanedPacks)
 	}
 
-	Verbosef("check snapshots, trees and blobs\n")
+	PrintDef("check snapshots, trees and blobs\n")
 	errChan = make(chan error)
 	go chkr.Structure(gopts.ctx, errChan)
 
@@ -228,7 +228,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 
 	if opts.CheckUnused {
 		for _, id := range chkr.UnusedBlobs() {
-			Verbosef("unused blob %v\n", id)
+			PrintDef("unused blob %v\n", id)
 			errorsFound = true
 		}
 	}
@@ -245,9 +245,9 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 		packCount := uint64(len(packs))
 
 		if packCount < chkr.CountPacks() {
-			Verbosef(fmt.Sprintf("read group #%d of %d data packs (out of total %d packs in %d groups)\n", bucket, packCount, chkr.CountPacks(), totalBuckets))
+			PrintDef(fmt.Sprintf("read group #%d of %d data packs (out of total %d packs in %d groups)\n", bucket, packCount, chkr.CountPacks(), totalBuckets))
 		} else {
-			Verbosef("read all data\n")
+			PrintDef("read all data\n")
 		}
 
 		p := newProgressMax(!gopts.Quiet, packCount, "packs")
@@ -273,7 +273,7 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 		return errors.Fatal("repository contains errors")
 	}
 
-	Verbosef("no errors were found\n")
+	PrintDef("no errors were found\n")
 
 	return nil
 }

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -104,7 +104,7 @@ func runCopy(opts CopyOptions, gopts GlobalOptions, args []string) error {
 	}
 
 	for sn := range FindFilteredSnapshots(ctx, srcRepo, opts.Hosts, opts.Tags, opts.Paths, args) {
-		Verbosef("\nsnapshot %s of %v at %s)\n", sn.ID().Str(), sn.Paths, sn.Time)
+		PrintDef("\nsnapshot %s of %v at %s)\n", sn.ID().Str(), sn.Paths, sn.Time)
 
 		// check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
 		srcOriginal := *sn.ID()
@@ -115,7 +115,7 @@ func runCopy(opts CopyOptions, gopts GlobalOptions, args []string) error {
 			isCopy := false
 			for _, originalSn := range originalSns {
 				if similarSnapshots(originalSn, sn) {
-					Verbosef("skipping source snapshot %s, was already copied to snapshot %s\n", sn.ID().Str(), originalSn.ID().Str())
+					PrintDef("skipping source snapshot %s, was already copied to snapshot %s\n", sn.ID().Str(), originalSn.ID().Str())
 					isCopy = true
 					break
 				}
@@ -124,7 +124,7 @@ func runCopy(opts CopyOptions, gopts GlobalOptions, args []string) error {
 				continue
 			}
 		}
-		Verbosef("  copy started, this may take a while...\n")
+		PrintDef("  copy started, this may take a while...\n")
 
 		if err := cloner.copyTree(ctx, *sn.Tree); err != nil {
 			return err
@@ -146,7 +146,7 @@ func runCopy(opts CopyOptions, gopts GlobalOptions, args []string) error {
 		if err != nil {
 			return err
 		}
-		Verbosef("snapshot %s saved\n", newID.Str())
+		PrintDef("snapshot %s saved\n", newID.Str())
 	}
 	return nil
 }

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -349,7 +349,7 @@ func runDiff(opts DiffOptions, gopts GlobalOptions, args []string) error {
 		return err
 	}
 
-	Verbosef("comparing snapshot %v to %v:\n\n", sn1.ID().Str(), sn2.ID().Str())
+	PrintDef("comparing snapshot %v to %v:\n\n", sn1.ID().Str(), sn2.ID().Str())
 
 	if sn1.Tree == nil {
 		return errors.Errorf("snapshot %v has nil tree", sn1.ID().Str())

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -163,10 +163,10 @@ func (s *statefulOutput) PrintPatternJSON(path string, node *restic.Node) {
 func (s *statefulOutput) PrintPatternNormal(path string, node *restic.Node) {
 	if s.newsn != s.oldsn {
 		if s.oldsn != nil {
-			Verbosef("\n")
+			PrintDef("\n")
 		}
 		s.oldsn = s.newsn
-		Verbosef("Found matching entries in snapshot %s from %s\n", s.oldsn.ID().Str(), s.oldsn.Time.Local().Format(TimeFormat))
+		PrintDef("Found matching entries in snapshot %s from %s\n", s.oldsn.ID().Str(), s.oldsn.Time.Local().Format(TimeFormat))
 	}
 	Println(formatNode(path, node, s.ListLong))
 }

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -130,13 +130,13 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 
 		if policy.Empty() && len(args) == 0 {
 			if !gopts.JSON {
-				Verbosef("no policy was specified, no snapshots will be removed\n")
+				PrintDef("no policy was specified, no snapshots will be removed\n")
 			}
 		}
 
 		if !policy.Empty() {
 			if !gopts.JSON {
-				Verbosef("Applying Policy: %v\n", policy)
+				PrintDef("Applying Policy: %v\n", policy)
 			}
 
 			for k, snapshotGroup := range snapshotGroups {

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -129,18 +129,14 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 		}
 
 		if policy.Empty() && len(args) == 0 {
-			if !gopts.JSON {
-				PrintDef("no policy was specified, no snapshots will be removed\n")
-			}
+			PrintDef("no policy was specified, no snapshots will be removed\n")
 		}
 
 		if !policy.Empty() {
-			if !gopts.JSON {
-				PrintDef("Applying Policy: %v\n", policy)
-			}
+			PrintDef("Applying Policy: %v\n", policy)
 
 			for k, snapshotGroup := range snapshotGroups {
-				if gopts.Verbose >= 1 && !gopts.JSON {
+				if !gopts.Quiet && !gopts.JSON {
 					err = PrintSnapshotGroupHeader(gopts.stdout, k)
 					if err != nil {
 						return err
@@ -191,9 +187,7 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 				return err
 			}
 		} else {
-			if !gopts.JSON {
-				Printf("Would have removed the following snapshots:\n%v\n\n", removeSnIDs)
-			}
+			Printf("Would have removed the following snapshots:\n%v\n\n", removeSnIDs)
 		}
 	}
 

--- a/cmd/restic/cmd_generate.go
+++ b/cmd/restic/cmd_generate.go
@@ -54,17 +54,17 @@ func writeManpages(dir string) error {
 		Date:    &date,
 	}
 
-	Verbosef("writing man pages to directory %v\n", dir)
+	PrintDef("writing man pages to directory %v\n", dir)
 	return doc.GenManTree(cmdRoot, header, dir)
 }
 
 func writeBashCompletion(file string) error {
-	Verbosef("writing bash completion file to %v\n", file)
+	PrintDef("writing bash completion file to %v\n", file)
 	return cmdRoot.GenBashCompletionFile(file)
 }
 
 func writeZSHCompletion(file string) error {
-	Verbosef("writing zsh completion file to %v\n", file)
+	PrintDef("writing zsh completion file to %v\n", file)
 	return cmdRoot.GenZshCompletionFile(file)
 }
 

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -76,11 +76,11 @@ func runInit(opts InitOptions, gopts GlobalOptions, args []string) error {
 		return errors.Fatalf("create key in repository at %s failed: %v\n", location.StripPassword(gopts.Repo), err)
 	}
 
-	Verbosef("created restic repository %v at %s\n", s.Config().ID[:10], location.StripPassword(gopts.Repo))
-	Verbosef("\n")
-	Verbosef("Please note that knowledge of your password is required to access\n")
-	Verbosef("the repository. Losing your password means that your data is\n")
-	Verbosef("irrecoverably lost.\n")
+	PrintDef("created restic repository %v at %s\n", s.Config().ID[:10], location.StripPassword(gopts.Repo))
+	PrintDef("\n")
+	PrintDef("Please note that knowledge of your password is required to access\n")
+	PrintDef("the repository. Losing your password means that your data is\n")
+	PrintDef("irrecoverably lost.\n")
 
 	return nil
 }

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -131,7 +131,7 @@ func addKey(gopts GlobalOptions, repo *repository.Repository) error {
 		return errors.Fatalf("creating new key failed: %v\n", err)
 	}
 
-	Verbosef("saved new key as %s\n", id)
+	PrintDef("saved new key as %s\n", id)
 
 	return nil
 }
@@ -147,7 +147,7 @@ func deleteKey(ctx context.Context, repo *repository.Repository, name string) er
 		return err
 	}
 
-	Verbosef("removed key %v\n", name)
+	PrintDef("removed key %v\n", name)
 	return nil
 }
 
@@ -168,7 +168,7 @@ func changePassword(gopts GlobalOptions, repo *repository.Repository) error {
 		return err
 	}
 
-	Verbosef("saved new key as %s\n", id)
+	PrintDef("saved new key as %s\n", id)
 
 	return nil
 }

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -184,7 +184,7 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 		}
 	} else {
 		printSnapshot = func(sn *restic.Snapshot) {
-			Verbosef("snapshot %s of %v filtered by %v at %s):\n", sn.ID().Str(), sn.Paths, dirs, sn.Time)
+			PrintDef("snapshot %s of %v filtered by %v at %s):\n", sn.ID().Str(), sn.Paths, dirs, sn.Time)
 		}
 		printNode = func(path string, node *restic.Node) {
 			Printf("%s\n", formatNode(path, node, lsOptions.ListLong))

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -143,8 +143,8 @@ func mount(opts MountOptions, gopts GlobalOptions, mountpoint string) error {
 	}
 	root := fuse.NewRoot(repo, cfg)
 
-	Printf("Now serving the repository at %s\n", mountpoint)
-	Printf("When finished, quit with Ctrl-c or umount the mountpoint.\n")
+	PrintDef("Now serving the repository at %s\n", mountpoint)
+	PrintDef("When finished, quit with Ctrl-c or umount the mountpoint.\n")
 
 	debug.Log("serving mount at %v", mountpoint)
 	err = fs.Serve(c, root)

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -104,7 +104,7 @@ func mount(opts MountOptions, gopts GlobalOptions, mountpoint string) error {
 	}
 
 	if _, err := resticfs.Stat(mountpoint); os.IsNotExist(errors.Cause(err)) {
-		Verbosef("Mountpoint %s doesn't exist, creating it\n", mountpoint)
+		PrintDef("Mountpoint %s doesn't exist, creating it\n", mountpoint)
 		err = resticfs.Mkdir(mountpoint, os.ModeDir|0700)
 		if err != nil {
 			return err

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -96,7 +96,7 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 		bytes     int64
 	}
 
-	Verbosef("counting files in repo\n")
+	PrintDef("counting files in repo\n")
 	err = repo.List(ctx, restic.PackFile, func(restic.ID, int64) error {
 		stats.packs++
 		return nil
@@ -105,7 +105,7 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 		return err
 	}
 
-	Verbosef("building new index for repo\n")
+	PrintDef("building new index for repo\n")
 
 	bar := newProgressMax(!gopts.Quiet, uint64(stats.packs), "packs")
 	idx, invalidFiles, err := index.New(ctx, repo, restic.NewIDSet(), bar)
@@ -122,7 +122,7 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 		stats.bytes += pack.Size
 		blobs += len(pack.Entries)
 	}
-	Verbosef("repository contains %v packs (%v blobs) with %v\n",
+	PrintDef("repository contains %v packs (%v blobs) with %v\n",
 		len(idx.Packs), blobs, formatBytes(uint64(stats.bytes)))
 
 	blobCount := make(map[restic.BlobHandle]int)
@@ -143,9 +143,9 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 		}
 	}
 
-	Verbosef("processed %d blobs: %d duplicate blobs, %v duplicate\n",
+	PrintDef("processed %d blobs: %d duplicate blobs, %v duplicate\n",
 		stats.blobs, duplicateBlobs, formatBytes(uint64(duplicateBytes)))
-	Verbosef("load all snapshots\n")
+	PrintDef("load all snapshots\n")
 
 	// find referenced blobs
 	snapshots, err := restic.LoadAllSnapshots(ctx, repo)
@@ -173,7 +173,7 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 			"https://github.com/restic/restic/issues/new/choose", missingBlobs)
 	}
 
-	Verbosef("found %d of %d data blobs still in use, removing %d blobs\n",
+	PrintDef("found %d of %d data blobs still in use, removing %d blobs\n",
 		len(usedBlobs), stats.blobs, stats.blobs-len(usedBlobs))
 
 	// find packs that need a rewrite
@@ -202,7 +202,7 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 	// find packs that are unneeded
 	removePacks := restic.NewIDSet()
 
-	Verbosef("will remove %d invalid files\n", len(invalidFiles))
+	PrintDef("will remove %d invalid files\n", len(invalidFiles))
 	for _, id := range invalidFiles {
 		removePacks.Insert(id)
 	}
@@ -233,7 +233,7 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 		rewritePacks.Delete(packID)
 	}
 
-	Verbosef("will delete %d packs and rewrite %d packs, this frees %s\n",
+	PrintDef("will delete %d packs and rewrite %d packs, this frees %s\n",
 		len(removePacks), len(rewritePacks), formatBytes(uint64(removeBytes)))
 
 	var obsoletePacks restic.IDSet
@@ -252,18 +252,18 @@ func pruneRepository(gopts GlobalOptions, repo restic.Repository) error {
 	}
 
 	if len(removePacks) != 0 {
-		Verbosef("remove %d old packs\n", len(removePacks))
+		PrintDef("remove %d old packs\n", len(removePacks))
 		DeleteFiles(gopts, repo, removePacks, restic.PackFile)
 	}
 
-	Verbosef("done\n")
+	PrintDef("done\n")
 	return nil
 }
 
 func getUsedBlobs(gopts GlobalOptions, repo restic.Repository, snapshots []*restic.Snapshot) (usedBlobs restic.BlobSet, err error) {
 	ctx := gopts.ctx
 
-	Verbosef("find data that is still in use for %d snapshots\n", len(snapshots))
+	PrintDef("find data that is still in use for %d snapshots\n", len(snapshots))
 
 	usedBlobs = restic.NewBlobSet()
 

--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -50,7 +50,7 @@ func runRebuildIndex(gopts GlobalOptions) error {
 }
 
 func rebuildIndex(ctx context.Context, repo restic.Repository, ignorePacks restic.IDSet) error {
-	Verbosef("counting files in repo\n")
+	PrintDef("counting files in repo\n")
 
 	var packs uint64
 	err := repo.List(ctx, restic.PackFile, func(restic.ID, int64) error {
@@ -67,13 +67,11 @@ func rebuildIndex(ctx context.Context, repo restic.Repository, ignorePacks resti
 		return err
 	}
 
-	if globalOptions.verbosity >= 2 {
-		for _, id := range invalidFiles {
-			Printf("skipped incomplete pack file: %v\n", id)
-		}
+	for _, id := range invalidFiles {
+		Verbosef("skipped incomplete pack file: %v\n", id)
 	}
 
-	Verbosef("finding old index files\n")
+	PrintDef("finding old index files\n")
 
 	var supersedes restic.IDs
 	err = repo.List(ctx, restic.IndexFile, func(id restic.ID, size int64) error {
@@ -89,9 +87,9 @@ func rebuildIndex(ctx context.Context, repo restic.Repository, ignorePacks resti
 		return errors.Fatalf("unable to save index, last error was: %v", err)
 	}
 
-	Verbosef("saved new indexes as %v\n", ids)
+	PrintDef("saved new indexes as %v\n", ids)
 
-	Verbosef("remove %d old index files\n", len(supersedes))
+	PrintDef("remove %d old index files\n", len(supersedes))
 	err = DeleteFilesChecked(globalOptions, repo, restic.NewIDSet(supersedes...), restic.IndexFile)
 	if err != nil {
 		return errors.Fatalf("unable to remove an old index: %v\n", err)

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -142,7 +142,7 @@ func runRecover(gopts GlobalOptions) error {
 		return errors.Fatalf("unable to save snapshot: %v", err)
 	}
 
-	Printf("saved new snapshot %v\n", id.Str())
+	PrintDef("saved new snapshot %v\n", id.Str())
 
 	return nil
 }

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -49,7 +49,7 @@ func runRecover(gopts GlobalOptions) error {
 		return err
 	}
 
-	Verbosef("load index files\n")
+	PrintDef("load index files\n")
 	if err = repo.LoadIndex(gopts.ctx); err != nil {
 		return err
 	}
@@ -67,11 +67,11 @@ func runRecover(gopts GlobalOptions) error {
 
 	cur := 0
 	max := len(trees)
-	Verbosef("load %d trees\n\n", len(trees))
+	PrintDef("load %d trees\n\n", len(trees))
 
 	for id := range trees {
 		cur++
-		Verbosef("\rtree (%v/%v)", cur, max)
+		PrintDef("\rtree (%v/%v)", cur, max)
 
 		if !trees[id] {
 			trees[id] = false
@@ -92,7 +92,7 @@ func runRecover(gopts GlobalOptions) error {
 			trees[subtree] = true
 		}
 	}
-	Verbosef("\ndone\n")
+	PrintDef("\ndone\n")
 
 	roots := restic.NewIDSet()
 	for id, seen := range trees {
@@ -103,7 +103,7 @@ func runRecover(gopts GlobalOptions) error {
 		roots.Insert(id)
 	}
 
-	Verbosef("found %d roots\n", len(roots))
+	PrintDef("found %d roots\n", len(roots))
 
 	tree := restic.NewTree()
 	for id := range roots {

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -184,14 +184,14 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		res.SelectFilter = selectIncludeFilter
 	}
 
-	Verbosef("restoring %s to %s\n", res.Snapshot(), opts.Target)
+	PrintDef("restoring %s to %s\n", res.Snapshot(), opts.Target)
 
 	err = res.RestoreTo(ctx, opts.Target)
 	if err == nil && opts.Verify {
-		Verbosef("verifying files in %s\n", opts.Target)
+		PrintDef("verifying files in %s\n", opts.Target)
 		var count int
 		count, err = res.VerifyFiles(ctx, opts.Target)
-		Verbosef("finished verifying %d files in %s\n", count, opts.Target)
+		PrintDef("finished verifying %d files in %s\n", count, opts.Target)
 	}
 	if totalErrors > 0 {
 		Printf("There were %d errors\n", totalErrors)

--- a/cmd/restic/cmd_self_update.go
+++ b/cmd/restic/cmd_self_update.go
@@ -71,7 +71,7 @@ func runSelfUpdate(opts SelfUpdateOptions, gopts GlobalOptions, args []string) e
 		}
 	}
 
-	Printf("writing restic to %v\n", opts.Output)
+	PrintDef("writing restic to %v\n", opts.Output)
 
 	v, err := selfupdate.DownloadLatestStableRelease(gopts.ctx, opts.Output, version, PrintDef)
 	if err != nil {
@@ -79,7 +79,7 @@ func runSelfUpdate(opts SelfUpdateOptions, gopts GlobalOptions, args []string) e
 	}
 
 	if v != version {
-		Printf("successfully updated restic to version %v\n", v)
+		PrintDef("successfully updated restic to version %v\n", v)
 	}
 
 	return nil

--- a/cmd/restic/cmd_self_update.go
+++ b/cmd/restic/cmd_self_update.go
@@ -73,7 +73,7 @@ func runSelfUpdate(opts SelfUpdateOptions, gopts GlobalOptions, args []string) e
 
 	Printf("writing restic to %v\n", opts.Output)
 
-	v, err := selfupdate.DownloadLatestStableRelease(gopts.ctx, opts.Output, version, Verbosef)
+	v, err := selfupdate.DownloadLatestStableRelease(gopts.ctx, opts.Output, version, PrintDef)
 	if err != nil {
 		return errors.Fatalf("unable to update restic: %v", err)
 	}

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -99,7 +99,7 @@ func runStats(gopts GlobalOptions, args []string) error {
 	}
 
 	if !gopts.JSON {
-		Printf("scanning...\n")
+		PrintDef("scanning...\n")
 	}
 
 	// create a container for the stats (and other needed state)

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -98,9 +98,7 @@ func runStats(gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	if !gopts.JSON {
-		PrintDef("scanning...\n")
-	}
+	PrintDef("scanning...\n")
 
 	// create a container for the stats (and other needed state)
 	stats := &statsContainer{

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -118,7 +118,7 @@ func runTag(opts TagOptions, gopts GlobalOptions, args []string) error {
 	}
 
 	if !gopts.NoLock {
-		Verbosef("create exclusive lock for repository\n")
+		PrintDef("create exclusive lock for repository\n")
 		lock, err := lockRepoExclusive(gopts.ctx, repo)
 		defer unlockRepo(lock)
 		if err != nil {
@@ -140,9 +140,9 @@ func runTag(opts TagOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 	if changeCnt == 0 {
-		Verbosef("no snapshots were modified\n")
+		PrintDef("no snapshots were modified\n")
 	} else {
-		Verbosef("modified tags on %v snapshots\n", changeCnt)
+		PrintDef("modified tags on %v snapshots\n", changeCnt)
 	}
 	return nil
 }

--- a/cmd/restic/cmd_unlock.go
+++ b/cmd/restic/cmd_unlock.go
@@ -51,6 +51,6 @@ func runUnlock(opts UnlockOptions, gopts GlobalOptions) error {
 		return err
 	}
 
-	Verbosef("successfully removed locks\n")
+	PrintDef("successfully removed locks\n")
 	return nil
 }

--- a/cmd/restic/delete.go
+++ b/cmd/restic/delete.go
@@ -48,9 +48,7 @@ func deleteFiles(gopts GlobalOptions, ignoreError bool, repo restic.Repository, 
 						return err
 					}
 				}
-				if !gopts.JSON {
-					Verboseff("removed %v\n", h)
-				}
+				Verboseff("removed %v\n", h)
 				bar.Report(restic.Stat{Blobs: 1})
 			}
 			return nil

--- a/cmd/restic/delete.go
+++ b/cmd/restic/delete.go
@@ -48,8 +48,8 @@ func deleteFiles(gopts GlobalOptions, ignoreError bool, repo restic.Repository, 
 						return err
 					}
 				}
-				if !gopts.JSON && gopts.verbosity > 2 {
-					Verbosef("removed %v\n", h)
+				if !gopts.JSON {
+					Verboseff("removed %v\n", h)
 				}
 				bar.Report(restic.Stat{Blobs: 1})
 			}

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -516,7 +516,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 
 	// cleanup old cache dirs if instructed to do so
 	if opts.CleanupCache {
-		Printf("removing %d old cache dirs from %v\n", len(oldCacheDirs), c.Base)
+		PrintDef("removing %d old cache dirs from %v\n", len(oldCacheDirs), c.Base)
 
 		for _, item := range oldCacheDirs {
 			dir := filepath.Join(c.Base, item.Name())

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -479,7 +479,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		return nil, errors.Fatalf("%s", err)
 	}
 
-	if stdoutIsTerminal() && !opts.JSON {
+	if stdoutIsTerminal() {
 		id := s.Config().ID
 		if len(id) > 8 {
 			id = id[:8]
@@ -497,7 +497,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		return s, nil
 	}
 
-	if c.Created && !opts.JSON {
+	if c.Created {
 		PrintDef("created new cache in %v\n", c.Base)
 	}
 

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -224,9 +224,23 @@ func Println(args ...interface{}) {
 	}
 }
 
+// PrintDef calls Printf to write the message when no special verbosity level is required.
+func PrintDef(format string, args ...interface{}) {
+	if globalOptions.verbosity >= 1 {
+		Printf(format, args...)
+	}
+}
+
 // Verbosef calls Printf to write the message when the verbose flag is set.
 func Verbosef(format string, args ...interface{}) {
-	if globalOptions.verbosity >= 1 {
+	if globalOptions.verbosity >= 2 {
+		Printf(format, args...)
+	}
+}
+
+// Verboseff calls Printf to write the message when the verbose=2 flag is set.
+func Verboseff(format string, args ...interface{}) {
+	if globalOptions.verbosity >= 3 {
 		Printf(format, args...)
 	}
 }
@@ -349,7 +363,7 @@ func ReadPassword(opts GlobalOptions, prompt string) (string, error) {
 		password, err = readPasswordTerminal(os.Stdin, os.Stderr, prompt)
 	} else {
 		password, err = readPassword(os.Stdin)
-		Verbosef("reading repository password from stdin\n")
+		PrintDef("reading repository password from stdin\n")
 	}
 
 	if err != nil {
@@ -470,9 +484,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		if len(id) > 8 {
 			id = id[:8]
 		}
-		if !opts.JSON {
-			Verbosef("repository %v opened successfully, password is correct\n", id)
-		}
+		PrintDef("repository %v opened successfully, password is correct\n", id)
 	}
 
 	if opts.NoCache {
@@ -486,7 +498,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 	}
 
 	if c.Created && !opts.JSON {
-		Verbosef("created new cache in %v\n", c.Base)
+		PrintDef("created new cache in %v\n", c.Base)
 	}
 
 	// start using the cache
@@ -515,7 +527,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		}
 	} else {
 		if stdoutIsTerminal() {
-			Verbosef("found %d old cache directories in %v, run `restic cache --cleanup` to remove them\n",
+			PrintDef("found %d old cache directories in %v, run `restic cache --cleanup` to remove them\n",
 				len(oldCacheDirs), c.Base)
 		}
 	}

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -36,12 +36,17 @@ directories in an encrypted repository stored on different backends.
 			return errors.Fatal("--quiet and --verbose cannot be specified at the same time")
 		}
 
-		switch {
-		case globalOptions.Verbose >= 2:
-			globalOptions.verbosity = 3
-		case globalOptions.Verbose > 0:
-			globalOptions.verbosity = 2
-		case globalOptions.Quiet:
+		// JSON implies quiet output
+		if !globalOptions.JSON {
+			switch {
+			case globalOptions.Verbose >= 2:
+				globalOptions.verbosity = 3
+			case globalOptions.Verbose > 0:
+				globalOptions.verbosity = 2
+			case globalOptions.Quiet:
+				globalOptions.verbosity = 0
+			}
+		} else {
 			globalOptions.verbosity = 0
 		}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR reworks the current print functions to better match the verbosity levels. It adds a `Defaultf` function (I'm open to using a different name, I don't really like it that much) that prints output when `verbosity` is greater than or equal to 1 (default) and a `Verboseff` function, that prints output when `verbosity` is greater than or equal to 3 (`--verbose=2` or `-vv`), and modifies `Verbosef` to print output when `verbosity` is greater than or equal to 2 (`--verbose`).

It then converts all current `Verbosef` calls to the appropriate `Defaultf`/`Verbosef`/`Verboseff` calls, in some cases removing some duplicated checks of the `verbosity` level, and changes some non-error `Printf` to `Defaultf` to suppress the output when `--quiet` is used.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
It came up in https://github.com/restic/restic/pull/2718#discussion_r502906278 where a new function Verboseff was first added.

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
