### PR TITLE
Fix string truncation in ui/termstatus

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -41,7 +41,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 	golang.org/x/sys v0.0.0-20201007082116-8445cc04cbdf
-	golang.org/x/text v0.3.3
+	golang.org/x/text v0.3.4
 	google.golang.org/api v0.32.0
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect
 	gopkg.in/ini.v1 v1.61.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -412,6 +412,8 @@ golang.org/x/text v0.3.1-0.20180807135948-17ff2d5776d2/go.mod h1:NqM8EUOU14njkJ3
 golang.org/x/text v0.3.2/go.mod h1:bEr9sfX3Q8Zfm5fL9x+3itogRgK3+ptLWKqgva+5dAk=
 golang.org/x/text v0.3.3 h1:cokOdA+Jmi5PJGXLlLllQSgYigAEfHXJAERHVMaCc2k=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
+golang.org/x/text v0.3.4 h1:0YWbFKbhXG/wIiuHDSKpS0Iy7FSA+u45VtBMfQcFTTc=
+golang.org/x/text v0.3.4/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20181108054448-85acf8d2951c/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20190308202827-9d24e82272b4/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20191024005414-555d28b269f0/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=

--- a/internal/ui/termstatus/status_test.go
+++ b/internal/ui/termstatus/status_test.go
@@ -5,7 +5,7 @@ import "testing"
 func TestTruncate(t *testing.T) {
 	var tests = []struct {
 		input  string
-		maxlen int
+		width  int
 		output string
 	}{
 		{"", 80, ""},
@@ -18,14 +18,17 @@ func TestTruncate(t *testing.T) {
 		{"foo", 1, "f"},
 		{"foo", 0, ""},
 		{"foo", -1, ""},
+		{"Löwen", 4, "Löwe"},
+		{"あああああああああ/data", 10, "あああああ"},
+		{"あああああああああ/data", 11, "あああああ"},
 	}
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			out := truncate(test.input, test.maxlen)
+			out := truncate(test.input, test.width)
 			if out != test.output {
-				t.Fatalf("wrong output for input %v, maxlen %d: want %q, got %q",
-					test.input, test.maxlen, test.output, out)
+				t.Fatalf("wrong output for input %v, width %d: want %q, got %q",
+					test.input, test.width, test.output, out)
 			}
 		})
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It handles Unicode properly when truncating strings in ui/termstatus, and tries to detect the display width of characters. It does so in a conservative, locale-neutral way.

The obvious alternative to this implementation is to use the Truncate function from github.com/mattn/go-runewidth. I decided against that package when I noticed it uses behaves differently depending on the locale and on an undocumented environment variable.

The upgrade to golang.org/x/text isn't strictly necessary, but the new version does add Unicode 13 tables for the width package that will be picked up by Go 1.16 when that's released.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes #3046.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
