### PR TITLE
Extended option to select V1 API for ListObjects on S3 backend

### DIFF
--- a/changelog/unreleased/issue-3083
+++ b/changelog/unreleased/issue-3083
@@ -1,0 +1,13 @@
+Enhancement: Allow usage of deprecated S3 ListObjectsV1 API
+
+Restic didn't work with some S3 API implementations that don't have a
+working ListObjectsV2 API endpoint. This concerns mainly Ceph versions
+before v14.2.5 , but may impact other S3 API implementations.
+
+Restic now allows selection of the older ListObjectsV1 endpoint by using
+the 's3.list-objects-v1' extended option, for instance:
+
+`restic -o s3.list-objects-v1=true snapshots`
+
+https://github.com/restic/restic/issues/3083
+https://github.com/restic/restic/pull/3085

--- a/changelog/unreleased/issue-3083
+++ b/changelog/unreleased/issue-3083
@@ -1,13 +1,19 @@
 Enhancement: Allow usage of deprecated S3 ListObjectsV1 API
 
 Restic didn't work with some S3 API implementations that don't have a
-working ListObjectsV2 API endpoint. This concerns mainly Ceph versions
-before v14.2.5 , but may impact other S3 API implementations.
+broken `ListObjectsV2` API endpoint. This concerns mainly Ceph versions
+before v14.2.5 , but may impact other S3 API implementations. When a broken
+server implementation is used, restic prints errors similar to the following:
 
-Restic now allows selection of the older ListObjectsV1 endpoint by using
-the 's3.list-objects-v1' extended option, for instance:
+    List() returned error: Truncated response should have continuation token set
 
-`restic -o s3.list-objects-v1=true snapshots`
+As a temporary workaround, restic now allows selection of the older
+`ListObjects` endpoint by using the `s3.list-objects-v1` extended option, for
+instance:
+
+    restic -o s3.list-objects-v1=true snapshots
+
+This option may be removed in future versions of restic.
 
 https://github.com/restic/restic/issues/3083
 https://github.com/restic/restic/pull/3085

--- a/changelog/unreleased/issue-3083
+++ b/changelog/unreleased/issue-3083
@@ -1,15 +1,14 @@
 Enhancement: Allow usage of deprecated S3 ListObjectsV1 API
 
-Restic didn't work with some S3 API implementations that don't have a
-broken `ListObjectsV2` API endpoint. This concerns mainly Ceph versions
-before v14.2.5 , but may impact other S3 API implementations. When a broken
-server implementation is used, restic prints errors similar to the following:
+Some S3 API implementations, e.g. Ceph before version 14.2.5, have a broken
+`ListObjectsV2` implementation which cause problems for restic when using their
+API endpoints. When a broken server implementation is used, restic prints
+errors similar to the following:
 
     List() returned error: Truncated response should have continuation token set
 
-As a temporary workaround, restic now allows selection of the older
-`ListObjects` endpoint by using the `s3.list-objects-v1` extended option, for
-instance:
+As a temporary workaround, restic now allows using the older `ListObjects`
+endpoint by setting the `s3.list-objects-v1` extended option, for instance:
 
     restic -o s3.list-objects-v1=true snapshots
 

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -339,6 +339,39 @@ For example with an actual endpoint:
 
     $ restic -o s3.bucket-lookup=dns -o s3.region=oss-eu-west-1 -r s3:https://oss-eu-west-1.aliyuncs.com/bucketname init
 
