### PR TITLE
Parallelize tree walk in prune and copy and add progress bar to check

### DIFF
--- a/changelog/unreleased/pull-3106
+++ b/changelog/unreleased/pull-3106
@@ -1,0 +1,10 @@
+Enhancement: Parallelize scan of snapshot content in copy and prune
+
+The copy and the prune commands used to traverse the directories of
+snapshots one by one to find used data. This snapshot traversal is
+now parallized which can speed up this step several times.
+
+In addition the check command now reports how many snapshots have
+already been processed.
+
+https://github.com/restic/restic/pull/3106

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -240,7 +240,11 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 
 	Verbosef("check snapshots, trees and blobs\n")
 	errChan = make(chan error)
-	go chkr.Structure(gopts.ctx, errChan)
+	go func() {
+		bar := newProgressMax(!gopts.Quiet, 0, "snapshots")
+		defer bar.Done()
+		chkr.Structure(gopts.ctx, bar, errChan)
+	}()
 
 	for err := range errChan {
 		errorsFound = true

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -183,7 +183,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 		visited := visitedTrees.Has(treeID)
 		visitedTrees.Insert(treeID)
 		return visited
-	})
+	}, nil)
 
 	wg.Go(func() error {
 		// reused buffer

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -574,20 +574,14 @@ func getUsedBlobs(gopts GlobalOptions, repo restic.Repository, ignoreSnapshots r
 
 	bar := newProgressMax(!gopts.Quiet, uint64(len(snapshotTrees)), "snapshots")
 	defer bar.Done()
-	for _, tree := range snapshotTrees {
-		debug.Log("process tree %v", tree)
 
-		err = restic.FindUsedBlobs(ctx, repo, tree, usedBlobs)
-		if err != nil {
-			if repo.Backend().IsNotExist(err) {
-				return nil, errors.Fatal("unable to load a tree from the repo: " + err.Error())
-			}
-
-			return nil, err
+	err = restic.FindUsedBlobs(ctx, repo, snapshotTrees, usedBlobs, bar)
+	if err != nil {
+		if repo.Backend().IsNotExist(err) {
+			return nil, errors.Fatal("unable to load a tree from the repo: " + err.Error())
 		}
 
-		debug.Log("processed tree %v", tree)
-		bar.Add(1)
+		return nil, err
 	}
 	return usedBlobs, nil
 }

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -166,7 +166,7 @@ func statsWalkSnapshot(ctx context.Context, snapshot *restic.Snapshot, repo rest
 	if statsOptions.countMode == countModeRawData {
 		// count just the sizes of unique blobs; we don't need to walk the tree
 		// ourselves in this case, since a nifty function does it for us
-		return restic.FindUsedBlobs(ctx, repo, *snapshot.Tree, stats.blobs)
+		return restic.FindUsedBlobs(ctx, repo, restic.IDs{*snapshot.Tree}, stats.blobs, nil)
 	}
 
 	err := walker.Walk(ctx, repo, *snapshot.Tree, restic.NewIDSet(), statsWalkTree(repo, stats))

--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -33,11 +33,14 @@ func newProgressMax(show bool, max uint64, description string) *progress.Counter
 	}
 	interval := calculateProgressInterval()
 
-	return progress.New(interval, func(v uint64, d time.Duration, final bool) {
-		status := fmt.Sprintf("[%s] %s  %d / %d %s",
-			formatDuration(d),
-			formatPercent(v, max),
-			v, max, description)
+	return progress.New(interval, max, func(v uint64, max uint64, d time.Duration, final bool) {
+		var status string
+		if max == 0 {
+			status = fmt.Sprintf("[%s]          %d %s", formatDuration(d), v, description)
+		} else {
+			status = fmt.Sprintf("[%s] %s  %d / %d %s",
+				formatDuration(d), formatPercent(v, max), v, max, description)
+		}
 
 		if w := stdoutTerminalWidth(); w > 0 {
 			status = shortenStatus(w, status)

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -354,8 +354,9 @@ func loadSnapshotTreeIDs(ctx context.Context, repo restic.Repository) (ids resti
 // Structure checks that for all snapshots all referenced data blobs and
 // subtrees are available in the index. errChan is closed after all trees have
 // been traversed.
-func (c *Checker) Structure(ctx context.Context, errChan chan<- error) {
+func (c *Checker) Structure(ctx context.Context, p *progress.Counter, errChan chan<- error) {
 	trees, errs := loadSnapshotTreeIDs(ctx, c.repo)
+	p.SetMax(uint64(len(trees)))
 	debug.Log("need to check %d trees from snapshots, %d errs returned", len(trees), len(errs))
 
 	for _, err := range errs {
@@ -376,7 +377,7 @@ func (c *Checker) Structure(ctx context.Context, errChan chan<- error) {
 		c.blobRefs.M.Insert(h)
 		c.blobRefs.Unlock()
 		return blobReferenced
-	}, nil)
+	}, p)
 
 	defer close(errChan)
 	for i := 0; i < defaultParallelism; i++ {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -376,7 +376,7 @@ func (c *Checker) Structure(ctx context.Context, errChan chan<- error) {
 		c.blobRefs.M.Insert(h)
 		c.blobRefs.Unlock()
 		return blobReferenced
-	})
+	}, nil)
 
 	defer close(errChan)
 	for i := 0; i < defaultParallelism; i++ {

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -43,7 +43,9 @@ func checkPacks(chkr *checker.Checker) []error {
 }
 
 func checkStruct(chkr *checker.Checker) []error {
-	return collectErrors(context.TODO(), chkr.Structure)
+	return collectErrors(context.TODO(), func(ctx context.Context, errChan chan<- error) {
+		chkr.Structure(ctx, nil, errChan)
+	})
 }
 
 func checkData(chkr *checker.Checker) []error {

--- a/internal/checker/testing.go
+++ b/internal/checker/testing.go
@@ -30,7 +30,7 @@ func TestCheckRepo(t testing.TB, repo restic.Repository) {
 
 	// structure
 	errChan = make(chan error)
-	go chkr.Structure(context.TODO(), errChan)
+	go chkr.Structure(context.TODO(), nil, errChan)
 
 	for err := range errChan {
 		t.Error(err)

--- a/internal/repository/master_index_test.go
+++ b/internal/repository/master_index_test.go
@@ -368,7 +368,7 @@ func TestIndexSave(t *testing.T) {
 	defer cancel()
 
 	errCh := make(chan error)
-	go checker.Structure(ctx, errCh)
+	go checker.Structure(ctx, nil, errCh)
 	i := 0
 	for err := range errCh {
 		t.Errorf("checker returned error: %v", err)

--- a/internal/restic/find.go
+++ b/internal/restic/find.go
@@ -27,7 +27,7 @@ func FindUsedBlobs(ctx context.Context, repo TreeLoader, treeID ID, blobs BlobSe
 		blobs.Insert(h)
 		lock.Unlock()
 		return blobReferenced
-	})
+	}, nil)
 
 	wg.Go(func() error {
 		for tree := range treeStream {

--- a/internal/restic/find.go
+++ b/internal/restic/find.go
@@ -1,6 +1,11 @@
 package restic
 
-import "context"
+import (
+	"context"
+	"sync"
+
+	"golang.org/x/sync/errgroup"
+)
 
 // TreeLoader loads a tree from a repository.
 type TreeLoader interface {
@@ -10,30 +15,38 @@ type TreeLoader interface {
 // FindUsedBlobs traverses the tree ID and adds all seen blobs (trees and data
 // blobs) to the set blobs. Already seen tree blobs will not be visited again.
 func FindUsedBlobs(ctx context.Context, repo TreeLoader, treeID ID, blobs BlobSet) error {
-	h := BlobHandle{ID: treeID, Type: TreeBlob}
-	if blobs.Has(h) {
-		return nil
-	}
-	blobs.Insert(h)
+	var lock sync.Mutex
 
-	tree, err := repo.LoadTree(ctx, treeID)
-	if err != nil {
-		return err
-	}
+	wg, ctx := errgroup.WithContext(ctx)
+	treeStream := StreamTrees(ctx, wg, repo, IDs{treeID}, func(treeID ID) bool {
+		// locking is necessary the goroutine below concurrently adds data blobs
+		lock.Lock()
+		h := BlobHandle{ID: treeID, Type: TreeBlob}
+		blobReferenced := blobs.Has(h)
+		// noop if already referenced
+		blobs.Insert(h)
+		lock.Unlock()
+		return blobReferenced
+	})
 
-	for _, node := range tree.Nodes {
-		switch node.Type {
-		case "file":
-			for _, blob := range node.Content {
-				blobs.Insert(BlobHandle{ID: blob, Type: DataBlob})
+	wg.Go(func() error {
+		for tree := range treeStream {
+			if tree.Error != nil {
+				return tree.Error
 			}
-		case "dir":
-			err := FindUsedBlobs(ctx, repo, *node.Subtree, blobs)
-			if err != nil {
-				return err
+
+			lock.Lock()
+			for _, node := range tree.Nodes {
+				switch node.Type {
+				case "file":
+					for _, blob := range node.Content {
+						blobs.Insert(BlobHandle{ID: blob, Type: DataBlob})
+					}
+				}
 			}
+			lock.Unlock()
 		}
-	}
-
-	return nil
+		return nil
+	})
+	return wg.Wait()
 }

--- a/internal/restic/find_test.go
+++ b/internal/restic/find_test.go
@@ -15,6 +15,8 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/ui/progress"
 )
 
 func loadIDSet(t testing.TB, filename string) restic.BlobSet {
@@ -92,9 +94,12 @@ func TestFindUsedBlobs(t *testing.T) {
 		snapshots = append(snapshots, sn)
 	}
 
+	p := progress.New(time.Second, findTestSnapshots, func(value uint64, total uint64, runtime time.Duration, final bool) {})
+	defer p.Done()
+
 	for i, sn := range snapshots {
 		usedBlobs := restic.NewBlobSet()
-		err := restic.FindUsedBlobs(context.TODO(), repo, restic.IDs{*sn.Tree}, usedBlobs, nil)
+		err := restic.FindUsedBlobs(context.TODO(), repo, restic.IDs{*sn.Tree}, usedBlobs, p)
 		if err != nil {
 			t.Errorf("FindUsedBlobs returned error: %v", err)
 			continue
@@ -104,6 +109,8 @@ func TestFindUsedBlobs(t *testing.T) {
 			t.Errorf("FindUsedBlobs returned an empty set")
 			continue
 		}
+
+		test.Equals(t, p.Get(), uint64(i+1))
 
 		goldenFilename := filepath.Join("testdata", fmt.Sprintf("used_blobs_snapshot%d", i))
 		want := loadIDSet(t, goldenFilename)
@@ -115,6 +122,40 @@ func TestFindUsedBlobs(t *testing.T) {
 
 		if *updateGoldenFiles {
 			saveIDSet(t, goldenFilename, usedBlobs)
+		}
+	}
+}
+
+func TestMultiFindUsedBlobs(t *testing.T) {
+	repo, cleanup := repository.TestRepository(t)
+	defer cleanup()
+
+	var snapshotTrees restic.IDs
+	for i := 0; i < findTestSnapshots; i++ {
+		sn := restic.TestCreateSnapshot(t, repo, findTestTime.Add(time.Duration(i)*time.Second), findTestDepth, 0)
+		t.Logf("snapshot %v saved, tree %v", sn.ID().Str(), sn.Tree.Str())
+		snapshotTrees = append(snapshotTrees, *sn.Tree)
+	}
+
+	want := restic.NewBlobSet()
+	for i := range snapshotTrees {
+		goldenFilename := filepath.Join("testdata", fmt.Sprintf("used_blobs_snapshot%d", i))
+		want.Merge(loadIDSet(t, goldenFilename))
+	}
+
+	p := progress.New(time.Second, findTestSnapshots, func(value uint64, total uint64, runtime time.Duration, final bool) {})
+	defer p.Done()
+
+	// run twice to check progress bar handling of duplicate tree roots
+	usedBlobs := restic.NewBlobSet()
+	for i := 1; i < 3; i++ {
+		err := restic.FindUsedBlobs(context.TODO(), repo, snapshotTrees, usedBlobs, p)
+		test.OK(t, err)
+		test.Equals(t, p.Get(), uint64(i*len(snapshotTrees)))
+
+		if !want.Equals(usedBlobs) {
+			t.Errorf("wrong list of blobs returned:\n  missing blobs: %v\n  extra blobs: %v",
+				want.Sub(usedBlobs), usedBlobs.Sub(want))
 		}
 	}
 }

--- a/internal/restic/find_test.go
+++ b/internal/restic/find_test.go
@@ -94,7 +94,7 @@ func TestFindUsedBlobs(t *testing.T) {
 
 	for i, sn := range snapshots {
 		usedBlobs := restic.NewBlobSet()
-		err := restic.FindUsedBlobs(context.TODO(), repo, *sn.Tree, usedBlobs)
+		err := restic.FindUsedBlobs(context.TODO(), repo, restic.IDs{*sn.Tree}, usedBlobs, nil)
 		if err != nil {
 			t.Errorf("FindUsedBlobs returned error: %v", err)
 			continue
@@ -133,12 +133,12 @@ func TestFindUsedBlobsSkipsSeenBlobs(t *testing.T) {
 	t.Logf("snapshot %v saved, tree %v", snapshot.ID().Str(), snapshot.Tree.Str())
 
 	usedBlobs := restic.NewBlobSet()
-	err := restic.FindUsedBlobs(context.TODO(), repo, *snapshot.Tree, usedBlobs)
+	err := restic.FindUsedBlobs(context.TODO(), repo, restic.IDs{*snapshot.Tree}, usedBlobs, nil)
 	if err != nil {
 		t.Fatalf("FindUsedBlobs returned error: %v", err)
 	}
 
-	err = restic.FindUsedBlobs(context.TODO(), ForbiddenRepo{}, *snapshot.Tree, usedBlobs)
+	err = restic.FindUsedBlobs(context.TODO(), ForbiddenRepo{}, restic.IDs{*snapshot.Tree}, usedBlobs, nil)
 	if err != nil {
 		t.Fatalf("FindUsedBlobs returned error: %v", err)
 	}
@@ -154,7 +154,7 @@ func BenchmarkFindUsedBlobs(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		blobs := restic.NewBlobSet()
-		err := restic.FindUsedBlobs(context.TODO(), repo, *sn.Tree, blobs)
+		err := restic.FindUsedBlobs(context.TODO(), repo, restic.IDs{*sn.Tree}, blobs, nil)
 		if err != nil {
 			b.Error(err)
 		}

--- a/internal/restic/tree_stream.go
+++ b/internal/restic/tree_stream.go
@@ -147,7 +147,9 @@ func filterTrees(ctx context.Context, trees IDs, loaderChan chan<- trackedID,
 }
 
 // StreamTrees iteratively loads the given trees and their subtrees. The skip method
-// is guaranteed to always be called from the same goroutine.
+// is guaranteed to always be called from the same goroutine. To shutdown the started
+// goroutines, either read all items from the channel or cancel the context. Then `Wait()`
+// on the errgroup until all goroutines were stopped.
 func StreamTrees(ctx context.Context, wg *errgroup.Group, repo TreeLoader, trees IDs, skip func(tree ID) bool, p *progress.Counter) <-chan TreeItem {
 	loaderChan := make(chan trackedID)
 	loadedTreeChan := make(chan trackedTreeItem)

--- a/internal/restic/tree_stream.go
+++ b/internal/restic/tree_stream.go
@@ -1,0 +1,155 @@
+package restic
+
+import (
+	"context"
+	"errors"
+	"sync"
+
+	"github.com/restic/restic/internal/debug"
+	"golang.org/x/sync/errgroup"
+)
+
+const streamTreeParallelism = 5
+
+// TreeItem is used to return either an error or the tree for a tree id
+type TreeItem struct {
+	ID
+	Error error
+	*Tree
+}
+
+// loadTreeWorker loads trees from repo and sends them to out.
+func loadTreeWorker(ctx context.Context, repo TreeLoader,
+	in <-chan ID, out chan<- TreeItem) {
+
+	for treeID := range in {
+		tree, err := repo.LoadTree(ctx, treeID)
+		debug.Log("load tree %v (%v) returned err: %v", tree, treeID, err)
+		job := TreeItem{ID: treeID, Error: err, Tree: tree}
+
+		select {
+		case <-ctx.Done():
+			return
+		case out <- job:
+		}
+	}
+}
+
+func filterTrees(ctx context.Context, backlog IDs, loaderChan chan<- ID,
+	in <-chan TreeItem, out chan<- TreeItem, skip func(tree ID) bool) {
+
+	var (
+		inCh                    = in
+		outCh                   chan<- TreeItem
+		loadCh                  chan<- ID
+		job                     TreeItem
+		nextTreeID              ID
+		outstandingLoadTreeJobs = 0
+	)
+
+	for {
+		if loadCh == nil && len(backlog) > 0 {
+			// process last added ids first, that is traverse the tree in depth-first order
+			ln := len(backlog) - 1
+			nextTreeID, backlog = backlog[ln], backlog[:ln]
+
+			if skip(nextTreeID) {
+				continue
+			}
+
+			loadCh = loaderChan
+		}
+
+		if loadCh == nil && outCh == nil && outstandingLoadTreeJobs == 0 {
+			debug.Log("backlog is empty, all channels nil, exiting")
+			return
+		}
+
+		select {
+		case <-ctx.Done():
+			return
+
+		case loadCh <- nextTreeID:
+			outstandingLoadTreeJobs++
+			loadCh = nil
+
+		case j, ok := <-inCh:
+			if !ok {
+				debug.Log("input channel closed")
+				inCh = nil
+				in = nil
+				continue
+			}
+
+			outstandingLoadTreeJobs--
+
+			debug.Log("input job tree %v", j.ID)
+
+			if j.Error != nil {
+				debug.Log("received job with error: %v (tree %v, ID %v)", j.Error, j.Tree, j.ID)
+			} else if j.Tree == nil {
+				debug.Log("received job with nil tree pointer: %v (ID %v)", j.Error, j.ID)
+				// send a new job with the new error instead of the old one
+				j = TreeItem{ID: j.ID, Error: errors.New("tree is nil and error is nil")}
+			} else {
+				subtrees := j.Tree.Subtrees()
+				debug.Log("subtrees for tree %v: %v", j.ID, subtrees)
+				// iterate backwards over subtree to compensate backwards traversal order of nextTreeID selection
+				for i := len(subtrees) - 1; i >= 0; i-- {
+					id := subtrees[i]
+					if id.IsNull() {
+						// We do not need to raise this error here, it is
+						// checked when the tree is checked. Just make sure
+						// that we do not add any null IDs to the backlog.
+						debug.Log("tree %v has nil subtree", j.ID)
+						continue
+					}
+					backlog = append(backlog, id)
+				}
+			}
+
+			job = j
+			outCh = out
+			inCh = nil
+
+		case outCh <- job:
+			debug.Log("tree sent to process: %v", job.ID)
+			outCh = nil
+			inCh = in
+		}
+	}
+}
+
+// StreamTrees iteratively loads the given trees and their subtrees. The skip method
+// is guaranteed to always be called from the same goroutine.
+func StreamTrees(ctx context.Context, wg *errgroup.Group, repo TreeLoader, trees IDs, skip func(tree ID) bool) <-chan TreeItem {
+	loaderChan := make(chan ID)
+	loadedTreeChan := make(chan TreeItem)
+	treeStream := make(chan TreeItem)
+
+	var loadTreeWg sync.WaitGroup
+
+	for i := 0; i < streamTreeParallelism; i++ {
+		loadTreeWg.Add(1)
+		wg.Go(func() error {
+			defer loadTreeWg.Done()
+			loadTreeWorker(ctx, repo, loaderChan, loadedTreeChan)
+			return nil
+		})
+	}
+
+	// close once all loadTreeWorkers have completed
+	wg.Go(func() error {
+		loadTreeWg.Wait()
+		close(loadedTreeChan)
+		return nil
+	})
+
+	wg.Go(func() error {
+		defer close(loaderChan)
+		defer close(treeStream)
+		filterTrees(ctx, trees, loaderChan, loadedTreeChan, treeStream, skip)
+		return nil
+	})
+	return treeStream
+}

--- a/internal/ui/progress/counter.go
+++ b/internal/ui/progress/counter.go
@@ -12,7 +12,7 @@ import (
 //
 // The final argument is true if Counter.Done has been called,
 // which means that the current call will be the last.
-type Func func(value uint64, runtime time.Duration, final bool)
+type Func func(value uint64, total uint64, runtime time.Duration, final bool)
 
 // A Counter tracks a running count and controls a goroutine that passes its
 // value periodically to a Func.
@@ -27,16 +27,19 @@ type Counter struct {
 
 	valueMutex sync.Mutex
 	value      uint64
+	max        uint64
 }
 
 // New starts a new Counter.
-func New(interval time.Duration, report Func) *Counter {
+func New(interval time.Duration, total uint64, report Func) *Counter {
 	c := &Counter{
 		report:  report,
 		start:   time.Now(),
 		stopped: make(chan struct{}),
 		stop:    make(chan struct{}),
+		max:     total,
 	}
+
 	if interval > 0 {
 		c.tick = time.NewTicker(interval)
 	}
@@ -53,6 +56,16 @@ func (c *Counter) Add(v uint64) {
 
 	c.valueMutex.Lock()
 	c.value += v
+	c.valueMutex.Unlock()
+}
+
+// SetMax sets the maximum expected counter value. This method is concurrency-safe.
+func (c *Counter) SetMax(max uint64) {
+	if c == nil {
+		return
+	}
+	c.valueMutex.Lock()
+	c.max = max
 	c.valueMutex.Unlock()
 }
 
@@ -77,11 +90,19 @@ func (c *Counter) get() uint64 {
 	return v
 }
 
+func (c *Counter) getMax() uint64 {
+	c.valueMutex.Lock()
+	max := c.max
+	c.valueMutex.Unlock()
+
+	return max
+}
+
 func (c *Counter) run() {
 	defer close(c.stopped)
 	defer func() {
 		// Must be a func so that time.Since isn't called at defer time.
-		c.report(c.get(), time.Since(c.start), true)
+		c.report(c.get(), c.getMax(), time.Since(c.start), true)
 	}()
 
 	var tick <-chan time.Time
@@ -101,6 +122,6 @@ func (c *Counter) run() {
 			return
 		}
 
-		c.report(c.get(), now.Sub(c.start), false)
+		c.report(c.get(), c.getMax(), now.Sub(c.start), false)
 	}
 }

--- a/internal/ui/progress/counter.go
+++ b/internal/ui/progress/counter.go
@@ -82,7 +82,8 @@ func (c *Counter) Done() {
 	*c = Counter{} // Prevent reuse.
 }
 
-func (c *Counter) get() uint64 {
+// Get the current Counter value. This method is concurrency-safe.
+func (c *Counter) Get() uint64 {
 	c.valueMutex.Lock()
 	v := c.value
 	c.valueMutex.Unlock()
@@ -102,7 +103,7 @@ func (c *Counter) run() {
 	defer close(c.stopped)
 	defer func() {
 		// Must be a func so that time.Since isn't called at defer time.
-		c.report(c.get(), c.getMax(), time.Since(c.start), true)
+		c.report(c.Get(), c.getMax(), time.Since(c.start), true)
 	}()
 
 	var tick <-chan time.Time
@@ -122,6 +123,6 @@ func (c *Counter) run() {
 			return
 		}
 
-		c.report(c.get(), c.getMax(), now.Sub(c.start), false)
+		c.report(c.Get(), c.getMax(), now.Sub(c.start), false)
 	}
 }

--- a/internal/ui/progress/counter_test.go
+++ b/internal/ui/progress/counter_test.go
@@ -10,23 +10,30 @@ import (
 
 func TestCounter(t *testing.T) {
 	const N = 100
+	const startTotal = uint64(12345)
 
 	var (
 		finalSeen  = false
 		increasing = true
 		last       uint64
+		lastTotal  = startTotal
 		ncalls     int
+		nmaxChange int
 	)
 
-	report := func(value uint64, d time.Duration, final bool) {
+	report := func(value uint64, total uint64, d time.Duration, final bool) {
 		finalSeen = true
 		if value < last {
 			increasing = false
 		}
 		last = value
+		if total != lastTotal {
+			nmaxChange++
+		}
+		lastTotal = total
 		ncalls++
 	}
-	c := progress.New(10*time.Millisecond, report)
+	c := progress.New(10*time.Millisecond, startTotal, report)
 
 	done := make(chan struct{})
 	go func() {
@@ -35,6 +42,7 @@ func TestCounter(t *testing.T) {
 			time.Sleep(time.Millisecond)
 			c.Add(1)
 		}
+		c.SetMax(42)
 	}()
 
 	<-done
@@ -43,6 +51,8 @@ func TestCounter(t *testing.T) {
 	test.Assert(t, finalSeen, "final call did not happen")
 	test.Assert(t, increasing, "values not increasing")
 	test.Equals(t, uint64(N), last)
+	test.Equals(t, uint64(42), lastTotal)
+	test.Equals(t, int(1), nmaxChange)
 
 	t.Log("number of calls:", ncalls)
 }
@@ -58,14 +68,14 @@ func TestCounterNoTick(t *testing.T) {
 	finalSeen := false
 	otherSeen := false
 
-	report := func(value uint64, d time.Duration, final bool) {
+	report := func(value, total uint64, d time.Duration, final bool) {
 		if final {
 			finalSeen = true
 		} else {
 			otherSeen = true
 		}
 	}
-	c := progress.New(0, report)
+	c := progress.New(0, 1, report)
 	time.Sleep(time.Millisecond)
 	c.Done()
 

--- a/internal/ui/progress/counter_test.go
+++ b/internal/ui/progress/counter_test.go
@@ -22,7 +22,9 @@ func TestCounter(t *testing.T) {
 	)
 
 	report := func(value uint64, total uint64, d time.Duration, final bool) {
-		finalSeen = true
+		if final {
+			finalSeen = true
+		}
 		if value < last {
 			increasing = false
 		}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR parallelizes the tree walking in `prune` to find used blobs and in `copy` to find tree blobs for copying. For that the parallel tree loading used by the `check` is extracted as `StreamTrees` and reused. Afterwards `StreamTrees` is enhanced with progress tracking which reports how many snapshots are already fully processed. This replaces the current progress tracking in prune and adds a progress bar to the `Structure` step of the `check` command.

The signature of the StreamTrees function is composed as follows:
```
func StreamTrees(
    // ctx must be tied to wg. These four parameters and the result channel are the result
    // of extracting the corresponding implementation from the checker into a function
    ctx context.Context, wg *errgroup.Group, repo restic.TreeLoader, trees restic.IDs,
    // allow the caller to track visited trees as necessary. This e.g. allows subtree skipping
    // across StreamTrees calls (used by copy) and caller specific tracking of visited trees
    // The latter is used to prevent duplicate bookkeeping in the checker
    visit func(tree restic.ID) bool,
    // progress bar
    p *progress.Counter
) <-chan TreeItem
```

There are currently a few open points:
- [x] I've put the parallel implementations into a `parallel` package. They might fit better into e.g. the `repository` package. I also have an implementation of a `StreamIndex` function to unify index loading, which however must reside in the `repository` package as everything else currently causes import loops.
- [x] I've split the `Structure` method of the checker into `LoadSnapshots` & `Structure` as a progress bar currently requires knowing the upper limit up front. This add quite a bit of boilerplate code at different locations. It might be to enhance the progress bar to allow setting the limit later on.

Tests and changelog are still missing. Most of the code should be tested indirectly, especially by the `FindUsedBlobs` test or the integration tests, but I haven't looked at the test coverage yet.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The changes made in this PR were mentioned in https://github.com/restic/restic/issues/2162#issuecomment-723562425 .

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
