### PR TITLE
Improve error reporting from restic diff

### DIFF
--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -55,9 +55,8 @@ func init() {
 func loadSnapshot(ctx context.Context, repo *repository.Repository, desc string) (*restic.Snapshot, error) {
 	id, err := restic.FindSnapshot(ctx, repo, desc)
 	if err != nil {
-		return nil, err
+		return nil, errors.Fatal(err.Error())
 	}
-
 	return restic.LoadSnapshot(ctx, repo, id)
 }
 

--- a/internal/restic/backend_find_test.go
+++ b/internal/restic/backend_find_test.go
@@ -2,6 +2,7 @@ package restic
 
 import (
 	"context"
+	"strings"
 	"testing"
 )
 
@@ -48,7 +49,7 @@ func TestFind(t *testing.T) {
 	}
 
 	f, err = Find(context.TODO(), m, SnapshotFile, "NotAPrefix")
-	if err != ErrNoIDPrefixFound {
+	if _, ok := err.(*NoIDByPrefixError); !ok || !strings.Contains(err.Error(), "NotAPrefix") {
 		t.Error("Expected no snapshots to be found.")
 	}
 	if f != "" {
@@ -58,8 +59,8 @@ func TestFind(t *testing.T) {
 	// Try to match with a prefix longer than any ID.
 	extraLengthID := samples[0].String() + "f"
 	f, err = Find(context.TODO(), m, SnapshotFile, extraLengthID)
-	if err != ErrNoIDPrefixFound {
-		t.Error("Expected no snapshots to be matched.")
+	if _, ok := err.(*NoIDByPrefixError); !ok || !strings.Contains(err.Error(), extraLengthID) {
+		t.Errorf("Wrong error %v for no snapshots matched", err)
 	}
 	if f != "" {
 		t.Errorf("Find should not return a match on error.")
@@ -67,8 +68,8 @@ func TestFind(t *testing.T) {
 
 	// Use a prefix that will match the prefix of multiple Ids in `samples`.
 	f, err = Find(context.TODO(), m, SnapshotFile, "20bdc140")
-	if err != ErrMultipleIDMatches {
-		t.Error("Expected multiple snapshots to be matched.")
+	if _, ok := err.(*MultipleIDMatchesError); !ok {
+		t.Errorf("Wrong error %v for multiple snapshots", err)
 	}
 	if f != "" {
 		t.Errorf("Find should not return a match on error.")


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Instead of a stacktrace, restic diff 111 222 now reports:

	Fatal: no matching ID found for prefix "111"

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes #3080.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
