### PR TITLE
Make restic cat respect --no-lock

### DIFF
--- a/changelog/unreleased/issue-2739
+++ b/changelog/unreleased/issue-2739
@@ -1,0 +1,5 @@
+Bugfix: Make cat command respect --no-lock
+
+Restic cat would not respect the --no-lock flag, it now does.
+
+https://github.com/restic/restic/issues/2739

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -42,10 +42,13 @@ func runCat(gopts GlobalOptions, args []string) error {
 		return err
 	}
 
-	lock, err := lockRepo(gopts.ctx, repo)
-	defer unlockRepo(lock)
-	if err != nil {
-		return err
+	if !gopts.NoLock {
+		lock, err := lockRepo(gopts.ctx, repo)
+		// Make the linter happy
+		if err != nil {
+			return err
+		}
+		defer func() { _ = unlockRepo(lock) }()
 	}
 
 	tpe := args[0]

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -44,11 +44,16 @@ func runCat(gopts GlobalOptions, args []string) error {
 
 	if !gopts.NoLock {
 		lock, err := lockRepo(gopts.ctx, repo)
-		// Make the linter happy
 		if err != nil {
 			return err
 		}
-		defer func() { _ = unlockRepo(lock) }()
+
+		defer func() {
+			err := unlockRepo(lock)
+			if err != nil {
+				Warnf("unlock repo failed: %v", err)
+			}
+		}()
 	}
 
 	tpe := args[0]


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Makes the cat command respect the --no-lock global flag


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2739 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
