### PR TITLE
check: check index for packs that are read

### DIFF
--- a/changelog/unreleased/pull-3048
+++ b/changelog/unreleased/pull-3048
@@ -1,0 +1,9 @@
+Enhancement: Check now checks index when reading packs
+
+Restic used to only verfiy the pack file content when calling `check --read-data`
+`check --read-data-subset` but did not check if the blobs within the pack are
+correctly contained in the index.
+This check is now added and may give an "Blob ID is not contained in index" error.
+If the index is not correct, it can be rebuilt by using the `rebuild-index` command.
+
+https://github.com/restic/restic/pull/3048


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds a check for `restic check --read-data*` that the blobs in the read pack are also contained in the index.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Discussed this when talking about #3006; this PR is however completely independent. 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
