### PR TITLE
Don't print progress on non-interactive terminals

### DIFF
--- a/changelog/unreleased/issue-2706
+++ b/changelog/unreleased/issue-2706
@@ -1,0 +1,16 @@
+Enhancement: Configurable progress reports for non-interactive terminals
+
+The `backup`, `check` and `prune` commands never printed any progress
+reports on non-interactive terminals. This behavior is now configurable
+using the `RESTIC_PROGRESS_FPS` environment variable. Use for example a
+value of `1` for an update per second or `0.01666` for an update per minute.
+
+The `backup` command now also prints the current progress when restic
+receives a `SIGUSR1` signal.
+
+Setting the `RESTIC_PROGRESS_FPS` environment variable or sending a `SIGUSR1`
+signal prints a status report even when `--quiet` was specified.
+
+https://github.com/restic/restic/issues/2706
+https://github.com/restic/restic/issues/3194
+https://github.com/restic/restic/pull/3199

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -11,7 +11,6 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
@@ -545,15 +544,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	}()
 	gopts.stdout, gopts.stderr = p.Stdout(), p.Stderr()
 
-	if s, ok := os.LookupEnv("RESTIC_PROGRESS_FPS"); ok {
-		fps, err := strconv.Atoi(s)
-		if err == nil && fps >= 1 {
-			if fps > 60 {
-				fps = 60
-			}
-			p.SetMinUpdatePause(time.Second / time.Duration(fps))
-		}
-	}
+	p.SetMinUpdatePause(calculateProgressInterval())
 
 	t.Go(func() error { return p.Run(t.Context(gopts.ctx)) })
 

--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -9,12 +9,10 @@ import (
 	"github.com/restic/restic/internal/ui/progress"
 )
 
