### PR TITLE
Don't retry permanent errors in backends

### DIFF
--- a/changelog/unreleased/issue-2453
+++ b/changelog/unreleased/issue-2453
@@ -1,0 +1,12 @@
+Enhancement: Improve handling of permanent backend errors
+
+When encountering errors in reading from or writing to storage backends,
+restic retries the failing operation up to nine times (for a total of ten
+attempts). It used to retry all backend operations, but now detects some
+permanent error conditions so it can report fatal errors earlier.
+
+Permanent failures include local disks being full and SSH connections
+dropping.
+
+https://github.com/restic/restic/issues/2453
+https://github.com/restic/restic/pull/3170

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -10,11 +10,13 @@ import (
 	"path"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/storage"
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/cenkalti/backoff/v4"
 )
 
 // Backend stores data on an azure endpoint.
@@ -119,7 +121,7 @@ func (be *Backend) Path() string {
 // Save stores data in the backend at the handle.
 func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	if err := h.Valid(); err != nil {
-		return err
+		return backoff.Permanent(err)
 	}
 
 	objName := be.Filename(h)
@@ -219,7 +221,7 @@ func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset
 func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
 	if err := h.Valid(); err != nil {
-		return nil, err
+		return nil, backoff.Permanent(err)
 	}
 
 	if offset < 0 {

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -11,6 +11,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/kurin/blazer/b2"
 )
 
@@ -150,7 +151,7 @@ func (be *b2Backend) Load(ctx context.Context, h restic.Handle, length int, offs
 func (be *b2Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
 	if err := h.Valid(); err != nil {
-		return nil, err
+		return nil, backoff.Permanent(err)
 	}
 
 	if offset < 0 {
@@ -189,7 +190,7 @@ func (be *b2Backend) Save(ctx context.Context, h restic.Handle, rd restic.Rewind
 	defer cancel()
 
 	if err := h.Valid(); err != nil {
-		return err
+		return backoff.Permanent(err)
 	}
 
 	be.sem.GetToken()

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -85,7 +85,7 @@ func (b *Local) IsNotExist(err error) bool {
 func (b *Local) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) (err error) {
 	debug.Log("Save %v", h)
 	if err := h.Valid(); err != nil {
-		return err
+		return backoff.Permanent(err)
 	}
 
 	filename := b.Filename(h)
@@ -162,7 +162,7 @@ func (b *Local) Load(ctx context.Context, h restic.Handle, length int, offset in
 func (b *Local) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
-		return nil, err
+		return nil, backoff.Permanent(err)
 	}
 
 	if offset < 0 {
@@ -193,7 +193,7 @@ func (b *Local) openReader(ctx context.Context, h restic.Handle, length int, off
 func (b *Local) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, error) {
 	debug.Log("Stat %v", h)
 	if err := h.Valid(); err != nil {
-		return restic.FileInfo{}, err
+		return restic.FileInfo{}, backoff.Permanent(err)
 	}
 
 	fi, err := fs.Stat(b.Filename(h))

--- a/internal/backend/local/local_internal_test.go
+++ b/internal/backend/local/local_internal_test.go
@@ -1,0 +1,42 @@
+package local
+
+import (
+	"context"
+	"errors"
+	"os"
+	"syscall"
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+
+	"github.com/cenkalti/backoff/v4"
+)
+
+func TestNoSpacePermanent(t *testing.T) {
+	oldOpenFile := openFile
+	defer func() {
+		openFile = oldOpenFile
+	}()
+
+	openFile = func(name string, flags int, mode os.FileMode) (*os.File, error) {
+		// The actual error from os.OpenFile is *os.PathError.
+		// Other functions called inside Save may return *os.SyscallError.
+		return nil, os.NewSyscallError("open", syscall.ENOSPC)
+	}
+
+	dir, cleanup := rtest.TempDir(t)
+	defer cleanup()
+
+	be, err := Open(context.Background(), Config{Path: dir})
+	rtest.OK(t, err)
+	defer be.Close()
+
+	h := restic.Handle{Type: restic.ConfigFile}
+	err = be.Save(context.Background(), h, nil)
+	_, ok := err.(*backoff.PermanentError)
+	rtest.Assert(t, ok,
+		"error type should be backoff.PermanentError, got %T", err)
+	rtest.Assert(t, errors.Is(err, syscall.ENOSPC),
+		"could not recover original ENOSPC error")
+}

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -16,6 +16,7 @@ import (
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/debug"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/sftp"
 )
 
@@ -99,7 +100,7 @@ func (r *SFTP) clientError() error {
 	select {
 	case err := <-r.result:
 		debug.Log("client has exited with err %v", err)
-		return err
+		return backoff.Permanent(err)
 	default:
 	}
 

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -264,7 +264,7 @@ func (r *SFTP) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader
 	}
 
 	if err := h.Valid(); err != nil {
-		return err
+		return backoff.Permanent(err)
 	}
 
 	filename := r.Filename(h)
@@ -311,7 +311,7 @@ func (r *SFTP) Load(ctx context.Context, h restic.Handle, length int, offset int
 func (r *SFTP) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
-		return nil, err
+		return nil, backoff.Permanent(err)
 	}
 
 	if offset < 0 {
@@ -346,7 +346,7 @@ func (r *SFTP) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, erro
 	}
 
 	if err := h.Valid(); err != nil {
-		return restic.FileInfo{}, err
+		return restic.FileInfo{}, backoff.Permanent(err)
 	}
 
 	fi, err := r.c.Lstat(r.Filename(h))

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -14,6 +14,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/ncw/swift"
 )
 
@@ -122,7 +123,7 @@ func (be *beSwift) Load(ctx context.Context, h restic.Handle, length int, offset
 func (be *beSwift) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
-		return nil, err
+		return nil, backoff.Permanent(err)
 	}
 
 	if offset < 0 {
@@ -162,7 +163,7 @@ func (be *beSwift) openReader(ctx context.Context, h restic.Handle, length int, 
 // Save stores data in the backend at the handle.
 func (be *beSwift) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	if err := h.Valid(); err != nil {
-		return err
+		return backoff.Permanent(err)
 	}
 
 	objName := be.Filename(h)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -3,6 +3,7 @@ package errors
 import (
 	"net/url"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 )
 
@@ -34,20 +35,19 @@ func Cause(err error) error {
 	}
 
 	for {
-		// unwrap *url.Error
-		if urlErr, ok := err.(*url.Error); ok {
-			err = urlErr.Err
-			continue
+		switch e := err.(type) {
+		case Causer: // github.com/pkg/errors
+			err = e.Cause()
+		case *backoff.PermanentError:
+			err = e.Err
+		case *url.Error:
+			err = e.Err
+		default:
+			return err
 		}
-
-		// if err is a Causer, return the cause for this error.
-		if c, ok := err.(Causer); ok {
-			err = c.Cause()
-			continue
-		}
-
-		break
 	}
-
-	return err
 }
+
+// Go 1.13-style error handling.
+
+func Is(x, y error) bool { return errors.Is(x, y) }

--- a/internal/restic/backend.go
+++ b/internal/restic/backend.go
@@ -6,6 +6,12 @@ import (
 )
 
 // Backend is used to store and access data.
+//
+// Backend operations that return an error will be retried when a Backend is
+// wrapped in a RetryBackend. To prevent that from happening, the operations
+// should return a github.com/cenkalti/backoff/v4.PermanentError. Errors from
+// the context package need not be wrapped, as context cancellation is checked
+// separately by the retrying logic.
 type Backend interface {
 	// Location returns a string that describes the type and location of the
 	// repository.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR does two things: it marks a few errors as don't-retry in the backends, and, perhaps more importantly, it introduces a convention to handle these errors in general.

To do the former, the PR has to introduce some new-style (Go 1.13) error handling with errors.Is, which is rather different from the pkg/errors style (errors.Cause) handling that restic has done so far. I considered extending internal/errors.Cause further to handle this, but I didn't, because changes in that function's behavior have consequences in the rest of the codebase that I found hard to fathom (if the Cause of a *os.PathError is no longer the error itself, do existing checks for specific errors continue to work? are they all tested?).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes #2453. Closes #3162.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
