### PR TITLE
Unify index loading

### DIFF
--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -110,10 +110,8 @@ func printPacks(ctx context.Context, repo *repository.Repository, wr io.Writer) 
 }
 
 func dumpIndexes(ctx context.Context, repo restic.Repository, wr io.Writer) error {
-	return repo.List(ctx, restic.IndexFile, func(id restic.ID, size int64) error {
+	return repository.ForAllIndexes(ctx, repo, func(id restic.ID, idx *repository.Index, oldFormat bool, err error) error {
 		Printf("index_id: %v\n", id)
-
-		idx, err := repository.LoadIndex(ctx, repo, id)
 		if err != nil {
 			return err
 		}

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -60,8 +60,7 @@ func runList(cmd *cobra.Command, opts GlobalOptions, args []string) error {
 	case "locks":
 		t = restic.LockFile
 	case "blobs":
-		return repo.List(opts.ctx, restic.IndexFile, func(id restic.ID, size int64) error {
-			idx, err := repository.LoadIndex(opts.ctx, repo, id)
+		return repository.ForAllIndexes(opts.ctx, repo, func(id restic.ID, idx *repository.Index, oldFormat bool, err error) error {
 			if err != nil {
 				return err
 			}
@@ -70,7 +69,6 @@ func runList(cmd *cobra.Command, opts GlobalOptions, args []string) error {
 			}
 			return nil
 		})
-
 	default:
 		return errors.Fatal("invalid type")
 	}

--- a/internal/repository/index_parallel.go
+++ b/internal/repository/index_parallel.go
@@ -1,0 +1,77 @@
+package repository
+
+import (
+	"context"
+	"sync"
+
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/restic"
+	"golang.org/x/sync/errgroup"
+)
+
+const loadIndexParallelism = 5
+
+// ForAllIndexes loads all index files in parallel and calls the given callback.
+// It is guaranteed that the function is not run concurrently. If the callback
+// returns an error, this function is cancelled and also returns that error.
+func ForAllIndexes(ctx context.Context, repo restic.Repository,
+	fn func(id restic.ID, index *Index, oldFormat bool, err error) error) error {
+
+	debug.Log("Start")
+
+	type FileInfo struct {
+		restic.ID
+		Size int64
+	}
+
+	var m sync.Mutex
+
+	// track spawned goroutines using wg, create a new context which is
+	// cancelled as soon as an error occurs.
+	wg, ctx := errgroup.WithContext(ctx)
+
+	ch := make(chan FileInfo)
+	// send list of index files through ch, which is closed afterwards
+	wg.Go(func() error {
+		defer close(ch)
+		return repo.List(ctx, restic.IndexFile, func(id restic.ID, size int64) error {
+			select {
+			case <-ctx.Done():
+				return nil
+			case ch <- FileInfo{id, size}:
+			}
+			return nil
+		})
+	})
+
+	// a worker receives an index ID from ch, loads the index, and sends it to indexCh
+	worker := func() error {
+		var buf []byte
+		for fi := range ch {
+			debug.Log("worker got file %v", fi.ID.Str())
+			var err error
+			var idx *Index
+			oldFormat := false
+
+			buf, err = repo.LoadAndDecrypt(ctx, buf[:0], restic.IndexFile, fi.ID)
+			if err == nil {
+				idx, oldFormat, err = DecodeIndex(buf, fi.ID)
+			}
+
+			m.Lock()
+			err = fn(fi.ID, idx, oldFormat, err)
+			m.Unlock()
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// run workers on ch
+	wg.Go(func() error {
+		return RunWorkers(loadIndexParallelism, worker)
+	})
+
+	return wg.Wait()
+}

--- a/internal/repository/index_parallel_test.go
+++ b/internal/repository/index_parallel_test.go
@@ -1,0 +1,46 @@
+package repository_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestRepositoryForAllIndexes(t *testing.T) {
+	repodir, cleanup := rtest.Env(t, repoFixture)
+	defer cleanup()
+
+	repo := repository.TestOpenLocal(t, repodir)
+
+	expectedIndexIDs := restic.NewIDSet()
+	rtest.OK(t, repo.List(context.TODO(), restic.IndexFile, func(id restic.ID, size int64) error {
+		expectedIndexIDs.Insert(id)
+		return nil
+	}))
+
+	// check that all expected indexes are loaded without errors
+	indexIDs := restic.NewIDSet()
+	var indexErr error
+	rtest.OK(t, repository.ForAllIndexes(context.TODO(), repo, func(id restic.ID, index *repository.Index, oldFormat bool, err error) error {
+		if err != nil {
+			indexErr = err
+		}
+		indexIDs.Insert(id)
+		return nil
+	}))
+	rtest.OK(t, indexErr)
+	rtest.Equals(t, expectedIndexIDs, indexIDs)
+
+	// must failed with the returned error
+	iterErr := errors.New("error to pass upwards")
+
+	err := repository.ForAllIndexes(context.TODO(), repo, func(id restic.ID, index *repository.Index, oldFormat bool, err error) error {
+		return iterErr
+	})
+
+	rtest.Equals(t, iterErr, err)
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -595,20 +595,6 @@ func (r *Repository) PrepareCache(indexIDs restic.IDSet) error {
 	return nil
 }
 
-// LoadIndex loads the index id from backend and returns it.
-func LoadIndex(ctx context.Context, repo restic.Repository, id restic.ID) (*Index, error) {
-	buf, err := repo.LoadAndDecrypt(ctx, nil, restic.IndexFile, id)
-	if err != nil {
-		return nil, err
-	}
-
-	idx, oldFormat, err := DecodeIndex(buf, id)
-	if oldFormat {
-		fmt.Fprintf(os.Stderr, "index %v has old format\n", id.Str())
-	}
-	return idx, err
-}
-
 // SearchKey finds a key with the supplied password, afterwards the config is
 // read and parsed. It tries at most maxKeys key files in the repo.
 func (r *Repository) SearchKey(ctx context.Context, password string, maxKeys int, keyHint string) error {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR unifies the code used to load the repository index between the checker and the regular `LoadIndex` method of the repository. The parallelized index loading is then also used in the debug and list command.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
This change was mentioned in https://github.com/restic/restic/issues/2162#issuecomment-723562425 .

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
