### PR TITLE
Replace restic.statT interface by concrete types

### DIFF
--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -506,7 +506,7 @@ func (node Node) sameExtendedAttributes(other Node) bool {
 	return true
 }
 
-func (node *Node) fillUser(stat statT) {
+func (node *Node) fillUser(stat *statT) {
 	uid, gid := stat.uid(), stat.gid()
 	node.UID, node.GID = uid, gid
 	node.User = lookupUsername(uid)
@@ -644,24 +644,11 @@ func (node *Node) fillExtendedAttributes(path string) error {
 	return nil
 }
 
-type statT interface {
-	dev() uint64
-	ino() uint64
-	nlink() uint64
-	uid() uint32
-	gid() uint32
-	rdev() uint64
-	size() int64
-	atim() syscall.Timespec
-	mtim() syscall.Timespec
-	ctim() syscall.Timespec
-}
-
 func mkfifo(path string, mode uint32) (err error) {
 	return mknod(path, mode|syscall.S_IFIFO, 0)
 }
 
-func (node *Node) fillTimes(stat statT) {
+func (node *Node) fillTimes(stat *statT) {
 	ctim := stat.ctim()
 	atim := stat.atim()
 	node.ChangeTime = time.Unix(ctim.Unix())

--- a/internal/restic/node_darwin.go
+++ b/internal/restic/node_darwin.go
@@ -10,6 +10,6 @@ func (node Node) device() int {
 	return int(node.Device)
 }
 
-func (s statUnix) atim() syscall.Timespec { return s.Atimespec }
-func (s statUnix) mtim() syscall.Timespec { return s.Mtimespec }
-func (s statUnix) ctim() syscall.Timespec { return s.Ctimespec }
+func (s statT) atim() syscall.Timespec { return s.Atimespec }
+func (s statT) mtim() syscall.Timespec { return s.Mtimespec }
+func (s statT) ctim() syscall.Timespec { return s.Ctimespec }

--- a/internal/restic/node_freebsd.go
+++ b/internal/restic/node_freebsd.go
@@ -12,6 +12,6 @@ func (node Node) device() uint64 {
 	return node.Device
 }
 
-func (s statUnix) atim() syscall.Timespec { return s.Atimespec }
-func (s statUnix) mtim() syscall.Timespec { return s.Mtimespec }
-func (s statUnix) ctim() syscall.Timespec { return s.Ctimespec }
+func (s statT) atim() syscall.Timespec { return s.Atimespec }
+func (s statT) mtim() syscall.Timespec { return s.Mtimespec }
+func (s statT) ctim() syscall.Timespec { return s.Ctimespec }

--- a/internal/restic/node_linux.go
+++ b/internal/restic/node_linux.go
@@ -7,7 +7,6 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/restic/restic/internal/errors"
-
 	"github.com/restic/restic/internal/fs"
 )
 
@@ -36,6 +35,6 @@ func (node Node) device() int {
 	return int(node.Device)
 }
 
-func (s statUnix) atim() syscall.Timespec { return s.Atim }
-func (s statUnix) mtim() syscall.Timespec { return s.Mtim }
-func (s statUnix) ctim() syscall.Timespec { return s.Ctim }
+func (s statT) atim() syscall.Timespec { return s.Atim }
+func (s statT) mtim() syscall.Timespec { return s.Mtim }
+func (s statT) ctim() syscall.Timespec { return s.Ctim }

--- a/internal/restic/node_netbsd.go
+++ b/internal/restic/node_netbsd.go
@@ -10,9 +10,9 @@ func (node Node) device() int {
 	return int(node.Device)
 }
 
-func (s statUnix) atim() syscall.Timespec { return s.Atimespec }
-func (s statUnix) mtim() syscall.Timespec { return s.Mtimespec }
-func (s statUnix) ctim() syscall.Timespec { return s.Ctimespec }
+func (s statT) atim() syscall.Timespec { return s.Atimespec }
+func (s statT) mtim() syscall.Timespec { return s.Mtimespec }
+func (s statT) ctim() syscall.Timespec { return s.Ctimespec }
 
 // Getxattr retrieves extended attribute data associated with path.
 func Getxattr(path, name string) ([]byte, error) {

--- a/internal/restic/node_openbsd.go
+++ b/internal/restic/node_openbsd.go
@@ -10,9 +10,9 @@ func (node Node) device() int {
 	return int(node.Device)
 }
 
-func (s statUnix) atim() syscall.Timespec { return s.Atim }
-func (s statUnix) mtim() syscall.Timespec { return s.Mtim }
-func (s statUnix) ctim() syscall.Timespec { return s.Ctim }
+func (s statT) atim() syscall.Timespec { return s.Atim }
+func (s statT) mtim() syscall.Timespec { return s.Mtim }
+func (s statT) ctim() syscall.Timespec { return s.Ctim }
 
 // Getxattr retrieves extended attribute data associated with path.
 func Getxattr(path, name string) ([]byte, error) {

--- a/internal/restic/node_solaris.go
+++ b/internal/restic/node_solaris.go
@@ -10,9 +10,9 @@ func (node Node) device() int {
 	return int(node.Device)
 }
 
-func (s statUnix) atim() syscall.Timespec { return s.Atim }
-func (s statUnix) mtim() syscall.Timespec { return s.Mtim }
-func (s statUnix) ctim() syscall.Timespec { return s.Ctim }
+func (s statT) atim() syscall.Timespec { return s.Atim }
+func (s statT) mtim() syscall.Timespec { return s.Mtim }
+func (s statT) ctim() syscall.Timespec { return s.Ctim }
 
 // Getxattr retrieves extended attribute data associated with path.
 func Getxattr(path, name string) ([]byte, error) {

--- a/internal/restic/node_unix.go
+++ b/internal/restic/node_unix.go
@@ -10,23 +10,20 @@ import (
 var mknod = syscall.Mknod
 var lchown = os.Lchown
 
-type statUnix syscall.Stat_t
+type statT syscall.Stat_t
 
-func toStatT(i interface{}) (statT, bool) {
-	if i == nil {
-		return nil, false
-	}
+func toStatT(i interface{}) (*statT, bool) {
 	s, ok := i.(*syscall.Stat_t)
 	if ok && s != nil {
-		return statUnix(*s), true
+		return (*statT)(s), true
 	}
 	return nil, false
 }
 
-func (s statUnix) dev() uint64   { return uint64(s.Dev) }
-func (s statUnix) ino() uint64   { return uint64(s.Ino) }
-func (s statUnix) nlink() uint64 { return uint64(s.Nlink) }
-func (s statUnix) uid() uint32   { return uint32(s.Uid) }
-func (s statUnix) gid() uint32   { return uint32(s.Gid) }
-func (s statUnix) rdev() uint64  { return uint64(s.Rdev) }
-func (s statUnix) size() int64   { return int64(s.Size) }
+func (s statT) dev() uint64   { return uint64(s.Dev) }
+func (s statT) ino() uint64   { return uint64(s.Ino) }
+func (s statT) nlink() uint64 { return uint64(s.Nlink) }
+func (s statT) uid() uint32   { return uint32(s.Uid) }
+func (s statT) gid() uint32   { return uint32(s.Gid) }
+func (s statT) rdev() uint64  { return uint64(s.Rdev) }
+func (s statT) size() int64   { return int64(s.Size) }

--- a/internal/restic/node_windows.go
+++ b/internal/restic/node_windows.go
@@ -42,40 +42,36 @@ func Setxattr(path, name string, data []byte) error {
 	return nil
 }
 
-type statWin syscall.Win32FileAttributeData
+type statT syscall.Win32FileAttributeData
 
-//ToStatT call the Windows system call Win32FileAttributeData.
-func toStatT(i interface{}) (statT, bool) {
-	if i == nil {
-		return nil, false
-	}
+func toStatT(i interface{}) (*statT, bool) {
 	s, ok := i.(*syscall.Win32FileAttributeData)
 	if ok && s != nil {
-		return statWin(*s), true
+		return (*statT)(s), true
 	}
 	return nil, false
 }
 
-func (s statWin) dev() uint64   { return 0 }
-func (s statWin) ino() uint64   { return 0 }
-func (s statWin) nlink() uint64 { return 0 }
-func (s statWin) uid() uint32   { return 0 }
-func (s statWin) gid() uint32   { return 0 }
-func (s statWin) rdev() uint64  { return 0 }
+func (s statT) dev() uint64   { return 0 }
+func (s statT) ino() uint64   { return 0 }
+func (s statT) nlink() uint64 { return 0 }
+func (s statT) uid() uint32   { return 0 }
+func (s statT) gid() uint32   { return 0 }
+func (s statT) rdev() uint64  { return 0 }
 
-func (s statWin) size() int64 {
+func (s statT) size() int64 {
 	return int64(s.FileSizeLow) | (int64(s.FileSizeHigh) << 32)
 }
 
-func (s statWin) atim() syscall.Timespec {
+func (s statT) atim() syscall.Timespec {
 	return syscall.NsecToTimespec(s.LastAccessTime.Nanoseconds())
 }
 
-func (s statWin) mtim() syscall.Timespec {
+func (s statT) mtim() syscall.Timespec {
 	return syscall.NsecToTimespec(s.LastWriteTime.Nanoseconds())
 }
 
-func (s statWin) ctim() syscall.Timespec {
+func (s statT) ctim() syscall.Timespec {
 	// Windows does not have the concept of a "change time" in the sense Unix uses it, so we're using the LastWriteTime here.
 	return syscall.NsecToTimespec(s.LastWriteTime.Nanoseconds())
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Removing the statT interface layer in internal/restic speeds up Node creation a tiny bit:

```
name                old time/op    new time/op    delta
NodeFillUser-8        1.81µs ± 9%    1.50µs ± 5%  -17.07%  (p=0.000 n=19+20)
NodeFromFileInfo-8    1.76µs ± 4%    1.49µs ± 6%  -15.63%  (p=0.000 n=20+19)

name                old alloc/op   new alloc/op   delta
NodeFillUser-8          496B ± 0%      352B ± 0%  -29.03%  (p=0.000 n=20+20)
NodeFromFileInfo-8      496B ± 0%      352B ± 0%  -29.03%  (p=0.000 n=20+20)

name                old allocs/op  new allocs/op  delta
NodeFillUser-8          3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=20+20)
NodeFromFileInfo-8      3.00 ± 0%      2.00 ± 0%  -33.33%  (p=0.000 n=20+20)
```

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
