### PR TITLE
Sanitize environment before starting backend processes (rclone, ssh)

### DIFF
--- a/internal/backend/foreground.go
+++ b/internal/backend/foreground.go
@@ -1,0 +1,26 @@
+package backend
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// StartForeground runs cmd in the foreground, by temporarily switching to the
+// new process group created for cmd. The returned function `bg` switches back
+// to the previous process group.
+//
+// The command's environment has all RESTIC_* variables removed.
+func StartForeground(cmd *exec.Cmd) (bg func() error, err error) {
+	env := os.Environ() // Returns a copy that we can modify.
+
+	cmd.Env = env[:0]
+	for _, kv := range env {
+		if strings.HasPrefix(kv, "RESTIC_") {
+			continue
+		}
+		cmd.Env = append(cmd.Env, kv)
+	}
+
+	return startForeground(cmd)
+}

--- a/internal/backend/foreground_solaris.go
+++ b/internal/backend/foreground_solaris.go
@@ -7,10 +7,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 )
 
-// StartForeground runs cmd in the foreground, by temporarily switching to the
-// new process group created for cmd. The returned function `bg` switches back
-// to the previous process group.
-func StartForeground(cmd *exec.Cmd) (bg func() error, err error) {
+func startForeground(cmd *exec.Cmd) (bg func() error, err error) {
 	// run the command in it's own process group so that SIGINT
 	// is not sent to it.
 	cmd.SysProcAttr = &syscall.SysProcAttr{

--- a/internal/backend/foreground_test.go
+++ b/internal/backend/foreground_test.go
@@ -1,0 +1,38 @@
+// +build !windows
+
+package backend_test
+
+import (
+	"bufio"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/restic/restic/internal/backend"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestForeground(t *testing.T) {
+	err := os.Setenv("RESTIC_PASSWORD", "supersecret")
+	rtest.OK(t, err)
+
+	cmd := exec.Command("env")
+	stdout, err := cmd.StdoutPipe()
+	rtest.OK(t, err)
+
+	bg, err := backend.StartForeground(cmd)
+	rtest.OK(t, err)
+	defer cmd.Wait()
+
+	err = bg()
+	rtest.OK(t, err)
+
+	sc := bufio.NewScanner(stdout)
+	for sc.Scan() {
+		if strings.HasPrefix(sc.Text(), "RESTIC_PASSWORD=") {
+			t.Error("subprocess got to see the password")
+		}
+	}
+	rtest.OK(t, err)
+}

--- a/internal/backend/foreground_unix.go
+++ b/internal/backend/foreground_unix.go
@@ -24,10 +24,7 @@ func tcsetpgrp(fd int, pid int) error {
 	return errno
 }
 
-// StartForeground runs cmd in the foreground, by temporarily switching to the
-// new process group created for cmd. The returned function `bg` switches back
-// to the previous process group.
-func StartForeground(cmd *exec.Cmd) (bg func() error, err error) {
+func startForeground(cmd *exec.Cmd) (bg func() error, err error) {
 	// open the TTY, we need the file descriptor
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
 	if err != nil {

--- a/internal/backend/foreground_windows.go
+++ b/internal/backend/foreground_windows.go
@@ -6,10 +6,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 )
 
-// StartForeground runs cmd in the foreground, by temporarily switching to the
-// new process group created for cmd. The returned function `bg` switches back
-// to the previous process group.
-func StartForeground(cmd *exec.Cmd) (bg func() error, err error) {
+func startForeground(cmd *exec.Cmd) (bg func() error, err error) {
 	// just start the process and hope for the best
 	err = cmd.Start()
 	if err != nil {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Subprocesses for backends are now started with a sanitized environment. The restic security model includes full trust of the local machine, so this should not fix any actual security problems, but it's better to be safe than sorry.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes #2192.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
