### PR TITLE
backup: Add options --set-path and --set-path-from

### DIFF
--- a/changelog/unreleased/issue-2714
+++ b/changelog/unreleased/issue-2714
@@ -1,0 +1,11 @@
+Enhancement: Allow to set paths saved in snapshots manually
+
+Restic backup always used to save the paths specified for the backup
+in the snapshot. We've added new options to set this directly. This
+allows to have clearer snapshots and use parent snapshots e.g. if
+the files to backup comes from a external file find tool. 
+
+https://github.com/restic/restic/issues/2246
+https://github.com/restic/restic/issues/2714
+https://github.com/restic/restic/issues/3198
+https://github.com/restic/restic/pull/3200

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -117,11 +117,17 @@ func init() {
 	f.StringVar(&backupOptions.ExcludeLargerThan, "exclude-larger-than", "", "max `size` of the files to be backed up (allowed suffixes: k/K, m/M, g/G, t/T)")
 	f.BoolVar(&backupOptions.Stdin, "stdin", false, "read backup from stdin")
 	f.StringVar(&backupOptions.StdinFilename, "stdin-filename", "stdin", "`filename` to use when reading from stdin")
+	err := f.MarkDeprecated("stdin-filename", "use --set-path")
+	if err != nil {
+		// MarkDeprecated only returns an error when the flag could not be found
+		panic(err)
+	}
+
 	f.Var(&backupOptions.Tags, "tag", "add `tags` for the new snapshot in the format `tag[,tag,...]` (can be specified multiple times)")
 
 	f.StringVarP(&backupOptions.Host, "host", "H", "", "set the `hostname` for the snapshot manually. To prevent an expensive rescan use the \"parent\" flag")
 	f.StringVar(&backupOptions.Host, "hostname", "", "set the `hostname` for the snapshot manually")
-	err := f.MarkDeprecated("hostname", "use --host")
+	err = f.MarkDeprecated("hostname", "use --host")
 	if err != nil {
 		// MarkDeprecated only returns an error when the flag could not be found
 		panic(err)

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -372,6 +372,11 @@ the list of files/patterns from there instead of a text file.
 In all cases, paths may be absolute or relative to ``restic backup``'s working
 directory.
 
+Note that if you use restic in combination with include files, by default all
+entries of the include files are added to the snapshots paths. This may break
+the finding of parent snapshots. Please consider setting the paths manually
+using ``--set-path`` or ``--set-path-from`` to reflect what is actually backuped.
+
 For example, maybe you want to backup files which have a name that matches a
 certain regular expression pattern (uses GNU ``find``):
 
@@ -383,14 +388,17 @@ You can then use restic to backup the filtered files:
 
 .. code-block:: console
 
-    $ restic -r /srv/restic-repo backup --files-from-raw /tmp/files_to_backup
+    $ restic -r /srv/restic-repo backup --files-from-raw /tmp/files_to_backup --set-path /tmp/somefiles
 
 You can combine all three options with each other and with the normal file arguments:
 
 .. code-block:: console
 
-    $ restic backup --files-from /tmp/files_to_backup /tmp/some_additional_file
-    $ restic backup --files-from /tmp/glob-pattern --files-from-raw /tmp/generated-list /tmp/some_additional_file
+    $ restic backup --files-from /tmp/files_to_backup /tmp/some_additional_file \
+                    --set-path /tmp/somefiles --set-path /tmp/some_additional_file
+    $ restic backup --files-from /tmp/glob-pattern --files-from-raw /tmp/generated-list /tmp/some_additional_file \
+                    --set-path-from /tmp/glob-pattern --set-path /tmp/somefiles --set-path /tmp/some_additional_file
+
 
 Comparing Snapshots
 *******************

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -471,11 +471,11 @@ use e.g. the fuse mounting option (see below) to mount the repository
 and read the file.
 
 By default, the file name ``stdin`` is used, a different name can be
-specified with ``--stdin-filename``, e.g. like this:
+specified with ``--set-path``, e.g. like this:
 
 .. code-block:: console
 
-    $ mysqldump [...] | restic -r /srv/restic-repo backup --stdin --stdin-filename production.sql
+    $ mysqldump [...] | restic -r /srv/restic-repo backup --stdin --set-path production.sql
 
 The option ``pipefail`` is highly recommended so that a non-zero exit code from
 one of the programs in the pipe (e.g. ``mysqldump`` here) makes the whole chain

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -727,6 +727,7 @@ func resolveRelativeTargets(filesys fs.FS, targets []string) ([]string, error) {
 // SnapshotOptions collect attributes for a new snapshot.
 type SnapshotOptions struct {
 	Tags           restic.TagList
+	Paths          []string
 	Hostname       string
 	Excludes       []string
 	Time           time.Time
@@ -827,7 +828,7 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 		return nil, restic.ID{}, err
 	}
 
-	sn, err := restic.NewSnapshot(targets, opts.Tags, opts.Hostname, opts.Time)
+	sn, err := restic.NewSnapshot(opts.Paths, opts.Tags, opts.Hostname, opts.Time)
 	if err != nil {
 		return nil, restic.ID{}, err
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds an option `--set-path` to `backup` which allows to manually set the path(s) saved in the snapshot and used for finding the parent snapshot. Also the option `--set-path-from` is added to read the paths from a file.

Both options are useful e.g. if the files to backup are selected by an external tool.

As `set-path` functionally replaces `--stdin-filename`, the latter is now marked as deprecated.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

closes #2714 
closes #3198 
allows users to use an easy workaround for #1514 by using `--files-from-raw` in combination with `fd` (or similar find tools) and `--set-path`
maybe also closes #2246 
closes #1376
closes #2092

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review