+Ceph
+****
+
+`Ceph Object Gateway <https://ceph.io/ceph-storage/object-storage/>`__ is an object
+storage interface built on top of librados to provide applications with a RESTful
+gateway to Ceph Storage Clusters.
+
+Ceph Rados Gateway (RGW) provides a S3 interface that is compatible with a large
+subset of the Amazon S3 RESTful API.
+
+You will need to setup the following environment variables with the proper credentials:
+
+.. code-block:: console
+
+    $ export AWS_ACCESS_KEY_ID=<YOUR-ACCESS-KEY-ID>
+    $ export AWS_SECRET_ACCESS_KEY=<YOUR-SECRET-ACCESS-KEY>
+
+Now you can easily initialize restic to use Ceph RGW as a backend with
+this command.
+
+.. code-block:: console
+
+    $ restic -r s3://<RGW-S3-ENDPOINT>/<RGW-S3-BUCKET> init
+    enter password for new backend:
+    enter password again:
+    created restic backend xxxxxxxxxx at s3://<RGW-S3-ENDPOINT>/<RGW-S3-BUCKET>
+    Please note that knowledge of your password is required to access
+    the repository. Losing your password means that your data is irrecoverably lost.
+
+.. note:: Version of Ceph before v14.2.5 do not implement the ListObjectsV2 API properly.
+          On these backends you need to provide the ``-o s3.list-objects-v1=true`` option
+          to use the ListObjects API instead.
+
 OpenStack Swift
 ***************
 

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -240,9 +240,12 @@ or is only available via HTTP, you can specify the URL to the server
 like this: ``s3:http://server:port/bucket_name``.
 
 
-.. note:: Certain S3-compatible servers do not properly implement the ListObjectsV2 API,
-          most notably Ceph versions before v14.2.5. On these backends you need to
-          provide the ``-o s3.list-objects-v1=true`` option to use the ListObjects API instead.
+.. note:: Certain S3-compatible servers do not properly implement the
+          ``ListObjectsV2`` API, most notably Ceph versions before v14.2.5. On these
+          backends, as a temporary workaround, you can provide the
+          ``-o s3.list-objects-v1=true`` option to use the older
+          ``ListObjects`` API instead. This option may be removed in future
+          versions of restic.
 
 
 Minio Server

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -239,6 +239,12 @@ For an S3-compatible server that is not Amazon (like Minio, see below),
 or is only available via HTTP, you can specify the URL to the server
 like this: ``s3:http://server:port/bucket_name``.
 
+
+.. note:: Certain S3-compatible servers do not properly implement the ListObjectsV2 API,
+          most notably Ceph versions before v14.2.5. On these backends you need to
+          provide the ``-o s3.list-objects-v1=true`` option to use the ListObjects API instead.
+
+
 Minio Server
 ************
 
@@ -338,39 +344,6 @@ For example with an actual endpoint:
 .. code-block:: console
 
     $ restic -o s3.bucket-lookup=dns -o s3.region=oss-eu-west-1 -r s3:https://oss-eu-west-1.aliyuncs.com/bucketname init
