### PR TITLE
Switch to the default set of golangci-lint linters

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -240,7 +240,7 @@ jobs:
           version: v1.29
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true
-          args: --verbose --timeout 5m --enable-all --disable wsl
+          args: --verbose --timeout 5m
 
         # only run golangci-lint for pull requests, otherwise ALL hints get
         # reported. We need to slowly address all issues until we can enable


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Currently nearly all golangci-lint linters are enabled. That creates lots of complaints about too long functions, global variables (which we don't want in general, but there are exceptions), uninitialized struct members, ... .

This PR switches back to the default set of linters. We'll probably want to enable a few additional linters again in the future though.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No. But see e.g. https://github.com/restic/restic/actions/runs/352726256 where the first four errors have either no good fix or are out of scope for the corresponding PR.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- ~~[ ] I have run `gofmt` on the code in all commits~~
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
