### PR TITLE
Add option to limit snapshots list

### DIFF
--- a/changelog/unreleased/pull-3167
+++ b/changelog/unreleased/pull-3167
@@ -1,0 +1,9 @@
+Enhancement: Allow limiting the snapshots list
+
+The `--last` option allowed limiting the output of the `snapshots`
+command to the latest snapshot for each host. The new `--latest n`
+option allows limiting the output to the latest `n` snapshots.
+
+This change deprecate `--last` in favour of `--latest 1`
+
+https://github.com/restic/restic/pull/3167


### PR DESCRIPTION
This patch adds a `--limit` option to limit snapshots list to the n
last snapshots. It is very similar to the `--last` one but does not
limit to one entry.

Output example:

    $ restic snapshots --limit 2
    repository 0d3eb989 opened successfully, password is correct
    ID        Time                 Host        Tags        Paths
    ------------------------------------------------------------
    5a33bdcc  2020-12-14 12:30:00  local                   /home
    73887d8e  2020-12-15 12:30:00  local                   /home
    ------------------------------------------------------------
    2 snapshots

To keep compatibility with previous versions a new function has been
added: `FilterSnapshotsWithLimit`. This function that filters a list
of snapshots to only return the N last entries for each hostname and
path. `FilterLastSnapshots` calls `FilterSnapshotsWithLimit(list, 1)`.


Signed-off-by: Sébastien Gross <seb•ɑƬ•chezwam•ɖɵʈ•org>



<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

`--last` option limit to the very last snapshot for each hosts. In
some case you want to show the n last snapshots. For example if you
want a weekly report of daily snapshots you cannot have this but by
using shell tools and wont report the correct number of snapshots.

This PR adds a `--limit` to limit display of the n last snapshots (see
above).


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [X] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
