### PR TITLE
Fix missing rand seed for restic check --read-data-subset=x%

### DIFF
--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -333,7 +334,9 @@ func selectRandomPacksByPercentage(allPacks map[restic.ID]int64, percentage floa
 	if packsToCheck < 1 {
 		packsToCheck = 1
 	}
-	idx := rand.Perm(packCount)
+	timeNs := time.Now().UnixNano()
+	r := rand.New(rand.NewSource(timeNs))
+	idx := r.Perm(packCount)
 
 	var keys []restic.ID
 	for k := range allPacks {


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
`rand.Perm()` in `restic/cmd/restic/cmd_check.go:332` always returns the same permutation. Thus this PR seeds rand with the current time in nanoseconds. 

The code worked before because since Go 1 the map iteration is in random order. I would still keep the permutation because the language specification only says "not specified", instead of specifically random.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No, since I only noticed it while trying to figure out which kind of random selection to expect when using the new --read-data-subset=x%. Since this is quite a simple "fix" I thought I'd just create this PR and see what you think.

rand.Perm() needs to be seeded https://github.com/golang/go/issues/20971
Golang Specs: https://golang.org/ref/spec#For_statements (Point 3 under "For statements with range clause")
Go 1 Release Notes: https://golang.org/doc/go1#iteration

I don't know a lot of Go, I found most of this through Google.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
