### PR TITLE
Stop retry if disk is full

### DIFF
--- a/internal/cache/file.go
+++ b/internal/cache/file.go
@@ -8,6 +8,7 @@ import (
 	"github.com/pkg/errors"
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/debug"
+	resticErrors "github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/restic"
 )
@@ -94,7 +95,7 @@ func (c *Cache) saveWriter(h restic.Handle) (io.WriteCloser, error) {
 	p := c.filename(h)
 	err := fs.MkdirAll(filepath.Dir(p), 0700)
 	if err != nil {
-		return nil, errors.WithStack(err)
+		return nil, resticErrors.Fatal(errors.WithStack(err).Error())
 	}
 
 	f, err := fs.OpenFile(p, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0400)
@@ -117,7 +118,7 @@ func (c *Cache) Save(h restic.Handle, rd io.Reader) error {
 	if err != nil {
 		_ = f.Close()
 		_ = c.remove(h)
-		return errors.Wrap(err, "Copy")
+		return resticErrors.Fatal(errors.Wrap(err, "Copy").Error())
 	}
 
 	if n <= crypto.Extension {


### PR DESCRIPTION

What does this PR change? What problem does it solve?
-----------------------------------------------------
Stop retry cycle in RetryBackend if error was caused by low space on disk.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #2453

Function given to RetryBackend is wrapped with extra check that causes retry cycle to stop if error is classified as unrecoverable.  But checking error message doesn't seem right. Creating specialized error types for filesystem, network, permissions, etc. seems like good idea, but requires changes throughout whole project. 
Any advice or ideas?

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
