### PR TITLE
ui/progress: fix counter segfault on arm

### DIFF
--- a/internal/ui/progress/counter.go
+++ b/internal/ui/progress/counter.go
@@ -20,12 +20,12 @@ type Func func(value uint64, runtime time.Duration, final bool)
 //
 // The Func is also called when SIGUSR1 (or SIGINFO, on BSD) is received.
 type Counter struct {
+	value   uint64 // first value in a struct is always 64bit aligned
 	report  Func
 	start   time.Time
 	stopped chan struct{} // Closed by run.
 	stop    chan struct{} // Close to stop run.
 	tick    *time.Ticker
-	value   uint64
 }
 
 // New starts a new Counter.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The value field in the counter struct is a 64bit integer. However, on
32bit platforms it was not aligned to 64 bits. While x86 allows atomic
accesses with a performance penalty, on ARM platform this causes a
segfault.

Move the value field to the head of the struct which is always
guaranteed to be 64bit aligned.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #3185.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~ I've reproduced the crash and tested the fix on my raspberrpi
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~ the affected code is not yet contained in a release.
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
