### PR TITLE
Simplify/optimize cached UID/GID lookups

### DIFF
--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -509,29 +509,26 @@ func (node Node) sameExtendedAttributes(other Node) bool {
 func (node *Node) fillUser(stat statT) {
 	uid, gid := stat.uid(), stat.gid()
 	node.UID, node.GID = uid, gid
-
-	node.User = lookupUsername(strconv.Itoa(int(uid)))
-	node.Group = lookupGroup(strconv.Itoa(int(gid)))
+	node.User = lookupUsername(uid)
+	node.Group = lookupGroup(gid)
 }
 
 var (
-	uidLookupCache      = make(map[string]string)
+	uidLookupCache      = make(map[uint32]string)
 	uidLookupCacheMutex = sync.RWMutex{}
 )
 
 // Cached user name lookup by uid. Returns "" when no name can be found.
-func lookupUsername(uid string) string {
+func lookupUsername(uid uint32) string {
 	uidLookupCacheMutex.RLock()
-	value, ok := uidLookupCache[uid]
+	username, ok := uidLookupCache[uid]
 	uidLookupCacheMutex.RUnlock()
 
 	if ok {
-		return value
+		return username
 	}
 
-	username := ""
-
-	u, err := user.LookupId(uid)
+	u, err := user.LookupId(strconv.Itoa(int(uid)))
 	if err == nil {
 		username = u.Username
 	}
@@ -544,23 +541,21 @@ func lookupUsername(uid string) string {
 }
 
 var (
-	gidLookupCache      = make(map[string]string)
+	gidLookupCache      = make(map[uint32]string)
 	gidLookupCacheMutex = sync.RWMutex{}
 )
 
 // Cached group name lookup by gid. Returns "" when no name can be found.
-func lookupGroup(gid string) string {
+func lookupGroup(gid uint32) string {
 	gidLookupCacheMutex.RLock()
-	value, ok := gidLookupCache[gid]
+	group, ok := gidLookupCache[gid]
 	gidLookupCacheMutex.RUnlock()
 
 	if ok {
-		return value
+		return group
 	}
 
-	group := ""
-
-	g, err := user.LookupGroupId(gid)
+	g, err := user.LookupGroupId(strconv.Itoa(int(gid)))
 	if err == nil {
 		group = g.Name
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

LookupUsername and lookupGroup in internal/restic/node.go returned an error value that was always nil. When a lookup fails, the user/group name is simply empty and doesn't show up in the JSON.

The functions also cached UIDs and GIDs as strings, meaning that every call would still need a strconv.Itoa call. This PR removes the error return, adds comments to explain the behavior, merges some variables with the equal meanings and pushes the strconv.Itoa calls down into the cache miss path.

Benchmark results:

```name                  old time/op    new time/op    delta
NodeFillUser-8          1.92µs ± 5%    1.75µs ± 3%   -8.89%  (p=0.000 n=10+10)
NodeFromFileInfo-8      1.89µs ± 7%    1.76µs ± 4%   -6.69%  (p=0.001 n=10+10)

name                  old alloc/op   new alloc/op   delta
NodeFillUser-8            504B ± 0%      496B ± 0%   -1.59%  (p=0.000 n=10+10)
NodeFromFileInfo-8        504B ± 0%      496B ± 0%   -1.59%  (p=0.000 n=10+10)

name                  old allocs/op  new allocs/op  delta
NodeFillUser-8            5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
NodeFromFileInfo-8        5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
```

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
