### PR TITLE
Add options to fine tune VSS snapshots

### DIFF
--- a/changelog/unreleased/pull-3067
+++ b/changelog/unreleased/pull-3067
@@ -1,6 +1,6 @@
 Enhancement: Add options to configure Windows Shadow Copy Service
 
-Restic always used 120 sec. timeout and unconditionally created VSS snapshots
+Restic always used 120 seconds timeout and unconditionally created VSS snapshots
 for all volume mount points on disk. Now this behavior can be fine-tuned by
 new options, like exclude specific volumes and mount points or completely
 disable auto snapshotting of volume mount points.

--- a/changelog/unreleased/pull-3067
+++ b/changelog/unreleased/pull-3067
@@ -15,4 +15,8 @@ changes timeout to five minutes and disable snapshotting of mount points on all 
 
 excludes drive `D:`, mount point `C:\MNT` and specific volume from VSS snapshotting.
 
+    restic backup --use-fs-snapshot -o vss.provider={b5946137-7b9f-4925-af80-51abd60b20d5}
+    
+uses 'Microsoft Software Shadow Copy provider 1.0' instead of the default provider.
+
 https://github.com/restic/restic/pull/3067

--- a/changelog/unreleased/pull-3067
+++ b/changelog/unreleased/pull-3067
@@ -2,21 +2,21 @@ Enhancement: Add options to configure Windows Shadow Copy Service
 
 Restic always used 120 sec. timeout and unconditionally created VSS snapshots
 for all volume mount points on disk. Now this behavior can be fine-tuned by
-new options, like exclude user specific volumes and mount points or completely
+new options, like exclude specific volumes and mount points or completely
 disable auto snapshotting of volume mount points.
 
 For example:
 
-    restic backup --use-fs-snapshot -o vss.timeout=5m -o vss.excludeallmountpoints=true
-    
+    restic backup --use-fs-snapshot -o vss.timeout=5m -o vss.exclude-all-mount-points=true
+
 changes timeout to five minutes and disable snapshotting of mount points on all volumes, and
 
-    restic backup --use-fs-snapshot -o vss.excludevolumes="d:\;c:\mnt\;\\?\Volume{e2e0315d-9066-4f97-8343-eb5659b35762}"
+    restic backup --use-fs-snapshot -o vss.exclude-volumes="d:\;c:\mnt\;\\?\Volume{e2e0315d-9066-4f97-8343-eb5659b35762}"
 
-excludes drive `D:`, mount point `C:\MNT` and specific volume from VSS snapshotting.
+excludes drive `d:`, mount point `c:\mnt` and specific volume from VSS snapshotting.
 
     restic backup --use-fs-snapshot -o vss.provider={b5946137-7b9f-4925-af80-51abd60b20d5}
-    
+
 uses 'Microsoft Software Shadow Copy provider 1.0' instead of the default provider.
 
 https://github.com/restic/restic/pull/3067

--- a/changelog/unreleased/pull-3067
+++ b/changelog/unreleased/pull-3067
@@ -1,0 +1,18 @@
+Enhancement: Add options to configure Windows Shadow Copy Service
+
+Restic always used 120 sec. timeout and unconditionally created VSS snapshots
+for all volume mount points on disk. Now this behavior can be fine-tuned by
+new options, like exclude user specific volumes and mount points or completely
+disable auto snapshotting of volume mount points.
+
+For example:
+
+    restic backup --use-fs-snapshot -o vss.timeout=5m -o vss.excludeallmountpoints=true
+    
+changes timeout to five minutes and disable snapshotting of mount points on all volumes, and
+
+    restic backup --use-fs-snapshot -o vss.excludevolumes="d:\;c:\mnt\;\\?\Volume{e2e0315d-9066-4f97-8343-eb5659b35762}"
+
+excludes drive `D:`, mount point `C:\MNT` and specific volume from VSS snapshotting.
+
+https://github.com/restic/restic/pull/3067

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -445,7 +445,16 @@ func findParentSnapshot(ctx context.Context, repo restic.ListerLoaderUnpacked, o
 }
 
 func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, term *termstatus.Terminal, args []string) error {
-	err := opts.Check(gopts, args)
+	var vsscfg fs.VSSConfig
+	var err error
+
+	if runtime.GOOS == "windows" {
+		if vsscfg, err = fs.ParseVSSConfig(gopts.extended); err != nil {
+			return err
+		}
+	}
+
+	err = opts.Check(gopts, args)
 	if err != nil {
 		return err
 	}
@@ -557,7 +566,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 			}
 		}
 
-		localVss := fs.NewLocalVss(errorHandler, messageHandler)
+		localVss := fs.NewLocalVss(errorHandler, messageHandler, vsscfg)
 		defer localVss.DeleteSnapshots()
 		targetFS = localVss
 	}

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -556,8 +556,8 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 			return err
 		}
 
