### PR TITLE
rebuild-index: code simplification

### DIFF
--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -60,7 +60,6 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 	var obsoleteIndexes restic.IDs
 	packSizeFromList := make(map[restic.ID]int64)
 	removePacks := restic.NewIDSet()
-	totalPacks := 0
 
 	if opts.ReadAllPacks {
 		// get old index files
@@ -76,7 +75,6 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 		err = repo.List(ctx, restic.PackFile, func(id restic.ID, size int64) error {
 			packSizeFromList[id] = size
 			removePacks.Insert(id)
-			totalPacks++
 			return nil
 		})
 		if err != nil {
@@ -99,7 +97,6 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 				packSizeFromList[id] = packSize
 				removePacks.Insert(id)
 			}
-			totalPacks++
 			delete(packSizeFromIndex, id)
 			return nil
 		})
@@ -123,11 +120,10 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 
 		for _, id := range invalidFiles {
 			Verboseff("skipped incomplete pack file: %v\n", id)
-			totalPacks--
 		}
 	}
 
-	err := rebuildIndexFiles(gopts, repo, removePacks, obsoleteIndexes, uint64(totalPacks))
+	err := rebuildIndexFiles(gopts, repo, removePacks, obsoleteIndexes)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -59,22 +59,13 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 
 	var obsoleteIndexes restic.IDs
 	packSizeFromList := make(map[restic.ID]int64)
+	packSizeFromIndex := make(map[restic.ID]int64)
 	removePacks := restic.NewIDSet()
 
 	if opts.ReadAllPacks {
-		// get old index files
+		// get list of old index files but start with empty index
 		err := repo.List(ctx, restic.IndexFile, func(id restic.ID, size int64) error {
 			obsoleteIndexes = append(obsoleteIndexes, id)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-
-		Verbosef("finding pack files in repo...\n")
-		err = repo.List(ctx, restic.PackFile, func(id restic.ID, size int64) error {
-			packSizeFromList[id] = size
-			removePacks.Insert(id)
 			return nil
 		})
 		if err != nil {
@@ -86,28 +77,27 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 		if err != nil {
 			return err
 		}
+		packSizeFromIndex = repo.Index().PackSize(ctx, false)
+	}
 
-		Verbosef("getting pack files to read...\n")
-		packSizeFromIndex := repo.Index().PackSize(ctx, false)
-
-		err = repo.List(ctx, restic.PackFile, func(id restic.ID, packSize int64) error {
-			size, ok := packSizeFromIndex[id]
-			if !ok || size != packSize {
-				// Pack was not referenced in index or size does not match
-				packSizeFromList[id] = packSize
-				removePacks.Insert(id)
-			}
-			delete(packSizeFromIndex, id)
-			return nil
-		})
-		if err != nil {
-			return err
-		}
-		for id := range packSizeFromIndex {
-			// forget pack files that are referenced in the index but do not exist
-			// when rebuilding the index
+	Verbosef("getting pack files to read...\n")
+	err := repo.List(ctx, restic.PackFile, func(id restic.ID, packSize int64) error {
+		size, ok := packSizeFromIndex[id]
+		if !ok || size != packSize {
+			// Pack was not referenced in index or size does not match
+			packSizeFromList[id] = packSize
 			removePacks.Insert(id)
 		}
+		delete(packSizeFromIndex, id)
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	for id := range packSizeFromIndex {
+		// forget pack files that are referenced in the index but do not exist
+		// when rebuilding the index
+		removePacks.Insert(id)
 	}
 
 	if len(packSizeFromList) > 0 {
@@ -123,7 +113,7 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 		}
 	}
 
-	err := rebuildIndexFiles(gopts, repo, removePacks, obsoleteIndexes)
+	err = rebuildIndexFiles(gopts, repo, removePacks, obsoleteIndexes)
 	if err != nil {
 		return err
 	}

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -100,8 +100,8 @@ func (mi *MasterIndex) Has(bh restic.BlobHandle) bool {
 }
 
 // Packs returns all packs that are covered by the index.
-// If packBlacklist ist given, those packs are only contained in the
-// resulting IDSet if they are contained in a non-final index.
+// If packBlacklist is given, those packs are only contained in the
+// resulting IDSet if they are contained in a non-final (newly written) index.
 func (mi *MasterIndex) Packs(packBlacklist restic.IDSet) restic.IDSet {
 	mi.idxMutex.RLock()
 	defer mi.idxMutex.RUnlock()

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -65,7 +65,6 @@ type MasterIndex interface {
 	Has(BlobHandle) bool
 	Lookup(BlobHandle) []PackedBlob
 	Count(BlobType) uint
-	Packs() IDSet
 	PackSize(ctx context.Context, onlyHdr bool) map[ID]int64
 
 	// Each returns a channel that yields all blobs known to the index. When


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Simplifies the code a bit, the two cases with and without `--read-all-packs` now use almost the same code.
Also simplifies the counting of packs for the index generation both in `rebuild-index` and in `prune`.

This PR conflicts with #3140 and should preferably be merged first as it allows easier code separation.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- I have not added documentation for the changes (in the manual)
- There's no new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
