### PR TITLE
do not require gs bucket permissions to init repository

### DIFF
--- a/changelog/unreleased/issue-3100
+++ b/changelog/unreleased/issue-3100
@@ -1,0 +1,10 @@
+Bugfix: Do not require gs bucket permissions when running init 
+
+Restic used to require bucket level permissions for the gs backend 
+in order to initialize a restic repository.
+
+It now allows a gs service account to initialize a repository if the 
+bucket does exist and the service account has permissions to write/read
+to that bucket.
+
+https://github.com/restic/restic/issues/3100

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -136,6 +136,11 @@ func Create(cfg Config, rt http.RoundTripper) (restic.Backend, error) {
 	ctx := context.Background()
 	exists, err := be.bucketExists(ctx, be.bucket)
 	if err != nil {
+		if e, ok := err.(*googleapi.Error); ok && e.Code == http.StatusForbidden {
+			// the bucket might exist!
+			// however, the client doesn't have storage.bucket.get permission
+			return be, nil
+		}
 		return nil, errors.Wrap(err, "service.Buckets.Get")
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

a gs service account may only have object permissions on an existing
bucket but no bucket create/get permissions.

these service accounts currently are blocked from initializing a
restic repository because restic can not determine if the bucket exists.

this PR updates the logic to assume the bucket exists when the bucket
attribute request results in a permissions denied error.

this way, restic can still initialize a repository if the service
account does have object permissions


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

fixes: https://github.com/restic/restic/issues/3100

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
