### PR TITLE
restore: Don't save pack content in memory 

### DIFF
--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -319,7 +319,7 @@ func (r *fileRestorer) loadBlob(rd io.Reader, blobID restic.ID, length int, buf 
 		buf = buf[:length]
 	}
 
-	n, err := rd.Read(buf)
+	n, err := io.ReadFull(rd, buf)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -251,16 +251,16 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) {
 		if bufferSize > maxBufferSize {
 			bufferSize = maxBufferSize
 		}
-		BufRd := bufio.NewReaderSize(rd, bufferSize)
+		bufRd := bufio.NewReaderSize(rd, bufferSize)
 		currentBlobEnd := start
 		var blobData, buf []byte
 		for _, blobID := range sortedBlobs {
 			blob := blobs[blobID]
-			_, err := BufRd.Discard(int(blob.offset - currentBlobEnd))
+			_, err := bufRd.Discard(int(blob.offset - currentBlobEnd))
 			if err != nil {
 				return err
 			}
-			blobData, buf, err = r.loadBlob(BufRd, blobID, blob.length, buf)
+			blobData, buf, err = r.loadBlob(bufRd, blobID, blob.length, buf)
 			if err != nil {
 				for file := range blob.files {
 					markFileError(file, err)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

`filerestorer.go` (which is used in restore) used to save packs (or at least large parts) in memory in order to process the blobs by a `ReaderAt`. As this is not supplied by the `Backend` implementation, the contents were loaded into a memory buffer.

This PR first sorts the blobs by the offset before processing them and thus allows to only use a `Reader` to read all blobs.
This remove the necessity to store the pack content in memory.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

See #2750 
This PR reduces memory usage a lot when using large pack sizes.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR.
- I have not added documentation for the changes (in the manual)
- There's no new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)) 
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
