### PR TITLE
Remove `--drive-use-trash=false` from rclone param

### DIFF
--- a/changelog/unreleased/issue-3095
+++ b/changelog/unreleased/issue-3095
@@ -1,0 +1,9 @@
+Change: Remove `--drive-use-trash=false` from default rclone params
+
+By default restic used launched rclone with --drive-use-trash=false,
+since google drive trash retention policy changed, it is no longer required.
+Rclone will now use what's provided in by the `--drive-use-trash
+parameter, `drive-use-trash` config or RCLONE_CONFIG_*_USE_TRASH env
+falling back to `true` as a default (as of: v1.53.2).
+
+https://github.com/restic/restic/issues/3095

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -601,10 +601,9 @@ For debugging rclone, you can set the environment variable ``RCLONE_VERBOSE=2``.
 The rclone backend has two additional options:
 
  * ``-o rclone.program`` specifies the path to rclone, the default value is just ``rclone``
- * ``-o rclone.args`` allows setting the arguments passed to rclone, by default this is ``serve restic --stdio --b2-hard-delete --drive-use-trash=false``
+ * ``-o rclone.args`` allows setting the arguments passed to rclone, by default this is ``serve restic --stdio --b2-hard-delete``
 
-The reason for the two last parameters (``--b2-hard-delete`` and
-``--drive-use-trash=false``) can be found in the corresponding GitHub `issue #1657`_.
+The reason for the ``--b2-hard-delete`` parameters can be found in the corresponding GitHub `issue #1657`_.
 
 In order to start rclone, restic will build a list of arguments by joining the
 following lists (in this order): ``rclone.program``, ``rclone.args`` and as the

--- a/internal/backend/rclone/config.go
+++ b/internal/backend/rclone/config.go
@@ -10,14 +10,14 @@ import (
 // Config contains all configuration necessary to start rclone.
 type Config struct {
 	Program     string `option:"program" help:"path to rclone (default: rclone)"`
-	Args        string `option:"args"    help:"arguments for running rclone (default: serve restic --stdio --b2-hard-delete --drive-use-trash=false)"`
+	Args        string `option:"args"    help:"arguments for running rclone (default: serve restic --stdio --b2-hard-delete)"`
 	Remote      string
 	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
 }
 
 var defaultConfig = Config{
 	Program:     "rclone",
-	Args:        "serve restic --stdio --b2-hard-delete --drive-use-trash=false",
+	Args:        "serve restic --stdio --b2-hard-delete",
 	Connections: 5,
 }
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Removes `--drive-use-trash=false` from default parameters passed to Rclone.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #3095 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR - **I don't think this is tested, is it fine?**
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/issue-3095` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
