### PR TITLE
Fix changelog for #3099

### DIFF
--- a/changelog/unreleased/pull-3099
+++ b/changelog/unreleased/pull-3099
@@ -1,6 +1,6 @@
 Enhancement: Reduce memory usage of check command
 
-The check command now requires less memory if it is run with the
+The check command now requires less memory if it is run without the
 `--check-unused` option.
 
 https://github.com/restic/restic/pull/3099


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
I've missed a negation in the changelog entry for #3099. The memory usage is only reduced when the `--unused-blobs` is not specified.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~ Unless we want some Inception-style changelogs :-)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
