### PR TITLE
bugfix: omit ENOTDATA for extended attributes

### DIFF
--- a/changelog/unreleased/issue-1800
+++ b/changelog/unreleased/issue-1800
@@ -1,0 +1,8 @@
+Bugfix: Ignore 'no data available' error during backup
+
+restic failed to backup files on some filesystems, for example certain configurations
+of CIFS on Linux, which return a "no data available" error when reading extended
+attributes. These errors are now ignored.
+
+https://github.com/restic/restic/issues/1800
+https://github.com/restic/restic/pull/3034

--- a/internal/restic/node_xattr.go
+++ b/internal/restic/node_xattr.go
@@ -16,7 +16,8 @@ import (
 // Getxattr retrieves extended attribute data associated with path.
 func Getxattr(path, name string) ([]byte, error) {
 	b, e := xattr.Get(path, name)
-	if err, ok := e.(*xattr.Error); ok && err.Err == syscall.ENOTSUP {
+	if err, ok := e.(*xattr.Error); ok &&
+		(err.Err == syscall.ENOTSUP || err.Err == xattr.ENOATTR) {
 		return nil, nil
 	}
 	return b, errors.Wrap(e, "Getxattr")
@@ -26,7 +27,8 @@ func Getxattr(path, name string) ([]byte, error) {
 // given path in the file system.
 func Listxattr(path string) ([]string, error) {
 	s, e := xattr.List(path)
-	if err, ok := e.(*xattr.Error); ok && err.Err == syscall.ENOTSUP {
+	if err, ok := e.(*xattr.Error); ok &&
+		(err.Err == syscall.ENOTSUP || err.Err == xattr.ENOATTR) {
 		return nil, nil
 	}
 	return s, errors.Wrap(e, "Listxattr")
@@ -35,7 +37,8 @@ func Listxattr(path string) ([]string, error) {
 // Setxattr associates name and data together as an attribute of path.
 func Setxattr(path, name string, data []byte) error {
 	e := xattr.Set(path, name, data)
-	if err, ok := e.(*xattr.Error); ok && err.Err == syscall.ENOTSUP {
+	if err, ok := e.(*xattr.Error); ok &&
+		(err.Err == syscall.ENOTSUP || err.Err == xattr.ENOATTR) {
 		return nil
 	}
 	return errors.Wrap(e, "Setxattr")


### PR DESCRIPTION
Signed-off-by: hoyho <luohaihao@gmail.com>



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
node_xattr.go have some operation on file extended attributes like xattr.Get xattr.List .
However, some file share do not support such operations. 
For example, backup source files from a cifs share may cause restic reporting an ENODATA error
and mount the cifs share with option `nouser_xattr` can omit this error because fs will report `ENOTSUP` instead and restic will absorb this error.
As mentioned in https://github.com/restic/restic/issues/1800#issuecomment-706516649 , we can whitelist ENOTDATA error

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
