### PR TITLE
Properly dump directories to tar

### DIFF
--- a/changelog/unreleased/issue-2319
+++ b/changelog/unreleased/issue-2319
@@ -1,0 +1,12 @@
+Bugfix: Correctly dump directories into tar files
+
+The dump command previously wrote directories in a tar file in a way which
+can cause compatibility problems. This caused for example 7zip on Windows
+to open tar files containing directories. In addition it was not possible
+to dump directories with extended attributes. These compatibility problems
+were fixed by properly setting the attributes of a directory.
+
+In addition a tar file now includes the name of the owner and group of a file.
+
+https://github.com/restic/restic/issues/2319
+https://github.com/restic/restic/pull/3039

--- a/changelog/unreleased/issue-2319
+++ b/changelog/unreleased/issue-2319
@@ -1,12 +1,12 @@
 Bugfix: Correctly dump directories into tar files
 
 The dump command previously wrote directories in a tar file in a way which
-can cause compatibility problems. This caused for example 7zip on Windows
-to open tar files containing directories. In addition it was not possible
+can cause compatibility problems. This caused, for example, 7zip on Windows
+to not open tar files containing directories. In addition it was not possible
 to dump directories with extended attributes. These compatibility problems
-were fixed by properly setting the attributes of a directory.
+are now corrected.
 
-In addition a tar file now includes the name of the owner and group of a file.
+In addition, a tar file now includes the name of the owner and group of a file.
 
 https://github.com/restic/restic/issues/2319
 https://github.com/restic/restic/pull/3039

--- a/internal/dump/acl_test.go
+++ b/internal/dump/acl_test.go
@@ -22,9 +22,23 @@ func Test_acl_decode(t *testing.T) {
 			want: "user::rw-\nuser:0:rwx\nuser:65534:rwx\ngroup::rwx\nmask::rwx\nother::r--\n",
 		},
 		{
+			name: "decode group",
+			args: args{
+				xattr: []byte{2, 0, 0, 0, 8, 0, 1, 0, 254, 255, 0, 0},
+			},
+			want: "group:65534:--x\n",
+		},
+		{
 			name: "decode fail",
 			args: args{
 				xattr: []byte("abctest"),
+			},
+			want: "",
+		},
+		{
+			name: "decode empty fail",
+			args: args{
+				xattr: []byte(""),
 			},
 			want: "",
 		},
@@ -35,6 +49,10 @@ func Test_acl_decode(t *testing.T) {
 			a.decode(tt.args.xattr)
 			if tt.want != a.String() {
 				t.Errorf("acl.decode() = %v, want: %v", a.String(), tt.want)
+			}
+			a.decode(tt.args.xattr)
+			if tt.want != a.String() {
+				t.Errorf("second acl.decode() = %v, want: %v", a.String(), tt.want)
 			}
 		})
 	}

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"context"
 	"io"
+	"os"
 	"path"
 	"path/filepath"
 	"strings"
@@ -65,6 +66,15 @@ func tarTree(ctx context.Context, repo restic.Repository, rootNode *restic.Node,
 	return err
 }
 
