### PR TITLE
prune: Add JSON support and separate code

### DIFF
--- a/changelog/unreleased/issue-3129
+++ b/changelog/unreleased/issue-3129
@@ -1,0 +1,7 @@
+Enhancement: Add JSON support to prune
+
+Restic `prune` now also supports the `--json` option and gives all
+statistics in JSON format.
+
+https://github.com/restic/restic/issues/3129
+https://github.com/restic/restic/pull/3140

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"math"
 	"sort"
 	"strconv"
@@ -595,6 +596,10 @@ func planPrune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, u
 
 // printPruneStats prints out the statistics
 func printPruneStats(gopts GlobalOptions, stats pruneStats) error {
+	if gopts.JSON {
+		return json.NewEncoder(gopts.stdout).Encode(stats)
+	}
+
 	Verboseff("\nused:         %10d blobs / %s\n", stats.Blobs.Used, formatBytes(stats.Size.Used))
 	if stats.Blobs.Duplicate > 0 {
 		Verboseff("duplicates:   %10d blobs / %s\n", stats.Blobs.Duplicate, formatBytes(stats.Size.Duplicate))

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -208,36 +208,58 @@ type packInfoWithID struct {
 	packInfo
 }
 
+type blobStats struct {
+	Used         uint `json:"used"`
+	Duplicate    uint `json:"duplicate"`
+	Unused       uint `json:"unused"`
+	Total        uint `json:"total"`
+	Repack       uint `json:"repack"`
+	RepackRm     uint `json:"repack_remove"`
+	Remove       uint `json:"remove"`
+	RemoveTotal  uint `json:"remove_total"`
+	Remain       uint `json:"remaining"`
+	RemainUnused uint `json:"remaining_unused"`
+}
+
+type sizeStats struct {
+	Used         uint64 `json:"used"`
+	Duplicate    uint64 `json:"duplicate"`
+	Unused       uint64 `json:"unused"`
+	Unref        uint64 `json:"unreferenced"`
+	Total        uint64 `json:"total"`
+	Repack       uint64 `json:"repack"`
+	RepackRm     uint64 `json:"repack_remove"`
+	Remove       uint64 `json:"remove"`
+	RemoveTotal  uint64 `json:"remove_total"`
+	Remain       uint64 `json:"remaining"`
+	RemainUnused uint64 `json:"remaining_unused"`
+}
+
+type packStats struct {
+	Used        uint `json:"used"`
+	Unused      uint `json:"unused"`
+	PartlyUsed  uint `json:"partly_used"`
+	Unref       uint `json:"unreferenced"`
+	Total       uint `json:"total"`
+	Keep        uint `json:"keep"`
+	Repack      uint `json:"repack"`
+	Remove      uint `json:"remove"`
+	RemoveTotal uint `json:"remove_total"`
+}
+
+type pruneStats struct {
+	MessageType string    `json:"message_type"` // "summary"
+	Blobs       blobStats `json:"blobs"`
+	Size        sizeStats `json:"bytes"`
+	Packs       packStats `json:"packfiles"`
+}
+
 // prune selects which files to rewrite and then does that. The map usedBlobs is
 // modified in the process.
 func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedBlobs restic.BlobSet) error {
 	ctx := gopts.ctx
 
-	var stats struct {
-		blobs struct {
-			used      uint
-			duplicate uint
-			unused    uint
-			remove    uint
-			repack    uint
-			repackrm  uint
-		}
-		size struct {
-			used      uint64
-			duplicate uint64
-			unused    uint64
-			remove    uint64
-			repack    uint64
-			repackrm  uint64
-			unref     uint64
-		}
-		packs struct {
-			used       uint
-			unused     uint
-			partlyUsed uint
-			keep       uint
-		}
-	}
+	var stats pruneStats
 
 	Verbosef("searching used packs...\n")
 
@@ -252,8 +274,8 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 		case usedBlobs.Has(bh): // used blob, move to keepBlobs
 			usedBlobs.Delete(bh)
 			keepBlobs.Insert(bh)
-			stats.size.used += size
-			stats.blobs.used++
+			stats.Size.Used += size
+			stats.Blobs.Used++
 		case keepBlobs.Has(bh): // duplicate blob
 			count, ok := duplicateBlobs[bh]
 			if !ok {
@@ -265,11 +287,11 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 				count++
 			}
 			duplicateBlobs[bh] = count
-			stats.size.duplicate += size
-			stats.blobs.duplicate++
+			stats.Size.Duplicate += size
+			stats.Blobs.Duplicate++
 		default:
-			stats.size.unused += size
-			stats.blobs.unused++
+			stats.Size.Unused += size
+			stats.Blobs.Unused++
 		}
 	}
 
