### PR TITLE
Add zip support to the `dump` command

### DIFF
--- a/changelog/unreleased/pull-3081
+++ b/changelog/unreleased/pull-3081
@@ -1,0 +1,8 @@
+Enhancement: Allow whole folder dump in ZIP format
+
+Previously, restic can dump the contents of a whole folder structure only
+in the tar format. The `dump` command now have a new flag to change output
+format to zip. Just pass `--archive zip` as an option to `restic dump`.
+
+https://github.com/restic/restic/pull/2433
+https://github.com/restic/restic/pull/3081

--- a/changelog/unreleased/pull-3081
+++ b/changelog/unreleased/pull-3081
@@ -1,7 +1,7 @@
-Enhancement: Allow whole folder dump in ZIP format
+Enhancement: Add zip format support to dump
 
-Previously, restic can dump the contents of a whole folder structure only
-in the tar format. The `dump` command now have a new flag to change output
+Previously, restic could dump the contents of a whole folder structure only
+in the tar format. The `dump` command now has a new flag to change output
 format to zip. Just pass `--archive zip` as an option to `restic dump`.
 
 https://github.com/restic/restic/pull/2433

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -128,10 +128,13 @@ e.g.:
 
 It is also possible to ``dump`` the contents of a whole folder structure to
 stdout. To retain the information about the files and folders Restic will
-output the contents in the tar format:
+output the contents in the tar (default) or zip formats:
 
 .. code-block:: console
 
     $ restic -r /srv/restic-repo dump latest /home/other/work > restore.tar
+ 
+.. code-block:: console
 
+    $ restic -r /srv/restic-repo dump -a zip latest /home/other/work > restore.zip
 

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -128,7 +128,7 @@ e.g.:
 
 It is also possible to ``dump`` the contents of a whole folder structure to
 stdout. To retain the information about the files and folders Restic will
-output the contents in the tar (default) or zip formats:
+output the contents in the tar (default) or zip format:
 
 .. code-block:: console
 

