### PR TITLE
Clean up internal/fuse

### DIFF
--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -68,7 +68,7 @@ func NewRoot(repo restic.Repository, cfg Config) *Root {
 		}
 	}
 
-	root.SnapshotsDir = NewSnapshotsDir(root, rootInode, NewSnapshotsDirStructure(root, cfg.PathTemplates, cfg.TimeTemplate), "")
+	root.SnapshotsDir = NewSnapshotsDir(root, rootInode, rootInode, NewSnapshotsDirStructure(root, cfg.PathTemplates, cfg.TimeTemplate), "")
 
 	return root
 }

--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -27,7 +27,6 @@ type Config struct {
 type Root struct {
 	repo      restic.Repository
 	cfg       Config
-	inode     uint64
 	blobCache *bloblru.Cache
 
 	*SnapshotsDir
@@ -50,7 +49,6 @@ func NewRoot(repo restic.Repository, cfg Config) *Root {
 
 	root := &Root{
 		repo:      repo,
-		inode:     rootInode,
 		cfg:       cfg,
 		blobCache: bloblru.New(blobCacheSize),
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Cleans up the internal/fuse package. Mainly:

* Generate inodes from parent directories instead of the root. Using the root gives the same inodes for distinct directories.
* Don't generate "." and ".." entries. bazil.org/fuse works fine without these, its examples don't generate them, and the ".." entries were incorrect anyway: SnapshotsDir was using the root for "..", regardless of its actual parent.
* Merged MetaDir back into Root. It was introduced in 2c02efd1fe1d35239e0bbacabebc6c2ef9140cc4 as a refactor, but all of its users have since dropped it except Root.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
