### PR TITLE
Refactor index decoding

### DIFF
--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -515,11 +515,8 @@ func (idx *Index) merge(idx2 *Index) error {
 // isErrOldIndex returns true if the error may be caused by an old index
 // format.
 func isErrOldIndex(err error) bool {
-	if e, ok := err.(*json.UnmarshalTypeError); ok && e.Value == "array" {
-		return true
-	}
-
-	return false
+	e, ok := err.(*json.UnmarshalTypeError)
+	return ok && e.Value == "array"
 }
 
 // DecodeIndex unserializes an index from buf.

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -457,14 +457,13 @@ func (r *Repository) LoadIndex(ctx context.Context) error {
 		var buf []byte
 		for fi := range ch {
 			var err error
-			var idx *Index
-			idx, buf, err = LoadIndexWithDecoder(ctx, r, buf[:0], fi.ID, DecodeIndex)
-			if err != nil && errors.Cause(err) == ErrOldIndexFormat {
-				idx, buf, err = LoadIndexWithDecoder(ctx, r, buf[:0], fi.ID, DecodeOldIndex)
-			}
-
+			buf, err = r.LoadAndDecrypt(ctx, buf[:0], restic.IndexFile, fi.ID)
 			if err != nil {
-				return errors.Wrap(err, fmt.Sprintf("unable to load index %v", fi.ID.Str()))
+				return errors.Wrapf(err, "unable to load index %s", fi.ID.Str())
+			}
+			idx, _, err := DecodeIndex(buf)
+			if err != nil {
+				return errors.Wrapf(err, "unable to decode index %s", fi.ID.Str())
 			}
 
 			select {
@@ -580,18 +579,16 @@ func (r *Repository) PrepareCache(indexIDs restic.IDSet) error {
 
 // LoadIndex loads the index id from backend and returns it.
 func LoadIndex(ctx context.Context, repo restic.Repository, id restic.ID) (*Index, error) {
-	idx, _, err := LoadIndexWithDecoder(ctx, repo, nil, id, DecodeIndex)
-	if err == nil {
-		return idx, nil
+	buf, err := repo.LoadAndDecrypt(ctx, nil, restic.IndexFile, id)
+	if err != nil {
+		return nil, err
 	}
 
-	if errors.Cause(err) == ErrOldIndexFormat {
+	idx, oldFormat, err := DecodeIndex(buf)
+	if oldFormat {
 		fmt.Fprintf(os.Stderr, "index %v has old format\n", id.Str())
-		idx, _, err := LoadIndexWithDecoder(ctx, repo, nil, id, DecodeOldIndex)
-		return idx, err
 	}
-
-	return nil, err
+	return idx, err
 }
 
 // SearchKey finds a key with the supplied password, afterwards the config is


### PR DESCRIPTION




<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

There were three places in the codebase that did

decode new-style index -> check error -> decode old-style index

via a system of callbacks. I've replaced all three by a single DecodeIndex that can handle both formats, saving some 20 lines of code, two public functions in internal/repository and one public error type.

There's still some repetition in the code, but I didn't see a clean way of getting rid it. Two of the call sites pass a buffer around that would have to become an argument and a fourth return value on DecodeIndex.

New-style decoding is as fast as it was before:

```
name                   old time/op  new time/op  delta
DecodeIndex-8           4.19s ± 2%   4.16s ± 1%   ~     (p=0.105 n=10+10)
DecodeIndexParallel-8   4.18s ± 1%   4.17s ± 1%   ~     (p=0.360 n=10+8)
```

Decoding old-format indices no longer requires loading and decrypting twice, so that may be faster, but there's no benchmark for that.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
