### PR TITLE
Don't separately allocate sync.{Mutex,Once} if not necessary

### DIFF
--- a/internal/fs/fs_local_vss.go
+++ b/internal/fs/fs_local_vss.go
@@ -21,7 +21,7 @@ type LocalVss struct {
 	FS
 	snapshots       map[string]VssSnapshot
 	failedSnapshots map[string]struct{}
-	mutex           *sync.RWMutex
+	mutex           sync.RWMutex
 	msgError        ErrorHandler
 	msgMessage      MessageHandler
 }
@@ -36,7 +36,6 @@ func NewLocalVss(msgError ErrorHandler, msgMessage MessageHandler) *LocalVss {
 		FS:              Local{},
 		snapshots:       make(map[string]VssSnapshot),
 		failedSnapshots: make(map[string]struct{}),
-		mutex:           &sync.RWMutex{},
 		msgError:        msgError,
 		msgMessage:      msgMessage,
 	}

--- a/internal/restic/progress.go
+++ b/internal/restic/progress.go
@@ -40,7 +40,7 @@ type Progress struct {
 	start      time.Time
 	c          *time.Ticker
 	cancel     chan struct{}
-	o          *sync.Once
+	once       sync.Once
 	d          time.Duration
 	lastUpdate time.Time
 
@@ -79,7 +79,6 @@ func (p *Progress) Start() {
 		return
 	}
 
-	p.o = &sync.Once{}
 	p.cancel = make(chan struct{})
 	p.running = true
 	p.Reset()
@@ -187,7 +186,7 @@ func (p *Progress) Done() {
 	}
 
 	p.running = false
-	p.o.Do(func() {
+	p.once.Do(func() {
 		close(p.cancel)
 	})
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Some cleanup of sync object usage. Separate allocation and access through a pointer suggests the objects are shared by multiple owners, but they're not.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
