### PR TITLE
Allow debug logging to pipes and terminals

### DIFF
--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -12,8 +12,6 @@ import (
 	"strings"
 
 	"github.com/restic/restic/internal/fs"
-
-	"github.com/restic/restic/internal/errors"
 )
 
 var opts struct {
@@ -50,20 +48,7 @@ func initDebugLogger() {
 
 	fmt.Fprintf(os.Stderr, "debug log file %v\n", debugfile)
 
-	f, err := fs.OpenFile(debugfile, os.O_WRONLY|os.O_APPEND, 0600)
-
-	if err == nil {
-		_, err = f.Seek(2, 0)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to seek to the end of %v: %v\n", debugfile, err)
-			os.Exit(3)
-		}
-	}
-
-	if err != nil && os.IsNotExist(errors.Cause(err)) {
-		f, err = fs.OpenFile(debugfile, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0600)
-	}
-
+	f, err := fs.OpenFile(debugfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0600)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to open debug log file: %v\n", err)
 		os.Exit(2)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It's sometimes useful to send the debug log to /dev/{tty,stdout,stderr} or a named pipe, but that it currently not possible because initDebugLogger tries to Seek on the log. This PR removes the Seek, which is useless anyway, because the file is opened in append mode.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Not that I know.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
