### PR TITLE
swift: Add support for id based keystone v3 auth parameters

### DIFF
--- a/changelog/unreleased/issue-3147
+++ b/changelog/unreleased/issue-3147
@@ -1,0 +1,11 @@
+Enhancement: Support further environment variables for swift authentication
+
+The swift backend now supports the following additional environment variables
+to pass authentication details to restic: `OS_USER_ID`, `OS_USER_DOMAIN_ID`,
+`OS_PROJECT_DOMAIN_ID` and `OS_TRUST_ID`.
+
+Depending on the openrc configuration file these might be required when the
+user and project domains differ.
+
+https://github.com/restic/restic/issues/3147
+https://github.com/restic/restic/pull/3158

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -375,10 +375,14 @@ the naming convention of those variables follows the official Python Swift clien
    $ export OS_AUTH_URL=<MY_AUTH_URL>
    $ export OS_REGION_NAME=<MY_REGION_NAME>
    $ export OS_USERNAME=<MY_USERNAME>
+   $ export OS_USER_ID=<MY_USER_ID>
    $ export OS_PASSWORD=<MY_PASSWORD>
    $ export OS_USER_DOMAIN_NAME=<MY_DOMAIN_NAME>
+   $ export OS_USER_DOMAIN_ID=<MY_DOMAIN_ID>
    $ export OS_PROJECT_NAME=<MY_PROJECT_NAME>
    $ export OS_PROJECT_DOMAIN_NAME=<MY_PROJECT_DOMAIN_NAME>
+   $ export OS_PROJECT_DOMAIN_ID=<MY_PROJECT_DOMAIN_ID>
+   $ export OS_TRUST_ID=<MY_TRUST_ID>
 
    # For keystone v3 application credential authentication (application credential id)
    $ export OS_AUTH_URL=<MY_AUTH_URL>

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -466,13 +466,17 @@ environment variables. The following lists these environment variables:
     OS_AUTH_URL                         Auth URL for keystone authentication
     OS_REGION_NAME                      Region name for keystone authentication
     OS_USERNAME                         Username for keystone authentication
+    OS_USER_ID                          User ID for keystone v3 authentication
     OS_PASSWORD                         Password for keystone authentication
     OS_TENANT_ID                        Tenant ID for keystone v2 authentication
     OS_TENANT_NAME                      Tenant name for keystone v2 authentication
 
     OS_USER_DOMAIN_NAME                 User domain name for keystone authentication
+    OS_USER_DOMAIN_ID                   User domain ID for keystone v3 authentication
     OS_PROJECT_NAME                     Project name for keystone authentication
     OS_PROJECT_DOMAIN_NAME              Project domain name for keystone authentication
+    OS_PROJECT_DOMAIN_ID                Project domain ID for keystone v3 authentication
+    OS_TRUST_ID                         Trust ID for keystone v3 authentication
 
     OS_APPLICATION_CREDENTIAL_ID        Application Credential ID (keystone v3)
     OS_APPLICATION_CREDENTIAL_NAME      Application Credential Name (keystone v3)

--- a/internal/backend/swift/config.go
+++ b/internal/backend/swift/config.go
@@ -10,15 +10,18 @@ import (
 
 // Config contains basic configuration needed to specify swift location for a swift server
 type Config struct {
-	UserName     string
-	Domain       string
-	APIKey       string
-	AuthURL      string
-	Region       string
-	Tenant       string
-	TenantID     string
-	TenantDomain string
-	TrustID      string
+	UserName       string
+	UserID         string
+	Domain         string
+	DomainID       string
+	APIKey         string
+	AuthURL        string
+	Region         string
+	Tenant         string
+	TenantID       string
+	TenantDomain   string
+	TenantDomainID string
+	TrustID        string
 
 	StorageURL string
 	AuthToken  string
@@ -88,9 +91,13 @@ func ApplyEnvironment(prefix string, cfg interface{}) error {
 		{&c.AuthURL, prefix + "OS_AUTH_URL"},
 
 		// v3 specific
+		{&c.UserID, prefix + "OS_USER_ID"},
 		{&c.Domain, prefix + "OS_USER_DOMAIN_NAME"},
+		{&c.DomainID, prefix + "OS_USER_DOMAIN_ID"},
 		{&c.Tenant, prefix + "OS_PROJECT_NAME"},
 		{&c.TenantDomain, prefix + "OS_PROJECT_DOMAIN_NAME"},
+		{&c.TenantDomainID, prefix + "OS_PROJECT_DOMAIN_ID"},
+		{&c.TrustID, prefix + "OS_TRUST_ID"},
 
 		// v2 specific
 		{&c.TenantID, prefix + "OS_TENANT_ID"},

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -42,13 +42,16 @@ func Open(cfg Config, rt http.RoundTripper) (restic.Backend, error) {
 	be := &beSwift{
 		conn: &swift.Connection{
 			UserName:                    cfg.UserName,
+			UserId:                      cfg.UserID,
 			Domain:                      cfg.Domain,
+			DomainId:                    cfg.DomainID,
 			ApiKey:                      cfg.APIKey,
 			AuthUrl:                     cfg.AuthURL,
 			Region:                      cfg.Region,
 			Tenant:                      cfg.Tenant,
 			TenantId:                    cfg.TenantID,
 			TenantDomain:                cfg.TenantDomain,
+			TenantDomainId:              cfg.TenantDomainID,
 			TrustId:                     cfg.TrustID,
 			StorageUrl:                  cfg.StorageURL,
 			AuthToken:                   cfg.AuthToken,


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This adds support for the following environment variables, which were
previously missing:

OS_USER_ID            User ID for keystone v3 authentication
OS_USER_DOMAIN_ID     User domain ID for keystone v3 authentication
OS_PROJECT_DOMAIN_ID  Project domain ID for keystone v3 authentication
OS_TRUST_ID           Trust ID for keystone v3 authentication

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #3147

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
