### PR TITLE
prune: Add option --keep-packs-from

### DIFF
--- a/changelog/unreleased/pull-3196
+++ b/changelog/unreleased/pull-3196
@@ -1,0 +1,7 @@
+Enhancement: Add option to keep packs to prune and forget
+
+We've added a new option to `prune` and `forget` which allows to always keep
+some pack files. This allows `prune` to work with storages which have early
+deletion fees or locked files. 
+
+https://github.com/restic/restic/pull/3196

--- a/cmd/restic/helpers.go
+++ b/cmd/restic/helpers.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/restic/restic/internal/restic"
+)
+
+func getIDsFromFiles(files []string) (restic.IDSet, error) {
+	ids := restic.NewIDSet()
+
+	for _, file := range files {
+		fromfile, err := readLines(file)
+		if err != nil {
+			return nil, err
+		}
+
+		// read IDs from file
+		for _, line := range fromfile {
+			id, err := restic.ParseID(line)
+			if err != nil {
+				return nil, err
+			}
+			ids.Insert(id)
+		}
+	}
+	return ids, nil
+}

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -358,6 +358,11 @@ The ``prune`` command accepts the following options:
   your repository exceeds the value given by ``--max-unused``.
   The default value is false.
 
+- ``--keep-packs-from`` allows to specify one or more files which contain the
+  names of pack files to always keep. This option is handy if some files in
+  the backend cannot or should not be removed, like unavailable/protected files
+  or files you want to keep in order to prevent an early deletion fee.
+
 -  ``--dry-run`` only show what ``prune`` would do.
 
 -  ``--verbose`` increased verbosity shows additional statistics for ``prune``.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds a new option `--keep-packs-from` to `prune`.
If given, `prune` reads the ids (= filenames) of pack files which will be always kept.

This is handy if you do not want to delete or repack some pack files for various reasons, like cold storages with early deletion fees or locked files, see #3195 (where I got the idea from).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

The early deletion fees were already mentioned in some cold storage discussions.
See also #3195

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- I have not added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
