### PR TITLE
Parallelize lock file loading

### DIFF
--- a/changelog/unreleased/pull-3130
+++ b/changelog/unreleased/pull-3130
@@ -1,4 +1,4 @@
-Enhancement: Parallelize reading of snapshots
+Enhancement: Parallelize reading of locks and snapshots
 
 Restic used to read snapshots sequentially. For repositories containing
 many snapshots this slowed down commands which have to read all snapshots.
@@ -6,4 +6,7 @@ Now the reading of snapshots is parallelized. This speeds up for example
 `prune`, `backup` and other commands that search for snapshots with certain
 properties or which have to find the `latest` snapshot.
 
+The speed up also applies to locks stored in the backup repository.
+
 https://github.com/restic/restic/pull/3130
+https://github.com/restic/restic/pull/3174


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR parallelizes loading of lock file. It complements the other PRs which parallelize loading of backend data. 

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~ Already covered by the existing tests
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