--- a/internal/dump/common.go
+++ b/internal/dump/common.go
@@ -1,0 +1,104 @@
+package dump
+
+import (
+	"context"
+	"io"
+	"path"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/walker"
+)
+
+// dumper implements saving node data.
+type dumper interface {
+	dumpNode(ctx context.Context, node *restic.Node, repo restic.Repository) error
+}
+
+// WriteDump will write the contents of the given tree to the given destination.
+// It will loop over all nodes in the tree and dump them recursively.
+type WriteDump func(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error
+
+func writeDump(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dmp dumper, dst io.Writer) error {
+	for _, rootNode := range tree.Nodes {
+		rootNode.Path = rootPath
+		err := dumpTree(ctx, repo, rootNode, rootPath, dmp)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func dumpTree(ctx context.Context, repo restic.Repository, rootNode *restic.Node, rootPath string, dmp dumper) error {
+	rootNode.Path = path.Join(rootNode.Path, rootNode.Name)
+	rootPath = rootNode.Path
+
+	if err := dmp.dumpNode(ctx, rootNode, repo); err != nil {
+		return err
+	}
+
+	// If this is no directory we are finished
+	if !IsDir(rootNode) {
+		return nil
+	}
+
+	err := walker.Walk(ctx, repo, *rootNode.Subtree, nil, func(_ restic.ID, nodepath string, node *restic.Node, err error) (bool, error) {
+		if err != nil {
+			return false, err
+		}
+		if node == nil {
+			return false, nil
+		}
+
+		node.Path = path.Join(rootPath, nodepath)
+
+		if IsFile(node) || IsLink(node) || IsDir(node) {
+			err := dmp.dumpNode(ctx, node, repo)
+			if err != nil {
+				return false, err
+			}
+		}
+
+		return false, nil
+	})
+
+	return err
+}
+
+// GetNodeData will write the contents of the node to the given output.
+func GetNodeData(ctx context.Context, output io.Writer, repo restic.Repository, node *restic.Node) error {
+	var (
+		buf []byte
+		err error
+	)
+	for _, id := range node.Content {
+		buf, err = repo.LoadBlob(ctx, restic.DataBlob, id, buf)
+		if err != nil {
+			return err
+		}
+
+		_, err = output.Write(buf)
+		if err != nil {
+			return errors.Wrap(err, "Write")
+		}
+	}
+
+	return nil
+}
+
+// IsDir checks if the given node is a directory.
+func IsDir(node *restic.Node) bool {
+	return node.Type == "dir"
+}
+
+// IsLink checks if the given node as a link.
+func IsLink(node *restic.Node) bool {
+	return node.Type == "symlink"
+}
+
+// IsFile checks if the given node is a file.
+func IsFile(node *restic.Node) bool {
+	return node.Type == "file"
+}

--- a/internal/dump/common.go
+++ b/internal/dump/common.go
@@ -12,6 +12,7 @@ import (
 
 // dumper implements saving node data.
 type dumper interface {
+	io.Closer
 	dumpNode(ctx context.Context, node *restic.Node, repo restic.Repository) error
 }
 
@@ -24,11 +25,13 @@ func writeDump(ctx context.Context, repo restic.Repository, tree *restic.Tree, r
 		rootNode.Path = rootPath
 		err := dumpTree(ctx, repo, rootNode, rootPath, dmp)
 		if err != nil {
+			dmp.Close()
+
 			return err
 		}
 	}
 
-	return nil
+	return dmp.Close()
 }
 
 func dumpTree(ctx context.Context, repo restic.Repository, rootNode *restic.Node, rootPath string, dmp dumper) error {

--- a/internal/dump/common_test.go
+++ b/internal/dump/common_test.go
@@ -1,0 +1,103 @@
+package dump
+
+import (
+	"bytes"
+	"context"
+	"testing"
+
+	"github.com/restic/restic/internal/archiver"
+	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func prepareTempdirRepoSrc(t testing.TB, src archiver.TestDir) (tempdir string, repo restic.Repository, cleanup func()) {
+	tempdir, removeTempdir := rtest.TempDir(t)
+	repo, removeRepository := repository.TestRepository(t)
+
+	archiver.TestCreateFiles(t, tempdir, src)
+
+	cleanup = func() {
+		removeRepository()
+		removeTempdir()
+	}
+
+	return tempdir, repo, cleanup
+}
+
+type CheckDump func(t *testing.T, testDir string, testDump *bytes.Buffer) error
+
+func WriteTest(t *testing.T, wd WriteDump, cd CheckDump) {
+	tests := []struct {
+		name   string
+		args   archiver.TestDir
+		target string
+	}{
+		{
+			name: "single file in root",
+			args: archiver.TestDir{
+				"file": archiver.TestFile{Content: "string"},
+			},
+			target: "/",
+		},
+		{
+			name: "multiple files in root",
+			args: archiver.TestDir{
+				"file1": archiver.TestFile{Content: "string"},
+				"file2": archiver.TestFile{Content: "string"},
+			},
+			target: "/",
+		},
+		{
+			name: "multiple files and folders in root",
+			args: archiver.TestDir{
+				"file1": archiver.TestFile{Content: "string"},
+				"file2": archiver.TestFile{Content: "string"},
+				"firstDir": archiver.TestDir{
+					"another": archiver.TestFile{Content: "string"},
+				},
+				"secondDir": archiver.TestDir{
+					"another2": archiver.TestFile{Content: "string"},
+				},
+			},
+			target: "/",
+		},
+		{
+			name: "file and symlink in root",
+			args: archiver.TestDir{
+				"file1": archiver.TestFile{Content: "string"},
+				"file2": archiver.TestSymlink{Target: "file1"},
+			},
+			target: "/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tmpdir, repo, cleanup := prepareTempdirRepoSrc(t, tt.args)
+			defer cleanup()
+
+			arch := archiver.New(repo, fs.Track{FS: fs.Local{}}, archiver.Options{})
+
+			back := rtest.Chdir(t, tmpdir)
+			defer back()
+
+			sn, _, err := arch.Snapshot(ctx, []string{"."}, archiver.SnapshotOptions{})
+			rtest.OK(t, err)
+
+			tree, err := repo.LoadTree(ctx, *sn.Tree)
+			rtest.OK(t, err)
+
+			dst := &bytes.Buffer{}
+			if err := wd(ctx, repo, tree, tt.target, dst); err != nil {
+				t.Fatalf("WriteDump() error = %v", err)
+			}
+			if err := cd(t, tmpdir, dst); err != nil {
+				t.Errorf("WriteDump() = does not match: %v", err)
+			}
+		})
+	}
+}

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -5,65 +5,31 @@ import (
 	"context"
 	"io"
 	"os"
-	"path"
 	"path/filepath"
 	"strings"
 
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
-	"github.com/restic/restic/internal/walker"
 )
 
-// WriteTar will write the contents of the given tree, encoded as a tar to the given destination.
-// It will loop over all nodes in the tree and dump them recursively.
-func WriteTar(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error {
-	tw := tar.NewWriter(dst)
-
-	for _, rootNode := range tree.Nodes {
-		rootNode.Path = rootPath
-		err := tarTree(ctx, repo, rootNode, rootPath, tw)
-		if err != nil {
-			_ = tw.Close()
-			return err
-		}
-	}
-	return tw.Close()
+type tarDumper struct {
+	w *tar.Writer
 }
 
-func tarTree(ctx context.Context, repo restic.Repository, rootNode *restic.Node, rootPath string, tw *tar.Writer) error {
-	rootNode.Path = path.Join(rootNode.Path, rootNode.Name)
-	rootPath = rootNode.Path
+// Statically ensure that tarDumper implements dumper.
+var _ dumper = tarDumper{}
 
-	if err := tarNode(ctx, tw, rootNode, repo); err != nil {
+// WriteTar will write the contents of the given tree, encoded as a tar to the given destination.
+func WriteTar(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error {
+	dmp := tarDumper{w: tar.NewWriter(dst)}
+
+	err := writeDump(ctx, repo, tree, rootPath, dmp, dst)
+	if err != nil {
+		dmp.w.Close()
 		return err
 	}
 
-	// If this is no directory we are finished
-	if !IsDir(rootNode) {
-		return nil
-	}
-
-	err := walker.Walk(ctx, repo, *rootNode.Subtree, nil, func(_ restic.ID, nodepath string, node *restic.Node, err error) (bool, error) {
-		if err != nil {
-			return false, err
-		}
-		if node == nil {
-			return false, nil
-		}
-
-		node.Path = path.Join(rootPath, nodepath)
-
-		if IsFile(node) || IsLink(node) || IsDir(node) {
-			err := tarNode(ctx, tw, node, repo)
-			if err != nil {
-				return false, err
-			}
-		}
-
-		return false, nil
-	})
-
-	return err
+	return dmp.w.Close()
 }
 
 // copied from archive/tar.FileInfoHeader
@@ -75,7 +41,7 @@ const (
 	c_ISVTX = 01000 // Save text (sticky bit)
 )
 
-func tarNode(ctx context.Context, tw *tar.Writer, node *restic.Node, repo restic.Repository) error {
+func (dmp tarDumper) dumpNode(ctx context.Context, node *restic.Node, repo restic.Repository) error {
 	relPath, err := filepath.Rel("/", node.Path)
 	if err != nil {
 		return err
@@ -120,13 +86,13 @@ func tarNode(ctx context.Context, tw *tar.Writer, node *restic.Node, repo restic
 		header.Name += "/"
 	}
 
-	err = tw.WriteHeader(header)
+	err = dmp.w.WriteHeader(header)
 
 	if err != nil {
 		return errors.Wrap(err, "TarHeader ")
 	}
 
-	return GetNodeData(ctx, tw, repo, node)
+	return GetNodeData(ctx, dmp.w, repo, node)
 }
 
 func parseXattrs(xattrs []restic.ExtendedAttribute) map[string]string {
@@ -146,47 +112,10 @@ func parseXattrs(xattrs []restic.ExtendedAttribute) map[string]string {
 					tmpMap["SCHILY.acl.default"] = na.String()
 				}
 			}
-
 		} else {
 			tmpMap["SCHILY.xattr."+attr.Name] = attrString
 		}
 	}
 
 	return tmpMap
-}
-
-// GetNodeData will write the contents of the node to the given output
-func GetNodeData(ctx context.Context, output io.Writer, repo restic.Repository, node *restic.Node) error {
-	var (
-		buf []byte
-		err error
-	)
-	for _, id := range node.Content {
-		buf, err = repo.LoadBlob(ctx, restic.DataBlob, id, buf)
-		if err != nil {
-			return err
-		}
-
-		_, err = output.Write(buf)
-		if err != nil {
-			return errors.Wrap(err, "Write")
-		}
-
-	}
-	return nil
-}
-
-// IsDir checks if the given node is a directory
-func IsDir(node *restic.Node) bool {
-	return node.Type == "dir"
-}
-
-// IsLink checks if the given node as a link
-func IsLink(node *restic.Node) bool {
-	return node.Type == "symlink"
-}
-
-// IsFile checks if the given node is a file
-func IsFile(node *restic.Node) bool {
-	return node.Type == "file"
 }

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -23,13 +23,10 @@ var _ dumper = tarDumper{}
 func WriteTar(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error {
 	dmp := tarDumper{w: tar.NewWriter(dst)}
 
-	err := writeDump(ctx, repo, tree, rootPath, dmp, dst)
-	if err != nil {
-		dmp.w.Close()
+	return writeDump(ctx, repo, tree, rootPath, dmp, dst)
+}
 
-		return err
-	}
-
+func (dmp tarDumper) Close() error {
 	return dmp.w.Close()
 }
 

--- a/internal/dump/tar_test.go
+++ b/internal/dump/tar_test.go
@@ -3,7 +3,6 @@ package dump
 import (
 	"archive/tar"
 	"bytes"
-	"context"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -13,99 +12,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/restic/restic/internal/archiver"
 	"github.com/restic/restic/internal/fs"
-	"github.com/restic/restic/internal/repository"
-	"github.com/restic/restic/internal/restic"
-	rtest "github.com/restic/restic/internal/test"
 )
 
-func prepareTempdirRepoSrc(t testing.TB, src archiver.TestDir) (tempdir string, repo restic.Repository, cleanup func()) {
-	tempdir, removeTempdir := rtest.TempDir(t)
-	repo, removeRepository := repository.TestRepository(t)
-
-	archiver.TestCreateFiles(t, tempdir, src)
-
-	cleanup = func() {
-		removeRepository()
-		removeTempdir()
-	}
-
-	return tempdir, repo, cleanup
-}
-
 func TestWriteTar(t *testing.T) {
-	tests := []struct {
-		name   string
-		args   archiver.TestDir
-		target string
-	}{
-		{
-			name: "single file in root",
-			args: archiver.TestDir{
-				"file": archiver.TestFile{Content: "string"},
-			},
-			target: "/",
-		},
-		{
-			name: "multiple files in root",
-			args: archiver.TestDir{
-				"file1": archiver.TestFile{Content: "string"},
-				"file2": archiver.TestFile{Content: "string"},
-			},
-			target: "/",
-		},
-		{
-			name: "multiple files and folders in root",
-			args: archiver.TestDir{
-				"file1": archiver.TestFile{Content: "string"},
-				"file2": archiver.TestFile{Content: "string"},
-				"firstDir": archiver.TestDir{
-					"another": archiver.TestFile{Content: "string"},
-				},
-				"secondDir": archiver.TestDir{
-					"another2": archiver.TestFile{Content: "string"},
-				},
-			},
-			target: "/",
-		},
-		{
-			name: "file and symlink in root",
-			args: archiver.TestDir{
-				"file1": archiver.TestFile{Content: "string"},
-				"file2": archiver.TestSymlink{Target: "file1"},
-			},
-			target: "/",
-		},
-	}
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			tmpdir, repo, cleanup := prepareTempdirRepoSrc(t, tt.args)
-			defer cleanup()
-
-			arch := archiver.New(repo, fs.Track{FS: fs.Local{}}, archiver.Options{})
-
-			back := rtest.Chdir(t, tmpdir)
-			defer back()
-
-			sn, _, err := arch.Snapshot(ctx, []string{"."}, archiver.SnapshotOptions{})
-			rtest.OK(t, err)
-
-			tree, err := repo.LoadTree(ctx, *sn.Tree)
-			rtest.OK(t, err)
-
-			dst := &bytes.Buffer{}
-			if err := WriteTar(ctx, repo, tree, tt.target, dst); err != nil {
-				t.Fatalf("WriteTar() error = %v", err)
-			}
-			if err := checkTar(t, tmpdir, dst); err != nil {
-				t.Errorf("WriteTar() = tar does not match: %v", err)
-			}
-		})
-	}
+	WriteTest(t, WriteTar, checkTar)
 }
 
 func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {

--- a/internal/dump/zip.go
+++ b/internal/dump/zip.go
@@ -1,0 +1,64 @@
+package dump
+
+import (
+	"archive/zip"
+	"context"
+	"io"
+	"path/filepath"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/restic"
+)
+
+type zipDumper struct {
+	w *zip.Writer
+}
+
+// Statically ensure that zipDumper implements dumper.
+var _ dumper = tarDumper{}
+
+// WriteZip will write the contents of the given tree, encoded as a zip to the given destination.
+func WriteZip(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error {
+	dmp := zipDumper{w: zip.NewWriter(dst)}
+
+	err := writeDump(ctx, repo, tree, rootPath, dmp, dst)
+	if err != nil {
+		dmp.w.Close()
+		return err
+	}
+
+	return dmp.w.Close()
+}
+
+func (dmp zipDumper) dumpNode(ctx context.Context, node *restic.Node, repo restic.Repository) error {
+	relPath, err := filepath.Rel("/", node.Path)
+	if err != nil {
+		return err
+	}
+
+	header := &zip.FileHeader{
+		Name:               filepath.ToSlash(relPath),
+		UncompressedSize64: node.Size,
+		Modified:           node.ModTime,
+	}
+	header.SetMode(node.Mode)
+
+	if IsDir(node) {
+		header.Name += "/"
+	}
+
+	w, err := dmp.w.CreateHeader(header)
+	if err != nil {
+		return errors.Wrap(err, "ZipHeader ")
+	}
+
+	if IsLink(node) {
+		if _, err = w.Write([]byte(node.LinkTarget)); err != nil {
+			return errors.Wrap(err, "Write")
+		}
+
+		return nil
+	}
+
+	return GetNodeData(ctx, w, repo, node)
+}

--- a/internal/dump/zip.go
+++ b/internal/dump/zip.go
@@ -21,13 +21,10 @@ var _ dumper = zipDumper{}
 func WriteZip(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error {
 	dmp := zipDumper{w: zip.NewWriter(dst)}
 
-	err := writeDump(ctx, repo, tree, rootPath, dmp, dst)
-	if err != nil {
-		dmp.w.Close()
+	return writeDump(ctx, repo, tree, rootPath, dmp, dst)
+}
 
-		return err
-	}
-
+func (dmp zipDumper) Close() error {
 	return dmp.w.Close()
 }
 

--- a/internal/dump/zip.go
+++ b/internal/dump/zip.go
@@ -15,7 +15,7 @@ type zipDumper struct {
 }
 
 // Statically ensure that zipDumper implements dumper.
-var _ dumper = tarDumper{}
+var _ dumper = zipDumper{}
 
 // WriteZip will write the contents of the given tree, encoded as a zip to the given destination.
 func WriteZip(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error {
@@ -24,6 +24,7 @@ func WriteZip(ctx context.Context, repo restic.Repository, tree *restic.Tree, ro
 	err := writeDump(ctx, repo, tree, rootPath, dmp, dst)
 	if err != nil {
 		dmp.w.Close()
+
 		return err
 	}
 
@@ -49,7 +50,7 @@ func (dmp zipDumper) dumpNode(ctx context.Context, node *restic.Node, repo resti
 
 	w, err := dmp.w.CreateHeader(header)
 	if err != nil {
-		return errors.Wrap(err, "ZipHeader ")
+		return errors.Wrap(err, "ZipHeader")
 	}
 
 	if IsLink(node) {

--- a/internal/dump/zip_test.go
+++ b/internal/dump/zip_test.go
@@ -1,0 +1,195 @@
+package dump
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/archiver"
+	"github.com/restic/restic/internal/fs"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestWriteZip(t *testing.T) {
+	tests := []struct {
+		name   string
+		args   archiver.TestDir
+		target string
+	}{
+		{
+			name: "single file in root",
+			args: archiver.TestDir{
+				"file": archiver.TestFile{Content: "string"},
+			},
+			target: "/",
+		},
+		{
+			name: "multiple files in root",
+			args: archiver.TestDir{
+				"file1": archiver.TestFile{Content: "string"},
+				"file2": archiver.TestFile{Content: "string"},
+			},
+			target: "/",
+		},
+		{
+			name: "multiple files and folders in root",
+			args: archiver.TestDir{
+				"file1": archiver.TestFile{Content: "string"},
+				"file2": archiver.TestFile{Content: "string"},
+				"firstDir": archiver.TestDir{
+					"another": archiver.TestFile{Content: "string"},
+				},
+				"secondDir": archiver.TestDir{
+					"another2": archiver.TestFile{Content: "string"},
+				},
+			},
+			target: "/",
+		},
+		{
+			name: "file and symlink in root",
+			args: archiver.TestDir{
+				"file1": archiver.TestFile{Content: "string"},
+				"file2": archiver.TestSymlink{Target: "file1"},
+			},
+			target: "/",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			tmpdir, repo, cleanup := prepareTempdirRepoSrc(t, tt.args)
+			defer cleanup()
+
+			arch := archiver.New(repo, fs.Track{FS: fs.Local{}}, archiver.Options{})
+
+			back := rtest.Chdir(t, tmpdir)
+			defer back()
+
+			sn, _, err := arch.Snapshot(ctx, []string{"."}, archiver.SnapshotOptions{})
+			rtest.OK(t, err)
+
+			tree, err := repo.LoadTree(ctx, *sn.Tree)
+			rtest.OK(t, err)
+
+			dst := &bytes.Buffer{}
+			if err := WriteZip(ctx, repo, tree, tt.target, dst); err != nil {
+				t.Fatalf("WriteZip() error = %v", err)
+			}
+			if err := checkZip(t, tmpdir, dst); err != nil {
+				t.Errorf("WriteZip() = zip does not match: %v", err)
+			}
+		})
+	}
+}
+
+func readZipFile(f *zip.File) ([]byte, error) {
+	rc, err := f.Open()
+	if err != nil {
+		return nil, err
+	}
+	defer rc.Close()
+
+	b := &bytes.Buffer{}
+	_, err = b.ReadFrom(rc)
+	if err != nil {
+		return nil, err
+	}
+
+	return b.Bytes(), nil
+}
+
+func checkZip(t *testing.T, testDir string, srcZip *bytes.Buffer) error {
+	z, err := zip.NewReader(bytes.NewReader(srcZip.Bytes()), int64(srcZip.Len()))
+	if err != nil {
+		return err
+	}
+
+	fileNumber := 0
+	zipFiles := len(z.File)
+
+	err = filepath.Walk(testDir, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if info.Name() != filepath.Base(testDir) {
+			fileNumber++
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	for _, f := range z.File {
+		matchPath := filepath.Join(testDir, f.Name)
+		match, err := os.Lstat(matchPath)
+		if err != nil {
+			return err
+		}
+
+		// check metadata, zip header contains time rounded to seconds
+		fileTime := match.ModTime().Truncate(time.Second)
+		zipTime := f.Modified
+		if !fileTime.Equal(zipTime) {
+			return fmt.Errorf("modTime does not match, got: %s, want: %s", zipTime, fileTime)
+		}
+		if f.Mode() != match.Mode() {
+			return fmt.Errorf("mode does not match, got: %v [%08x], want: %v [%08x]",
+				f.Mode(), uint32(f.Mode()), match.Mode(), uint32(match.Mode()))
+		}
+		t.Logf("Mode is %v [%08x] for %s", f.Mode(), uint32(f.Mode()), f.Name)
+
+		switch {
+		case f.FileInfo().IsDir():
+			filebase := filepath.ToSlash(match.Name())
+			if filepath.Base(f.Name) != filebase {
+				return fmt.Errorf("foldernames don't match got %v want %v", filepath.Base(f.Name), filebase)
+			}
+			if !strings.HasSuffix(f.Name, "/") {
+				return fmt.Errorf("foldernames must end with separator got %v", f.Name)
+			}
+		case f.Mode()&os.ModeSymlink != 0:
+			target, err := fs.Readlink(matchPath)
+			if err != nil {
+				return err
+			}
+			linkName, err := readZipFile(f)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if target != string(linkName) {
+				return fmt.Errorf("symlink target does not match, got %s want %s", string(linkName), target)
+			}
+		default:
+			if uint64(match.Size()) != f.UncompressedSize64 {
+				return fmt.Errorf("size does not match got %v want %v", f.UncompressedSize64, match.Size())
+			}
+			contentsFile, err := ioutil.ReadFile(matchPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+			contentsZip, err := readZipFile(f)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if string(contentsZip) != string(contentsFile) {
+				return fmt.Errorf("contents does not match, got %s want %s", contentsZip, contentsFile)
+			}
+		}
+	}
+
+	if zipFiles != fileNumber {
+		return fmt.Errorf("not the same amount of files got %v want %v", zipFiles, fileNumber)
+	}
+
+	return nil
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR loosely based on @brentadamson PR [#2433](https://github.com/restic/restic/pull/2433), the main difference is splitting walk and tar/zip logic.
I also added some tests (copy-pasted from tar part) and fix some bugs.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://forum.restic.net/t/restoring-files-directly-into-a-single-compressed-archive/968/13

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