+// copied from archive/tar.FileInfoHeader
+const (
+	// Mode constants from the USTAR spec:
+	// See http://pubs.opengroup.org/onlinepubs/9699919799/utilities/pax.html#tag_20_92_13_06
+	c_ISUID = 04000 // Set uid
+	c_ISGID = 02000 // Set gid
+	c_ISVTX = 01000 // Save text (sticky bit)
+)
+
 func tarNode(ctx context.Context, tw *tar.Writer, node *restic.Node, repo restic.Repository) error {
 	relPath, err := filepath.Rel("/", node.Path)
 	if err != nil {
@@ -74,13 +84,28 @@ func tarNode(ctx context.Context, tw *tar.Writer, node *restic.Node, repo restic
 	header := &tar.Header{
 		Name:       filepath.ToSlash(relPath),
 		Size:       int64(node.Size),
-		Mode:       int64(node.Mode),
+		Mode:       int64(node.Mode.Perm()), // c_IS* constants are added later
 		Uid:        int(node.UID),
 		Gid:        int(node.GID),
 		ModTime:    node.ModTime,
 		AccessTime: node.AccessTime,
 		ChangeTime: node.ChangeTime,
 		PAXRecords: parseXattrs(node.ExtendedAttributes),
+	}
+
+	// adapted from archive/tar.FileInfoHeader
+	if node.Mode&os.ModeSetuid != 0 {
+		header.Mode |= c_ISUID
+	}
+	if node.Mode&os.ModeSetgid != 0 {
+		header.Mode |= c_ISGID
+	}
+	if node.Mode&os.ModeSticky != 0 {
+		header.Mode |= c_ISVTX
+	}
+
+	if IsFile(node) {
+		header.Typeflag = tar.TypeReg
 	}
 
 	if IsLink(node) {
@@ -90,6 +115,7 @@ func tarNode(ctx context.Context, tw *tar.Writer, node *restic.Node, repo restic
 
 	if IsDir(node) {
 		header.Typeflag = tar.TypeDir
+		header.Name += "/"
 	}
 
 	err = tw.WriteHeader(header)

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -87,6 +87,8 @@ func tarNode(ctx context.Context, tw *tar.Writer, node *restic.Node, repo restic
 		Mode:       int64(node.Mode.Perm()), // c_IS* constants are added later
 		Uid:        int(node.UID),
 		Gid:        int(node.GID),
+		Uname:      node.User,
+		Gname:      node.Group,
 		ModTime:    node.ModTime,
 		AccessTime: node.AccessTime,
 		ChangeTime: node.ChangeTime,

--- a/internal/dump/tar_test.go
+++ b/internal/dump/tar_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -65,6 +66,14 @@ func TestWriteTar(t *testing.T) {
 				"secondDir": archiver.TestDir{
 					"another2": archiver.TestFile{Content: "string"},
 				},
+			},
+			target: "/",
+		},
+		{
+			name: "file and symlink in root",
+			args: archiver.TestDir{
+				"file1": archiver.TestFile{Content: "string"},
+				"file2": archiver.TestSymlink{Target: "file1"},
 			},
 			target: "/",
 		},
@@ -128,7 +137,7 @@ func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {
 		}
 
 		matchPath := filepath.Join(testDir, hdr.Name)
-		match, err := os.Stat(matchPath)
+		match, err := os.Lstat(matchPath)
 		if err != nil {
 			return err
 		}
@@ -138,6 +147,10 @@ func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {
 		tarTime := hdr.ModTime
 		if !fileTime.Equal(tarTime) {
 			return fmt.Errorf("modTime does not match, got: %s, want: %s", fileTime, tarTime)
+		}
+
+		if os.FileMode(hdr.Mode).Perm() != match.Mode().Perm() || os.FileMode(hdr.Mode)&^os.ModePerm != 0 {
+			return fmt.Errorf("mode does not match, got: %v, want: %v", os.FileMode(hdr.Mode), match.Mode())
 		}
 
 		if hdr.Typeflag == tar.TypeDir {
@@ -151,7 +164,17 @@ func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {
 			if filepath.Base(hdr.Name) != filebase {
 				return fmt.Errorf("foldernames don't match got %v want %v", filepath.Base(hdr.Name), filebase)
 			}
-
+			if !strings.HasSuffix(hdr.Name, "/") {
+				return fmt.Errorf("foldernames must end with separator got %v", hdr.Name)
+			}
+		} else if hdr.Typeflag == tar.TypeSymlink {
+			target, err := fs.Readlink(matchPath)
+			if err != nil {
+				return err
+			}
+			if target != hdr.Linkname {
+				return fmt.Errorf("symlink target does not match, got %s want %s", target, hdr.Linkname)
+			}
 		} else {
 			if match.Size() != hdr.Size {
 				return fmt.Errorf("size does not match got %v want %v", hdr.Size, match.Size())

--- a/internal/dump/tar_test.go
+++ b/internal/dump/tar_test.go
@@ -153,7 +153,8 @@ func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {
 			return fmt.Errorf("mode does not match, got: %v, want: %v", os.FileMode(hdr.Mode), match.Mode())
 		}
 
-		if hdr.Typeflag == tar.TypeDir {
+		switch hdr.Typeflag {
+		case tar.TypeDir:
 			// this is a folder
 			if hdr.Name == "." {
 				// we don't need to check the root folder
@@ -167,7 +168,7 @@ func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {
 			if !strings.HasSuffix(hdr.Name, "/") {
 				return fmt.Errorf("foldernames must end with separator got %v", hdr.Name)
 			}
-		} else if hdr.Typeflag == tar.TypeSymlink {
+		case tar.TypeSymlink:
 			target, err := fs.Readlink(matchPath)
 			if err != nil {
 				return err
@@ -175,7 +176,7 @@ func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {
 			if target != hdr.Linkname {
 				return fmt.Errorf("symlink target does not match, got %s want %s", target, hdr.Linkname)
 			}
-		} else {
+		default:
 			if match.Size() != hdr.Size {
 				return fmt.Errorf("size does not match got %v want %v", hdr.Size, match.Size())
 			}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The `dump` command previously wrote directories in a tar file in a way which can cause compatibility problems. It accidentally forced the usage of the GNU header format for directories. 7zip on Windows fails to read such directories and in addition it is not possible to dump directories with extended attributes.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
#2319

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