@@ -377,7 +399,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 			// Pack was not referenced in index and is not used  => immediately remove!
 			Verboseff("will remove pack %v as it is unused and not indexed\n", id.Str())
 			removePacksFirst.Insert(id)
-			stats.size.unref += uint64(packSize)
+			stats.Size.Unref += uint64(packSize)
 			return nil
 		}
 
@@ -393,11 +415,11 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 		// statistics
 		switch {
 		case p.usedBlobs == 0:
-			stats.packs.unused++
+			stats.Packs.Unused++
 		case p.unusedBlobs == 0:
-			stats.packs.used++
+			stats.Packs.Used++
 		default:
-			stats.packs.partlyUsed++
+			stats.Packs.PartlyUsed++
 		}
 
 		mustCompress := false
@@ -414,16 +436,16 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 		case p.usedBlobs == 0:
 			// All blobs in pack are no longer used => remove pack!
 			removePacks.Insert(id)
-			stats.blobs.remove += p.unusedBlobs
-			stats.size.remove += p.unusedSize
+			stats.Blobs.Remove += p.unusedBlobs
+			stats.Size.Remove += p.unusedSize
 
 		case opts.RepackCachableOnly && p.tpe == restic.DataBlob:
 			// if this is a data pack and --repack-cacheable-only is set => keep pack!
-			stats.packs.keep++
+			stats.Packs.Keep++
 
 		case p.unusedBlobs == 0 && p.tpe != restic.InvalidBlob && !mustCompress:
 			// All blobs in pack are used and not mixed => keep pack!
-			stats.packs.keep++
+			stats.Packs.Keep++
 
 		default:
 			// all other packs are candidates for repacking
@@ -446,8 +468,8 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 	for id, p := range indexPack {
 		if p.usedBlobs == 0 {
 			ignorePacks.Insert(id)
-			stats.blobs.remove += p.unusedBlobs
-			stats.size.remove += p.unusedSize
+			stats.Blobs.Remove += p.unusedBlobs
+			stats.Size.Remove += p.unusedSize
 			delete(indexPack, id)
 		}
 	}
@@ -467,7 +489,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 	}
 
 	// calculate limit for number of unused bytes in the repo after repacking
-	maxUnusedSizeAfter := opts.maxUnusedBytes(stats.size.used)
+	maxUnusedSizeAfter := opts.maxUnusedBytes(stats.Size.Used)
 
 	// Sort repackCandidates such that packs with highest ratio unused/used space are picked first.
 	// This is equivalent to sorting by unused / total space.
