### PR TITLE
check: Add option `--read-data-from`

### DIFF
--- a/changelog/unreleased/pull-3203
+++ b/changelog/unreleased/pull-3203
@@ -1,0 +1,9 @@
+Enhancement: Allow to check specific pack files
+
+Restic check used to check either all packfiles or a subset that is chosen
+either in a deterministic or random way but did not allow to specify the pack
+files to check directly.
+This feature is now added. It allows to fine-tune the checking process or support
+troubleshooting in case of corrupted repositories.
+
+https://github.com/restic/restic/pull/3203

--- a/cmd/restic/helpers.go
+++ b/cmd/restic/helpers.go
@@ -1,0 +1,26 @@
+package main
+
+import (
+	"github.com/restic/restic/internal/restic"
+)
+
+func getIDsFromFiles(files []string) (restic.IDSet, error) {
+	ids := restic.NewIDSet()
+
+	for _, file := range files {
+		fromfile, err := readLines(file)
+		if err != nil {
+			return nil, err
+		}
+
+		// read IDs from file
+		for _, line := range fromfile {
+			id, err := restic.ParseID(line)
+			if err != nil {
+				return nil, err
+			}
+			ids.Insert(id)
+		}
+	}
+	return ids, nil
+}

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -281,3 +281,19 @@ integer:
 .. code-block:: console
 
     $ restic -r /srv/restic-repo check --read-data-subset=10%
+
+Another alternative is to use ``--read-data-from`` which allows to give one or
+more file(s) which contain(s) all pack filenames to check:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo list packs > packlist
+    $ restic -r /srv/restic-repo check --read-data-from=packlist
+
+You can also use ``-`` as filename to read from stdin, e.g. to only check one pack
+file (note that in this case you cannot enter your password from stdin):
+
+.. code-block:: console
+
+    $ echo 5873ed5dfd240c99eed14a1605a04f561ac45287a656d86730b76ae21be324f9 | \
+      restic -r /srv/restic-repo check --read-data-from=- --password-file=pass.txt


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds an option to `check` to read the pack files to be checked from a file.
This is handy to control which files are actually read by `check`. Also allows to only check a few pack files in troubleshooting cases without needing to download all pack files (which might be very expensive and time-consuming)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

see #3202 
In the forum there was a discussion (don't find it right now) where a user wanted to troubleshoot some corrupt pack file but rejected to run a full `check --read-data` as this would cost too much...

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
