### PR TITLE
Bugfix for rebuild-index

### DIFF
--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -96,7 +96,7 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 			size, ok := packSizeFromIndex[id]
 			if !ok || size != packSize {
 				// Pack was not referenced in index or size does not match
-				packSizeFromList[id] = size
+				packSizeFromList[id] = packSize
 				removePacks.Insert(id)
 			}
 			totalPacks++


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Fixes a bug in `rebuild-index`: If the size calculated by the index does not fit the real pack size, the pack file will be read but ignored if the index size is wrong. This bug was not present when calling `rebuild-index --read-all-packs`.
I discovered the bug while I was trying out the simplification that came up to me after a code review.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

see #3148 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- I have not added tests for all changes in this PR
- I have not added documentation for the changes (in the manual)
- There's no new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
