### PR TITLE
Add PGP fingerprint to 020_installation.rst

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -188,8 +188,20 @@ are considered stable and releases are made regularly in a controlled manner.
 There's both pre-compiled binaries for different platforms as well as the source
 code available for download. Just download and run the one matching your system.
 
-The official binaries can be updated in place using the ``restic self-update``
-command (needs restic 0.9.3 or later):
+On your first installation, if you desire, you can verify the integrity of your
+downloads by testing the SHA-256 checksums listed in ``SHA256SUMS`` and verifying
+the integrity of the file ``SHA256SUMS`` with the PGP signature in ``SHA256SUMS.asc``. 
+The PGP signature was created using the key (`0x91A6868BD3F7A907 <https://pgp.mit.edu/pks/lookup?op=get&search=0xCF8F18F2844575973F79D4E191A6868BD3F7A907>`__):
+
+::
+
+    pub   4096R/91A6868BD3F7A907 2014-11-01
+          Key fingerprint = CF8F 18F2 8445 7597 3F79  D4E1 91A6 868B D3F7 A907
+          uid                          Alexander Neumann <alexander@bumpern.de>
+          sub   4096R/D5FC2ACF4043FDF1 2014-11-01
+
+Once downloaded, the official binaries can be updated in place using the 
+``restic self-update`` command (needs restic 0.9.3 or later):
 
 .. code-block:: console
 

--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -191,7 +191,7 @@ code available for download. Just download and run the one matching your system.
 On your first installation, if you desire, you can verify the integrity of your
 downloads by testing the SHA-256 checksums listed in ``SHA256SUMS`` and verifying
 the integrity of the file ``SHA256SUMS`` with the PGP signature in ``SHA256SUMS.asc``. 
-The PGP signature was created using the key (`0x91A6868BD3F7A907 <https://pgp.mit.edu/pks/lookup?op=get&search=0xCF8F18F2844575973F79D4E191A6868BD3F7A907>`__):
+The PGP signature was created using the key (`0x91A6868BD3F7A907 <https://restic.net/gpg-key-alex.asc>`__):
 
 ::
 


### PR DESCRIPTION
I like the idea of verifying the integrity of applications, I download from the internet. So I was very happy to see that restic does provide SHA256-checksums which are signed with the maintainers PGP key.

The only thing I miss: I could not find a direct way to download the used PGP key and verify the keys fingerprint.

Doing some searches, I found:
* https://github.com/restic/rest-server/issues/121
* https://restic.net/blog/2015-09-16/verifying-code-archive-integrity/

To help other restic users, I think you should add information about your PGP key/fingerprint to this installation doc, too. To save you some precious time, I created a draft, how this doc might be expanded, in this pull-request. You are free to accept it or change the text to your liking.

I copied the key/fingerprint text from: ``restic/restic/master/doc/090_participating.rst``

Thank you for your work in restic!


What does this PR change? What problem does it solve?
-----------------------------------------------------

My pull request enhances the installation documentation.


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Only discussion I found is in the neighbor project "rest-server": https://github.com/restic/rest-server/issues/121


Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [-] I have added tests for all changes in this PR  -> no tests for "doc update" possible
- [x] I have added documentation for the changes (in the manual)
- [-] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [-] I have run `gofmt` on the code in all commits -> not applicable
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