@@ -488,19 +510,19 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 
 	repack := func(id restic.ID, p packInfo) {
 		repackPacks.Insert(id)
-		stats.blobs.repack += p.unusedBlobs + p.usedBlobs
-		stats.size.repack += p.unusedSize + p.usedSize
-		stats.blobs.repackrm += p.unusedBlobs
-		stats.size.repackrm += p.unusedSize
+		stats.Blobs.Repack += p.unusedBlobs + p.usedBlobs
+		stats.Size.Repack += p.unusedSize + p.usedSize
+		stats.Blobs.RepackRm += p.unusedBlobs
+		stats.Size.RepackRm += p.unusedSize
 	}
 
 	for _, p := range repackCandidates {
-		reachedUnusedSizeAfter := (stats.size.unused-stats.size.remove-stats.size.repackrm < maxUnusedSizeAfter)
-		reachedRepackSize := stats.size.repack+p.unusedSize+p.usedSize >= opts.MaxRepackBytes
+		reachedUnusedSizeAfter := (stats.Size.Unused-stats.Size.Remove-stats.Size.RepackRm < maxUnusedSizeAfter)
+		reachedRepackSize := stats.Size.Repack+p.unusedSize+p.usedSize >= opts.MaxRepackBytes
 
 		switch {
 		case reachedRepackSize:
-			stats.packs.keep++
+			stats.Packs.Keep++
 
 		case p.tpe != restic.DataBlob, p.uncompressed:
 			// repacking non-data packs / uncompressed-trees is only limited by repackSize
@@ -508,7 +530,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 
 		case reachedUnusedSizeAfter:
 			// for all other packs stop repacking if tolerated unused size is reached.
-			stats.packs.keep++
+			stats.Packs.Keep++
 
 		default:
 			repack(p.ID, p.packInfo)
@@ -529,39 +551,50 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 		keepBlobs = nil
 	}
 
-	Verboseff("\nused:         %10d blobs / %s\n", stats.blobs.used, formatBytes(stats.size.used))
-	if stats.blobs.duplicate > 0 {
-		Verboseff("duplicates:   %10d blobs / %s\n", stats.blobs.duplicate, formatBytes(stats.size.duplicate))
-	}
-	Verboseff("unused:       %10d blobs / %s\n", stats.blobs.unused, formatBytes(stats.size.unused))
-	if stats.size.unref > 0 {
-		Verboseff("unreferenced:                    %s\n", formatBytes(stats.size.unref))
-	}
-	totalBlobs := stats.blobs.used + stats.blobs.unused + stats.blobs.duplicate
-	totalSize := stats.size.used + stats.size.duplicate + stats.size.unused + stats.size.unref
-	unusedSize := stats.size.duplicate + stats.size.unused
-	Verboseff("total:        %10d blobs / %s\n", totalBlobs, formatBytes(totalSize))
-	Verboseff("unused size: %s of total size\n", formatPercent(unusedSize, totalSize))
+	// calculate totals for statistics
+	stats.MessageType = "summary"
+	stats.Blobs.Total = stats.Blobs.Used + stats.Blobs.Unused + stats.Blobs.Duplicate
+	stats.Blobs.RemoveTotal = stats.Blobs.Remove + stats.Blobs.RepackRm
+	stats.Blobs.Remain = stats.Blobs.Total - stats.Blobs.RemoveTotal
+	stats.Size.Total = stats.Size.Used + stats.Size.Duplicate + stats.Size.Unused + stats.Size.Unref
+	stats.Size.Unused = stats.Size.Duplicate + stats.Size.Unused
+	stats.Size.RemoveTotal = stats.Size.Remove + stats.Size.RepackRm + stats.Size.Unref
+	stats.Size.Remain = stats.Size.Total - stats.Size.RemoveTotal
+	stats.Size.RemainUnused = stats.Size.Unused - stats.Size.Remove - stats.Size.RepackRm
+	stats.Packs.Unref = uint(len(removePacksFirst))
+	stats.Packs.Total = stats.Packs.Used + stats.Packs.PartlyUsed + stats.Packs.Unused + stats.Packs.Unref
+	stats.Packs.Repack = uint(len(repackPacks))
+	stats.Packs.Remove = uint(len(removePacks))
+	stats.Packs.RemoveTotal = stats.Packs.Unref + stats.Packs.Remove
 
-	Verbosef("\nto repack:    %10d blobs / %s\n", stats.blobs.repack, formatBytes(stats.size.repack))
-	Verbosef("this removes: %10d blobs / %s\n", stats.blobs.repackrm, formatBytes(stats.size.repackrm))
-	Verbosef("to delete:    %10d blobs / %s\n", stats.blobs.remove, formatBytes(stats.size.remove+stats.size.unref))
-	totalPruneSize := stats.size.remove + stats.size.repackrm + stats.size.unref
-	Verbosef("total prune:  %10d blobs / %s\n", stats.blobs.remove+stats.blobs.repackrm, formatBytes(totalPruneSize))
-	Verbosef("remaining:    %10d blobs / %s\n", totalBlobs-(stats.blobs.remove+stats.blobs.repackrm), formatBytes(totalSize-totalPruneSize))
-	unusedAfter := unusedSize - stats.size.remove - stats.size.repackrm
+	Verboseff("\nused:         %10d blobs / %s\n", stats.Blobs.Used, formatBytes(stats.Size.Used))
+	if stats.Blobs.Duplicate > 0 {
+		Verboseff("duplicates:   %10d blobs / %s\n", stats.Blobs.Duplicate, formatBytes(stats.Size.Duplicate))
+	}
+	Verboseff("unused:       %10d blobs / %s\n", stats.Blobs.Unused, formatBytes(stats.Size.Unused))
+	if stats.Size.Unref > 0 {
+		Verboseff("unreferenced:                    %s\n", formatBytes(stats.Size.Unref))
+	}
+	Verboseff("total:        %10d blobs / %s\n", stats.Blobs.Total, formatBytes(stats.Size.Total))
+	Verboseff("unused size: %s of total size\n", formatPercent(stats.Size.Unused, stats.Size.Total))
+
+	Verbosef("\nto repack:    %10d blobs / %s\n", stats.Blobs.Repack, formatBytes(stats.Size.Repack))
+	Verbosef("this removes: %10d blobs / %s\n", stats.Blobs.RepackRm, formatBytes(stats.Size.RepackRm))
+	Verbosef("to delete:    %10d blobs / %s\n", stats.Blobs.Remove, formatBytes(stats.Size.Remove+stats.Size.Unref))
+	Verbosef("total prune:  %10d blobs / %s\n", stats.Blobs.RemoveTotal, formatBytes(stats.Size.RemoveTotal))
+	Verbosef("remaining:    %10d blobs / %s\n", stats.Blobs.Remain, formatBytes(stats.Size.Remain))
 	Verbosef("unused size after prune: %s (%s of remaining size)\n",
-		formatBytes(unusedAfter), formatPercent(unusedAfter, totalSize-totalPruneSize))
+		formatBytes(stats.Size.RemainUnused), formatPercent(stats.Size.RemainUnused, stats.Size.Remain))
 	Verbosef("\n")
