### PR TITLE
Don't retry when "Permission denied" occurs in local backend

### DIFF
--- a/changelog/unreleased/issue-2453
+++ b/changelog/unreleased/issue-2453
@@ -5,8 +5,10 @@ restic retries the failing operation up to nine times (for a total of ten
 attempts). It used to retry all backend operations, but now detects some
 permanent error conditions so it can report fatal errors earlier.
 
-Permanent failures include local disks being full and SSH connections
-dropping.
+Permanent failures include local disks being full, SSH connections
+dropping and permission errors.
 
 https://github.com/restic/restic/issues/2453
 https://github.com/restic/restic/pull/3170
+https://github.com/restic/restic/issues/3180
+https://github.com/restic/restic/pull/3181

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -91,9 +91,8 @@ func (b *Local) Save(ctx context.Context, h restic.Handle, rd restic.RewindReade
 	filename := b.Filename(h)
 
 	defer func() {
-		// Mark non-retriable errors as such (currently only
-		// "no space left on device").
-		if errors.Is(err, syscall.ENOSPC) {
+		// Mark non-retriable errors as such
+		if errors.Is(err, syscall.ENOSPC) || os.IsPermission(err) {
 			err = backoff.Permanent(err)
 		}
 	}()


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Make "Permission denied" an permanent error in local backend, so it is not retried by RetryBackend.

Closes #3180

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
