### PR TITLE
Prevent Windows going to sleep while restic operations in progress

### DIFF
--- a/changelog/unreleased/pull-3218
+++ b/changelog/unreleased/pull-3218
@@ -1,0 +1,7 @@
+Enhancement: Prevent Windows entering sleep/hibernation-mode
+
+Previously, restic didn't prevent Windows from going to sleep 
+during some lengthy operations. This is fixed now.
+
+https://github.com/restic/restic/pull/3218
+https://github.com/restic/restic/issues/3216

--- a/cmd/restic/main_windows.go
+++ b/cmd/restic/main_windows.go
@@ -1,0 +1,88 @@
+// +build windows
+
+package main
+
+import (
+	"fmt"
+	"syscall"
+	"unsafe"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sys/windows"
+)
+
+func init() {
+	f := cmdRoot.PersistentPreRunE
+	cmdRoot.PersistentPreRunE = func(c *cobra.Command, args []string) error {
+		if h, err := PowerCreateRequest(fmt.Sprintf("Restic %s in progress.", c.Name())); err == nil {
+			_ = PowerSetRequest(h, PowerRequestSystemRequired)
+			_ = PowerSetRequest(h, PowerRequestExecutionRequired)
+		}
+
+		return f(c, args)
+	}
+}
+
+type PowerRequestType int
+
+//nolint:deadcode
+const (
+	PowerRequestDisplayRequired PowerRequestType = iota
+	PowerRequestSystemRequired
+	PowerRequestAwayModeRequired
+	PowerRequestExecutionRequired
+)
+
+func PowerCreateRequest(reason string) (handle windows.Handle, err error) {
+	if err := procPowerCreateRequest.Find(); err != nil {
+		return windows.InvalidHandle, err
+	}
+	var reasonPtr *uint16
+	if reasonPtr, err = windows.UTF16PtrFromString(reason); err != nil {
+		return windows.InvalidHandle, err
+	}
+	ctx := powerReasonContext{
+		Version:            0, // POWER_REQUEST_CONTEXT_VERSION
+		Flags:              1, // POWER_REQUEST_CONTEXT_SIMPLE_STRING
+		SimpleReasonString: reasonPtr,
+	}
+	r0, _, e1 := syscall.Syscall(procPowerCreateRequest.Addr(), 1, uintptr(unsafe.Pointer(&ctx)), 0, 0)
+	handle = windows.Handle(r0)
+	if handle == windows.InvalidHandle {
+		if e1 != 0 {
+			err = e1
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+
+	return
+}
+
+func PowerSetRequest(request windows.Handle, requestType PowerRequestType) (err error) {
+	r1, _, e1 := syscall.Syscall(procPowerSetRequest.Addr(), 2, uintptr(request), uintptr(requestType), 0)
+	if r1 == 0 {
+		if e1 != 0 {
+			err = e1
+		} else {
+			err = syscall.EINVAL
+		}
+	}
+
+	return
+}
+
+type powerReasonContext struct {
+	Version            uint32
+	Flags              uint32
+	SimpleReasonString *uint16
+	_                  uint32
+	_                  uint32
+	_                  **uint16
+}
+
+var (
+	kernel32Dll            = windows.NewLazySystemDLL("kernel32.dll")
+	procPowerCreateRequest = kernel32Dll.NewProc("PowerCreateRequest")
+	procPowerSetRequest    = kernel32Dll.NewProc("PowerSetRequest")
+)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

From #3216:
>To save power my PC goes into sleep state after an hour of inactivity. However opertions like restic prune could last a lot longer.
>Currently powercfg /requests does not show any request when restic is running.
>I'd like that restic informs Windows not to go into sleepstates when restic is performing operations.

Some popular console apps like [Wget](https://github.com/mirror/wget/blob/9f3df123bbe1cbf5873cea25169da4568122f026/src/mswindows.c#L433) and [Rar](https://github.com/pmachapman/unrar/blob/d559fa4c2d19d442a8109ad435611c735efa2cfe/system.cpp#L96) already do this.

In this PR I prefer to use [`Power*Request`](https://docs.microsoft.com/en-us/windows/win32/api/winbase/nf-winbase-powercreaterequest) API instead of XP-era `SetThreadExecutionState`: new API has a clear scope (owned kernel object instead of a global flag) and allows describing the reason of sleep blocking.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Issue #3216

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
~~- [ ] I have added tests for all changes in this PR~~
~~- [ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review