### PR TITLE
Fix setting of ID in DecodeIndex

### DIFF
--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -121,7 +121,7 @@ func (c *Checker) LoadIndex(ctx context.Context) (hints []error, errs []error) {
 
 			buf, err = c.repo.LoadAndDecrypt(ctx, buf[:0], restic.IndexFile, fi.ID)
 			if err == nil {
-				idx, oldFormat, err = repository.DecodeIndex(buf)
+				idx, oldFormat, err = repository.DecodeIndex(buf, fi.ID)
 			}
 
 			if oldFormat {

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -520,7 +520,7 @@ func isErrOldIndex(err error) bool {
 }
 
 // DecodeIndex unserializes an index from buf.
-func DecodeIndex(buf []byte) (idx *Index, oldFormat bool, err error) {
+func DecodeIndex(buf []byte, id restic.ID) (idx *Index, oldFormat bool, err error) {
 	debug.Log("Start decoding index")
 	idxJSON := &jsonIndex{}
 
@@ -563,6 +563,7 @@ func DecodeIndex(buf []byte) (idx *Index, oldFormat bool, err error) {
 		}
 	}
 	idx.supersedes = idxJSON.Supersedes
+	idx.ids = append(idx.ids, id)
 	idx.final = true
 
 	debug.Log("done")

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -461,7 +461,7 @@ func (r *Repository) LoadIndex(ctx context.Context) error {
 			if err != nil {
 				return errors.Wrapf(err, "unable to load index %s", fi.ID.Str())
 			}
-			idx, _, err := DecodeIndex(buf)
+			idx, _, err := DecodeIndex(buf, fi.ID)
 			if err != nil {
 				return errors.Wrapf(err, "unable to decode index %s", fi.ID.Str())
 			}
@@ -580,7 +580,7 @@ func LoadIndex(ctx context.Context, repo restic.Repository, id restic.ID) (*Inde
 		return nil, err
 	}
 
-	idx, oldFormat, err := DecodeIndex(buf)
+	idx, oldFormat, err := DecodeIndex(buf, id)
 	if oldFormat {
 		fmt.Fprintf(os.Stderr, "index %v has old format\n", id.Str())
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It seems like #3019 removed the setting if the index ID in `DecodeIndex`. Currently, the index ID is only used to remove unused index files from the cache which is now broken but should not affect the usage of restic too much.
However, #2842 depends on this functionality to be able to delete obsolete index files after the new index is built.

This PR again adds this functionality to `DecodeIndex`. Also added a test to check that the index is really set.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Found it when debugging an unexpected error in #2842

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
