### PR TITLE
Extend help output with short overview

### DIFF
--- a/changelog/unreleased/pull-3225
+++ b/changelog/unreleased/pull-3225
@@ -1,6 +1,0 @@
-Enhancement: Extend cli help output
-
-Added a short overview of the most important commands to the commandline
-help output to help new users get started.
-
-https://github.com/restic/restic/pull/3225

--- a/changelog/unreleased/pull-3225
+++ b/changelog/unreleased/pull-3225
@@ -1,0 +1,6 @@
+Enhancement: Extend cli help output
+
+Added a short overview of the most important commands to the commandline
+help output to help new users get started.
+
+https://github.com/restic/restic/pull/3225

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -18,40 +18,16 @@ import (
 	"github.com/restic/restic/internal/errors"
 )
 
-// LongDescription is shown in the cli help output
-const LongDescription = `
+// cmdRoot is the base command when no other command has been specified.
+var cmdRoot = &cobra.Command{
+	Use:   "restic",
+	Short: "Backup and restore files",
+	Long: `
 restic is a backup program which allows saving multiple revisions of files and
 directories in an encrypted repository stored on different backends.
 
-To get started with a local test repository, first define some environment variables:
-    export RESTIC_REPOSITORY=/tmp/restic-example
-    export RESTIC_PASSWORD=some-strong-password
-
-Initialize the repository (first time only):
-    restic init
-
-Create your first backup:
-    restic backup /etc/hosts 
-
-You can list all the snapshots you created with:
-    restic snapshots
-
-You can restore a backup by noting the snapshot ID you want and running:
-    restic restore --target /tmp/some-target-dir your-snapshot-ID
-
-It is a good idea to periodically check your repository's metadata:
-    restic check
-    # or full data:
-    restic check --read-data
-
-The full documentation can be found at https://restic.readthedocs.io/
-`
-
-// cmdRoot is the base command when no other command has been specified.
-var cmdRoot = &cobra.Command{
-	Use:               "restic",
-	Short:             "Backup and restore files",
-	Long:              LongDescription,
+The full documentation can be found at https://restic.readthedocs.io/ .
+`,
 	SilenceErrors:     true,
 	SilenceUsage:      true,
 	DisableAutoGenTag: true,

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -18,14 +18,40 @@ import (
 	"github.com/restic/restic/internal/errors"
 )
 
-// cmdRoot is the base command when no other command has been specified.
-var cmdRoot = &cobra.Command{
-	Use:   "restic",
-	Short: "Backup and restore files",
-	Long: `
+// LongDescription is shown in the cli help output
+const LongDescription = `
 restic is a backup program which allows saving multiple revisions of files and
 directories in an encrypted repository stored on different backends.
-`,
+
+To get started with a local test repository, first define some environment variables:
+    export RESTIC_REPOSITORY=/tmp/restic-example
+    export RESTIC_PASSWORD=some-strong-password
+
+Initialize the repository (first time only):
+    restic init
+
+Create your first backup:
+    restic backup /etc/hosts 
+
+You can list all the snapshots you created with:
+    restic snapshots
+
+You can restore a backup by noting the snapshot ID you want and running:
+    restic restore --target /tmp/some-target-dir your-snapshot-ID
+
+It is a good idea to periodically check your repository's metadata:
+    restic check
+    # or full data:
+    restic check --read-data
+
+The full documentation can be found at https://restic.readthedocs.io/
+`
+
+// cmdRoot is the base command when no other command has been specified.
+var cmdRoot = &cobra.Command{
+	Use:               "restic",
+	Short:             "Backup and restore files",
+	Long:              LongDescription,
 	SilenceErrors:     true,
 	SilenceUsage:      true,
 	DisableAutoGenTag: true,

--- a/doc/010_introduction.rst
+++ b/doc/010_introduction.rst
@@ -17,3 +17,47 @@ Introduction
 Restic is a fast and secure backup program. In the following sections, we will
 present typical workflows, starting with installing, preparing a new
 repository, and making the first backup.
+
+Quickstart Guide
+****************
+
+To get started with a local repository, first define some environment variables:
+
+.. code-block:: console
+
+    export RESTIC_REPOSITORY=/srv/restic-repo
+    export RESTIC_PASSWORD=some-strong-password
+
+Initialize the repository (first time only):
+
+.. code-block:: console
+
+    restic init
+
+Create your first backup:
+
+.. code-block:: console
+
+    restic backup ~/work
+
+You can list all the snapshots you created with:
+
+.. code-block:: console
+
+    restic snapshots
+
+You can restore a backup by noting the snapshot ID you want and running:
+
+.. code-block:: console
+
+    restic restore --target /tmp/restore-work your-snapshot-ID
+
+It is a good idea to periodically check your repository's metadata:
+
+.. code-block:: console
+
+    restic check
+    # or full data:
+    restic check --read-data
+
+For more details continue reading the next sections.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The list of subcommands can be confusing for first time users. This adds a short overview of the most important commands to help new users get started.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
