### PR TITLE
Change implementation of BlobSet

### DIFF
--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -132,7 +132,7 @@ func NewDiffStats() *DiffStats {
 
 // updateBlobs updates the blob counters in the stats struct.
 func updateBlobs(repo restic.Repository, blobs restic.BlobSet, stats *DiffStat) {
-	for h := range blobs {
+	_ = blobs.ForAll(func(h restic.BlobHandle) error {
 		switch h.Type {
 		case restic.DataBlob:
 			stats.DataBlobs++
@@ -143,11 +143,12 @@ func updateBlobs(repo restic.Repository, blobs restic.BlobSet, stats *DiffStat) 
 		size, found := repo.LookupBlobSize(h.ID, h.Type)
 		if !found {
 			Warnf("unable to find blob size for %v\n", h)
-			continue
+			return nil
 		}
 
 		stats.Bytes += uint64(size)
-	}
+		return nil
+	})
 }
 
 func (c *Comparer) printDir(ctx context.Context, mode string, stats *DiffStat, blobs restic.BlobSet, prefix string, id restic.ID) error {

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -244,7 +244,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 	}
 
 	// Check if all used blobs have been found in index
-	if len(usedBlobs) != 0 {
+	if usedBlobs.Len() != 0 {
 		Warnf("%v not found in the new index\n"+
 			"Data blobs seem to be missing, aborting prune to prevent further data loss!\n"+
 			"Please report this error (along with the output of the 'prune' run) at\n"+
@@ -546,7 +546,7 @@ func getUsedBlobs(gopts GlobalOptions, repo restic.Repository, ignoreSnapshots r
 			return nil
 		})
 	if err != nil {
-		return nil, err
+		return restic.BlobSet{}, err
 	}
 
 	Verbosef("finding data that is still in use for %d snapshots\n", len(snapshotTrees))
@@ -561,10 +561,10 @@ func getUsedBlobs(gopts GlobalOptions, repo restic.Repository, ignoreSnapshots r
 		err = restic.FindUsedBlobs(ctx, repo, tree, usedBlobs)
 		if err != nil {
 			if repo.Backend().IsNotExist(err) {
-				return nil, errors.Fatal("unable to load a tree from the repo: " + err.Error())
+				return restic.BlobSet{}, errors.Fatal("unable to load a tree from the repo: " + err.Error())
 			}
 
-			return nil, err
+			return restic.BlobSet{}, err
 		}
 
 		debug.Log("processed tree %v", tree)

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -124,13 +124,17 @@ func runStats(gopts GlobalOptions, args []string) error {
 
 	if statsOptions.countMode == countModeRawData {
 		// the blob handles have been collected, but not yet counted
-		for blobHandle := range stats.blobs {
+		err := stats.blobs.ForAll(func(blobHandle restic.BlobHandle) error {
 			blobSize, found := repo.LookupBlobSize(blobHandle.ID, blobHandle.Type)
 			if !found {
 				return fmt.Errorf("blob %v not found", blobHandle)
 			}
 			stats.TotalSize += uint64(blobSize)
 			stats.TotalBlobCount++
+			return nil
+		})
+		if err != nil {
+			return err
 		}
 	}
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -629,7 +629,7 @@ func (c *Checker) UnusedBlobs(ctx context.Context) (blobs restic.BlobHandles) {
 	c.blobRefs.Lock()
 	defer c.blobRefs.Unlock()
 
-	debug.Log("checking %d blobs", len(c.blobRefs.M))
+	debug.Log("checking %d blobs", c.blobRefs.M.Len())
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -25,7 +25,7 @@ const numRepackWorkers = 8
 // The map keepBlobs is modified by Repack, it is used to keep track of which
 // blobs have been processed.
 func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, keepBlobs restic.BlobSet, p *progress.Counter) (obsoletePacks restic.IDSet, err error) {
-	debug.Log("repacking %d packs while keeping %d blobs", len(packs), len(keepBlobs))
+	debug.Log("repacking %d packs while keeping %d blobs", len(packs), keepBlobs.Len())
 
 	wg, wgCtx := errgroup.WithContext(ctx)
 

--- a/internal/restic/find_test.go
+++ b/internal/restic/find_test.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"testing"
 	"time"
 
@@ -52,12 +51,7 @@ func saveIDSet(t testing.TB, filename string, s restic.BlobSet) {
 		return
 	}
 
-	var hs restic.BlobHandles
-	for h := range s {
-		hs = append(hs, h)
-	}
-
-	sort.Sort(hs)
+	hs := s.List()
 
 	enc := json.NewEncoder(f)
 	for _, h := range hs {
@@ -100,7 +94,7 @@ func TestFindUsedBlobs(t *testing.T) {
 			continue
 		}
 
-		if len(usedBlobs) == 0 {
+		if usedBlobs.Len() == 0 {
 			t.Errorf("FindUsedBlobs returned an empty set")
 			continue
 		}
@@ -159,6 +153,6 @@ func BenchmarkFindUsedBlobs(b *testing.B) {
 			b.Error(err)
 		}
 
-		b.Logf("found %v blobs", len(blobs))
+		b.Logf("found %v blobs", blobs.Len())
 	}
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Changes the implementation of `BlobSet` from `map[BlobHandle]struct{}` to `[NumBlobTypes]IDSet`.
This has the following advantages:

- uses less memory for large number of blobs within a BlobSet
- is thread-safe if blobs of different types are added or deleted concurrently (can e.g. be used in #3106)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No. 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-  I have not added tests for all changes in this PR, but modified the current ones
-  I have not added documentation for the changes (in the manual) - not needed
-  There's no new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)) - user should hardly notice this change
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
