### PR TITLE
Compute packsizes in MasterIndex

### DIFF
--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"github.com/restic/restic/internal/pack"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 
@@ -91,17 +90,7 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 		}
 
 		Verbosef("getting pack files to read...\n")
-
-		// Compute size of each pack from index entries
-		packSizeFromIndex := make(map[restic.ID]int64)
-		for blob := range repo.Index().Each(ctx) {
-			size, ok := packSizeFromIndex[blob.PackID]
-			if !ok {
-				size = pack.HeaderSize
-			}
-			// update packSizeFromIndex
-			packSizeFromIndex[blob.PackID] = size + int64(pack.PackedSizeOfBlob(blob.Length))
-		}
+		packSizeFromIndex := repo.Index().PackSize(ctx, false)
 
 		err = repo.List(ctx, restic.PackFile, func(id restic.ID, packSize int64) error {
 			size, ok := packSizeFromIndex[id]

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -178,13 +178,7 @@ func (c *Checker) LoadIndex(ctx context.Context) (hints []error, errs []error) {
 	c.masterIndex.MergeFinalIndexes()
 
 	// compute pack size using index entries
-	for blob := range c.masterIndex.Each(ctx) {
-		size, ok := c.packs[blob.PackID]
-		if !ok {
-			size = pack.HeaderSize
-		}
-		c.packs[blob.PackID] = size + int64(pack.PackedSizeOfBlob(blob.Length))
-	}
+	c.packs = c.masterIndex.PackSize(ctx, false)
 
 	debug.Log("checking for duplicate packs")
 	for packID := range c.packs {
@@ -749,17 +743,17 @@ func checkPack(ctx context.Context, r restic.Repository, id restic.ID, size int6
 		return errors.Errorf("Pack size does not match, want %v, got %v", size, realSize)
 	}
 
-	blobs, _, err := pack.List(r.Key(), packfile, size)
+	blobs, hdrSize, err := pack.List(r.Key(), packfile, size)
 	if err != nil {
 		return err
 	}
 
 	var errs []error
 	var buf []byte
-	sizeFromBlobs := int64(pack.HeaderSize) // pack size computed only from blob information
+	sizeFromBlobs := uint(hdrSize)
 	idx := r.Index()
 	for i, blob := range blobs {
-		sizeFromBlobs += int64(pack.PackedSizeOfBlob(blob.Length))
+		sizeFromBlobs += blob.Length
 		debug.Log("  check blob %d: %v", i, blob)
 
 		buf = buf[:cap(buf)]
@@ -809,7 +803,7 @@ func checkPack(ctx context.Context, r restic.Repository, id restic.ID, size int6
 		}
 	}
 
-	if sizeFromBlobs != size {
+	if int64(sizeFromBlobs) != size {
 		debug.Log("Pack size does not match, want %v, got %v", size, sizeFromBlobs)
 		errs = append(errs, errors.Errorf("Pack size does not match, want %v, got %v", size, sizeFromBlobs))
 	}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -749,7 +749,7 @@ func checkPack(ctx context.Context, r restic.Repository, id restic.ID, size int6
 		return errors.Errorf("Pack size does not match, want %v, got %v", size, realSize)
 	}
 
-	blobs, err := pack.List(r.Key(), packfile, size)
+	blobs, _, err := pack.List(r.Key(), packfile, size)
 	if err != nil {
 		return err
 	}

--- a/internal/pack/pack_internal_test.go
+++ b/internal/pack/pack_internal_test.go
@@ -41,7 +41,7 @@ func TestParseHeaderEntry(t *testing.T) {
 	buf.Reset()
 	_ = binary.Write(buf, binary.LittleEndian, &h)
 
-	b, err = parseHeaderEntry(buf.Bytes()[:entrySize-1])
+	b, err = parseHeaderEntry(buf.Bytes()[:EntrySize-1])
 	rtest.Assert(t, err != nil, "no error for short input")
 }
 
@@ -58,7 +58,7 @@ func (rd *countingReaderAt) ReadAt(p []byte, off int64) (n int, err error) {
 func TestReadHeaderEagerLoad(t *testing.T) {
 
 	testReadHeader := func(dataSize, entryCount, expectedReadInvocationCount int) {
-		expectedHeader := rtest.Random(0, entryCount*int(entrySize)+crypto.Extension)
+		expectedHeader := rtest.Random(0, entryCount*int(EntrySize)+crypto.Extension)
 
 		buf := &bytes.Buffer{}
 		buf.Write(rtest.Random(0, dataSize))                                // pack blobs data
@@ -83,8 +83,8 @@ func TestReadHeaderEagerLoad(t *testing.T) {
 	testReadHeader(100, eagerEntries+1, 2)
 
 	// file size == eager header load size
-	eagerLoadSize := int((eagerEntries * entrySize) + crypto.Extension)
-	headerSize := int(1*entrySize) + crypto.Extension
+	eagerLoadSize := int((eagerEntries * EntrySize) + crypto.Extension)
+	headerSize := int(1*EntrySize) + crypto.Extension
 	dataSize := eagerLoadSize - headerSize - binary.Size(uint32(0))
 	testReadHeader(dataSize-1, 1, 1)
 	testReadHeader(dataSize, 1, 1)
@@ -96,8 +96,8 @@ func TestReadHeaderEagerLoad(t *testing.T) {
 
 func TestReadRecords(t *testing.T) {
 	testReadRecords := func(dataSize, entryCount, totalRecords int) {
-		totalHeader := rtest.Random(0, totalRecords*int(entrySize)+crypto.Extension)
-		off := len(totalHeader) - (entryCount*int(entrySize) + crypto.Extension)
+		totalHeader := rtest.Random(0, totalRecords*int(EntrySize)+crypto.Extension)
+		off := len(totalHeader) - (entryCount*int(EntrySize) + crypto.Extension)
 		if off < 0 {
 			off = 0
 		}
@@ -127,8 +127,8 @@ func TestReadRecords(t *testing.T) {
 	testReadRecords(100, eagerEntries, eagerEntries+1)
 
 	// file size == eager header load size
-	eagerLoadSize := int((eagerEntries * entrySize) + crypto.Extension)
-	headerSize := int(1*entrySize) + crypto.Extension
+	eagerLoadSize := int((eagerEntries * EntrySize) + crypto.Extension)
+	headerSize := int(1*EntrySize) + crypto.Extension
 	dataSize := eagerLoadSize - headerSize - binary.Size(uint32(0))
 	testReadRecords(dataSize-1, 1, 1)
 	testReadRecords(dataSize, 1, 1)

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/pack"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui/progress"
 	"golang.org/x/sync/errgroup"
@@ -109,6 +110,27 @@ func (mi *MasterIndex) Packs() restic.IDSet {
 	}
 
 	return packs
+}
+
+// PackSize returns the size of all packs computed by index information.
+// If onlyHdr is set to true, only the size of the header is returned
+// Note that this function only gives correct sizes, if there are no
+// duplicates in the index.
+func (mi *MasterIndex) PackSize(ctx context.Context, onlyHdr bool) map[restic.ID]int64 {
+	packSize := make(map[restic.ID]int64)
+
+	for blob := range mi.Each(ctx) {
+		size, ok := packSize[blob.PackID]
+		if !ok {
+			size = pack.HeaderSize
+		}
+		if !onlyHdr {
+			size += int64(blob.Length)
+		}
+		packSize[blob.PackID] = size + int64(pack.EntrySize)
+	}
+
+	return packSize
 }
 
 // Count returns the number of blobs of type t in the index.

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -92,7 +92,7 @@ func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, kee
 		for job := range processQueue {
 			tempfile, packID, packLength := job.tempfile, job.hash, job.packLength
 
-			blobs, err := pack.List(repo.Key(), tempfile, packLength)
+			blobs, _, err := pack.List(repo.Key(), tempfile, packLength)
 			if err != nil {
 				return err
 			}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -740,16 +740,11 @@ func (r *Repository) List(ctx context.Context, t restic.FileType, fn func(restic
 }
 
 // ListPack returns the list of blobs saved in the pack id and the length of
-// the file as stored in the backend.
-func (r *Repository) ListPack(ctx context.Context, id restic.ID, size int64) ([]restic.Blob, int64, error) {
+// the the pack header.
+func (r *Repository) ListPack(ctx context.Context, id restic.ID, size int64) ([]restic.Blob, uint32, error) {
 	h := restic.Handle{Type: restic.PackFile, Name: id.String()}
 
-	blobs, err := pack.List(r.Key(), restic.ReaderAt(ctx, r.Backend(), h), size)
-	if err != nil {
-		return nil, 0, err
-	}
-
-	return blobs, size, nil
+	return pack.List(r.Key(), restic.ReaderAt(ctx, r.Backend(), h), size)
 }
 
 // Delete calls backend.Delete() if implemented, and returns an error

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -66,6 +66,7 @@ type MasterIndex interface {
 	Lookup(ID, BlobType) []PackedBlob
 	Count(BlobType) uint
 	Packs() IDSet
+	PackSize(ctx context.Context, onlyHdr bool) map[ID]int64
 
 	// Each returns a channel that yields all blobs known to the index. When
 	// the context is cancelled, the background goroutine terminates. This

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -32,7 +32,10 @@ type Repository interface {
 	//
 	// The function fn is called in the same Goroutine List() was called from.
 	List(ctx context.Context, t FileType, fn func(ID, int64) error) error
-	ListPack(context.Context, ID, int64) ([]Blob, int64, error)
+
+	// ListPack returns the list of blobs saved in the pack id and the length of
+	// the the pack header.
+	ListPack(context.Context, ID, int64) ([]Blob, uint32, error)
 
 	Flush(context.Context) error
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Cleans up code where pack (header) sizes are computed from index entries.
Now all code which takes assumptions on the pack format is either in `internal/pack` or in `MasterIndex.PackSize()`. This makes modification to the pack format more easy in the future.

This PR introduces a small change in the new pruning algorithm (see #2718): Now the complete header is treated as "used space" within a pack, whereas before only the header length and header crypto were treated as "used space" + only the header entries of really used blobs. The difference however should be marginal and may only slightly change the decision which pack to repack and which to keep.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

see #3006 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- I have not added documentation for the changes (in the manual)
- There's no new file in `changelog/unreleased/` that describes the changes for our users - this is too technical for users to notice.
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
