### PR TITLE
doc: Fix misc missing/incorrect text in manual

### DIFF
--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -9,6 +9,7 @@ Usage help is available:
 .. code-block:: console
 
     $ ./restic --help
+
     restic is a backup program which allows saving multiple revisions of files and
     directories in an encrypted repository stored on different backends.
 
@@ -34,7 +35,7 @@ Usage help is available:
       migrate       Apply migrations
       mount         Mount the repository
       prune         Remove unneeded data from the repository
-      rebuild-index Build a new index file
+      rebuild-index Build a new index
       recover       Recover data from the repository
       restore       Extract the data from a snapshot
       self-update   Update the restic binary
@@ -62,7 +63,7 @@ Usage help is available:
       -r, --repo repository            repository to backup to or restore from (default: $RESTIC_REPOSITORY)
           --repository-file file       file to read the repository location from (default: $RESTIC_REPOSITORY_FILE)
           --tls-client-cert file       path to a file containing PEM encoded TLS client certificate and private key
-      -v, --verbose n                  be verbose (specify --verbose multiple times or level --verbose=n)
+      -v, --verbose n                  be verbose (specify multiple times or a level using --verbose=n, max level/times is 3)
 
     Use "restic [command] --help" for more information about a command.
 
@@ -75,6 +76,7 @@ command:
 .. code-block:: console
 
     $ ./restic backup --help
+
     The "backup" command creates a new snapshot and saves the files and directories
     given as the arguments.
 
@@ -94,7 +96,9 @@ command:
           --exclude-file file                      read exclude patterns from a file (can be specified multiple times)
           --exclude-if-present filename[:header]   takes filename[:header], exclude contents of directories containing filename (except filename itself) if header of that file is as provided (can be specified multiple times)
           --exclude-larger-than size               max size of the files to be backed up (allowed suffixes: k/K, m/M, g/G, t/T)
-          --files-from file                        read the files to backup from file (can be combined with file args/can be specified multiple times)
+          --files-from file                        read the files to backup from file (can be combined with file args; can be specified multiple times)
+          --files-from-raw file                    read the files to backup from file (can be combined with file args; can be specified multiple times)
+          --files-from-verbatim file               read the files to backup from file (can be combined with file args; can be specified multiple times)
       -f, --force                                  force re-reading the target files/directories (overrides the "parent" flag)
       -h, --help                                   help for backup
       -H, --host hostname                          set the hostname for the snapshot manually. To prevent an expensive rescan use the "parent" flag
@@ -105,7 +109,7 @@ command:
           --parent snapshot                        use this parent snapshot (default: last snapshot in the repo that has the same target files/directories)
           --stdin                                  read backup from stdin
           --stdin-filename filename                filename to use when reading from stdin (default "stdin")
-          --tag tag                                add `tags` for the new snapshot in the format `tag[,tag,...]` (can be specified multiple times)
+          --tag tags                               add tags for the new snapshot in the format `tag[,tag,...]` (can be specified multiple times) (default [])
           --time time                              time of the backup (ex. '2012-11-01 22:08:41') (default: now)
           --use-fs-snapshot                        use filesystem snapshot where possible (currently only Windows VSS)
           --with-atime                             store the atime for all files and directories
@@ -127,7 +131,7 @@ command:
       -r, --repo repository            repository to backup to or restore from (default: $RESTIC_REPOSITORY)
           --repository-file file       file to read the repository location from (default: $RESTIC_REPOSITORY_FILE)
           --tls-client-cert file       path to a file containing PEM encoded TLS client certificate and private key
-      -v, --verbose n                  be verbose (specify --verbose multiple times or level --verbose=n)
+      -v, --verbose n                  be verbose (specify multiple times or a level using --verbose=n, max level/times is 3)
 
 Subcommand that support showing progress information such as ``backup``,
 ``check`` and ``prune`` will do so unless the quiet flag ``-q`` or


### PR DESCRIPTION
To be merged AFTER #3017.

Fixes various small incorrect or missing bits of information in the manual documentation.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
