### PR TITLE
progress: report only when done if stdout is not terminal

### DIFF
--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -17,7 +17,7 @@ func newProgressMax(show bool, max uint64, description string) *progress.Counter
 
 	interval := time.Second / 60
 	if !stdoutIsTerminal() {
-		interval = time.Second
+		interval = progress.OnlyWhenDone
 	} else {
 		fps, err := strconv.ParseInt(os.Getenv("RESTIC_PROGRESS_FPS"), 10, 64)
 		if err == nil && fps >= 1 {


### PR DESCRIPTION
This prevents logs from being filled with spam once per second, fixing a
regression from previous versions that only showed the status once at
the very end.

Fixes #3221