-	Verboseff("totally used packs: %10d\n", stats.packs.used)
-	Verboseff("partly used packs:  %10d\n", stats.packs.partlyUsed)
-	Verboseff("unused packs:       %10d\n\n", stats.packs.unused)
+	Verboseff("totally used packs: %10d\n", stats.Packs.Used)
+	Verboseff("partly used packs:  %10d\n", stats.Packs.PartlyUsed)
+	Verboseff("unused packs:       %10d\n\n", stats.Packs.Unused)
 
-	Verboseff("to keep:      %10d packs\n", stats.packs.keep)
-	Verboseff("to repack:    %10d packs\n", len(repackPacks))
-	Verboseff("to delete:    %10d packs\n", len(removePacks))
-	if len(removePacksFirst) > 0 {
-		Verboseff("to delete:    %10d unreferenced packs\n\n", len(removePacksFirst))
+	Verboseff("to keep:      %10d packs\n", stats.Packs.Keep)
+	Verboseff("to repack:    %10d packs\n", stats.Packs.Repack)
+	Verboseff("to delete:    %10d packs\n", stats.Packs.Remove)
+	if stats.Packs.Unref > 0 {
+		Verboseff("to delete:    %10d unreferenced packs\n\n", stats.Packs.Unref)
 	}
 
 	if opts.DryRun {

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -191,21 +191,17 @@ func runPruneWithRepo(opts PruneOptions, gopts GlobalOptions, repo *repository.R
 		return err
 	}
 
-	return prune(opts, gopts, repo, usedBlobs)
-}
+	plan, stats, err := planPrune(opts, gopts, repo, usedBlobs)
+	if err != nil {
+		return err
+	}
 
-type packInfo struct {
-	usedBlobs    uint
-	unusedBlobs  uint
-	usedSize     uint64
-	unusedSize   uint64
-	tpe          restic.BlobType
-	uncompressed bool
-}
+	err = printPruneStats(gopts, stats)
+	if err != nil {
+		return err
+	}
 
-type packInfoWithID struct {
-	ID restic.ID
-	packInfo
+	return doPrune(opts, gopts, repo, plan)
 }
 
 type blobStats struct {
@@ -254,12 +250,33 @@ type pruneStats struct {
 	Packs       packStats `json:"packfiles"`
 }
 
-// prune selects which files to rewrite and then does that. The map usedBlobs is
-// modified in the process.
-func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedBlobs restic.BlobSet) error {
-	ctx := gopts.ctx
+type prunePlan struct {
+	removePacksFirst restic.IDSet   // packs to remove first (unreferenced packs)
+	repackPacks      restic.IDSet   // packs to repack
+	keepBlobs        restic.BlobSet // blobs to keep during repacking
+	removePacks      restic.IDSet   // packs to remove
+	ignorePacks      restic.IDSet   // packs to ignore when rebuilding the index
+}
 
-	var stats pruneStats
+// planPrune selects which files to rewrite and which to delete and which blobs to keep.
+// Also some summary statistics are returned.
+// The map usedBlobs is modified in the process.
+func planPrune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedBlobs restic.BlobSet) (plan prunePlan, stats pruneStats, err error) {
+	type packInfo struct {
+		usedBlobs    uint
+		unusedBlobs  uint
+		usedSize     uint64
+		unusedSize   uint64
+		tpe          restic.BlobType
+		uncompressed bool
+	}
+
+	type packInfoWithID struct {
+		ID restic.ID
+		packInfo
+	}
+
+	ctx := gopts.ctx
 
 	Verbosef("searching used packs...\n")
 
@@ -302,7 +319,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 			"Will not start prune to prevent (additional) data loss!\n"+
 			"Please report this error (along with the output of the 'prune' run) at\n"+
 			"https://github.com/restic/restic/issues/new/choose\n", usedBlobs)
-		return errorIndexIncomplete
+		return plan, stats, errorIndexIncomplete
 	}
 
 	indexPack := make(map[restic.ID]packInfo)
