### PR TITLE
Fix formatting of `restic options` command

### DIFF
--- a/cmd/restic/cmd_options.go
+++ b/cmd/restic/cmd_options.go
@@ -23,8 +23,14 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 	DisableAutoGenTag: true,
 	Run: func(cmd *cobra.Command, args []string) {
 		fmt.Printf("All Extended Options:\n")
+		var maxLen int
 		for _, opt := range options.List() {
-			fmt.Printf("  %-15s   %s\n", opt.Namespace+"."+opt.Name, opt.Text)
+			if l := len(opt.Namespace + "." + opt.Name); l > maxLen {
+				maxLen = l
+			}
+		}
+		for _, opt := range options.List() {
+			fmt.Printf("  %*s  %s\n", -maxLen, opt.Namespace+"."+opt.Name, opt.Text)
 		}
 	},
 }

--- a/internal/options/options_test.go
+++ b/internal/options/options_test.go
@@ -125,6 +125,7 @@ type Target struct {
 	Name    string        `option:"name"`
 	ID      int           `option:"id"`
 	Timeout time.Duration `option:"timeout"`
+	Switch  bool          `option:"switch"`
 	Other   string
 }
 
@@ -155,7 +156,15 @@ var setTests = []struct {
 			"timeout": "10m3s",
 		},
 		Target{
-			Timeout: time.Duration(10*time.Minute + 3*time.Second),
+			Timeout: 10*time.Minute + 3*time.Second,
+		},
+	},
+	{
+		Options{
+			"switch": "true",
+		},
+		Target{
+			Switch: true,
 		},
 	},
 }
@@ -202,6 +211,13 @@ var invalidSetTests = []struct {
 		"ns",
 		`time: missing unit in duration "?2134"?`,
 	},
+	{
+		Options{
+			"switch": "yes",
+		},
+		"ns",
+		`strconv.ParseBool: parsing "yes": invalid syntax`,
+	},
 }
 
 func TestOptionsApplyInvalid(t *testing.T) {
@@ -213,9 +229,9 @@ func TestOptionsApplyInvalid(t *testing.T) {
 				t.Fatalf("expected error %v not found", test.err)
 			}
 
-			matched, err := regexp.MatchString(test.err, err.Error())
-			if err != nil {
-				t.Fatal(err)
+			matched, e := regexp.MatchString(test.err, err.Error())
+			if e != nil {
+				t.Fatal(e)
 			}
 
 			if !matched {
@@ -226,11 +242,11 @@ func TestOptionsApplyInvalid(t *testing.T) {
 }
 
 func TestListOptions(t *testing.T) {
-	var teststruct = struct {
+	teststruct := struct {
 		Foo string `option:"foo" help:"bar text help"`
 	}{}
 
-	var tests = []struct {
+	tests := []struct {
 		cfg  interface{}
 		opts []Help
 	}{
@@ -281,7 +297,7 @@ func TestListOptions(t *testing.T) {
 }
 
 func TestAppendAllOptions(t *testing.T) {
-	var tests = []struct {
+	tests := []struct {
 		cfgs map[string]interface{}
 		opts []Help
 	}{


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

`Printf` in `cmd_options.go` uses fixed (%-15s) formatting to simulate two-column table of extended options.
This PR adds code to dynamically calculate the column width based on the longest option name.

Before:
```
All Extended Options:
  azure.connections   set a limit for the number of concurrent connections (default: 20)
  b2.connections    set a limit for the number of concurrent connections (default: 5)
  gs.connections    set a limit for the number of concurrent connections (default: 20)
  local.layout      use this backend directory layout (default: auto-detect)
  rclone.args       arguments for running rclone (default: serve restic --stdio --b2-hard-delete)
  rclone.connections   set a limit for the number of concurrent connections (default: 5)
  rclone.program    path to rclone (default: rclone)
  rest.connections   set a limit for the number of concurrent connections (default: 5)
  s3.bucket-lookup   bucket lookup style: 'auto', 'dns', or 'path'
  s3.connections    set a limit for the number of concurrent connections (default: 5)
  s3.layout         use this backend layout (default: auto-detect)
  s3.list-objects-v1   use deprecated V1 api for ListObjects calls
  s3.region         set region
  s3.retries        set the number of retries attempted
  s3.storage-class   set S3 storage class (STANDARD, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING or REDUCED_REDUNDANCY)
  sftp.command      specify command to create sftp connection
  sftp.layout       use this backend directory layout (default: auto-detect)
  swift.connections   set a limit for the number of concurrent connections (default: 5)
```

After:
```
All Extended Options:
  azure.connections   set a limit for the number of concurrent connections (default: 20)
  b2.connections      set a limit for the number of concurrent connections (default: 5)
  gs.connections      set a limit for the number of concurrent connections (default: 20)
  local.layout        use this backend directory layout (default: auto-detect)
  rclone.args         arguments for running rclone (default: serve restic --stdio --b2-hard-delete)
  rclone.connections  set a limit for the number of concurrent connections (default: 5)
  rclone.program      path to rclone (default: rclone)
  rest.connections    set a limit for the number of concurrent connections (default: 5)
  s3.bucket-lookup    bucket lookup style: 'auto', 'dns', or 'path'
  s3.connections      set a limit for the number of concurrent connections (default: 5)
  s3.layout           use this backend layout (default: auto-detect)
  s3.list-objects-v1  use deprecated V1 api for ListObjects calls
  s3.region           set region
  s3.retries          set the number of retries attempted
  s3.storage-class    set S3 storage class (STANDARD, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING or REDUCED_REDUNDANCY)
  sftp.command        specify command to create sftp connection
  sftp.layout         use this backend directory layout (default: auto-detect)
  swift.connections   set a limit for the number of concurrent connections (default: 5)
```

Also PR #3085 adds `bool` support to `options` package, but without a corresponding test. This has been fixed too.

And the last change fixes reuse of the `err` variable in `TestOptionsApplyInvalid`, which can lead to panic instead of test failure.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No, but this PR based on first commit of #3067.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
~~- [x] I have added documentation for the changes (in the manual)~~
~~- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
