### PR TITLE
termstatus: Fix canUpdateStatus detection for redirected output on windows

### DIFF
--- a/changelog/unreleased/issue-3111
+++ b/changelog/unreleased/issue-3111
@@ -1,0 +1,9 @@
+Bugfix: Correctly detect output redirection for `backup` command on Windows
+
+On Windows, since restic 0.10.0 the `backup` command did not properly detect
+when the output was redirected to a file. This caused restic to output
+terminal control characters. This has been fixed by correcting the terminal
+detection.
+
+https://github.com/restic/restic/issues/3111
+https://github.com/restic/restic/pull/3150

--- a/internal/ui/termstatus/terminal_windows.go
+++ b/internal/ui/termstatus/terminal_windows.go
@@ -88,8 +88,8 @@ func canUpdateStatus(fd uintptr) bool {
 		return true
 	}
 
-	// check if the output file type is a pipe (0x0003)
-	if isPipe(fd) {
+	// check that the output file type is a pipe (0x0003)
+	if !isPipe(fd) {
 		return false
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The canUpdateStatus check was simplified in #2608, but it accidentally flipped
the condition. The correct check is as follows: If the output is a pipe then
restic probably runs in mintty/cygwin. In that case it's possible to
update the output status. In all other cases it isn't.

This commit PR to condition again to offer the previous and correct
behavior.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #3111.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
