### PR TITLE
Warn when unlock fails instead of returning an error

### DIFF
--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -48,12 +48,7 @@ func runCat(gopts GlobalOptions, args []string) error {
 			return err
 		}
 
-		defer func() {
-			err := unlockRepo(lock)
-			if err != nil {
-				Warnf("unlock repo failed: %v", err)
-			}
-		}()
+		defer unlockRepo(lock)
 	}
 
 	tpe := args[0]

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -85,9 +85,9 @@ func refreshLocks(wg *sync.WaitGroup, done <-chan struct{}) {
 	}
 }
 
-func unlockRepo(lock *restic.Lock) error {
+func unlockRepo(lock *restic.Lock) {
 	if lock == nil {
-		return nil
+		return
 	}
 
 	globalLocks.Lock()
@@ -99,18 +99,17 @@ func unlockRepo(lock *restic.Lock) error {
 			debug.Log("unlocking repository with lock %v", lock)
 			if err := lock.Unlock(); err != nil {
 				debug.Log("error while unlocking: %v", err)
-				return err
+				Warnf("error while unlocking: %v", err)
+				return
 			}
 
 			// remove the lock from the list of locks
 			globalLocks.locks = append(globalLocks.locks[:i], globalLocks.locks[i+1:]...)
-			return nil
+			return
 		}
 	}
 
 	debug.Log("unable to find lock %v in the global list of locks, ignoring", lock)
-
-	return nil
 }
 
 func unlockAll() error {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Only one caller of unlockRepo checks its return value, because checking inside a defer statement is a chore. Let's drop the return value and put a Warnf inside the function instead.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

This is what I meant in my comment on #3125.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
