### PR TITLE
Return context error in mem backend

### DIFF
--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -91,7 +91,7 @@ func saveFile(t testing.TB, repo restic.Repository, filename string, filesystem 
 		t.Fatal(err)
 	}
 
-	err = repo.Flush(ctx)
+	err = repo.Flush(context.Background())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -839,6 +839,7 @@ func TestArchiverSaveDir(t *testing.T) {
 				t.Errorf("wrong stats returned in TreeBlobs, want > 0, got %d", stats.TreeBlobs)
 			}
 
+			ctx = context.Background()
 			node.Name = targetNodeName
 			tree := &restic.Tree{Nodes: []*restic.Node{node}}
 			treeID, err := repo.SaveTree(ctx, tree)
@@ -934,7 +935,7 @@ func TestArchiverSaveDirIncremental(t *testing.T) {
 
 		t.Logf("node subtree %v", node.Subtree)
 
-		err = repo.Flush(ctx)
+		err = repo.Flush(context.Background())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1091,6 +1092,7 @@ func TestArchiverSaveTree(t *testing.T) {
 				t.Fatal(err)
 			}
 
+			ctx = context.Background()
 			err = repo.Flush(ctx)
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Check for context error in mem backend. Before, in most mem backend methods, the context was not used. So problems with the context could not be recognized in tests.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

See #3063 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have modified tests in archiver code which had context problems
- I have not added documentation for the changes (in the manual)
- There's no new file in `changelog/unreleased/` that describes the changes for our users (no changes for users)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
