### PR TITLE
Handle EINTR from os.Chmod (Linux+CIFS)

### DIFF
--- a/internal/fs/file_unix_test.go
+++ b/internal/fs/file_unix_test.go
@@ -1,0 +1,48 @@
+// +build !windows
+
+package fs
+
+import (
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/test"
+)
+
+func TestChmodEINTR(t *testing.T) {
+	defer func() { osChmod = os.Chmod }()
+
+	numFail := 10
+	osChmod = func(filename string, mode os.FileMode) error {
+		numFail--
+		if numFail >= 0 {
+			return &os.PathError{Err: syscall.EINTR}
+		}
+		return os.Chmod(filename, mode)
+	}
+
+	err := Chmod("/no/file/here", 0700)
+	test.Assert(t, os.IsNotExist(err), "wrong error from Chmod: %v", err)
+
+	numFail = 9999
+	err = Chmod("/no/file/here", 0700)
+	err = errors.Cause(err)
+	switch err := err.(type) {
+	case *os.PathError:
+		test.Equals(t, syscall.EINTR, err.Err)
+	default:
+		t.Error(err)
+	}
+}
+
+func TestChmodENOTSUP(t *testing.T) {
+	defer func() { osChmod = os.Chmod }()
+
+	osChmod = func(string, os.FileMode) error {
+		return &os.PathError{Err: syscall.ENOTSUP}
+	}
+
+	test.OK(t, Chmod("/whatever", 0600))
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Handle EINTR from os.Chmod by retrying the operation at most a reasonable (100) number of times.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes #3060.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