-
-Ceph
-****
-
-`Ceph Object Gateway <https://ceph.io/ceph-storage/object-storage/>`__ is an object
-storage interface built on top of librados to provide applications with a RESTful
-gateway to Ceph Storage Clusters.
-
-Ceph Rados Gateway (RGW) provides a S3 interface that is compatible with a large
-subset of the Amazon S3 RESTful API.
-
-You will need to setup the following environment variables with the proper credentials:
-
-.. code-block:: console
-
-    $ export AWS_ACCESS_KEY_ID=<YOUR-ACCESS-KEY-ID>
-    $ export AWS_SECRET_ACCESS_KEY=<YOUR-SECRET-ACCESS-KEY>
-
-Now you can easily initialize restic to use Ceph RGW as a backend with
-this command.
-
-.. code-block:: console
-
-    $ restic -r s3://<RGW-S3-ENDPOINT>/<RGW-S3-BUCKET> init
-    enter password for new backend:
-    enter password again:
-    created restic backend xxxxxxxxxx at s3://<RGW-S3-ENDPOINT>/<RGW-S3-BUCKET>
-    Please note that knowledge of your password is required to access
-    the repository. Losing your password means that your data is irrecoverably lost.
-
-.. note:: Version of Ceph before v14.2.5 do not implement the ListObjectsV2 API properly.
-          On these backends you need to provide the ``-o s3.list-objects-v1=true`` option
-          to use the ListObjects API instead.
 
 OpenStack Swift
 ***************

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -23,8 +23,8 @@ type Config struct {
 	Connections   uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
 	MaxRetries    uint   `option:"retries" help:"set the number of retries attempted"`
 	Region        string `option:"region" help:"set region"`
-	BucketLookup  string `option:"bucket-lookup" help:"bucket lookup style: 'auto', 'dns', or 'path'."`
-	ListObjectsV1 bool   `option:"list-objects-v1" help:"use deprecated V1 api for ListObjects calls."`
+	BucketLookup  string `option:"bucket-lookup" help:"bucket lookup style: 'auto', 'dns', or 'path'"`
+	ListObjectsV1 bool   `option:"list-objects-v1" help:"use deprecated V1 api for ListObjects calls"`
 }
 
 // NewConfig returns a new Config with the default values filled in.

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -20,16 +20,18 @@ type Config struct {
 	Layout        string `option:"layout" help:"use this backend layout (default: auto-detect)"`
 	StorageClass  string `option:"storage-class" help:"set S3 storage class (STANDARD, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING or REDUCED_REDUNDANCY)"`
 
-	Connections  uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
-	MaxRetries   uint   `option:"retries" help:"set the number of retries attempted"`
-	Region       string `option:"region" help:"set region"`
-	BucketLookup string `option:"bucket-lookup" help:"bucket lookup style: 'auto', 'dns', or 'path'."`
+	Connections   uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	MaxRetries    uint   `option:"retries" help:"set the number of retries attempted"`
+	Region        string `option:"region" help:"set region"`
+	BucketLookup  string `option:"bucket-lookup" help:"bucket lookup style: 'auto', 'dns', or 'path'."`
+	ListObjectsV1 bool   `option:"list-objects-v1" help:"use deprecated V1 api for ListObjects calls."`
 }
 
 // NewConfig returns a new Config with the default values filled in.
 func NewConfig() Config {
 	return Config{
-		Connections: 5,
+		Connections:   5,
+		ListObjectsV1: false,
 	}
 }
 

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -205,9 +205,12 @@ func (be *Backend) ReadDir(ctx context.Context, dir string) (list []os.FileInfo,
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	debug.Log("using ListObjectsV1(%v)", be.cfg.ListObjectsV1)
+
 	for obj := range be.client.ListObjects(ctx, be.cfg.Bucket, minio.ListObjectsOptions{
 		Prefix:    dir,
 		Recursive: false,
+		UseV1:     be.cfg.ListObjectsV1,
 	}) {
 		if obj.Err != nil {
 			return nil, err
@@ -427,12 +430,15 @@ func (be *Backend) List(ctx context.Context, t restic.FileType, fn func(restic.F
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	debug.Log("using ListObjectsV1(%v)", be.cfg.ListObjectsV1)
+
 	// NB: unfortunately we can't protect this with be.sem.GetToken() here.
 	// Doing so would enable a deadlock situation (gh-1399), as ListObjects()
 	// starts its own goroutine and returns results via a channel.
 	listresp := be.client.ListObjects(ctx, be.cfg.Bucket, minio.ListObjectsOptions{
 		Prefix:    prefix,
 		Recursive: recursive,
+		UseV1:     be.cfg.ListObjectsV1,
 	})
 
 	for obj := range listresp {

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -199,6 +199,14 @@ func (o Options) Apply(ns string, dst interface{}) error {
 
 			v.Field(i).SetUint(vi)
 
+		case "bool":
+			vi, err := strconv.ParseBool(value)
+			if err != nil {
+				return err
+			}
+
+			v.Field(i).SetBool(vi)
+
 		case "Duration":
 			d, err := time.ParseDuration(value)
 			if err != nil {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Provides an extended option to select the V1 ListObjects API for S3 backends that do not properly
implement the ListObjectsV2 API (versions of Ceph before v14.2.5) .

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #3083 

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [X] I have added documentation for the changes (in the manual)
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