@@ -393,7 +410,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 
 	// loop over all packs and decide what to do
 	bar := newProgressMax(!gopts.Quiet, uint64(len(indexPack)), "packs processed")
-	err := repo.List(ctx, restic.PackFile, func(id restic.ID, packSize int64) error {
+	err = repo.List(ctx, restic.PackFile, func(id restic.ID, packSize int64) error {
 		p, ok := indexPack[id]
 		if !ok {
 			// Pack was not referenced in index and is not used  => immediately remove!
@@ -458,7 +475,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 	})
 	bar.Done()
 	if err != nil {
-		return err
+		return plan, stats, err
 	}
 
 	// At this point indexPacks contains only missing packs!
@@ -479,7 +496,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 		for id := range indexPack {
 			Warnf("  %v\n", id)
 		}
-		return errorPacksMissing
+		return plan, stats, errorPacksMissing
 	}
 	if len(ignorePacks) != 0 {
 		Warnf("Missing but unneeded pack files are referenced in the index, will be repaired\n")
@@ -567,6 +584,17 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 	stats.Packs.Remove = uint(len(removePacks))
 	stats.Packs.RemoveTotal = stats.Packs.Unref + stats.Packs.Remove
 
+	plan.removePacksFirst = removePacksFirst
+	plan.repackPacks = repackPacks
+	plan.keepBlobs = keepBlobs
+	plan.removePacks = removePacks
+	plan.ignorePacks = ignorePacks
+
+	return plan, stats, nil
+}
+
+// printPruneStats prints out the statistics
+func printPruneStats(gopts GlobalOptions, stats pruneStats) error {
 	Verboseff("\nused:         %10d blobs / %s\n", stats.Blobs.Used, formatBytes(stats.Size.Used))
 	if stats.Blobs.Duplicate > 0 {
 		Verboseff("duplicates:   %10d blobs / %s\n", stats.Blobs.Duplicate, formatBytes(stats.Size.Duplicate))
@@ -596,42 +624,53 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 	if stats.Packs.Unref > 0 {
 		Verboseff("to delete:    %10d unreferenced packs\n\n", stats.Packs.Unref)
 	}
+	return nil
+}
+
+// doPrune does the actual pruning:
+// - remove unreferenced packs first
+// - repack given pack files while keeping the given blobs
+// - rebuild the index while ignoring all files that will be deleted
+// - delete the files
+// plan.removePacks and plan.ignorePacks are modified in this function.
+func doPrune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, plan prunePlan) (err error) {
+	ctx := gopts.ctx
 
 	if opts.DryRun {
 		if !gopts.JSON && gopts.verbosity >= 2 {
-			if len(removePacksFirst) > 0 {
-				Printf("Would have removed the following unreferenced packs:\n%v\n\n", removePacksFirst)
+			if len(plan.removePacksFirst) > 0 {
+				Printf("Would have removed the following unreferenced packs:\n%v\n\n", plan.removePacksFirst)
 			}
-			Printf("Would have repacked and removed the following packs:\n%v\n\n", repackPacks)
-			Printf("Would have removed the following no longer used packs:\n%v\n\n", removePacks)
+			Printf("Would have repacked and removed the following packs:\n%v\n\n", plan.repackPacks)
+			Printf("Would have removed the following no longer used packs:\n%v\n\n", plan.removePacks)
 		}
 		// Always quit here if DryRun was set!
 		return nil
 	}
 
 	// unreferenced packs can be safely deleted first
-	if len(removePacksFirst) != 0 {
+	if len(plan.removePacksFirst) != 0 {
 		Verbosef("deleting unreferenced packs\n")
-		DeleteFiles(gopts, repo, removePacksFirst, restic.PackFile)
+		DeleteFiles(gopts, repo, plan.removePacksFirst, restic.PackFile)
 	}
 
-	if len(repackPacks) != 0 {
+	if len(plan.repackPacks) != 0 {
 		Verbosef("repacking packs\n")
-		bar := newProgressMax(!gopts.Quiet, uint64(len(repackPacks)), "packs repacked")
-		_, err := repository.Repack(ctx, repo, repo, repackPacks, keepBlobs, bar)
+		bar := newProgressMax(!gopts.Quiet, uint64(len(plan.repackPacks)), "packs repacked")
+		_, err := repository.Repack(ctx, repo, repo, plan.repackPacks, plan.keepBlobs, bar)
 		bar.Done()
 		if err != nil {
 			return errors.Fatalf("%s", err)
 		}
 
 		// Also remove repacked packs
-		removePacks.Merge(repackPacks)
+		plan.removePacks.Merge(plan.repackPacks)
 	}
 
-	if len(ignorePacks) == 0 {
-		ignorePacks = removePacks
+	if len(plan.ignorePacks) == 0 {
+		plan.ignorePacks = plan.removePacks
 	} else {
-		ignorePacks.Merge(removePacks)
+		plan.ignorePacks.Merge(plan.removePacks)
 	}
 
 	if opts.unsafeRecovery {
@@ -641,20 +680,20 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 		if err != nil {
 			return errors.Fatalf("%s", err)
 		}
-	} else if len(ignorePacks) != 0 {
-		err = rebuildIndexFiles(gopts, repo, ignorePacks, nil)
+	} else if len(plan.ignorePacks) != 0 {
+		err = rebuildIndexFiles(gopts, repo, plan.ignorePacks, nil)
 		if err != nil {
 			return errors.Fatalf("%s", err)
 		}
 	}
 
-	if len(removePacks) != 0 {
-		Verbosef("removing %d old packs\n", len(removePacks))
-		DeleteFiles(gopts, repo, removePacks, restic.PackFile)
+	if len(plan.removePacks) != 0 {
+		Verbosef("removing %d old packs\n", len(plan.removePacks))
+		DeleteFiles(gopts, repo, plan.removePacks, restic.PackFile)
 	}
 
 	if opts.unsafeRecovery {
-		_, err = writeIndexFiles(gopts, repo, ignorePacks, nil)
+		_, err = writeIndexFiles(gopts, repo, plan.ignorePacks, nil)
 		if err != nil {
 			return errors.Fatalf("%s", err)
 		}

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -447,6 +447,8 @@ The ``prune`` command accepts the following options:
 
 -  ``--verbose`` increased verbosity shows additional statistics for ``prune``.
 
+-  ``--json`` gives the statistics in JSON format.
+
 
 Recovering from "no free space" errors
 **************************************


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Separates the pruning code in three functions:

- Find out what to do
- Print statistcs (+ added JSON output here)
- do the actual pruning work

In a next step, unit tests can be added for all three parts (not included here)

This PR conflicts with #2881 - I'll fix this depending on what PR is tackled first.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Refactoring the code: discussion with @fd0 
Also closes #3129 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
