### PR TITLE
backup: Fix shutdown hang when running in the background on linux

### DIFF
--- a/changelog/unreleased/pull-3152
+++ b/changelog/unreleased/pull-3152
@@ -1,0 +1,8 @@
+Bugfix: On Linux `backup` hangs during exit when run as a background job
+
+On Linux, when running in the background restic failed to stop the terminal
+output of the `backup` command after it had completed. This caused restic to
+hang until moved to the foreground. This has been fixed.
+
+https://github.com/restic/restic/pull/3152
+https://forum.restic.net/t/restic-alpine-container-cron-hangs-epoll-pwait/3334

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -96,11 +96,9 @@ func (t *Terminal) run(ctx context.Context) {
 	for {
 		select {
 		case <-ctx.Done():
-			if IsProcessBackground(t.fd) {
-				// ignore all messages, do nothing, we are in the background process group
-				continue
+			if !IsProcessBackground(t.fd) {
+				t.undoStatus(len(status))
 			}
-			t.undoStatus(len(status))
 
 			return
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
On Linux, during shutdown the backup commands waits for the terminal output goroutine to stop. However while running in the background that goroutine ignored the canceled context.

This PR lets the goroutine exit instead.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The hang was reported in the forum https://forum.restic.net/t/restic-alpine-container-cron-hangs-epoll-pwait/3334 . 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~ Tested manually.
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
