### PR TITLE
Make loading snapshots parallel

### DIFF
--- a/changelog/unreleased/pull-3130
+++ b/changelog/unreleased/pull-3130
@@ -1,0 +1,9 @@
+Enhancement: Parallelize reading of snapshots
+
+Restic used to read snapshots sequentially. For repositories containing
+many snapshots this slowed down commands which have to read all snapshots.
+Now the reading of snapshots is parallelized. This speeds up for example
+`prune`, `backup` and other commands that search for snapshots with certain
+properties or which have to find the `latest` snapshot.
+
+https://github.com/restic/restic/pull/3130

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -55,8 +55,7 @@ func prettyPrintJSON(wr io.Writer, item interface{}) error {
 }
 
 func debugPrintSnapshots(ctx context.Context, repo *repository.Repository, wr io.Writer) error {
-	return repo.List(ctx, restic.SnapshotFile, func(id restic.ID, size int64) error {
-		snapshot, err := restic.LoadSnapshot(ctx, repo, id)
+	return restic.ForAllSnapshots(ctx, repo, nil, func(id restic.ID, snapshot *restic.Snapshot, err error) error {
 		if err != nil {
 			return err
 		}

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -126,25 +126,6 @@ func ForAllSnapshots(ctx context.Context, repo Repository, excludeIDs IDSet, fn 
 	return wg.Wait()
 }
 
-// LoadAllSnapshots returns a list of all snapshots in the repo.
-// If a snapshot ID is in excludeIDs, it will not be included in the result.
-func LoadAllSnapshots(ctx context.Context, repo Repository, excludeIDs IDSet) (snapshots Snapshots, err error) {
-	err = ForAllSnapshots(ctx, repo, excludeIDs, func(id ID, sn *Snapshot, err error) error {
-		if err != nil {
-			return err
-		}
-
-		snapshots = append(snapshots, sn)
-		return nil
-	})
-
-	if err != nil {
-		return nil, err
-	}
-
-	return snapshots, nil
-}
-
 func (sn Snapshot) String() string {
 	return fmt.Sprintf("<Snapshot %s of %v at %s by %s@%s>",
 		sn.id.Str(), sn.Paths, sn.Time, sn.Username, sn.Hostname)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Loads snaphots files in parallel, like already done by `restic check`.
This speeds up many commands if there is a large number of snapshots in the repository.

Note that this should be also included in #3121 (either here or there depending on the order of PR merge)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

The issue came up quite often, but so far only the possibility to change the repo format (snapshot blobs) has been discussed.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-  I have not added tests for all changes in this PR, but existing tests still pass
-  I have not added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
