### PR TITLE
vss: fix potential crash (not reachable in restic)

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -556,8 +556,8 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 
 	var targetFS fs.FS = fs.Local{}
 	if runtime.GOOS == "windows" && opts.UseFsSnapshot {
-		if !fs.HasSufficientPrivilegesForVSS() {
-			return errors.Fatal("user doesn't have sufficient privileges to use VSS snapshots\n")
+		if err = fs.HasSufficientPrivilegesForVSS(); err != nil {
+			return err
 		}
 
 		errorHandler := func(item string, err error) error {

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -286,7 +286,7 @@ func TestBackup(t *testing.T) {
 }
 
 func TestBackupWithFilesystemSnapshots(t *testing.T) {
-	if runtime.GOOS == "windows" && fs.HasSufficientPrivilegesForVSS() {
+	if runtime.GOOS == "windows" && fs.HasSufficientPrivilegesForVSS() == nil {
 		testBackup(t, true)
 	}
 }

--- a/internal/fs/vss.go
+++ b/internal/fs/vss.go
@@ -26,8 +26,8 @@ type VssSnapshot struct {
 }
 
 // HasSufficientPrivilegesForVSS returns true if the user is allowed to use VSS.
-func HasSufficientPrivilegesForVSS() bool {
-	return false
+func HasSufficientPrivilegesForVSS() error {
+	return errors.New("VSS snapshots are only supported on windows")
 }
 
 // NewVssSnapshot creates a new vss snapshot. If creating the snapshots doesn't

--- a/internal/fs/vss_windows.go
+++ b/internal/fs/vss_windows.go
@@ -716,22 +716,14 @@ func initializeVssCOMInterface() (*ole.IUnknown, error) {
 	return oleIUnknown, nil
 }
 
-// HasSufficientPrivilegesForVSS returns true if the user is allowed to use VSS.
-func HasSufficientPrivilegesForVSS() bool {
+// HasSufficientPrivilegesForVSS returns nil if the user is allowed to use VSS.
+func HasSufficientPrivilegesForVSS() error {
 	oleIUnknown, err := initializeVssCOMInterface()
 	if oleIUnknown != nil {
 		oleIUnknown.Release()
 	}
 
-	if err != nil {
-		if e, ok := err.(*vssError); ok {
-			if e.hresult == E_ACCESSDENIED {
-				return false
-			}
-		}
-	}
-
-	return true
+	return err
 }
 
 // NewVssSnapshot creates a new vss snapshot. If creating the snapshots doesn't

--- a/internal/fs/vss_windows.go
+++ b/internal/fs/vss_windows.go
@@ -698,6 +698,10 @@ func initializeVssCOMInterface() (*ole.IUnknown, uintptr, error) {
 	var oleIUnknown *ole.IUnknown
 	result, _, _ := vssInstance.Call(uintptr(unsafe.Pointer(&oleIUnknown)))
 
+	if oleIUnknown == nil {
+		return nil, result, newVssError("Failed to initialize COM interface", HRESULT(result))
+	}
+
 	return oleIUnknown, result, nil
 }
 
@@ -735,14 +739,11 @@ func NewVssSnapshot(
 	timeoutInMillis := uint32(timeoutInSeconds * 1000)
 
 	oleIUnknown, result, err := initializeVssCOMInterface()
-	if err != nil {
-		if oleIUnknown != nil {
-			oleIUnknown.Release()
-		}
-		return VssSnapshot{}, err
-	}
 	if oleIUnknown != nil {
 		defer oleIUnknown.Release()
+	}
+	if err != nil {
+		return VssSnapshot{}, err
 	}
 
 	switch HRESULT(result) {

--- a/internal/fs/vss_windows.go
+++ b/internal/fs/vss_windows.go
@@ -741,7 +741,9 @@ func NewVssSnapshot(
 		}
 		return VssSnapshot{}, err
 	}
-	defer oleIUnknown.Release()
+	if oleIUnknown != nil {
+		defer oleIUnknown.Release()
+	}
 
 	switch HRESULT(result) {
 	case S_OK:


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->
This fixes a potential crash in the VSS code. This is currently not reachable because restic checks for sufficient permissions before calling this code. If used somewhere this ends up dereferencing nil.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Mentioned in https://github.com/restic/restic/pull/2274 by @tigerwill90

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
