### PR TITLE
backup: Add --resume option

### DIFF
--- a/changelog/unreleased/pull-2880
+++ b/changelog/unreleased/pull-2880
@@ -1,0 +1,10 @@
+Enhancement: Improve recover command
+
+Restic recover used to generate a snapshot that contains all root trees
+even those which are already referenced by a snapshot.
+It now only processes trees not referenced at all.
+Also now `recover` has new options that allow to generate one snapshot
+per unreferenced tree and specify which tags should be added to the
+newly generated snapshot(s).
+
+https://github.com/restic/restic/pull/2880

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -510,7 +510,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	}
 
 	type ArchiveProgressReporter interface {
-		CompleteItem(item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration)
+		CompleteItem(item string, previous []*restic.Node, current *restic.Node, s archiver.ItemStats, d time.Duration)
 		StartFile(filename string)
 		CompleteBlob(filename string, bytes uint64)
 		ScannerError(item string, fi os.FileInfo, err error) error
@@ -681,11 +681,11 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	}
 
 	snapshotOpts := archiver.SnapshotOptions{
-		Excludes:       opts.Excludes,
-		Tags:           opts.Tags.Flatten(),
-		Time:           timeStamp,
-		Hostname:       opts.Host,
-		ParentSnapshot: *parentSnapshotID,
+		Excludes:        opts.Excludes,
+		Tags:            opts.Tags.Flatten(),
+		Time:            timeStamp,
+		Hostname:        opts.Host,
+		ParentSnapshots: restic.IDs{*parentSnapshotID},
 	}
 
 	if !gopts.JSON {

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -144,7 +144,8 @@ func runCopy(opts CopyOptions, gopts GlobalOptions, args []string) error {
 		debug.Log("flushed packs and saved index")
 
 		// save snapshot
-		sn.Parent = nil // Parent does not have relevance in the new repo.
+		sn.Parent = nil  // Parent does not have relevance in the new repo.
+		sn.Parents = nil // Parents does not have relevance in the new repo.
 		// Use Original as a persistent snapshot ID
 		if sn.Original == nil {
 			sn.Original = sn.ID()

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"time"
 
@@ -11,11 +12,11 @@ import (
 
 var cmdRecover = &cobra.Command{
 	Use:   "recover [flags]",
-	Short: "Recover data from the repository",
+	Short: "Recover data from the repository not referenced by snapshots",
 	Long: `
 The "recover" command builds a new snapshot from all directories it can find in
-the raw data of the repository. It can be used if, for example, a snapshot has
-been removed by accident with "forget".
+the raw data of the repository which are not referenced in an existing snapshot.
+It can be used if, for example, a snapshot has been removed by accident with "forget".
 
 EXIT STATUS
 ===========
@@ -24,15 +25,28 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 `,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		return runRecover(globalOptions)
+		return runRecover(globalOptions, recoverOptions)
 	},
 }
 
-func init() {
-	cmdRoot.AddCommand(cmdRecover)
+type RecoverOptions struct {
+	Split  bool
+	DryRun bool
+	Tags   restic.TagLists
 }
 
-func runRecover(gopts GlobalOptions) error {
+var recoverOptions RecoverOptions
+
+func init() {
+	cmdRoot.AddCommand(cmdRecover)
+	recoverFlags := cmdRecover.Flags()
+	recoverFlags.BoolVar(&recoverOptions.Split, "split", false, "generate one snapshot per unreferenced directory")
+	recoverFlags.BoolVarP(&recoverOptions.DryRun, "dry-run", "n", false, "only show what would be done")
+	recoverOptions.Tags = restic.TagLists{[]string{"recovered"}}
+	recoverFlags.Var(&recoverOptions.Tags, "tag", "`tags` which will be added to the new snapshot(s) in the format `tag[,tag,...]` (can be given multiple times)")
+}
+
+func runRecover(gopts GlobalOptions, opts RecoverOptions) error {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return err
@@ -59,24 +73,14 @@ func runRecover(gopts GlobalOptions) error {
 	trees := make(map[restic.ID]bool)
 
 	for blob := range repo.Index().Each(gopts.ctx) {
-		if blob.Blob.Type != restic.TreeBlob {
-			continue
+		if blob.Type == restic.TreeBlob {
+			trees[blob.Blob.ID] = false
 		}
-		trees[blob.Blob.ID] = false
 	}
 
-	cur := 0
-	max := len(trees)
-	Verbosef("load %d trees\n\n", len(trees))
-
+	Verbosef("load %d trees\n", len(trees))
+	bar := newProgressMax(!gopts.Quiet, uint64(len(trees)), "trees loaded")
 	for id := range trees {
-		cur++
-		Verbosef("\rtree (%v/%v)", cur, max)
-
-		if !trees[id] {
-			trees[id] = false
-		}
-
 		tree, err := repo.LoadTree(gopts.ctx, id)
 		if err != nil {
 			Warnf("unable to load tree %v: %v\n", id.Str(), err)
@@ -84,65 +88,96 @@ func runRecover(gopts GlobalOptions) error {
 		}
 
 		for _, node := range tree.Nodes {
-			if node.Type != "dir" || node.Subtree == nil {
-				continue
+			if node.Type == "dir" && node.Subtree != nil {
+				trees[*node.Subtree] = true
 			}
-
-			subtree := *node.Subtree
-			trees[subtree] = true
 		}
+		bar.Add(1)
 	}
-	Verbosef("\ndone\n")
+	bar.Done()
+
+	Verbosef("load snapshots\n")
+	err = restic.ForAllSnapshots(gopts.ctx, repo, nil, func(id restic.ID, sn *restic.Snapshot, err error) error {
+		trees[*sn.Tree] = true
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+	Verbosef("done\n")
 
 	roots := restic.NewIDSet()
 	for id, seen := range trees {
-		if seen {
-			continue
+		if !seen {
+			Verboseff("found root tree %v\n", id.Str())
+			roots.Insert(id)
 		}
+	}
+	Printf("\nfound %d unreferenced roots\n", len(roots))
 
-		roots.Insert(id)
+	switch {
+	case len(roots) == 0:
+		Verbosef("no snapshot to write.\n")
+		return nil
+	case opts.DryRun:
+		Verbosef("dry run: not writing anything.\n")
+		return nil
 	}
 
-	Verbosef("found %d roots\n", len(roots))
+	if !opts.Split {
+		tree := restic.NewTree()
+		for id := range roots {
+			var subtreeID = id
+			node := restic.Node{
+				Type:       "dir",
+				Name:       id.Str(),
+				Mode:       0755,
+				Subtree:    &subtreeID,
+				AccessTime: time.Now(),
+				ModTime:    time.Now(),
+				ChangeTime: time.Now(),
+			}
+			err := tree.Insert(&node)
+			if err != nil {
+				return err
+			}
+		}
 
-	tree := restic.NewTree()
+		treeID, err := repo.SaveTree(gopts.ctx, tree)
+		if err != nil {
+			return errors.Fatalf("unable to save new tree to the repo: %v", err)
+		}
+
+		err = repo.Flush(gopts.ctx)
+		if err != nil {
+			return errors.Fatalf("unable to save blobs to the repo: %v", err)
+		}
+
+		return createSnapshot(gopts.ctx, "/recover", hostname, opts.Tags.Flatten(), repo, &treeID)
+	}
+
 	for id := range roots {
-		var subtreeID = id
-		node := restic.Node{
-			Type:       "dir",
-			Name:       id.Str(),
-			Mode:       0755,
-			Subtree:    &subtreeID,
-			AccessTime: time.Now(),
-			ModTime:    time.Now(),
-			ChangeTime: time.Now(),
+		err := createSnapshot(gopts.ctx, "/"+id.Str(), hostname, opts.Tags.Flatten(), repo, &id)
+		if err != nil {
+			return err
 		}
-		tree.Insert(&node)
 	}
+	return nil
+}
 
-	treeID, err := repo.SaveTree(gopts.ctx, tree)
-	if err != nil {
-		return errors.Fatalf("unable to save new tree to the repo: %v", err)
-	}
-
-	err = repo.Flush(gopts.ctx)
-	if err != nil {
-		return errors.Fatalf("unable to save blobs to the repo: %v", err)
-	}
-
-	sn, err := restic.NewSnapshot([]string{"/recover"}, []string{}, hostname, time.Now())
+func createSnapshot(ctx context.Context, name, hostname string, tags []string, repo restic.Repository, tree *restic.ID) error {
+	sn, err := restic.NewSnapshot([]string{name}, tags, hostname, time.Now())
 	if err != nil {
 		return errors.Fatalf("unable to save snapshot: %v", err)
 	}
 
-	sn.Tree = &treeID
+	sn.Tree = tree
 
-	id, err := repo.SaveJSONUnpacked(gopts.ctx, restic.SnapshotFile, sn)
+	id, err := repo.SaveJSONUnpacked(ctx, restic.SnapshotFile, sn)
 	if err != nil {
 		return errors.Fatalf("unable to save snapshot: %v", err)
 	}
 
 	Printf("saved new snapshot %v\n", id.Str())
-
 	return nil
 }

--- a/cmd/restic/integration_fuse_test.go
+++ b/cmd/restic/integration_fuse_test.go
@@ -181,7 +181,7 @@ func TestMount(t *testing.T) {
 	checkSnapshots(t, env.gopts, repo, env.mountpoint, env.repo, snapshotIDs, 3)
 
 	// third backup, explicit incremental
-	bopts := BackupOptions{Parent: snapshotIDs[0].String()}
+	bopts := BackupOptions{Parents: []string{snapshotIDs[0].String()}}
 	testRunBackup(t, "", []string{env.testdata}, bopts, env.gopts)
 	snapshotIDs = testRunList(t, "snapshots", env.gopts)
 	rtest.Assert(t, len(snapshotIDs) == 3,

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -321,7 +321,7 @@ func testBackup(t *testing.T, useFsSnapshot bool) {
 
 	testRunCheck(t, env.gopts)
 	// third backup, explicit incremental
-	opts.Parent = snapshotIDs[0].String()
+	opts.Parents = []string{snapshotIDs[0].String()}
 	testRunBackup(t, filepath.Dir(env.testdata), []string{"testdata"}, opts, env.gopts)
 	snapshotIDs = testRunList(t, "snapshots", env.gopts)
 	rtest.Assert(t, len(snapshotIDs) == 3,

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -67,7 +67,7 @@ type Archiver struct {
 	//
 	// CompleteItem may be called asynchronously from several different
 	// goroutines!
-	CompleteItem func(item string, previous, current *restic.Node, s ItemStats, d time.Duration)
+	CompleteItem func(item string, previous []*restic.Node, current *restic.Node, s ItemStats, d time.Duration)
 
 	// StartFile is called when a file is being processed by a worker.
 	StartFile func(filename string)
@@ -131,7 +131,7 @@ func New(repo restic.Repository, fs fs.FS, opts Options) *Archiver {
 		FS:           fs,
 		Options:      opts.ApplyDefaults(),
 
-		CompleteItem: func(string, *restic.Node, *restic.Node, ItemStats, time.Duration) {},
+		CompleteItem: func(string, []*restic.Node, *restic.Node, ItemStats, time.Duration) {},
 		StartFile:    func(string) {},
 		CompleteBlob: func(string, uint64) {},
 		IgnoreInode:  false,
@@ -222,7 +222,7 @@ func (arch *Archiver) wrapLoadTreeError(id restic.ID, err error) error {
 
 // SaveDir stores a directory in the repo and returns the node. snPath is the
 // path within the current snapshot.
-func (arch *Archiver) SaveDir(ctx context.Context, snPath string, fi os.FileInfo, dir string, previous *restic.Tree, complete CompleteFunc) (d FutureTree, err error) {
+func (arch *Archiver) SaveDir(ctx context.Context, snPath string, fi os.FileInfo, dir string, previous []*restic.Tree, complete CompleteFunc) (d FutureTree, err error) {
 	debug.Log("%v %v", snPath, dir)
 
 	treeNode, err := arch.nodeFromFileInfo(dir, fi)
@@ -246,9 +246,15 @@ func (arch *Archiver) SaveDir(ctx context.Context, snPath string, fi os.FileInfo
 		}
 
 		pathname := arch.FS.Join(dir, name)
-		oldNode := previous.Find(name)
+		var oldNodes []*restic.Node
+		for _, p := range previous {
+			oldNode := p.Find(name)
+			if oldNode != nil {
+				oldNodes = append(oldNodes, oldNode)
+			}
+		}
 		snItem := join(snPath, name)
-		fn, excluded, err := arch.Save(ctx, snItem, pathname, oldNode)
+		fn, excluded, err := arch.Save(ctx, snItem, pathname, oldNodes)
 
 		// return error early if possible
 		if err != nil {
@@ -335,7 +341,7 @@ func (arch *Archiver) allBlobsPresent(previous *restic.Node) bool {
 // Errors and completion needs to be handled by the caller.
 //
 // snPath is the path within the current snapshot.
-func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous *restic.Node) (fn FutureNode, excluded bool, err error) {
+func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous []*restic.Node) (fn FutureNode, excluded bool, err error) {
 	start := time.Now()
 
 	fn = FutureNode{
@@ -379,18 +385,21 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 
 		// check if the file has not changed before performing a fopen operation (more expensive, specially
 		// in network filesystems)
-		if previous != nil && !fileChanged(fi, previous, arch.IgnoreInode) {
-			if arch.allBlobsPresent(previous) {
+		for _, p := range previous {
+			if fileChanged(fi, p, arch.IgnoreInode) {
+				continue
+			}
+			if arch.allBlobsPresent(p) {
 				debug.Log("%v hasn't changed, using old list of blobs", target)
-				arch.CompleteItem(snPath, previous, previous, ItemStats{}, time.Since(start))
-				arch.CompleteBlob(snPath, previous.Size)
+				arch.CompleteItem(snPath, previous, p, ItemStats{}, time.Since(start))
+				arch.CompleteBlob(snPath, p.Size)
 				fn.node, err = arch.nodeFromFileInfo(target, fi)
 				if err != nil {
 					return FutureNode{}, false, err
 				}
 
 				// copy list of blobs
-				fn.node.Content = previous.Content
+				fn.node.Content = p.Content
 
 				return fn, false, nil
 			}
@@ -398,7 +407,7 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 			debug.Log("%v hasn't changed, but contents are missing!", target)
 			// There are contents missing - inform user!
 			err := errors.Errorf("parts of %v not found in the repository index; storing the file again", target)
-			arch.error(abstarget, fi, err)
+			_ = arch.error(abstarget, fi, err)
 		}
 
 		// reopen file and do an fstat() on the open file to check it is still
@@ -448,13 +457,26 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 
 		snItem := snPath + "/"
 		start := time.Now()
-		oldSubtree, err := arch.loadSubtree(ctx, previous)
-		if err != nil {
-			arch.error(abstarget, fi, err)
+		// sort previous by subtree to prevent loading duplicate subtrees
+		sort.Slice(previous, func(i, j int) bool {
+			return previous[i].Subtree.Less(*previous[j].Subtree)
+		})
+		var oldSubtrees []*restic.Tree
+		var last restic.ID
+		for _, p := range previous {
+			if p.Subtree.Equal(last) {
+				continue
+			}
+			oldSubtree, err := arch.loadSubtree(ctx, p)
+			if err != nil {
+				_ = arch.error(abstarget, fi, err)
+			}
+			oldSubtrees = append(oldSubtrees, oldSubtree)
+			last = *p.Subtree
 		}
 
 		fn.isTree = true
-		fn.tree, err = arch.SaveDir(ctx, snPath, fi, target, oldSubtree,
+		fn.tree, err = arch.SaveDir(ctx, snPath, fi, target, oldSubtrees,
 			func(node *restic.Node, stats ItemStats) {
 				arch.CompleteItem(snItem, previous, node, stats, time.Since(start))
 			})
@@ -545,7 +567,7 @@ func (arch *Archiver) statDir(dir string) (os.FileInfo, error) {
 
 // SaveTree stores a Tree in the repo, returned is the tree. snPath is the path
 // within the current snapshot.
-func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, previous *restic.Tree) (*restic.Tree, error) {
+func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, previous []*restic.Tree) (*restic.Tree, error) {
 	debug.Log("%v (%v nodes), parent %v", snPath, len(atree.Nodes), previous)
 
 	tree := restic.NewTree()
@@ -567,9 +589,17 @@ func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, 
 			return nil, ctx.Err()
 		}
 
+		var oldNodes []*restic.Node
+		for _, p := range previous {
+			oldNode := p.Find(name)
+			if oldNode != nil {
+				oldNodes = append(oldNodes, oldNode)
+			}
+		}
+
 		// this is a leaf node
 		if subatree.Path != "" {
-			fn, excluded, err := arch.Save(ctx, join(snPath, name), subatree.Path, previous.Find(name))
+			fn, excluded, err := arch.Save(ctx, join(snPath, name), subatree.Path, oldNodes)
 
 			if err != nil {
 				err = arch.error(subatree.Path, fn.fi, err)
@@ -592,15 +622,18 @@ func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, 
 
 		snItem := join(snPath, name) + "/"
 		start := time.Now()
-
-		oldNode := previous.Find(name)
-		oldSubtree, err := arch.loadSubtree(ctx, oldNode)
-		if err != nil {
-			arch.error(join(snPath, name), nil, err)
+		var oldSubtrees []*restic.Tree
+		for _, oldNode := range oldNodes {
+			oldSubtree, err := arch.loadSubtree(ctx, oldNode)
+			if err != nil {
+				_ = arch.error(join(snPath, name), nil, err)
+				continue
+			}
+			oldSubtrees = append(oldSubtrees, oldSubtree)
 		}
 
 		// not a leaf node, archive subtree
-		subtree, err := arch.SaveTree(ctx, join(snPath, name), &subatree, oldSubtree)
+		subtree, err := arch.SaveTree(ctx, join(snPath, name), &subatree, oldSubtrees)
 		if err != nil {
 			return nil, err
 		}
@@ -636,7 +669,7 @@ func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, 
 			return nil, err
 		}
 
-		arch.CompleteItem(snItem, oldNode, node, nodeStats, time.Since(start))
+		arch.CompleteItem(snItem, oldNodes, node, nodeStats, time.Since(start))
 	}
 
 	debug.Log("waiting on %d nodes", len(futureNodes))
@@ -726,39 +759,42 @@ func resolveRelativeTargets(filesys fs.FS, targets []string) ([]string, error) {
 
 // SnapshotOptions collect attributes for a new snapshot.
 type SnapshotOptions struct {
-	Tags           restic.TagList
-	Hostname       string
-	Excludes       []string
-	Time           time.Time
-	ParentSnapshot restic.ID
+	Tags            restic.TagList
+	Hostname        string
+	Excludes        []string
+	Time            time.Time
+	ParentSnapshots restic.IDs
 }
 
-// loadParentTree loads a tree referenced by snapshot id. If id is null, nil is returned.
-func (arch *Archiver) loadParentTree(ctx context.Context, snapshotID restic.ID) *restic.Tree {
-	if snapshotID.IsNull() {
-		return nil
-	}
+// loadParentTrees loads the trees referenced by the given snapshot ids.
+func (arch *Archiver) loadParentTrees(ctx context.Context, snapshotIDs restic.IDs) (trees []*restic.Tree) {
+	for _, snapshotID := range snapshotIDs {
+		if snapshotID.IsNull() {
+			continue
+		}
 
-	debug.Log("load parent snapshot %v", snapshotID)
-	sn, err := restic.LoadSnapshot(ctx, arch.Repo, snapshotID)
-	if err != nil {
-		debug.Log("unable to load snapshot %v: %v", snapshotID, err)
-		return nil
-	}
+		debug.Log("load parent snapshot %v", snapshotID)
+		sn, err := restic.LoadSnapshot(ctx, arch.Repo, snapshotID)
+		if err != nil {
+			debug.Log("unable to load snapshot %v: %v", snapshotID, err)
+			continue
+		}
 
-	if sn.Tree == nil {
-		debug.Log("snapshot %v has empty tree %v", snapshotID)
-		return nil
-	}
+		if sn.Tree == nil {
+			debug.Log("snapshot %v has empty tree %v", snapshotID)
+			continue
+		}
 
-	debug.Log("load parent tree %v", *sn.Tree)
-	tree, err := arch.Repo.LoadTree(ctx, *sn.Tree)
-	if err != nil {
-		debug.Log("unable to load tree %v: %v", *sn.Tree, err)
-		arch.error("/", nil, arch.wrapLoadTreeError(*sn.Tree, err))
-		return nil
+		debug.Log("load parent tree %v", *sn.Tree)
+		tree, err := arch.Repo.LoadTree(ctx, *sn.Tree)
+		if err != nil {
+			debug.Log("unable to load tree %v: %v", *sn.Tree, err)
+			_ = arch.error("/", nil, arch.wrapLoadTreeError(*sn.Tree, err))
+			continue
+		}
+		trees = append(trees, tree)
 	}
-	return tree
+	return trees
 }
 
 // runWorkers starts the worker pools, which are stopped when the context is cancelled.
@@ -797,7 +833,7 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 		arch.runWorkers(wctx, &t)
 
 		debug.Log("starting snapshot")
-		tree, err := arch.SaveTree(wctx, "/", atree, arch.loadParentTree(wctx, opts.ParentSnapshot))
+		tree, err := arch.SaveTree(wctx, "/", atree, arch.loadParentTrees(wctx, opts.ParentSnapshots))
 		if err != nil {
 			return err
 		}
@@ -833,9 +869,10 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 	}
 
 	sn.Excludes = opts.Excludes
-	if !opts.ParentSnapshot.IsNull() {
-		id := opts.ParentSnapshot
-		sn.Parent = &id
+	if len(opts.ParentSnapshots) == 1 {
+		sn.Parent = &opts.ParentSnapshots[0]
+	} else {
+		sn.Parents = opts.ParentSnapshots
 	}
 	sn.Tree = &rootTreeID
 

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -498,14 +498,19 @@ func fileChanged(fi os.FileInfo, node *restic.Node, ignoreInode bool) bool {
 		return true
 	}
 
+	// check size
+	if uint64(fi.Size()) != node.Size {
+		return true
+	}
+
 	// check status change timestamp
 	extFI := fs.ExtendedStat(fi)
 	if !ignoreInode && !extFI.ChangeTime.Equal(node.ChangeTime) {
 		return true
 	}
 
-	// check size
-	if uint64(fi.Size()) != node.Size || uint64(extFI.Size) != node.Size {
+	// check size using extFI
+	if uint64(extFI.Size) != node.Size {
 		return true
 	}
 

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -53,6 +53,9 @@ type Archiver struct {
 	FS           fs.FS
 	Options      Options
 
+	// Allow to give extra previous trees that are checked for each dir
+	ExtraPreviousTrees []*restic.Tree
+
 	blobSaver *BlobSaver
 	fileSaver *FileSaver
 	treeSaver *TreeSaver
@@ -591,6 +594,13 @@ func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, 
 
 		var oldNodes []*restic.Node
 		for _, p := range previous {
+			oldNode := p.Find(name)
+			if oldNode != nil {
+				oldNodes = append(oldNodes, oldNode)
+			}
+		}
+
+		for _, p := range arch.ExtraPreviousTrees {
 			oldNode := p.Find(name)
 			if oldNode != nil {
 				oldNodes = append(oldNodes, oldNode)

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1058,7 +1058,7 @@ func TestArchiverSaveTree(t *testing.T) {
 
 			var stat ItemStats
 			lock := &sync.Mutex{}
-			arch.CompleteItem = func(item string, previous, current *restic.Node, s ItemStats, d time.Duration) {
+			arch.CompleteItem = func(item string, previous []*restic.Node, current *restic.Node, s ItemStats, d time.Duration) {
 				lock.Lock()
 				defer lock.Unlock()
 				stat.Add(s)
@@ -1648,8 +1648,8 @@ func TestArchiverParent(t *testing.T) {
 			})
 
 			opts := SnapshotOptions{
-				Time:           time.Now(),
-				ParentSnapshot: firstSnapshotID,
+				Time:            time.Now(),
+				ParentSnapshots: restic.IDs{firstSnapshotID},
 			}
 			_, secondSnapshotID, err := arch.Snapshot(ctx, []string{"."}, opts)
 			if err != nil {
@@ -2030,8 +2030,8 @@ func snapshot(t testing.TB, repo restic.Repository, fs fs.FS, parent restic.ID, 
 	arch := New(repo, fs, Options{})
 
 	sopts := SnapshotOptions{
-		Time:           time.Now(),
-		ParentSnapshot: parent,
+		Time:            time.Now(),
+		ParentSnapshots: restic.IDs{parent},
 	}
 	snapshot, snapshotID, err := arch.Snapshot(ctx, []string{filename}, sopts)
 	if err != nil {

--- a/internal/archiver/testing.go
+++ b/internal/archiver/testing.go
@@ -17,7 +17,7 @@ import (
 )
 
 // TestSnapshot creates a new snapshot of path.
-func TestSnapshot(t testing.TB, repo restic.Repository, path string, parent *restic.ID) *restic.Snapshot {
+func TestSnapshot(t testing.TB, repo restic.Repository, path string, parent restic.IDs) *restic.Snapshot {
 	arch := New(repo, fs.Local{}, Options{})
 	opts := SnapshotOptions{
 		Time:     time.Now(),
@@ -25,7 +25,7 @@ func TestSnapshot(t testing.TB, repo restic.Repository, path string, parent *res
 		Tags:     []string{"test"},
 	}
 	if parent != nil {
-		opts.ParentSnapshot = *parent
+		opts.ParentSnapshots = parent
 	}
 	sn, _, err := arch.Snapshot(context.TODO(), []string{path}, opts)
 	if err != nil {

--- a/internal/restic/id.go
+++ b/internal/restic/id.go
@@ -83,6 +83,27 @@ func (id ID) Equal(other ID) bool {
 	return id == other
 }
 
+// Less compares an ID to another other.
+func (id ID) Less(other ID) bool {
+	if len(id) < len(other) {
+		return true
+	}
+
+	for k, b := range id {
+		if b == other[k] {
+			continue
+		}
+
+		if b < other[k] {
+			return true
+		}
+
+		return false
+	}
+
+	return false
+}
+
 // EqualString compares this ID to another one, given as a string.
 func (id ID) EqualString(other string) (bool, error) {
 	s, err := hex.DecodeString(other)

--- a/internal/restic/ids.go
+++ b/internal/restic/ids.go
@@ -13,23 +13,7 @@ func (ids IDs) Len() int {
 }
 
 func (ids IDs) Less(i, j int) bool {
-	if len(ids[i]) < len(ids[j]) {
-		return true
-	}
-
-	for k, b := range ids[i] {
-		if b == ids[j][k] {
-			continue
-		}
-
-		if b < ids[j][k] {
-			return true
-		}
-
-		return false
-	}
-
-	return false
+	return ids[i].Less(ids[j])
 }
 
 func (ids IDs) Swap(i, j int) {

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -17,6 +17,7 @@ import (
 type Snapshot struct {
 	Time     time.Time `json:"time"`
 	Parent   *ID       `json:"parent,omitempty"`
+	Parents  IDs       `json:"parents,omitempty"`
 	Tree     *ID       `json:"tree"`
 	Paths    []string  `json:"paths"`
 	Hostname string    `json:"hostname,omitempty"`

--- a/internal/ui/json/backup.go
+++ b/internal/ui/json/backup.go
@@ -228,7 +228,7 @@ func (b *Backup) CompleteBlob(filename string, bytes uint64) {
 
 // CompleteItem is the status callback function for the archiver when a
 // file/dir has been saved successfully.
-func (b *Backup) CompleteItem(item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration) {
+func (b *Backup) CompleteItem(item string, previous []*restic.Node, current *restic.Node, s archiver.ItemStats, d time.Duration) {
 	b.summary.Lock()
 	b.summary.ItemStats.Add(s)
 	b.summary.Unlock()
@@ -261,6 +261,14 @@ func (b *Backup) CompleteItem(item string, previous, current *restic.Node, s arc
 		}
 	}
 
+	inPrevious := false
+	for _, p := range previous {
+		if p.Equals(*current) {
+			inPrevious = true
+			break
+		}
+	}
+
 	if current.Type == "dir" {
 		if previous == nil {
 			if b.v >= 3 {
@@ -279,7 +287,7 @@ func (b *Backup) CompleteItem(item string, previous, current *restic.Node, s arc
 			return
 		}
 
-		if previous.Equals(*current) {
+		if inPrevious {
 			if b.v >= 3 {
 				b.print(verboseUpdate{
 					MessageType: "verbose_status",
@@ -328,7 +336,7 @@ func (b *Backup) CompleteItem(item string, previous, current *restic.Node, s arc
 			return
 		}
 
-		if previous.Equals(*current) {
+		if inPrevious {
 			if b.v >= 3 {
 				b.print(verboseUpdate{
 					MessageType: "verbose_status",


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds an option `--resume` to the backup command.

When specified, this option does:
- search for unreferences trees, like `recover`. These trees may exist due to an aborted backup
- use these tree as additional "parent trees" for each dir to backup, i.e. do a brute-force check whether these unreferenced trees may contain a suitable parent tree for the dirs to backup

=> This should effectively speed up "resumed backups", i.e. repetitions of backups that aborted and therefore could not write snapshots. It should especially work well if already big parts were processed during that aborted backup run.

There is however the trade-off that searching for unreferenced trees needs to read all trees and all snapshots in the repo.

Note that this PR relies on #2880 and on the first commits of #3121 and is therefore marked as draft. 
Moreover, I strongly recommend to merge #3228 to not have too many unreferenced trees.

The code should work already but I did not do any performance tests yet.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
closes #2280 
alternative to #2960 

https://forum.restic.net/t/quicker-interrupted-backup-resumption/3470/6

Checklist
---------
- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
