### PR TITLE
Improve context cancel handling in archiver and backends

### DIFF
--- a/changelog/unreleased/issue-3151
+++ b/changelog/unreleased/issue-3151
@@ -1,0 +1,9 @@
+Bugfix: Never create invalid snapshots on backup interruption
+
+When canceling a backup run in the wrong moment it was possible that
+restic created a snapshot with an invalid "null" tree. This caused
+check and other operations to fail. The backup command now properly
+handles interruptions and never saves a snapshot in that case.
+
+https://github.com/restic/restic/issues/3151
+https://github.com/restic/restic/pull/3164

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -803,7 +803,8 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 	t.Kill(nil)
 	werr := t.Wait()
 	debug.Log("err is %v, werr is %v", err, werr)
-	if err == nil || errors.Cause(err) == context.Canceled {
+	// Use werr when it might contain a more specific error than "context canceled"
+	if err == nil || (errors.Cause(err) == context.Canceled && werr != nil) {
 		err = werr
 	}
 

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -178,6 +178,10 @@ func (arch *Archiver) saveTree(ctx context.Context, t *restic.Tree) (restic.ID, 
 		s.TreeBlobs++
 		s.TreeSize += uint64(len(buf))
 	}
+	// The context was canceled in the meantime, res.ID() might be invalid
+	if ctx.Err() != nil {
+		return restic.ID{}, s, ctx.Err()
+	}
 	return res.ID(), s, nil
 }
 

--- a/internal/backend/backend_retry.go
+++ b/internal/backend/backend_retry.go
@@ -33,6 +33,16 @@ func NewRetryBackend(be restic.Backend, maxTries int, report func(string, error,
 }
 
 func (be *RetryBackend) retry(ctx context.Context, msg string, f func() error) error {
+	// Don't do anything when called with an already cancelled context. There would be
+	// no retries in that case either, so be consistent and abort always.
+	// This enforces a strict contract for backend methods: Using a cancelled context
+	// will prevent any backup repository modifications. This simplifies ensuring that
+	// a backup repository is not modified any further after a context was cancelled.
+	// The 'local' backend for example does not provide this guarantee on its own.
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+
 	err := backoff.RetryNotify(f,
 		backoff.WithContext(backoff.WithMaxRetries(backoff.NewExponentialBackOff(), uint64(be.MaxTries)), ctx),
 		func(err error, d time.Duration) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR is a more comprehensive variant of #3155. It consists of two parts:
The changes to the archiver ensure that a 'context canceled' error triggered by a canceled background context won't be lost. In addition `saveTree` which is also responsible for the final tree root upload now properly reports a canceled context as error.

The second part of this PR can be seen as a "defense in depth" measure: It immediately fails all backend operations that use a canceled context. This would also prevent a snapshot to be saved if the background context was previously canceled. Currently for example most operations of the local backend still work when run with a canceled context. The rest backend would fail in that constellation. However, retries work for neither backend. 

[Edit]Checking for a canceled context as first step in the RetryBackend also has the benefit that this avoid playing whack-a-mole with possibly missing context checks in all the different backends and their methods which can have multiple code path depending on the object size.

The current inconsistent context handling could actually cause further problems down the line. My assumption (before this PR) was that a canceled context prevents further commands which take a context from making changes. Or put differently: Canceling a context should work as a sort of barrier, such that a canceled context behaves similar to a crash of restic in that there's a clear point in time which splits operations in before (have been completed by now), currently active (might or might not succeed) and after (always fail; in case of a crash: are never issued). Properly checking all errors is currently necessary to give that guarantee, however, a single missing error check / handling can cause problems. Preventing further repository modifications provides a generic solution to stop such bugs from causing permanent repository damage.[/Edit]

Either part of this PR is enough to fix the problem from #3151. There are currently no new test / changelog as I want to get feedback on the approach first.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #3151.
The approach itself hasn't been discussed yet.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
