### PR TITLE
Fix error handling in filerestorer and fix #3166

### DIFF
--- a/changelog/unreleased/issue-3166
+++ b/changelog/unreleased/issue-3166
@@ -1,0 +1,9 @@
+Bugfix: Improve error handling in restore
+
+Restic restore used to not print errors while downloading file contents from
+the repository. restore also incorrectly exited with a zero error code even 
+when there were errors during the restore process. Now, a non-zero code is
+returned.
+
+https://github.com/restic/restic/issues/3166
+https://github.com/restic/restic/pull/3207

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -191,14 +191,26 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 	Verbosef("restoring %s to %s\n", res.Snapshot(), opts.Target)
 
 	err = res.RestoreTo(ctx, opts.Target)
-	if err == nil && opts.Verify {
+	if err != nil {
+		return err
+	}
+
+	if totalErrors > 0 {
+		return errors.Fatalf("There were %d errors\n", totalErrors)
+	}
+
+	if opts.Verify {
 		Verbosef("verifying files in %s\n", opts.Target)
 		var count int
 		count, err = res.VerifyFiles(ctx, opts.Target)
+		if err != nil {
+			return err
+		}
+		if totalErrors > 0 {
+			return errors.Fatalf("There were %d errors\n", totalErrors)
+		}
 		Verbosef("finished verifying %d files in %s\n", count, opts.Target)
 	}
-	if totalErrors > 0 {
-		Printf("There were %d errors\n", totalErrors)
-	}
-	return err
+
+	return nil
 }

--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -262,5 +262,5 @@ func TestErrorRestoreFiles(t *testing.T) {
 	r.files = repo.files
 
 	err := r.restoreFiles(context.TODO())
-	rtest.Assert(t, err != nil, "restoreFiles should have reported an error!")
+	rtest.Equals(t, loadError, err)
 }

--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/restic/restic/internal/crypto"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
@@ -236,4 +237,30 @@ func TestFileRestorerPackSkip(t *testing.T) {
 			},
 		},
 	}, files)
+}
+
+func TestErrorRestoreFiles(t *testing.T) {
+	tempdir, cleanup := rtest.TempDir(t)
+	defer cleanup()
+	content := []TestFile{
+		{
+			name: "file1",
+			blobs: []TestBlob{
+				{"data1-1", "pack1-1"},
+			},
+		}}
+
+	repo := newTestRepo(content)
+
+	loadError := errors.New("load error")
+	// loader always returns an error
+	repo.loader = func(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+		return loadError
+	}
+
+	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup)
+	r.files = repo.files
+
+	err := r.restoreFiles(context.TODO())
+	rtest.Assert(t, err != nil, "restoreFiles should have reported an error!")
 }

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -216,6 +216,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 	idx := restic.NewHardlinkIndex()
 
 	filerestorer := newFileRestorer(dst, res.repo.Backend().Load, res.repo.Key(), res.repo.Index().Lookup)
+	filerestorer.Error = res.Error
 
 	debug.Log("first pass for %q", dst)
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The FileRestorer in `internal/restorer/filerestorer.go` collects errors for files but does not process these errors.
This is fixed in this PR.

A test case is added which fails without the fix in `filerestorer.go`

Also `restic restore` now return a non-zero error code if there were errors.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Found it when testing #3109 
fixes #3166 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
-  I have not added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)) - do we need one?
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
