### PR TITLE
Defer channel closing outside repository.RunWorkers

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -135,14 +135,10 @@ func (c *Checker) LoadIndex(ctx context.Context) (hints []error, errs []error) {
 		return nil
 	}
 
-	// final closes indexCh after all workers have terminated
-	final := func() {
-		close(resultCh)
-	}
-
 	// run workers on ch
 	wg.Go(func() error {
-		return repository.RunWorkers(defaultParallelism, worker, final)
+		defer close(resultCh)
+		return repository.RunWorkers(defaultParallelism, worker)
 	})
 
 	// receive decoded indexes

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -476,14 +476,10 @@ func (r *Repository) LoadIndex(ctx context.Context) error {
 		return nil
 	}
 
-	// final closes indexCh after all workers have terminated
-	final := func() {
-		close(indexCh)
-	}
-
 	// run workers on ch
 	wg.Go(func() error {
-		return RunWorkers(loadIndexParallelism, worker, final)
+		defer close(indexCh)
+		return RunWorkers(loadIndexParallelism, worker)
 	})
 
 	// receive decoded indexes

--- a/internal/repository/worker_group.go
+++ b/internal/repository/worker_group.go
@@ -5,10 +5,8 @@ import (
 )
 
 // RunWorkers runs count instances of workerFunc using an errgroup.Group.
-// After all workers have terminated, finalFunc is run. If an error occurs in
-// one of the workers, it is returned. FinalFunc is always run, regardless of
-// any other previous errors.
-func RunWorkers(count int, workerFunc func() error, finalFunc func()) error {
+// If an error occurs in one of the workers, it is returned.
+func RunWorkers(count int, workerFunc func() error) error {
 	var wg errgroup.Group
 
 	// run workers
@@ -16,12 +14,5 @@ func RunWorkers(count int, workerFunc func() error, finalFunc func()) error {
 		wg.Go(workerFunc)
 	}
 
-	// wait for termination
-	err := wg.Wait()
-
-	// make sure finalFunc is run
-	finalFunc()
-
-	// return error from workers to the caller
-	return err
+	return wg.Wait()
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This is a tiny refactor that replaces a callback by a defer'd call. It's mostly stylistic, but it might make some stack traces shorter: when a worker goroutine panics, other goroutines have a chance of exiting, so their stack no longer needs to be reported

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Can be considered a follow-up to #2560.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
