### PR TITLE
Fix IsProcessBackground on Linux with stdin redirection

### DIFF
--- a/internal/ui/termstatus/background.go
+++ b/internal/ui/termstatus/background.go
@@ -4,6 +4,6 @@ package termstatus
 
 // IsProcessBackground reports whether the current process is running in the
 // background. Not implemented for this platform.
-func IsProcessBackground() bool {
+func IsProcessBackground(uintptr) bool {
 	return false
 }

--- a/internal/ui/termstatus/background_linux_test.go
+++ b/internal/ui/termstatus/background_linux_test.go
@@ -1,0 +1,19 @@
+package termstatus
+
+import (
+	"os"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestIsProcessBackground(t *testing.T) {
+	tty, err := os.Open("/dev/tty")
+	if err != nil {
+		t.Skipf("can't open terminal: %v", err)
+	}
+	defer tty.Close()
+
+	_, err = isProcessBackground(tty.Fd())
+	rtest.OK(t, err)
+}

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -95,7 +95,7 @@ func (t *Terminal) run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			if IsProcessBackground() {
+			if IsProcessBackground(t.fd) {
 				// ignore all messages, do nothing, we are in the background process group
 				continue
 			}
@@ -104,7 +104,7 @@ func (t *Terminal) run(ctx context.Context) {
 			return
 
 		case msg := <-t.msg:
-			if IsProcessBackground() {
+			if IsProcessBackground(t.fd) {
 				// ignore all messages, do nothing, we are in the background process group
 				continue
 			}
@@ -136,7 +136,7 @@ func (t *Terminal) run(ctx context.Context) {
 			}
 
 		case stat := <-t.status:
-			if IsProcessBackground() {
+			if IsProcessBackground(t.fd) {
 				// ignore all messages, do nothing, we are in the background process group
 				continue
 			}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

ui/termstatus.IsProcessBackground previously assumed that stdin was the terminal, causing it to report false when stdin was redirected. It now checks the actual terminal's fd.

To see the faulty behavior, run `restic backup --stdin < /dev/zero &` (or omit the & and hit Ctrl+Z, then bg).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Not that I know.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
