### PR TITLE
Return an error for invalid sizes

### DIFF
--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -314,6 +314,10 @@ func rejectBySize(maxSizeStr string) (RejectFunc, error) {
 }
 
 func parseSizeStr(sizeStr string) (int64, error) {
+	if sizeStr == "" {
+		return 0, errors.New("expected size, got empty string")
+	}
+
 	numStr := sizeStr[:len(sizeStr)-1]
 	var unit int64 = 1
 
@@ -333,7 +337,7 @@ func parseSizeStr(sizeStr string) (int64, error) {
 	}
 	value, err := strconv.ParseInt(numStr, 10, 64)
 	if err != nil {
-		return 0, nil
+		return 0, err
 	}
 	return value * unit, nil
 }

--- a/cmd/restic/exclude_test.go
+++ b/cmd/restic/exclude_test.go
@@ -219,6 +219,25 @@ func TestParseSizeStr(t *testing.T) {
 	}
 }
 
+func TestParseInvalidSizeStr(t *testing.T) {
+	invalidSizes := []string{
+		"",
+		" ",
+		"foobar",
+		"zzz",
+	}
+
+	for _, s := range invalidSizes {
+		v, err := parseSizeStr(s)
+		if err == nil {
+			t.Errorf("wanted error for invalid value %q, got nil", s)
+		}
+		if v != 0 {
+			t.Errorf("wanted zero for invalid value %q, got: %v", s, v)
+		}
+	}
+}
+
 // TestIsExcludedByFileSize is for testing the instance of
 // --exclude-larger-than parameters
 func TestIsExcludedByFileSize(t *testing.T) {


### PR DESCRIPTION
While reviewing #2718, I noticed that restic does not detect empty byte size specifications and uses zero instead. I've fixed the bug in the parsing code and added tests.