-		errorHandler := func(item string, err error) error {
-			return progressReporter.Error(item, err)
+		errorHandler := func(item string, err error) {
+			_ = progressReporter.Error(item, err)
 		}
 
 		messageHandler := func(msg string, args ...interface{}) {

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -56,11 +56,12 @@ snapshot for each volume that contains files to backup. Files are read from the
 VSS snapshot instead of the regular filesystem. This allows to backup files that are
 exclusively locked by another process during the backup.
 
-You can use three additional options to change VSS behaviour:
+You can use additional options to change VSS behaviour:
 
  * ``-o vss.timeout`` specifies timeout for VSS snapshot creation, the default value is 120 seconds
  * ``-o vss.excludeallmountpoints`` disable auto snapshotting of all volume mount points
  * ``-o vss.excludevolumes`` allows excluding specific volumes or volume mount points from snapshotting
+ * ``-o vss.provider`` specifies VSS provider used for snapshotting
 
 E.g., 2.5 minutes timeout with mount points snapshotting disabled can be specified as
 
@@ -73,6 +74,20 @@ and excluding drive ``D:\``, mount point ``C:\mnt`` and volume ``\\?\Volume{04ce
 .. code-block:: console
 
     -o vss.excludevolumes="d:;c:\MNT\;\\?\volume{04ce0545-3391-11e0-ba2f-806e6f6e6963}"
+
+VSS provider can be specified by GUID
+
+.. code-block:: console
+
+    -o vss.provider={3f900f90-00e9-440e-873a-96ca5eb079e5}
+
+or by name
+
+.. code-block:: console
+
+    -o vss.provider="Hyper-V IC Software Shadow Copy Provider"
+
+Also ``MS`` can be used as alias for ``Microsoft Software Shadow Copy provider 1.0``.
 
 By default VSS ignores Outlook OST files. This is not a restriction of restic
 but the default Windows VSS configuration. The files not to snapshot are

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -56,6 +56,24 @@ snapshot for each volume that contains files to backup. Files are read from the
 VSS snapshot instead of the regular filesystem. This allows to backup files that are
 exclusively locked by another process during the backup.
 
+You can use three additional options to change VSS behaviour:
+
+ * ``-o vss.timeout`` specifies timeout for VSS snapshot creation, the default value is 120 seconds
+ * ``-o vss.excludeallmountpoints`` disable auto snapshotting of all volume mount points
+ * ``-o vss.excludevolumes`` allows excluding specific volumes or volume mount points from snapshotting
+
+E.g., 2.5 minutes timeout with mount points snapshotting disabled can be specified as
+
+.. code-block:: console
+
+    -o vss.timeout=2m30s -o vss.excludeallmountpoints=true
+
+and excluding drive ``D:\``, mount point ``C:\mnt`` and volume ``\\?\Volume{04ce0545-3391-11e0-ba2f-806e6f6e6963}\`` as
+
+.. code-block:: console
+
+    -o vss.excludevolumes="d:;c:\MNT\;\\?\volume{04ce0545-3391-11e0-ba2f-806e6f6e6963}"
+
 By default VSS ignores Outlook OST files. This is not a restriction of restic
 but the default Windows VSS configuration. The files not to snapshot are
 configured in the Windows registry under the following key:

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -59,21 +59,21 @@ exclusively locked by another process during the backup.
 You can use additional options to change VSS behaviour:
 
  * ``-o vss.timeout`` specifies timeout for VSS snapshot creation, the default value is 120 seconds
- * ``-o vss.excludeallmountpoints`` disable auto snapshotting of all volume mount points
- * ``-o vss.excludevolumes`` allows excluding specific volumes or volume mount points from snapshotting
+ * ``-o vss.exclude-all-mount-points`` disable auto snapshotting of all volume mount points
+ * ``-o vss.exclude-volumes`` allows excluding specific volumes or volume mount points from snapshotting
  * ``-o vss.provider`` specifies VSS provider used for snapshotting
 
-E.g., 2.5 minutes timeout with mount points snapshotting disabled can be specified as
+For example a 2.5 minutes timeout with snapshotting of mount points disabled can be specified as
 
 .. code-block:: console
 
-    -o vss.timeout=2m30s -o vss.excludeallmountpoints=true
+    -o vss.timeout=2m30s -o vss.exclude-all-mount-points=true
 
-and excluding drive ``D:\``, mount point ``C:\mnt`` and volume ``\\?\Volume{04ce0545-3391-11e0-ba2f-806e6f6e6963}\`` as
+and excluding drive ``d:\``, mount point ``c:\mnt`` and volume ``\\?\Volume{04ce0545-3391-11e0-ba2f-806e6f6e6963}\`` as
 
 .. code-block:: console
 
-    -o vss.excludevolumes="d:;c:\MNT\;\\?\volume{04ce0545-3391-11e0-ba2f-806e6f6e6963}"
+    -o vss.exclude-volumes="d:;c:\mnt\;\\?\volume{04ce0545-3391-11e0-ba2f-806e6f6e6963}"
 
 VSS provider can be specified by GUID
 

--- a/internal/fs/fs_local_vss.go
+++ b/internal/fs/fs_local_vss.go
@@ -165,7 +165,6 @@ func (fs *LocalVss) isMountPointExcluded(mountPoint string) bool {
 // If creation of a snapshot fails the file's original path is returned as
 // a fallback.
 func (fs *LocalVss) snapshotPath(path string) string {
-
 	fixPath := fixpath(path)
 
 	if strings.HasPrefix(fixPath, `\\?\UNC\`) {
@@ -268,9 +267,8 @@ func (fs *LocalVss) snapshotPath(path string) string {
 		snapshotPath = fs.Join(snapshot.GetSnapshotDeviceObject(),
 			strings.TrimPrefix(fixPath, volumeName))
 		if snapshotPath == snapshot.GetSnapshotDeviceObject() {
-			snapshotPath = snapshotPath + string(filepath.Separator)
+			snapshotPath += string(filepath.Separator)
 		}
-
 	} else {
 		// no snapshot is available for the requested path:
 		//  -> try to backup without a snapshot

--- a/internal/fs/fs_local_vss.go
+++ b/internal/fs/fs_local_vss.go
@@ -14,8 +14,8 @@ import (
 
 // VSSConfig holds extended options of windows volume shadow copy service.
 type VSSConfig struct {
-	ExcludeAllMountPoints bool          `option:"excludeallmountpoints" help:"exclude mountpoints from snapshotting on all volumes"`
-	ExcludeVolumes        string        `option:"excludevolumes" help:"semicolon separated list of volumes to exclude from snapshotting (ex. 'c:\\;e:\\mnt;\\\\?\\Volume{...}')"`
+	ExcludeAllMountPoints bool          `option:"exclude-all-mount-points" help:"exclude mountpoints from snapshotting on all volumes"`
+	ExcludeVolumes        string        `option:"exclude-volumes" help:"semicolon separated list of volumes to exclude from snapshotting (ex. 'c:\\;e:\\mnt;\\\\?\\Volume{...}')"`
 	Timeout               time.Duration `option:"timeout" help:"time that the VSS can spend creating snapshot before timing out"`
 	Provider              string        `option:"provider" help:"VSS provider identifier which will be used for snapshotting"`
 }
@@ -80,7 +80,7 @@ func parseMountPoints(list string, msgError ErrorHandler) (volumes map[string]st
 	}
 	for _, s := range strings.Split(list, ";") {
 		if v, err := GetVolumeNameForVolumeMountPoint(s); err != nil {
-			msgError(s, errors.Errorf("failed to parse vss.excludevolumes [%s]: %s", s, err))
+			msgError(s, errors.Errorf("failed to parse vss.exclude-volumes [%s]: %s", s, err))
 		} else {
 			if volumes == nil {
 				volumes = make(map[string]struct{})

--- a/internal/fs/fs_local_vss.go
+++ b/internal/fs/fs_local_vss.go
@@ -43,8 +43,8 @@ func ParseVSSConfig(o options.Options) (VSSConfig, error) {
 	return cfg, nil
 }
 
-// ErrorHandler is used to report errors via callback
-type ErrorHandler func(item string, err error) error
+// ErrorHandler is used to report errors via callback.
+type ErrorHandler func(item string, err error)
 
 // MessageHandler is used to report errors/messages via callbacks.
 type MessageHandler func(msg string, args ...interface{})
@@ -114,7 +114,7 @@ func (fs *LocalVss) DeleteSnapshots() {
 
 	for volumeName, snapshot := range fs.snapshots {
 		if err := snapshot.Delete(); err != nil {
-			_ = fs.msgError(volumeName, errors.Errorf("failed to delete VSS snapshot: %s", err))
+			fs.msgError(volumeName, errors.Errorf("failed to delete VSS snapshot: %s", err))
 			activeSnapshots[volumeName] = snapshot
 		}
 	}

--- a/internal/fs/fs_local_vss_test.go
+++ b/internal/fs/fs_local_vss_test.go
@@ -274,11 +274,7 @@ func TestParseProvider(t *testing.T) {
 				if err != nil {
 					result = err.Error()
 				}
-				matched, err := regexp.MatchString(test.result, result)
-				if err != nil {
-					panic(err)
-				}
-				if !matched || test.result == "" {
+				if test.result != result || test.result == "" {
 					t.Fatalf("wrong result, want:\n  %#v\ngot:\n  %#v", test.result, result)
 				}
 			} else if !ole.IsEqualGUID(id, test.id) {

--- a/internal/fs/fs_local_vss_test.go
+++ b/internal/fs/fs_local_vss_test.go
@@ -1,0 +1,211 @@
+// +build windows
+
+package fs
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/options"
+)
+
+func matchStrings(ptrs []string, strs []string) bool {
+	if len(ptrs) != len(strs) {
+		return false
+	}
+
+	for i, p := range ptrs {
+		matched, err := regexp.MatchString(p, strs[i])
+		if err != nil {
+			panic(err)
+		}
+		if !matched {
+			return false
+		}
+	}
+
+	return true
+}
+
+func matchMap(strs []string, m map[string]struct{}) bool {
+	if len(strs) != len(m) {
+		return false
+	}
+
+	for _, s := range strs {
+		if _, ok := m[s]; !ok {
+			return false
+		}
+	}
+
+	return true
+}
+
+func TestVSSConfig(t *testing.T) {
+	type config struct {
+		excludeAllMountPoints bool
+		timeout               time.Duration
+	}
+	setTests := []struct {
+		input  options.Options
+		output config
+	}{
+		{
+			options.Options{
+				"vss.timeout": "6h38m42s",
+			},
+			config{
+				timeout: 23922000000000,
+			},
+		},
+		{
+			options.Options{
+				"vss.excludeallmountpoints": "t",
+			},
+			config{
+				excludeAllMountPoints: true,
+				timeout:               120000000000,
+			},
+		},
+		{
+			options.Options{
+				"vss.excludeallmountpoints": "0",
+				"vss.excludevolumes":        "",
+				"vss.timeout":               "120s",
+			},
+			config{
+				timeout: 120000000000,
+			},
+		},
+	}
+	for i, test := range setTests {
+		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
+			cfg, err := ParseVSSConfig(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			errorHandler := func(item string, err error) error {
+				t.Fatalf("unexpected error (%v)", err)
+
+				return nil
+			}
+			messageHandler := func(msg string, args ...interface{}) {
+				t.Fatalf("unexpected message (%s)", fmt.Sprintf(msg, args))
+			}
+
+			dst := NewLocalVss(errorHandler, messageHandler, cfg)
+
+			if dst.excludeAllMountPoints != test.output.excludeAllMountPoints ||
+				dst.excludeVolumes != nil || dst.timeout != test.output.timeout {
+				t.Fatalf("wrong result, want:\n  %#v\ngot:\n  %#v", test.output, dst)
+			}
+		})
+	}
+}
+
+func TestParseMountPoints(t *testing.T) {
+	volumeMatch := regexp.MustCompile(`^\\\\\?\\Volume\{[0-9a-f]{8}(?:-[0-9a-f]{4}){3}-[0-9a-f]{12}\}\\$`)
+
+	// It's not a good idea to test functions based on GetVolumeNameForVolumeMountPoint by calling
+	// GetVolumeNameForVolumeMountPoint itself, but we have restricted test environment:
+	// cannot manage volumes and can only be sure that the mount point C:\ exists
+	sysVolume, err := GetVolumeNameForVolumeMountPoint("C:")
+	if err != nil {
+		t.Fatal(err)
+	}
+	// We don't know a valid volume GUID path for C:\, but we'll at least check its format
+	if !volumeMatch.MatchString(sysVolume) {
+		t.Fatalf("invalid volume GUID path: %s", sysVolume)
+	}
+	sysVolumeMutated := strings.ToUpper(sysVolume[:len(sysVolume)-1])
+	sysVolumeMatch := strings.ToLower(sysVolume)
+
+	type check struct {
+		volume string
+		result bool
+	}
+	setTests := []struct {
+		input  options.Options
+		output []string
+		checks []check
+		errors []string
+	}{
+		{
+			options.Options{
+				"vss.excludevolumes": `c:;c:\;` + sysVolume + `;` + sysVolumeMutated,
+			},
+			[]string{
+				sysVolumeMatch,
+			},
+			[]check{
+				{`c:\`, true},
+				{`c:`, true},
+				{sysVolume, true},
+				{sysVolumeMutated, true},
+			},
+			[]string{},
+		},
+		{
+			options.Options{
+				"vss.excludevolumes": `z:\nonexistent;c:;c:\windows\;\\?\Volume{39b9cac2-bcdb-4d51-97c8-0d0677d607fb}\`,
+			},
+			[]string{
+				sysVolumeMatch,
+			},
+			[]check{
+				{`c:\windows\`, false},
+				{`\\?\Volume{39b9cac2-bcdb-4d51-97c8-0d0677d607fb}\`, false},
+				{`c:`, true},
+				{``, false},
+			},
+			[]string{
+				`failed to parse vss\.excludevolumes \[z:\\nonexistent\]:.*`,
+				`failed to parse vss\.excludevolumes \[c:\\windows\\\]:.*`,
+				`failed to parse vss\.excludevolumes \[\\\\\?\\Volume\{39b9cac2-bcdb-4d51-97c8-0d0677d607fb\}\\\]:.*`,
+				`failed to get volume from mount point \[c:\\windows\\\]:.*`,
+				`failed to get volume from mount point \[\\\\\?\\Volume\{39b9cac2-bcdb-4d51-97c8-0d0677d607fb\}\\\]:.*`,
+				`failed to get volume from mount point \[\]:.*`,
+			},
+		},
+	}
+
+	for i, test := range setTests {
+		t.Run(fmt.Sprintf("test-%d", i), func(t *testing.T) {
+			cfg, err := ParseVSSConfig(test.input)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			var log []string
+			errorHandler := func(item string, err error) error {
+				log = append(log, strings.TrimSpace(err.Error()))
+
+				return nil
+			}
+			messageHandler := func(msg string, args ...interface{}) {
+				t.Fatalf("unexpected message (%s)", fmt.Sprintf(msg, args))
+			}
+
+			dst := NewLocalVss(errorHandler, messageHandler, cfg)
+
+			if !matchMap(test.output, dst.excludeVolumes) {
+				t.Fatalf("wrong result, want:\n  %#v\ngot:\n  %#v",
+					test.output, dst.excludeVolumes)
+			}
+
+			for _, c := range test.checks {
+				if dst.isMountPointExcluded(c.volume) != c.result {
+					t.Fatalf(`wrong check: isMountPointExcluded("%s") != %v`, c.volume, c.result)
+				}
+			}
+
+			if !matchStrings(test.errors, log) {
+				t.Fatalf("wrong log, want:\n  %#v\ngot:\n  %#v", test.errors, log)
+			}
+		})
+	}
+}

--- a/internal/fs/fs_local_vss_test.go
+++ b/internal/fs/fs_local_vss_test.go
@@ -127,10 +127,12 @@ func TestParseMountPoints(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// We don't know a valid volume GUID path for C:\, but we'll at least check its format
+	// We don't know a valid volume GUID path for c:\, but we'll at least check its format
 	if !volumeMatch.MatchString(sysVolume) {
 		t.Fatalf("invalid volume GUID path: %s", sysVolume)
 	}
+	// Changing the case and removing trailing backslash allows tests
+	// the equality of different ways of writing a volume name
 	sysVolumeMutated := strings.ToUpper(sysVolume[:len(sysVolume)-1])
 	sysVolumeMatch := strings.ToLower(sysVolume)
 

--- a/internal/fs/fs_local_vss_test.go
+++ b/internal/fs/fs_local_vss_test.go
@@ -88,10 +88,8 @@ func TestVSSConfig(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			errorHandler := func(item string, err error) error {
+			errorHandler := func(item string, err error) {
 				t.Fatalf("unexpected error (%v)", err)
-
-				return nil
 			}
 			messageHandler := func(msg string, args ...interface{}) {
 				t.Fatalf("unexpected message (%s)", fmt.Sprintf(msg, args))
@@ -181,10 +179,8 @@ func TestParseMountPoints(t *testing.T) {
 			}
 
 			var log []string
-			errorHandler := func(item string, err error) error {
+			errorHandler := func(item string, err error) {
 				log = append(log, strings.TrimSpace(err.Error()))
-
-				return nil
 			}
 			messageHandler := func(msg string, args ...interface{}) {
 				t.Fatalf("unexpected message (%s)", fmt.Sprintf(msg, args))

--- a/internal/fs/fs_local_vss_test.go
+++ b/internal/fs/fs_local_vss_test.go
@@ -154,10 +154,10 @@ func TestParseMountPoints(t *testing.T) {
 				sysVolumeMatch,
 			},
 			[]check{
-				{`c:\`, true},
-				{`c:`, true},
-				{sysVolume, true},
-				{sysVolumeMutated, true},
+				{`c:\`, false},
+				{`c:`, false},
+				{sysVolume, false},
+				{sysVolumeMutated, false},
 			},
 			[]string{},
 		},
@@ -169,10 +169,10 @@ func TestParseMountPoints(t *testing.T) {
 				sysVolumeMatch,
 			},
 			[]check{
-				{`c:\windows\`, false},
-				{`\\?\Volume{39b9cac2-bcdb-4d51-97c8-0d0677d607fb}\`, false},
-				{`c:`, true},
-				{``, false},
+				{`c:\windows\`, true},
+				{`\\?\Volume{39b9cac2-bcdb-4d51-97c8-0d0677d607fb}\`, true},
+				{`c:`, false},
+				{``, true},
 			},
 			[]string{
 				`failed to parse vss\.exclude-volumes \[z:\\nonexistent\]:.*`,
@@ -208,8 +208,8 @@ func TestParseMountPoints(t *testing.T) {
 			}
 
 			for _, c := range test.checks {
-				if dst.isMountPointExcluded(c.volume) != c.result {
-					t.Fatalf(`wrong check: isMountPointExcluded("%s") != %v`, c.volume, c.result)
+				if dst.isMountPointIncluded(c.volume) != c.result {
+					t.Fatalf(`wrong check: isMountPointIncluded("%s") != %v`, c.volume, c.result)
 				}
 			}
 

--- a/internal/fs/fs_local_vss_test.go
+++ b/internal/fs/fs_local_vss_test.go
@@ -70,8 +70,8 @@ func TestVSSConfig(t *testing.T) {
 		},
 		{
 			options.Options{
-				"vss.excludeallmountpoints": "t",
-				"vss.provider":              "{b5946137-7b9f-4925-af80-51abd60b20d5}",
+				"vss.exclude-all-mount-points": "t",
+				"vss.provider":                 "{b5946137-7b9f-4925-af80-51abd60b20d5}",
 			},
 			config{
 				excludeAllMountPoints: true,
@@ -81,10 +81,10 @@ func TestVSSConfig(t *testing.T) {
 		},
 		{
 			options.Options{
-				"vss.excludeallmountpoints": "0",
-				"vss.excludevolumes":        "",
-				"vss.timeout":               "120s",
-				"vss.provider":              "Microsoft Software Shadow Copy provider 1.0",
+				"vss.exclude-all-mount-points": "0",
+				"vss.exclude-volumes":          "",
+				"vss.timeout":                  "120s",
+				"vss.provider":                 "Microsoft Software Shadow Copy provider 1.0",
 			},
 			config{
 				timeout:  120000000000,
@@ -148,7 +148,7 @@ func TestParseMountPoints(t *testing.T) {
 	}{
 		{
 			options.Options{
-				"vss.excludevolumes": `c:;c:\;` + sysVolume + `;` + sysVolumeMutated,
+				"vss.exclude-volumes": `c:;c:\;` + sysVolume + `;` + sysVolumeMutated,
 			},
 			[]string{
 				sysVolumeMatch,
@@ -163,7 +163,7 @@ func TestParseMountPoints(t *testing.T) {
 		},
 		{
 			options.Options{
-				"vss.excludevolumes": `z:\nonexistent;c:;c:\windows\;\\?\Volume{39b9cac2-bcdb-4d51-97c8-0d0677d607fb}\`,
+				"vss.exclude-volumes": `z:\nonexistent;c:;c:\windows\;\\?\Volume{39b9cac2-bcdb-4d51-97c8-0d0677d607fb}\`,
 			},
 			[]string{
 				sysVolumeMatch,
@@ -175,9 +175,9 @@ func TestParseMountPoints(t *testing.T) {
 				{``, false},
 			},
 			[]string{
-				`failed to parse vss\.excludevolumes \[z:\\nonexistent\]:.*`,
-				`failed to parse vss\.excludevolumes \[c:\\windows\\\]:.*`,
-				`failed to parse vss\.excludevolumes \[\\\\\?\\Volume\{39b9cac2-bcdb-4d51-97c8-0d0677d607fb\}\\\]:.*`,
+				`failed to parse vss\.exclude-volumes \[z:\\nonexistent\]:.*`,
+				`failed to parse vss\.exclude-volumes \[c:\\windows\\\]:.*`,
+				`failed to parse vss\.exclude-volumes \[\\\\\?\\Volume\{39b9cac2-bcdb-4d51-97c8-0d0677d607fb\}\\\]:.*`,
 				`failed to get volume from mount point \[c:\\windows\\\]:.*`,
 				`failed to get volume from mount point \[\\\\\?\\Volume\{39b9cac2-bcdb-4d51-97c8-0d0677d607fb\}\\\]:.*`,
 				`failed to get volume from mount point \[\]:.*`,

--- a/internal/fs/vss.go
+++ b/internal/fs/vss.go
@@ -41,7 +41,7 @@ func GetVolumeNameForVolumeMountPoint(mountPoint string) (string, error) {
 
 // NewVssSnapshot creates a new vss snapshot. If creating the snapshots doesn't
 // finish within the timeout an error is returned.
-func NewVssSnapshot(
+func NewVssSnapshot(_ string,
 	_ string, _ time.Duration, _ VolumeFilter, _ ErrorHandler) (VssSnapshot, error) {
 	return VssSnapshot{}, errors.New("VSS snapshots are only supported on windows")
 }

--- a/internal/fs/vss.go
+++ b/internal/fs/vss.go
@@ -33,7 +33,7 @@ func HasSufficientPrivilegesForVSS() error {
 	return errors.New("VSS snapshots are only supported on windows")
 }
 
-// GetVolumeNameForVolumeMountPoint clear input parameter
+// GetVolumeNameForVolumeMountPoint add trailing backslash to input parameter
 // and calls the equivalent windows api.
 func GetVolumeNameForVolumeMountPoint(mountPoint string) (string, error) {
 	return mountPoint, nil

--- a/internal/fs/vss.go
+++ b/internal/fs/vss.go
@@ -33,10 +33,16 @@ func HasSufficientPrivilegesForVSS() error {
 	return errors.New("VSS snapshots are only supported on windows")
 }
 
+// GetVolumeNameForVolumeMountPoint clear input parameter
+// and calls the equivalent windows api.
+func GetVolumeNameForVolumeMountPoint(mountPoint string) (string, error) {
+	return mountPoint, nil
+}
+
 // NewVssSnapshot creates a new vss snapshot. If creating the snapshots doesn't
 // finish within the timeout an error is returned.
 func NewVssSnapshot(
-	_ string, _ time.Duration, _ ErrorHandler) (VssSnapshot, error) {
+	_ string, _ time.Duration, _ VolumeFilter, _ ErrorHandler) (VssSnapshot, error) {
 	return VssSnapshot{}, errors.New("VSS snapshots are only supported on windows")
 }
 

--- a/internal/fs/vss.go
+++ b/internal/fs/vss.go
@@ -4,6 +4,8 @@
 package fs
 
 import (
+	"time"
+
 	"github.com/restic/restic/internal/errors"
 )
 
@@ -34,7 +36,7 @@ func HasSufficientPrivilegesForVSS() error {
 // NewVssSnapshot creates a new vss snapshot. If creating the snapshots doesn't
 // finish within the timeout an error is returned.
 func NewVssSnapshot(
-	_ string, _ uint, _ ErrorHandler) (VssSnapshot, error) {
+	_ string, _ time.Duration, _ ErrorHandler) (VssSnapshot, error) {
 	return VssSnapshot{}, errors.New("VSS snapshots are only supported on windows")
 }
 

--- a/internal/fs/vss_windows.go
+++ b/internal/fs/vss_windows.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
+	"time"
 	"unsafe"
 
 	ole "github.com/go-ole/go-ole"
@@ -617,8 +618,13 @@ func (vssAsync *IVSSAsync) QueryStatus() (HRESULT, uint32) {
 
 // WaitUntilAsyncFinished waits until either the async call is finished or
 // the given timeout is reached.
-func (vssAsync *IVSSAsync) WaitUntilAsyncFinished(millis uint32) error {
-	hresult := vssAsync.Wait(millis)
+func (vssAsync *IVSSAsync) WaitUntilAsyncFinished(timeout time.Duration) error {
+	const maxTimeout = 2147483647 * time.Millisecond
+	if timeout > maxTimeout {
+		timeout = maxTimeout
+	}
+
+	hresult := vssAsync.Wait(uint32(timeout.Milliseconds()))
 	err := newVssErrorIfResultNotOK("Wait() failed", hresult)
 	if err != nil {
 		vssAsync.Cancel()
@@ -677,7 +683,7 @@ type VssSnapshot struct {
 	snapshotProperties   VssSnapshotProperties
 	snapshotDeviceObject string
 	mountPointInfo       map[string]MountPoint
-	timeoutInMillis      uint32
+	timeout              time.Duration
 }
 
 // GetSnapshotDeviceObject returns root path to access the snapshot files
@@ -730,7 +736,7 @@ func HasSufficientPrivilegesForVSS() error {
 // NewVssSnapshot creates a new vss snapshot. If creating the snapshots doesn't
 // finish within the timeout an error is returned.
 func NewVssSnapshot(
-	volume string, timeoutInSeconds uint, msgError ErrorHandler) (VssSnapshot, error) {
+	volume string, timeout time.Duration, msgError ErrorHandler) (VssSnapshot, error) {
 	is64Bit, err := isRunningOn64BitWindows()
 
 	if err != nil {
@@ -744,7 +750,7 @@ func NewVssSnapshot(
 			runtime.GOARCH))
 	}
 
-	timeoutInMillis := uint32(timeoutInSeconds * 1000)
+	deadline := time.Now().Add(timeout)
 
 	oleIUnknown, err := initializeVssCOMInterface()
 	if oleIUnknown != nil {
@@ -796,7 +802,7 @@ func NewVssSnapshot(
 	}
 
 	err = callAsyncFunctionAndWait(iVssBackupComponents.GatherWriterMetadata,
-		"GatherWriterMetadata", timeoutInMillis)
+		"GatherWriterMetadata", deadline)
 	if err != nil {
 		iVssBackupComponents.Release()
 		return VssSnapshot{}, err
@@ -854,7 +860,7 @@ func NewVssSnapshot(
 	}
 
 	err = callAsyncFunctionAndWait(iVssBackupComponents.PrepareForBackup, "PrepareForBackup",
-		timeoutInMillis)
+		deadline)
 	if err != nil {
 		// After calling PrepareForBackup one needs to call AbortBackup() before releasing the VSS
 		// instance for proper cleanup.
@@ -865,7 +871,7 @@ func NewVssSnapshot(
 	}
 
 	err = callAsyncFunctionAndWait(iVssBackupComponents.DoSnapshotSet, "DoSnapshotSet",
-		timeoutInMillis)
+		deadline)
 	if err != nil {
 		iVssBackupComponents.AbortBackup()
 		iVssBackupComponents.Release()
@@ -901,7 +907,7 @@ func NewVssSnapshot(
 	}
 
 	return VssSnapshot{iVssBackupComponents, snapshotSetID, snapshotProperties,
-		snapshotProperties.GetSnapshotDeviceObject(), mountPointInfo, timeoutInMillis}, nil
+		snapshotProperties.GetSnapshotDeviceObject(), mountPointInfo, time.Until(deadline)}, nil
 }
 
 // Delete deletes the created snapshot.
@@ -922,8 +928,10 @@ func (p *VssSnapshot) Delete() error {
 	if p.iVssBackupComponents != nil {
 		defer p.iVssBackupComponents.Release()
 
+		deadline := time.Now().Add(p.timeout)
+
 		err = callAsyncFunctionAndWait(p.iVssBackupComponents.BackupComplete, "BackupComplete",
-			p.timeoutInMillis)
+			deadline)
 		if err != nil {
 			return err
 		}
@@ -945,7 +953,7 @@ type asyncCallFunc func() (*IVSSAsync, error)
 
 // callAsyncFunctionAndWait calls an async functions and waits for it to either
 // finish or timeout.
-func callAsyncFunctionAndWait(function asyncCallFunc, name string, timeoutInMillis uint32) error {
+func callAsyncFunctionAndWait(function asyncCallFunc, name string, deadline time.Time) error {
 	iVssAsync, err := function()
 	if err != nil {
 		return err
@@ -955,7 +963,12 @@ func callAsyncFunctionAndWait(function asyncCallFunc, name string, timeoutInMill
 		return newVssTextError(fmt.Sprintf("%s() returned nil", name))
 	}
 
-	err = iVssAsync.WaitUntilAsyncFinished(timeoutInMillis)
+	timeout := time.Until(deadline)
+	if timeout <= 0 {
+		return newVssTextError(fmt.Sprintf("%s() deadline exceeded", name))
+	}
+
+	err = iVssAsync.WaitUntilAsyncFinished(timeout)
 	iVssAsync.Release()
 	return err
 }

--- a/internal/fs/vss_windows.go
+++ b/internal/fs/vss_windows.go
@@ -828,7 +828,7 @@ func HasSufficientPrivilegesForVSS() error {
 	return err
 }
 
-// GetVolumeNameForVolumeMountPoint clear input parameter
+// GetVolumeNameForVolumeMountPoint add trailing backslash to input parameter
 // and calls the equivalent windows api.
 func GetVolumeNameForVolumeMountPoint(mountPoint string) (string, error) {
 	if mountPoint != "" && mountPoint[len(mountPoint)-1] != filepath.Separator {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Original [VSS PR](https://github.com/restic/restic/pull/2274) use some not-so-universal defaults.

First of all, current Restic architecture don't allow listing all mount points **required** for backup and we have to enumerate mount points for a given volume and create VSS snapshots for **all** of them. This can lead to problems if some of this unnecessary mount points links to locked, filled or otherwise unsupported volumes. @fgma has made every effort to avoid this problems, but it's not feasible in all cases. On the other hand, Restic don't follow mount points: if you backup `C:\`, mount point `C:\mnt` will be saved as link `/c/mnt -> d:\`. So snapshotting mount points may only make sense for paths like `C:\mnt\somedir`.

Extended option `-o vss.excludeallmountpoints` solves this problem by enterely disabling mount points snapshotting.

Another problem can occurred with backups from multiple volumes (e.g. I backup files with some extensions from all drives), but VSS required only on certain volumes. Why not take a snapshot of them all: because snapshotting of large volumes can take several minutes.

Extended option `-o vss.excludevolumes` allows you to fine-tune VSS snapshots by excluding specific volumes. Mount points to this volumes are also excluded.

Thus, volumes can be specified in three ways: as drive letter `D:\`, as mount point `C:\mnt`, or as volume GUID path `\\?\Volume{b151601a-34a4-11e0-b644-806e6f6e6963}\`. The trailing slash can always be omitted `F:`. Before comparison, all specified volumes are converted (with reporting in case of errors) to the form of a volume GUID path, so if `C:\mnt` links to `D:\` then `-o vss.excludevolumes=d:` and `-o vss.excludevolumes=c:\mnt` will give the same results.

Also, default VSS provider may lead to [some](https://forum.restic.net/t/windows-shadow-copy-snapshot-vss-unexpected-provider-error/3674)  [problems](https://forum.restic.net/t/use-fs-snapshot-not-working-on-w2k19-server/3864). With the option `-o vss.provider`, vss provider can be specified in three ways: GUID, name and `MS` as alias for `{b5946137-7b9f-4925-af80-51abd60b20d5}`.

And the last potential problem is timeout: in my case, it takes more than a minute to take the longest snapshot. It's too close to the default timeout of 120 seconds.

The extended option `-o vss.timeout` option allows you to change this timeout. My implementation internally uses deadline concept (idiomatic for Go) instead of timeouts.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

I mention some of this issues in the [VSS Support PR](https://github.com/restic/restic/pull/2274#issuecomment-713183799)
Also see [timeout issue](https://github.com/restic/restic/issues/3142), [provider issue #1](https://forum.restic.net/t/windows-shadow-copy-snapshot-vss-unexpected-provider-error/3674) and [provider issue #2](https://forum.restic.net/t/use-fs-snapshot-not-working-on-w2k19-server/3864).

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
