### PR TITLE
prune: don't print stacktrace on console

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -489,7 +489,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 		_, err := repository.Repack(ctx, repo, repackPacks, keepBlobs, bar)
 		bar.Done()
 		if err != nil {
-			return err
+			return errors.Fatalf("%s", err)
 		}
 
 		// Since repacking will only add new packs, we can calculate the number
@@ -505,7 +505,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 			len(removePacks) + packsAddedByRepack
 		err = rebuildIndexFiles(gopts, repo, removePacks, nil, uint64(totalpacks))
 		if err != nil {
-			return err
+			return errors.Fatalf("%s", err)
 		}
 
 		Verbosef("removing %d old packs\n", len(removePacks))


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Don't print a stacktrace on the console when the repack or index rebuild step of prune fail.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #2759

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
