### PR TITLE
Properly check that --quiet and --verbose are not combined

### DIFF
--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -32,7 +32,7 @@ directories in an encrypted repository stored on different backends.
 	PersistentPreRunE: func(c *cobra.Command, args []string) error {
 		// set verbosity, default is one
 		globalOptions.verbosity = 1
-		if globalOptions.Quiet && (globalOptions.Verbose > 1) {
+		if globalOptions.Quiet && globalOptions.Verbose > 0 {
 			return errors.Fatal("--quiet and --verbose cannot be specified at the same time")
 		}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Due to a typo `--quiet --verbose` was accepted whereas `--quiet --verbose=2` was rejected. If `--verbose` is specified once, then `globalOptions.Verbose == 1`. Previously `--quiet --verbose` would silently ignore the `--verbose` flag. Now restic also rejects `--quiet --verbose`.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
