### PR TITLE
archiver: Handle error before cancelling workers

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -692,6 +692,10 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		p.V("start backup on %v", targets)
 	}
 	_, id, err := arch.Snapshot(gopts.ctx, targets, snapshotOpts)
+	if errors.Cause(err) == context.Canceled {
+		return errors.Fatal("canceled")
+	}
+
 	if err != nil {
 		return errors.Fatalf("unable to save snapshot: %v", err)
 	}

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -798,7 +798,13 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 
 		return arch.saveTree(wctx, tree)
 	}()
-	debug.Log("saved tree, error: %v", err)
+
+	if err != nil {
+		debug.Log("error while saving tree: %v", err)
+		return nil, restic.ID{}, err
+	}
+
+	debug.Log("saved tree %v, error: %v", rootTreeID, err)
 
 	t.Kill(nil)
 	werr := t.Wait()


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Correct cancellation handling, prevent creation of snapshots which reference a null ID as the tree.

I'd like to get some feedback on the approach. I'm not sure if there's anything else that needs to be done...

The issue can be reproduced with the patch in 

https://github.com/restic/restic/issues/3151#issuecomment-740138653

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #3151

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
