### PR TITLE
doc: Clarify calendar boundaries for --keep-* options

### DIFF
--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -191,6 +191,10 @@ The ``forget`` command accepts the following parameters:
    made in the two years, five months, seven days, and three hours before the
    latest snapshot.
 
+.. note:: All calendar related ``--keep-*`` options work on the natural time
+    boundaries and not relative to when you run the ``forget`` command. Weeks
+    are Monday 00:00 -> Sunday 23:59, days 00:00 to 23:59, hours :00 to :59, etc.
+
 Multiple policies will be ORed together so as to be as inclusive as possible
 for keeping snapshots.
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Clarifies how weeks, days, hours, etc are bound to natural time boundaries rather than relative to when you run the `forget` command, to close #2747.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #2747.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