-// newProgressMax returns a progress.Counter that prints to stdout.
-func newProgressMax(show bool, max uint64, description string) *progress.Counter {
-	if !show {
-		return nil
-	}
-
+// calculateProgressInterval returns the interval configured via RESTIC_PROGRESS_FPS
+// or if unset returns an interval for 60fps on interactive terminals and 0 (=disabled)
+// for non-interactive terminals
+func calculateProgressInterval() time.Duration {
 	interval := time.Second / 60
 	fps, err := strconv.ParseInt(os.Getenv("RESTIC_PROGRESS_FPS"), 10, 64)
 	if err == nil && fps >= 1 {
@@ -25,6 +23,15 @@ func newProgressMax(show bool, max uint64, description string) *progress.Counter
 	} else if !stdoutIsTerminal() {
 		interval = 0
 	}
+	return interval
+}
+
+// newProgressMax returns a progress.Counter that prints to stdout.
+func newProgressMax(show bool, max uint64, description string) *progress.Counter {
+	if !show {
+		return nil
+	}
+	interval := calculateProgressInterval()
 
 	return progress.New(interval, func(v uint64, d time.Duration, final bool) {
 		status := fmt.Sprintf("[%s] %s  %d / %d %s",

--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -16,16 +16,14 @@ func newProgressMax(show bool, max uint64, description string) *progress.Counter
 	}
 
 	interval := time.Second / 60
-	if !stdoutIsTerminal() {
-		interval = 0
-	} else {
-		fps, err := strconv.ParseInt(os.Getenv("RESTIC_PROGRESS_FPS"), 10, 64)
-		if err == nil && fps >= 1 {
-			if fps > 60 {
-				fps = 60
-			}
-			interval = time.Second / time.Duration(fps)
+	fps, err := strconv.ParseInt(os.Getenv("RESTIC_PROGRESS_FPS"), 10, 64)
+	if err == nil && fps >= 1 {
+		if fps > 60 {
+			fps = 60
 		}
+		interval = time.Second / time.Duration(fps)
+	} else if !stdoutIsTerminal() {
+		interval = 0
 	}
 
 	return progress.New(interval, func(v uint64, d time.Duration, final bool) {

--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -14,12 +14,12 @@ import (
 // for non-interactive terminals
 func calculateProgressInterval() time.Duration {
 	interval := time.Second / 60
-	fps, err := strconv.ParseInt(os.Getenv("RESTIC_PROGRESS_FPS"), 10, 64)
-	if err == nil && fps >= 1 {
+	fps, err := strconv.ParseFloat(os.Getenv("RESTIC_PROGRESS_FPS"), 64)
+	if err == nil && fps > 0 {
 		if fps > 60 {
 			fps = 60
 		}
-		interval = time.Second / time.Duration(fps)
+		interval = time.Duration(float64(time.Second) / fps)
 	} else if !stdoutIsTerminal() {
 		interval = 0
 	}

--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -17,7 +17,7 @@ func newProgressMax(show bool, max uint64, description string) *progress.Counter
 
 	interval := time.Second / 60
 	if !stdoutIsTerminal() {
-		interval = time.Second
+		interval = 0
 	} else {
 		fps, err := strconv.ParseInt(os.Getenv("RESTIC_PROGRESS_FPS"), 10, 64)
 		if err == nil && fps >= 1 {

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -133,15 +133,14 @@ command:
           --tls-client-cert file       path to a file containing PEM encoded TLS client certificate and private key
       -v, --verbose n                  be verbose (specify multiple times or a level using --verbose=n, max level/times is 3)
 
-Subcommand that support showing progress information such as ``backup``,
+Subcommands that support showing progress information such as ``backup``,
 ``check`` and ``prune`` will do so unless the quiet flag ``-q`` or
-``--quiet`` is set. When running from a non-interactive console progress
-reporting will be limited to once every 10 seconds to not fill your
-logs. Use ``backup`` with the quiet flag ``-q`` or ``--quiet`` to skip
-the initial scan of the source directory, this may shorten the backup
-time needed for large directories.
+``--quiet`` is set. For interactive consoles the environment variable
+``RESTIC_PROGRESS_FPS`` can be used to control the frequency of progress
+reporting. When running from a non-interactive console progress reporting
+is disabled to not fill your logs.
 
-Additionally on Unix systems if ``restic`` receives a SIGUSR1 signal the
+Additionally, on Unix systems if ``restic`` receives a SIGUSR1 signal the
 current progress will be written to the standard output so you can check up
 on the status at will.
 

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -138,7 +138,8 @@ Subcommands that support showing progress information such as ``backup``,
 ``--quiet`` is set. When running from a non-interactive console progress
 reporting is disabled by default to not fill your logs. For interactive
 and non-interactive consoles the environment variable ``RESTIC_PROGRESS_FPS``
-can be used to control the frequency of progress reporting.
+can be used to control the frequency of progress reporting. Use for example
+``0.016666`` to only update the progress once per minute.
 
 Additionally, on Unix systems if ``restic`` receives a SIGUSR1 signal the
 current progress will be written to the standard output so you can check up

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -145,6 +145,9 @@ Additionally, on Unix systems if ``restic`` receives a SIGUSR1 signal the
 current progress will be written to the standard output so you can check up
 on the status at will.
 
+Setting the `RESTIC_PROGRESS_FPS` environment variable or sending a `SIGUSR1`
+signal prints a status report even when `--quiet` was specified.
+
 Manage tags
 -----------
 

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -135,10 +135,10 @@ command:
 
 Subcommands that support showing progress information such as ``backup``,
 ``check`` and ``prune`` will do so unless the quiet flag ``-q`` or
-``--quiet`` is set. For interactive consoles the environment variable
-``RESTIC_PROGRESS_FPS`` can be used to control the frequency of progress
-reporting. When running from a non-interactive console progress reporting
-is disabled to not fill your logs.
+``--quiet`` is set. When running from a non-interactive console progress
+reporting is disabled by default to not fill your logs. For interactive
+and non-interactive consoles the environment variable ``RESTIC_PROGRESS_FPS``
+can be used to control the frequency of progress reporting.
 
 Additionally, on Unix systems if ``restic`` receives a SIGUSR1 signal the
 current progress will be written to the standard output so you can check up

--- a/internal/ui/backup.go
+++ b/internal/ui/backup.go
@@ -90,7 +90,11 @@ func (b *Backup) Run(ctx context.Context) error {
 	defer t.Stop()
 	defer close(b.closed)
 	// Reset status when finished
-	defer b.term.SetStatus([]string{""})
+	defer func() {
+		if b.term.CanUpdateStatus() {
+			b.term.SetStatus([]string{""})
+		}
+	}()
 
 	for {
 		select {
@@ -132,7 +136,7 @@ func (b *Backup) Run(ctx context.Context) error {
 		}
 
 		// limit update frequency
-		if time.Since(lastUpdate) < b.MinUpdatePause {
+		if time.Since(lastUpdate) < b.MinUpdatePause || b.MinUpdatePause == 0 {
 			continue
 		}
 		lastUpdate = time.Now()

--- a/internal/ui/backup.go
+++ b/internal/ui/backup.go
@@ -378,9 +378,7 @@ func (b *Backup) ReportTotal(item string, s archiver.ScanStats) {
 // Finish prints the finishing messages.
 func (b *Backup) Finish(snapshotID restic.ID) {
 	// wait for the status update goroutine to shut down
-	select {
-	case <-b.closed:
-	}
+	<-b.closed
 
 	b.P("\n")
 	b.P("Files:       %5d new, %5d changed, %5d unmodified\n", b.summary.Files.New, b.summary.Files.Changed, b.summary.Files.Unchanged)

--- a/internal/ui/backup.go
+++ b/internal/ui/backup.go
@@ -32,7 +32,6 @@ type Backup struct {
 	MinUpdatePause time.Duration
 
 	term  *termstatus.Terminal
-	v     uint
 	start time.Time
 
 	totalBytes uint64
@@ -61,7 +60,6 @@ func NewBackup(term *termstatus.Terminal, verbosity uint) *Backup {
 		Message:      NewMessage(term, verbosity),
 		StdioWrapper: NewStdioWrapper(term),
 		term:         term,
-		v:            verbosity,
 		start:        time.Now(),
 
 		// limit to 60fps by default

--- a/internal/ui/progress/counter_test.go
+++ b/internal/ui/progress/counter_test.go
@@ -53,3 +53,22 @@ func TestCounterNil(t *testing.T) {
 	c.Add(1)
 	c.Done()
 }
+
+func TestCounterNoTick(t *testing.T) {
+	finalSeen := false
+	otherSeen := false
+
+	report := func(value uint64, d time.Duration, final bool) {
+		if final {
+			finalSeen = true
+		} else {
+			otherSeen = true
+		}
+	}
+	c := progress.New(0, report)
+	time.Sleep(time.Millisecond)
+	c.Done()
+
+	test.Assert(t, finalSeen, "final call did not happen")
+	test.Assert(t, !otherSeen, "unexpected status update")
+}

--- a/internal/ui/signals/signals.go
+++ b/internal/ui/signals/signals.go
@@ -1,0 +1,24 @@
+package signals
+
+import (
+	"os"
+	"sync"
+)
+
+// GetProgressChannel returns a channel with which a single listener
+// receives each incoming signal.
+func GetProgressChannel() <-chan os.Signal {
+	signals.Once.Do(func() {
+		signals.ch = make(chan os.Signal, 1)
+		setupSignals()
+	})
+
+	return signals.ch
+}
+
+// XXX The fact that signals is a single global variable means that only one
+// listener receives each incoming signal.
+var signals struct {
+	ch chan os.Signal
+	sync.Once
+}

--- a/internal/ui/signals/signals_bsd.go
+++ b/internal/ui/signals/signals_bsd.go
@@ -1,6 +1,6 @@
 // +build darwin dragonfly freebsd netbsd openbsd
 
-package progress
+package signals
 
 import (
 	"os/signal"

--- a/internal/ui/signals/signals_sysv.go
+++ b/internal/ui/signals/signals_sysv.go
@@ -1,6 +1,6 @@
 // +build aix linux solaris
 
-package progress
+package signals
 
 import (
 	"os/signal"

--- a/internal/ui/signals/signals_windows.go
+++ b/internal/ui/signals/signals_windows.go
@@ -1,3 +1,3 @@
-package progress
+package signals
 
 func setupSignals() {}

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -314,17 +314,24 @@ func (t *Terminal) SetStatus(lines []string) {
 		return
 	}
 
-	width, _, err := terminal.GetSize(int(t.fd))
-	if err != nil || width <= 0 {
-		// use 80 columns by default
-		width = 80
+	// only truncate interactive status output
+	var width int
+	if t.canUpdateStatus {
+		var err error
+		width, _, err = terminal.GetSize(int(t.fd))
+		if err != nil || width <= 0 {
+			// use 80 columns by default
+			width = 80
+		}
 	}
 
 	// make sure that all lines have a line break and are not too long
 	for i, line := range lines {
 		line = strings.TrimRight(line, "\n")
-		line = truncate(line, width-2) + "\n"
-		lines[i] = line
+		if width > 0 {
+			line = truncate(line, width-2)
+		}
+		lines[i] = line + "\n"
 	}
 
 	// make sure the last line does not have a line break


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The PR revert the progress bar updates to the old behavior of not printing progress updates on non-interactive terminals.

As an additional change, the `RESTIC_PROGRESS_FPS` environment variable is now also interpreted for non-interactive terminals. This makes it possible to use the environment variable to also get regular progress updates on non-interactive terminals.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #3194.
See #2706 for further discussions.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR **We currently have no means for testing the `progress.go` change, however, I've verified that it works manually.**
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
