### PR TITLE
Speed-up caching/pack download via SFTP

### DIFF
--- a/internal/hashing/reader.go
+++ b/internal/hashing/reader.go
@@ -5,25 +5,47 @@ import (
 	"io"
 )
 
-// Reader hashes all data read from the underlying reader.
-type Reader struct {
-	r io.Reader
+// ReadSumer hashes all data read from the underlying reader.
+type ReadSumer interface {
+	io.Reader
+	// Sum returns the hash of the data read so far.
+	Sum(d []byte) []byte
+}
+
+type reader struct {
+	io.Reader
 	h hash.Hash
 }
 
-// NewReader returns a new Reader that uses the hash h.
-func NewReader(r io.Reader, h hash.Hash) *Reader {
-	return &Reader{
-		h: h,
-		r: io.TeeReader(r, h),
-	}
+type readWriterTo struct {
+	reader
+	writerTo io.WriterTo
 }
 
-func (h *Reader) Read(p []byte) (int, error) {
-	return h.r.Read(p)
+// NewReader returns a new ReadSummer that uses the hash h. If the underlying
+// reader supports WriteTo then the returned reader will do so too.
+func NewReader(r io.Reader, h hash.Hash) ReadSumer {
+	rs := reader{
+		Reader: io.TeeReader(r, h),
+		h:      h,
+	}
+
+	if _, ok := r.(io.WriterTo); ok {
+		return &readWriterTo{
+			reader:   rs,
+			writerTo: r.(io.WriterTo),
+		}
+	}
+
+	return &rs
 }
 
 // Sum returns the hash of the data read so far.
-func (h *Reader) Sum(d []byte) []byte {
+func (h *reader) Sum(d []byte) []byte {
 	return h.h.Sum(d)
+}
+
+// WriteTo reads all data into the passed writer
+func (h *readWriterTo) WriteTo(w io.Writer) (int64, error) {
+	return h.writerTo.WriteTo(NewWriter(w, h.h))
 }

--- a/internal/limiter/limiter.go
+++ b/internal/limiter/limiter.go
@@ -20,6 +20,10 @@ type Limiter interface {
 	// for downloads.
 	Downstream(r io.Reader) io.Reader
 
+	// Downstream returns a rate limited reader that is intended to be used
+	// for downloads.
+	DownstreamWriter(r io.Writer) io.Writer
+
 	// Transport returns an http.RoundTripper limited with the limiter.
 	Transport(http.RoundTripper) http.RoundTripper
 }

--- a/internal/limiter/limiter_backend_test.go
+++ b/internal/limiter/limiter_backend_test.go
@@ -1,0 +1,109 @@
+package limiter
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/restic/restic/internal/mock"
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func randomBytes(t *testing.T, size int) []byte {
+	data := make([]byte, size)
+	_, err := io.ReadFull(rand.Reader, data)
+	rtest.OK(t, err)
+	return data
+}
+
+func TestLimitBackendSave(t *testing.T) {
+	testHandle := restic.Handle{Type: restic.PackFile, Name: "test"}
+	data := randomBytes(t, 1234)
+
+	be := mock.NewBackend()
+	be.SaveFn = func(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
+		buf := new(bytes.Buffer)
+		_, err := io.Copy(buf, rd)
+		if err != nil {
+			return nil
+		}
+		if !bytes.Equal(data, buf.Bytes()) {
+			return fmt.Errorf("data mismatch")
+		}
+		return nil
+	}
+	limiter := NewStaticLimiter(42*1024, 42*1024)
+	limbe := LimitBackend(be, limiter)
+
+	rd := restic.NewByteReader(data)
+	err := limbe.Save(context.TODO(), testHandle, rd)
+	rtest.OK(t, err)
+}
+
+type tracedReadWriteToCloser struct {
+	io.Reader
+	io.WriterTo
+	Traced bool
+}
+
+func newTracedReadWriteToCloser(rd *bytes.Reader) *tracedReadWriteToCloser {
+	return &tracedReadWriteToCloser{Reader: rd, WriterTo: rd}
+}
+
+func (r *tracedReadWriteToCloser) WriteTo(w io.Writer) (n int64, err error) {
+	r.Traced = true
+	return r.WriterTo.WriteTo(w)
+}
+
+func (r *tracedReadWriteToCloser) Close() error {
+	return nil
+}
+
+func TestLimitBackendLoad(t *testing.T) {
+	testHandle := restic.Handle{Type: restic.PackFile, Name: "test"}
+	data := randomBytes(t, 1234)
+
+	for _, test := range []struct {
+		innerWriteTo, outerWriteTo bool
+	}{{false, false}, {false, true}, {true, false}, {true, true}} {
+		be := mock.NewBackend()
+		src := newTracedReadWriteToCloser(bytes.NewReader(data))
+		be.OpenReaderFn = func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+			if length != 0 || offset != 0 {
+				return nil, fmt.Errorf("Not supported")
+			}
+			// test both code paths in WriteTo of limitedReadCloser
+			if test.innerWriteTo {
+				return src, nil
+			}
+			return newTracedReadCloser(src), nil
+		}
+		limiter := NewStaticLimiter(42*1024, 42*1024)
+		limbe := LimitBackend(be, limiter)
+
+		err := limbe.Load(context.TODO(), testHandle, 0, 0, func(rd io.Reader) error {
+			dataRead := new(bytes.Buffer)
+			// test both Read and WriteTo
+			if !test.outerWriteTo {
+				rd = newTracedReadCloser(rd)
+			}
+			_, err := io.Copy(dataRead, rd)
+			if err != nil {
+				return err
+			}
+			if !bytes.Equal(data, dataRead.Bytes()) {
+				return fmt.Errorf("read broken data")
+			}
+
+			return nil
+		})
+		rtest.OK(t, err)
+		rtest.Assert(t, src.Traced == (test.innerWriteTo && test.outerWriteTo),
+			"unexpected/missing writeTo call innerWriteTo %v outerWriteTo %v",
+			test.innerWriteTo, test.outerWriteTo)
+	}
+}

--- a/internal/limiter/static_limiter.go
+++ b/internal/limiter/static_limiter.go
@@ -46,6 +46,10 @@ func (l staticLimiter) Downstream(r io.Reader) io.Reader {
 	return l.limitReader(r, l.downstream)
 }
 
+func (l staticLimiter) DownstreamWriter(w io.Writer) io.Writer {
+	return l.limitWriter(w, l.downstream)
+}
+
 type roundTripper func(*http.Request) (*http.Response, error)
 
 func (rt roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
@@ -55,7 +59,7 @@ func (rt roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 func (l staticLimiter) roundTripper(rt http.RoundTripper, req *http.Request) (*http.Response, error) {
 	if req.Body != nil {
 		req.Body = limitedReadCloser{
-			limited:  l.Upstream(req.Body),
+			Reader:   l.Upstream(req.Body),
 			original: req.Body,
 		}
 	}
@@ -64,7 +68,7 @@ func (l staticLimiter) roundTripper(rt http.RoundTripper, req *http.Request) (*h
 
 	if res != nil && res.Body != nil {
 		res.Body = limitedReadCloser{
-			limited:  l.Downstream(res.Body),
+			Reader:   l.Downstream(res.Body),
 			original: res.Body,
 		}
 	}

--- a/internal/limiter/static_limiter_test.go
+++ b/internal/limiter/static_limiter_test.go
@@ -1,0 +1,108 @@
+package limiter
+
+import (
+	"bytes"
+	"crypto/rand"
+	"fmt"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/restic/restic/internal/test"
+)
+
+func TestLimiterWrapping(t *testing.T) {
+	reader := bytes.NewReader([]byte{})
+	writer := new(bytes.Buffer)
+
+	for _, limits := range []struct {
+		upstream   int
+		downstream int
+	}{
+		{0, 0},
+		{42, 0},
+		{0, 42},
+		{42, 42},
+	} {
+		limiter := NewStaticLimiter(limits.upstream*1024, limits.downstream*1024)
+
+		mustWrapUpstream := limits.upstream > 0
+		test.Equals(t, limiter.Upstream(reader) != reader, mustWrapUpstream)
+		test.Equals(t, limiter.UpstreamWriter(writer) != writer, mustWrapUpstream)
+
+		mustWrapDownstream := limits.downstream > 0
+		test.Equals(t, limiter.Downstream(reader) != reader, mustWrapDownstream)
+		test.Equals(t, limiter.DownstreamWriter(writer) != writer, mustWrapDownstream)
+	}
+}
+
+type tracedReadCloser struct {
+	io.Reader
+	Closed bool
+}
+
+func newTracedReadCloser(rd io.Reader) *tracedReadCloser {
+	return &tracedReadCloser{Reader: rd}
+}
+
+func (r *tracedReadCloser) Close() error {
+	r.Closed = true
+	return nil
+}
+
+func TestRoundTripperReader(t *testing.T) {
+	limiter := NewStaticLimiter(42*1024, 42*1024)
+	data := make([]byte, 1234)
+	_, err := io.ReadFull(rand.Reader, data)
+	test.OK(t, err)
+
+	var send *tracedReadCloser = newTracedReadCloser(bytes.NewReader(data))
+	var recv *tracedReadCloser
+
+	rt := limiter.Transport(roundTripper(func(req *http.Request) (*http.Response, error) {
+		buf := new(bytes.Buffer)
+		_, err := io.Copy(buf, req.Body)
+		if err != nil {
+			return nil, err
+		}
+		err = req.Body.Close()
+		if err != nil {
+			return nil, err
+		}
+
+		recv = newTracedReadCloser(bytes.NewReader(buf.Bytes()))
+		return &http.Response{Body: recv}, nil
+	}))
+
+	res, err := rt.RoundTrip(&http.Request{Body: send})
+	test.OK(t, err)
+
+	out := new(bytes.Buffer)
+	n, err := io.Copy(out, res.Body)
+	test.OK(t, err)
+	test.Equals(t, int64(len(data)), n)
+	test.OK(t, res.Body.Close())
+
+	test.Assert(t, send.Closed, "request body not closed")
+	test.Assert(t, recv.Closed, "result body not closed")
+	test.Assert(t, bytes.Equal(data, out.Bytes()), "data ping-pong failed")
+}
+
+func TestRoundTripperCornerCases(t *testing.T) {
+	limiter := NewStaticLimiter(42*1024, 42*1024)
+
+	rt := limiter.Transport(roundTripper(func(req *http.Request) (*http.Response, error) {
+		return &http.Response{}, nil
+	}))
+
+	res, err := rt.RoundTrip(&http.Request{})
+	test.OK(t, err)
+	test.Assert(t, res != nil, "round tripper returned no response")
+
+	rt = limiter.Transport(roundTripper(func(req *http.Request) (*http.Response, error) {
+		return nil, fmt.Errorf("error")
+	}))
+
+	_, err = rt.RoundTrip(&http.Request{})
+	test.Assert(t, err != nil, "round tripper lost an error")
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Running the `check` command using SFTP took longer (12 minutes) than e.g. using rclone via ssh as backend (8 minutes) with the backup repository located on a server in the local network. This shows that the SFTP communication pattern bottlenecks the performance. This PR makes sure that the latency optimized `WriteTo` method of the SFTP reader is used which reduces the run time of my check example to 8 minutes.

The main difference between the REST interface used for rclone and the reader provided by the SFTP library is that the former requests the relevant file part in a single request, whereas the latter issues requests for small parts to read on demand. The on-demand part becomes a bottleneck when the latency to the SFTP server exceeds a few hundred microseconds (**micro** and not milli!). The SFTP reader provides a `WriteTo` method which allows it to request and stream larger parts of a file at once, which fixes the latency problem. `io.Copy` which is used when downloading a pack file to the cache or downloading it to check the pack hash, tries to use `WriteTo` by default (then `ReadFrom`) and then falls back to reading and writing a 32kB buffer. However, neither the `hashing.Reader` (only used for the `check` command and the repack step of the `prune` command) and the `limiter.limitedReadCloser` (is always used even without bandwidth limits) supported `WriteTo` such that `io.Copy` had to fallback to read and write small file chunks. As the read method has to request 32kB data and wait for the reply it is very sensitive to communication latency to the SFTP server.

This PR adds support for `WriteTo` to the `hashing.Reader` and the `Load` method of the `limiter.LimitBackend`. This allows `io.Copy` to use the optimized `WriteTo` code path if supported by the underlying reader. The `WriteTo` method is only added if the underlying reader support it, thus providing an automatic fallback to the normal `io.Copy` behavior if possible.

The upload path is adapted to always use `ReadFrom` provided by the SFTP library for best performance. This is a one-line change as the `io.Copy` call inside the SFTP backend has access to the writer returned by the library.

The core part of this PR is only about 80 lines long, the remainder are tests. A significant part of the tests were necessary as `./internal/limiter` previously had no test coverage at all.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR.
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
