### PR TITLE
Limit progress bar updates to once per second on non-terminal outputs

### DIFF
--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -16,7 +16,7 @@ func newProgressMax(show bool, max uint64, description string) *progress.Counter
 	}
 
 	interval := time.Second / 60
-	if !stdinIsTerminal() {
+	if !stdoutIsTerminal() {
 		interval = time.Second
 	} else {
 		fps, err := strconv.ParseInt(os.Getenv("RESTIC_PROGRESS_FPS"), 10, 64)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
PR #3058 rewrote the progress bar implementation and in that progress reenabled it for non-terminal output.

However, the code accidentally checked whether stdin is a terminal instead of stdout, the former is not relevant here as the output is printed on stdout.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Reported at https://forum.restic.net/t/new-prune-log-spam/3284 .

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~ There's no nice way right now to test this.
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)). ~~ I haven't added a changelog entry as this PR is a fixup for #3058, which (currently) does not have a changelog entry.
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
