### PR TITLE
Ensure handle is valid before passing it to a Backend

### DIFF
--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -118,10 +118,6 @@ func (be *Backend) Path() string {
 
 // Save stores data in the backend at the handle.
 func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
-	if err := h.Valid(); err != nil {
-		return err
-	}
-
 	objName := be.Filename(h)
 
 	debug.Log("Save %v at %v", h, objName)

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -149,10 +149,6 @@ func (be *b2Backend) Load(ctx context.Context, h restic.Handle, length int, offs
 
 func (be *b2Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
-	if err := h.Valid(); err != nil {
-		return nil, err
-	}
-
 	if offset < 0 {
 		return nil, errors.New("offset is negative")
 	}

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -195,10 +195,6 @@ func (be *Backend) Path() string {
 
 // Save stores data in the backend at the handle.
 func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
-	if err := h.Valid(); err != nil {
-		return err
-	}
-
 	objName := be.Filename(h)
 
 	debug.Log("Save %v at %v", h, objName)

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -82,10 +82,6 @@ func (b *Local) IsNotExist(err error) bool {
 // Save stores data in the backend at the handle.
 func (b *Local) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	debug.Log("Save %v", h)
-	if err := h.Valid(); err != nil {
-		return err
-	}
-
 	filename := b.Filename(h)
 
 	// create new file

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -60,10 +60,6 @@ func (be *MemoryBackend) IsNotExist(err error) bool {
 
 // Save adds new Data to the backend.
 func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
-	if err := h.Valid(); err != nil {
-		return err
-	}
-
 	be.m.Lock()
 	defer be.m.Unlock()
 

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -108,10 +108,6 @@ func (b *Backend) Location() string {
 
 // Save stores data in the backend at the handle.
 func (b *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
-	if err := h.Valid(); err != nil {
-		return err
-	}
-
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -259,10 +259,6 @@ func (be *Backend) Path() string {
 func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	debug.Log("Save %v", h)
 
-	if err := h.Valid(); err != nil {
-		return err
-	}
-
 	objName := be.Filename(h)
 
 	be.sem.GetToken()

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -262,10 +262,6 @@ func (r *SFTP) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader
 		return err
 	}
 
-	if err := h.Valid(); err != nil {
-		return err
-	}
-
 	filename := r.Filename(h)
 
 	// create new file

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -121,10 +121,6 @@ func (be *beSwift) Load(ctx context.Context, h restic.Handle, length int, offset
 
 func (be *beSwift) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
-	if err := h.Valid(); err != nil {
-		return nil, err
-	}
-
 	if offset < 0 {
 		return nil, errors.New("offset is negative")
 	}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -315,6 +315,9 @@ func (r *Repository) SaveUnpacked(ctx context.Context, t restic.FileType, p []by
 		id = restic.Hash(ciphertext)
 	}
 	h := restic.Handle{Type: t, Name: id.String()}
+	if err := h.Valid(); err != nil {
+		return restic.ID{}, err
+	}
 
 	err = r.be.Save(ctx, h, restic.NewByteReader(ciphertext))
 	if err != nil {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It validates handles before passing them to backends, rather than repeating the validation code inside every backend (except the wrapper types).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

This is a first step toward not retrying fatal errors, which needs error inspection inside the backend (see comments at #3162). The alternative to this approach is wrapping the error from Handle.Valid in a backoff.PermanentError everywhere, which I felt was too repetitive and error-prone.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
