### PR TITLE
Rephrase #3095/#3102 changelog entry

### DIFF
--- a/changelog/unreleased/issue-3095
+++ b/changelog/unreleased/issue-3095
@@ -1,9 +1,17 @@
-Change: Remove `--drive-use-trash=false` from default rclone params
+Change: Deleting files on Google Drive now moves them to the trash
 
-By default restic used launched rclone with --drive-use-trash=false,
-since google drive trash retention policy changed, it is no longer required.
-Rclone will now use what's provided in by the `--drive-use-trash
-parameter, `drive-use-trash` config or RCLONE_CONFIG_*_USE_TRASH env
-falling back to `true` as a default (as of: v1.53.2).
+When deleting files on Google Drive via an rclone backend, restic used
+to bypass the trash folder and required using the `-o rclone.args`
+option to enable the trash folder. This ensured that deleted files in
+Google Drive were not kept indefinitely in the trash folder. Since
+Google Drive's trash retention policy changed to deleting trashed files
+after 30 days, this is no longer needed.
+
+Restic now leaves it up to rclone and its configuration to use or not
+use the trash folder when deleting files. The default is to use the
+trash folder, as of rclone 1.53.2. To re-enable the restic 0.11 behavior,
+set the `RCLONE_DRIVE_USE_TRASH` environment variable or change the
+rclone configuration. See the rclone documentation for details.
 
 https://github.com/restic/restic/issues/3095
+https://github.com/restic/restic/pull/3102


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Rephrases the changelog entry for #3095/#3102 and fixes a syntax error (missing backtick). It was discussing the implementation, rather than the observable behavior.