### PR TITLE
backup: Add resuming from aborted backups

### DIFF
--- a/changelog/unreleased/issue-2280
+++ b/changelog/unreleased/issue-2280
@@ -1,0 +1,10 @@
+Enhancement: Add resuming from aborted backups
+
+Restic always used re-read all files if a backup was aborted and 
+restarted after.
+This is now changed such that files in already saved directories will
+only be re-read if they are changed between the backup runs.
+
+https://github.com/restic/restic/issues/2280
+https://github.com/restic/restic/pull/3230
+https://forum.restic.net/t/quicker-interrupted-backup-resumption/3470

--- a/changelog/unreleased/issue-3118
+++ b/changelog/unreleased/issue-3118
@@ -1,0 +1,11 @@
+Enhancement: Allow multiple parent snapshots in the backup command
+
+Restic used to take the latest snapshot with identical paths as
+parent snapshots. This is now enhanced and multiple parent snapshots
+can be specified. Restic also by default uses more than one snapshot
+as parent, when this is appropriate, e.g. if subdirs of a newly backed-up
+dir already exist in previous snapshots.
+
+https://github.com/restic/restic/issues/3118
+https://github.com/restic/restic/pull/3121
+https://forum.restic.net/t/backup-parent-behavior/3286

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -69,7 +69,7 @@ Exit status is 3 if some source data could not be read (incomplete snapshot crea
 
 // BackupOptions bundles all options for the backup command.
 type BackupOptions struct {
-	Parent                  string
+	Parents                 []string
 	Force                   bool
 	Excludes                []string
 	InsensitiveExcludes     []string
@@ -103,7 +103,7 @@ func init() {
 	cmdRoot.AddCommand(cmdBackup)
 
 	f := cmdBackup.Flags()
-	f.StringVar(&backupOptions.Parent, "parent", "", "use this parent `snapshot` (default: last snapshot in the repo that has the same target files/directories)")
+	f.StringArrayVar(&backupOptions.Parents, "parent", nil, "use this parent `snapshot` (can be specified multiple times, default: last snapshots in the repo that include the same target)")
 	f.BoolVarP(&backupOptions.Force, "force", "f", false, `force re-reading the target files/directories (overrides the "parent" flag)`)
 	f.StringArrayVarP(&backupOptions.Excludes, "exclude", "e", nil, "exclude a `pattern` (can be specified multiple times)")
 	f.StringArrayVar(&backupOptions.InsensitiveExcludes, "iexclude", nil, "same as --exclude `pattern` but ignores the casing of filenames")
@@ -472,28 +472,32 @@ func collectTargets(opts BackupOptions, args []string) (targets []string, err er
 
 // parent returns the ID of the parent snapshot. If there is none, nil is
 // returned.
-func findParentSnapshot(ctx context.Context, repo restic.Repository, opts BackupOptions, targets []string) (parentID *restic.ID, err error) {
-	// Force using a parent
-	if !opts.Force && opts.Parent != "" {
-		id, err := restic.FindSnapshot(ctx, repo, opts.Parent)
-		if err != nil {
-			return nil, errors.Fatalf("invalid id %q: %v", opts.Parent, err)
-		}
+func findParentSnapshots(ctx context.Context, repo restic.Repository, opts BackupOptions, targets []string) (parentIDs restic.IDs, err error) {
 
-		parentID = &id
+	if opts.Force {
+		return parentIDs, nil
 	}
 
-	// Find last snapshot to set it as parent, if not already set
-	if !opts.Force && parentID == nil {
+	// Process given parents
+	for _, p := range opts.Parents {
+		id, err := restic.FindSnapshot(ctx, repo, p)
+		if err != nil {
+			return nil, errors.Fatalf("invalid id %q: %v", p, err)
+		}
+		parentIDs = append(parentIDs, id)
+	}
+
+	// Find last snapshot to set it as parent, if no parents are given
+	if parentIDs == nil {
 		id, err := restic.FindLatestSnapshot(ctx, repo, targets, []restic.TagList{}, []string{opts.Host})
 		if err == nil {
-			parentID = &id
+			parentIDs = append(parentIDs, id)
 		} else if err != restic.ErrNoSnapshotFound {
 			return nil, err
 		}
 	}
 
-	return parentID, nil
+	return parentIDs, nil
 }
 
 func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Terminal, args []string) error {
@@ -579,14 +583,14 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		return err
 	}
 
-	parentSnapshotID, err := findParentSnapshot(gopts.ctx, repo, opts, targets)
+	parentSnapshotIDs, err := findParentSnapshots(gopts.ctx, repo, opts, targets)
 	if err != nil {
 		return err
 	}
 
 	if !gopts.JSON {
-		if parentSnapshotID != nil {
-			progressPrinter.P("using parent snapshot %v\n", parentSnapshotID.Str())
+		if len(parentSnapshotIDs) > 0 {
+			progressPrinter.P("using parent snapshots %v\n", parentSnapshotIDs)
 		} else {
 			progressPrinter.P("no parent snapshot found, will read all files\n")
 		}
@@ -677,16 +681,12 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		arch.ChangeIgnoreFlags |= archiver.ChangeIgnoreCtime
 	}
 
-	if parentSnapshotID == nil {
-		parentSnapshotID = &restic.ID{}
-	}
-
 	snapshotOpts := archiver.SnapshotOptions{
 		Excludes:        opts.Excludes,
 		Tags:            opts.Tags.Flatten(),
 		Time:            timeStamp,
 		Hostname:        opts.Host,
-		ParentSnapshots: restic.IDs{*parentSnapshotID},
+		ParentSnapshots: parentSnapshotIDs,
 	}
 
 	if !gopts.JSON {

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -682,11 +682,11 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	}
 
 	snapshotOpts := archiver.SnapshotOptions{
-		Excludes:       opts.Excludes,
-		Tags:           opts.Tags.Flatten(),
-		Time:           timeStamp,
-		Hostname:       opts.Host,
-		ParentSnapshot: *parentSnapshotID,
+		Excludes:        opts.Excludes,
+		Tags:            opts.Tags.Flatten(),
+		Time:            timeStamp,
+		Hostname:        opts.Host,
+		ParentSnapshots: restic.IDs{*parentSnapshotID},
 	}
 
 	if !gopts.JSON {

--- a/cmd/restic/cmd_backup_resume.go
+++ b/cmd/restic/cmd_backup_resume.go
@@ -1,0 +1,161 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
+)
+
+type finishedDir struct {
+	ID   restic.ID `json:"id"`
+	Path string    `json:"path"`
+}
+
+type resume struct {
+	*os.File
+}
+
+// removeOldResumeFiles removes all resume files in resumedir
+// that are older than maxAge
+func removeOldResumeFiles(resumedir string, maxAge time.Duration) {
+	f, err := fs.Open(resumedir)
+	if err != nil {
+		if !os.IsNotExist(errors.Cause(err)) {
+			Warnf("could not read resume dir %v: %v\n", resumedir, err)
+		}
+		return
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	entries, err := f.Readdir(-1)
+	if err != nil {
+		Warnf("could not read resume dir %v: %v\n", resumedir, err)
+		return
+	}
+
+	for _, entry := range entries {
+		if entry.ModTime().Before(time.Now().Add(-maxAge)) {
+			filename := filepath.Join(resumedir, entry.Name())
+			Verboseff("removing old resume file %s\n", filename)
+			err := os.Remove(filename)
+			if err != nil {
+				Warnf("could not remove old resume file %v: %v\n", filename, err)
+			}
+		}
+	}
+}
+
+const maxResumeAge = 30 * 24 * time.Hour
+
+// getResume tries to load resume data for the given targets string.
+// Moreover, it opens a new resume file to write resume data into.
+// This function does not return an error as all error cases only
+// lead to warnings that are printed out.
+func getResume(targets []string, repo *repository.Repository, force bool) (*resume, map[string]restic.ID) {
+	cache := repo.Cache
+	if force || cache == nil {
+		// only use resume functionality if no forced backup and if there is a cache
+		return nil, nil
+	}
+	resumedir := filepath.Join(cache.BaseDir(), repo.Config().ID, "resume")
+	_ = fs.MkdirAll(resumedir, 0700)
+	removeOldResumeFiles(resumedir, maxResumeAge)
+
+	targetString := fmt.Sprintf("%v", targets)
+	id := restic.Hash([]byte(targetString))
+	filename := filepath.Join(resumedir, id.String())
+
+	dirs := readResume(filename, repo)
+
+	f, err := os.Create(filename)
+	if err != nil {
+		Warnf("could not create resume file %v: %v\n", filename, err)
+		return nil, dirs
+	}
+
+	return &resume{f}, dirs
+}
+
+// getResume tries to load resume data from the given filename
+func readResume(filename string, repo restic.Repository) map[string]restic.ID {
+	dirs := make(map[string]restic.ID)
+	f, err := fs.Open(filename)
+	if err != nil {
+		if !os.IsNotExist(errors.Cause(err)) {
+			Warnf("could not open resume file %v: %v\n", filename, err)
+		}
+		return nil
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+
+	found := false
+	dec := json.NewDecoder(f)
+	for {
+		var fd finishedDir
+		if err := dec.Decode(&fd); err != nil {
+			break
+		}
+		debug.Log("found entry '%v' in resume file", fd)
+
+		found = true
+
+		// only use trees that are in the index
+		if !repo.Index().Has(restic.BlobHandle{ID: fd.ID, Type: restic.TreeBlob}) {
+			debug.Log("ignoring id '%v' from resume file - not in index", fd.ID)
+			continue
+		}
+
+		// remove paths if superpaths is also contained
+		for path := range dirs {
+			if strings.HasPrefix(path, fd.Path) {
+				debug.Log("resume file: '%v' is superseded by '%v'", path, fd.Path)
+				delete(dirs, path)
+			}
+		}
+
+		dirs[fd.Path] = fd.ID
+	}
+
+	if found && len(dirs) == 0 {
+		Verboseff("found resume data but index doesn't contain it\n")
+	}
+
+	return dirs
+}
+
+// writeFinishedDir writes the information about a finished tree to the resume file
+func (r *resume) writeFinishedDir(item string, current *restic.Node) {
+	if r == nil {
+		return
+	}
+
+	if current != nil && current.Type == "dir" {
+		f := finishedDir{ID: *current.Subtree, Path: item}
+		_ = json.NewEncoder(r).Encode(f)
+	}
+}
+
+// Done removes the resume file.
+// Should be called after the snapshot has been written to the repo.
+func (r *resume) Done() {
+	if r == nil {
+		return
+	}
+
+	filename := r.Name()
+	_ = r.Close()
+	_ = os.Remove(filename)
+}

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -143,7 +143,8 @@ func runCopy(opts CopyOptions, gopts GlobalOptions, args []string) error {
 		debug.Log("flushed packs and saved index")
 
 		// save snapshot
-		sn.Parent = nil // Parent does not have relevance in the new repo.
+		sn.Parent = nil  // Parent does not have relevance in the new repo.
+		sn.Parents = nil // Parents does not have relevance in the new repo.
 		// Use Original as a persistent snapshot ID
 		if sn.Original == nil {
 			sn.Original = sn.ID()

--- a/cmd/restic/integration_fuse_test.go
+++ b/cmd/restic/integration_fuse_test.go
@@ -181,7 +181,7 @@ func TestMount(t *testing.T) {
 	checkSnapshots(t, env.gopts, repo, env.mountpoint, env.repo, snapshotIDs, 3)
 
 	// third backup, explicit incremental
-	bopts := BackupOptions{Parent: snapshotIDs[0].String()}
+	bopts := BackupOptions{Parents: []string{snapshotIDs[0].String()}}
 	testRunBackup(t, "", []string{env.testdata}, bopts, env.gopts)
 	snapshotIDs = testRunList(t, "snapshots", env.gopts)
 	rtest.Assert(t, len(snapshotIDs) == 3,

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -322,7 +322,7 @@ func testBackup(t *testing.T, useFsSnapshot bool) {
 
 	testRunCheck(t, env.gopts)
 	// third backup, explicit incremental
-	opts.Parent = snapshotIDs[0].String()
+	opts.Parents = []string{snapshotIDs[0].String()}
 	testRunBackup(t, filepath.Dir(env.testdata), []string{"testdata"}, opts, env.gopts)
 	snapshotIDs = testRunList(t, "snapshots", env.gopts)
 	rtest.Assert(t, len(snapshotIDs) == 3,

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -135,6 +135,43 @@ Now is a good time to run ``restic check`` to verify that all data
 is properly stored in the repository. You should run this command regularly
 to make sure the internal structure of the repository is free of errors.
 
+Using previous backups
+**********************
+
+If you have already backed up some directories in existing snapshots,
+restic tries to find those so-called "parent snapshots" to speed up the
+backup.
+
+For example, if you have already have the following snapshots:
+
+
+.. code-block:: console
+
+    ID        Time                 Host    Tags        Paths
+    -----------------------------------------------------------------
+    5f3db49e  2020-07-16 19:12:29  host                /home/foo/bar1
+    1d97c1a6  2020-07-16 20:09:40  host                /home/foo/bar2
+    -----------------------------------------------------------------
+
+and now you back up ``/home/foo``, restic will choose both snapshots as
+parent snapshots. Parent snapshots can also be manually set by the 
+``--parent`` option.
+
+When you backup with parent snapshots, restic only reads those files that
+are new or have been modified since those snapshots.
+This is decided based on the following attributes of the file in the file
+system:
+
+ * Type (file, symlink, or directory?)
+ * Modification time
+ * Size
+ * Inode number (internal number used to reference a file in a file system)
+
+Please be aware that when you backup different directories (or the
+directories to be saved have a variable name component like a
+time/date), restic always needs to read all files and only afterwards
+can compute which parts of the files need to be saved.
+
 File change detection
 *********************
 

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1093,7 +1093,7 @@ func TestArchiverSaveTree(t *testing.T) {
 
 			var stat ItemStats
 			lock := &sync.Mutex{}
-			arch.CompleteItem = func(item string, previous, current *restic.Node, s ItemStats, d time.Duration) {
+			arch.CompleteItem = func(item string, previous []*restic.Node, current *restic.Node, s ItemStats, d time.Duration) {
 				lock.Lock()
 				defer lock.Unlock()
 				stat.Add(s)
@@ -1683,8 +1683,8 @@ func TestArchiverParent(t *testing.T) {
 			})
 
 			opts := SnapshotOptions{
-				Time:           time.Now(),
-				ParentSnapshot: firstSnapshotID,
+				Time:            time.Now(),
+				ParentSnapshots: restic.IDs{firstSnapshotID},
 			}
 			_, secondSnapshotID, err := arch.Snapshot(ctx, []string{"."}, opts)
 			if err != nil {
@@ -2064,8 +2064,8 @@ func snapshot(t testing.TB, repo restic.Repository, fs fs.FS, parent restic.ID, 
 	arch := New(repo, fs, Options{})
 
 	sopts := SnapshotOptions{
-		Time:           time.Now(),
-		ParentSnapshot: parent,
+		Time:            time.Now(),
+		ParentSnapshots: restic.IDs{parent},
 	}
 	snapshot, snapshotID, err := arch.Snapshot(ctx, []string{filename}, sopts)
 	if err != nil {

--- a/internal/archiver/testing.go
+++ b/internal/archiver/testing.go
@@ -17,7 +17,7 @@ import (
 )
 
 // TestSnapshot creates a new snapshot of path.
-func TestSnapshot(t testing.TB, repo restic.Repository, path string, parent *restic.ID) *restic.Snapshot {
+func TestSnapshot(t testing.TB, repo restic.Repository, path string, parent restic.IDs) *restic.Snapshot {
 	arch := New(repo, fs.Local{}, Options{})
 	opts := SnapshotOptions{
 		Time:     time.Now(),
@@ -25,7 +25,7 @@ func TestSnapshot(t testing.TB, repo restic.Repository, path string, parent *res
 		Tags:     []string{"test"},
 	}
 	if parent != nil {
-		opts.ParentSnapshot = *parent
+		opts.ParentSnapshots = parent
 	}
 	sn, _, err := arch.Snapshot(context.TODO(), []string{path}, opts)
 	if err != nil {

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -94,7 +94,7 @@ func (idx *Index) Final() bool {
 
 const (
 	indexMaxBlobs = 50000
-	indexMaxAge   = 10 * time.Minute
+	indexMaxAge   = 5 * time.Minute
 )
 
 // IndexFull returns true iff the index is "full enough" to be saved as a preliminary index.

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -288,7 +288,7 @@ func (r *Repository) SaveAndEncrypt(ctx context.Context, t restic.BlobType, data
 	}
 
 	// if the pack is not full enough, put back to the list
-	if packer.Size() < minPackSize {
+	if !packer.IsFull(minPackSize) {
 		debug.Log("pack is not full enough (%d bytes)", packer.Size())
 		pm.insertPacker(packer)
 		return nil

--- a/internal/restic/id.go
+++ b/internal/restic/id.go
@@ -83,6 +83,27 @@ func (id ID) Equal(other ID) bool {
 	return id == other
 }
 
+// Less compares an ID to another other.
+func (id ID) Less(other ID) bool {
+	if len(id) < len(other) {
+		return true
+	}
+
+	for k, b := range id {
+		if b == other[k] {
+			continue
+		}
+
+		if b < other[k] {
+			return true
+		}
+
+		return false
+	}
+
+	return false
+}
+
 // EqualString compares this ID to another one, given as a string.
 func (id ID) EqualString(other string) (bool, error) {
 	s, err := hex.DecodeString(other)

--- a/internal/restic/ids.go
+++ b/internal/restic/ids.go
@@ -13,23 +13,7 @@ func (ids IDs) Len() int {
 }
 
 func (ids IDs) Less(i, j int) bool {
-	if len(ids[i]) < len(ids[j]) {
-		return true
-	}
-
-	for k, b := range ids[i] {
-		if b == ids[j][k] {
-			continue
-		}
-
-		if b < ids[j][k] {
-			return true
-		}
-
-		return false
-	}
-
-	return false
+	return ids[i].Less(ids[j])
 }
 
 func (ids IDs) Swap(i, j int) {

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -17,6 +17,7 @@ import (
 type Snapshot struct {
 	Time     time.Time `json:"time"`
 	Parent   *ID       `json:"parent,omitempty"`
+	Parents  IDs       `json:"parents,omitempty"`
 	Tree     *ID       `json:"tree"`
 	Paths    []string  `json:"paths"`
 	Hostname string    `json:"hostname,omitempty"`

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -13,18 +13,27 @@ import (
 // ErrNoSnapshotFound is returned when no snapshot for the given criteria could be found.
 var ErrNoSnapshotFound = errors.New("no snapshot found")
 
-// FindLatestSnapshot finds latest snapshot with optional target/directory, tags and hostname filters.
-func FindLatestSnapshot(ctx context.Context, repo Repository, targets []string, tagLists []TagList, hostnames []string) (ID, error) {
+// abs turns paths to cleaned absolute paths
+func abs(targets []string) ([]string, error) {
 	var err error
 	absTargets := make([]string, 0, len(targets))
 	for _, target := range targets {
 		if !filepath.IsAbs(target) {
 			target, err = filepath.Abs(target)
 			if err != nil {
-				return ID{}, errors.Wrap(err, "Abs")
+				return nil, errors.Wrap(err, "absTargets")
 			}
 		}
 		absTargets = append(absTargets, filepath.Clean(target))
+	}
+	return absTargets, nil
+}
+
+// FindLatestSnapshot finds latest snapshot with optional target/directory, tags and hostname filters.
+func FindLatestSnapshot(ctx context.Context, repo Repository, targets []string, tagLists []TagList, hostnames []string) (ID, error) {
+	absTargets, err := abs(targets)
+	if err != nil {
+		return ID{}, err
 	}
 
 	var (
@@ -69,6 +78,60 @@ func FindLatestSnapshot(ctx context.Context, repo Repository, targets []string, 
 	}
 
 	return latestID, nil
+}
+
+// FindParentSnapshots returns the snapshots that should be picked as parents.
+func FindParentSnapshots(ctx context.Context, repo Repository, targets []string, hostname string) (IDs, error) {
+	absTargets, err := abs(targets)
+	if err != nil {
+		return nil, err
+	}
+
+	var snapshots []*Snapshot
+
+	err = ForAllSnapshots(ctx, repo, nil, func(snapshotID ID, snapshot *Snapshot, err error) error {
+		if err != nil {
+			return errors.Errorf("Error loading snapshot %v: %v", snapshotID.Str(), err)
+		}
+
+		if !snapshot.HasHostname([]string{hostname}) {
+			return nil
+		}
+
+		if !snapshot.MatchPaths(absTargets) {
+			return nil
+		}
+
+		// ignore this snapshot if already superseded
+		for _, sn := range snapshots {
+			if sn.Supersedes(snapshot, absTargets) {
+				fmt.Printf("%v is superseded by %v\n", snapshot.ID(), sn.ID())
+				return nil
+			}
+		}
+
+		// add snapshot after removing snapshots that are superseded by this one
+		snapshotsNew := snapshots[:0]
+		for _, sn := range snapshots {
+			if !snapshot.Supersedes(sn, absTargets) {
+				snapshotsNew = append(snapshotsNew, sn)
+			} else {
+				fmt.Printf("%v is superseded by %v\n", sn.ID(), snapshot.ID())
+			}
+		}
+		snapshots = append(snapshotsNew, snapshot)
+		return nil
+	})
+
+	if err != nil {
+		return nil, err
+	}
+
+	snapshotIDs := make(IDs, 0, len(snapshots))
+	for _, sn := range snapshots {
+		snapshotIDs = append(snapshotIDs, *sn.ID())
+	}
+	return snapshotIDs, nil
 }
 
 // FindSnapshot takes a string and tries to find a snapshot whose ID matches

--- a/internal/restic/snapshot_test.go
+++ b/internal/restic/snapshot_test.go
@@ -1,6 +1,7 @@
 package restic_test
 
 import (
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -23,4 +24,110 @@ func TestTagList(t *testing.T) {
 
 	r := sn.HasTags(tags)
 	rtest.Assert(t, r, "Failed to match untagged snapshot")
+}
+
+func TestSnapshotMatch(t *testing.T) {
+	s := string(filepath.Separator)
+	pathFooBar1 := []string{"home" + s + "foo" + s + "bar1"}
+	pathFooBar2 := []string{"home" + s + "foo" + s + "bar2"}
+	pathFooBars := []string{"home" + s + "foo" + s + "bar1", "home" + s + "foo" + s + "bar2"}
+	pathFoo := []string{"home" + s + "foo", "home" + s + "xxx"}
+
+	snFooBar1 := &restic.Snapshot{Paths: pathFooBar1}
+	rtest.Equals(t, true, snFooBar1.MatchPaths(pathFooBar1))
+	rtest.Equals(t, false, snFooBar1.MatchPaths(pathFooBar2))
+	rtest.Equals(t, true, snFooBar1.MatchPaths(pathFooBars))
+	rtest.Equals(t, true, snFooBar1.MatchPaths(pathFoo))
+
+	snFoo := &restic.Snapshot{Paths: pathFoo}
+	rtest.Equals(t, true, snFoo.MatchPaths(pathFooBar1))
+	rtest.Equals(t, true, snFoo.MatchPaths(pathFooBar2))
+	rtest.Equals(t, true, snFoo.MatchPaths(pathFooBars))
+	rtest.Equals(t, true, snFoo.MatchPaths(pathFoo))
+
+	snFooBars := &restic.Snapshot{Paths: pathFooBars}
+	rtest.Equals(t, true, snFooBars.MatchPaths(pathFooBar1))
+	rtest.Equals(t, true, snFooBars.MatchPaths(pathFooBar2))
+	rtest.Equals(t, true, snFooBars.MatchPaths(pathFooBars))
+	rtest.Equals(t, true, snFooBars.MatchPaths(pathFoo))
+
+}
+
+func TestSnapshotSupersedes(t *testing.T) {
+	time1 := time.Now()
+	time2 := time1.Add(time.Hour)
+
+	s := string(filepath.Separator)
+	pathFooBar1 := []string{"home" + s + "foo" + s + "bar1"}
+	pathFooBar2 := []string{"home" + s + "foo" + s + "bar2"}
+	pathFoo := []string{"home" + s + "foo"}
+	pathFooBars := []string{"home" + s + "foo" + s + "bar1", "home" + s + "foo" + s + "bar2"}
+
+	// test prior snapshot vs. later snapshot
+	snTime1 := &restic.Snapshot{Paths: pathFooBar1, Time: time1}
+	snTime2 := &restic.Snapshot{Paths: pathFooBar1, Time: time2}
+	rtest.Equals(t, true, snTime2.Supersedes(snTime1, pathFooBar1))
+	rtest.Equals(t, false, snTime1.Supersedes(snTime2, pathFooBar1))
+	// equal times => supersedes
+	rtest.Equals(t, true, snTime1.Supersedes(snTime1, pathFooBar1))
+
+	// Note that for the path tests we here always use identical times.
+	// In real-life scenarios additional to paths matching a snapshot
+	// needs to newer than another snapshot to supersede.
+	snFooBar1 := &restic.Snapshot{Paths: pathFooBar1, Time: time1}
+	snFooBar2 := &restic.Snapshot{Paths: pathFooBar2, Time: time1}
+	snFoo := &restic.Snapshot{Paths: pathFoo, Time: time1}
+	snFooBars := &restic.Snapshot{Paths: pathFooBars, Time: time1}
+
+	// only /foo/bar1 supersedes /foo/bar2 w.r.t. /foo/bar1
+	rtest.Equals(t, true, snFooBar1.Supersedes(snFooBar2, pathFooBar1))
+	rtest.Equals(t, false, snFooBar2.Supersedes(snFooBar1, pathFooBar1))
+	// only /foo/bar2 supersedes /foo/bar1 w.r.t. /foo/bar2
+	rtest.Equals(t, false, snFooBar1.Supersedes(snFooBar2, pathFooBar2))
+	rtest.Equals(t, true, snFooBar2.Supersedes(snFooBar1, pathFooBar2))
+	// neither /foo/bar1 nor /foo/bar2 supersede each other w.r.t. /foo
+	rtest.Equals(t, false, snFooBar1.Supersedes(snFooBar2, pathFoo))
+	rtest.Equals(t, false, snFooBar2.Supersedes(snFooBar1, pathFoo))
+	// neither /foo/bar1 nor /foo/bar2 supersede each other w.r.t. [/foo/bar1,/foo/bar2]
+	rtest.Equals(t, false, snFooBar1.Supersedes(snFooBar2, pathFooBars))
+	rtest.Equals(t, false, snFooBar2.Supersedes(snFooBar1, pathFooBars))
+
+	// /foo/bar1 and /foo supersede each other w.r.t. /foo/bar1
+	rtest.Equals(t, true, snFooBar1.Supersedes(snFoo, pathFooBar1))
+	rtest.Equals(t, true, snFoo.Supersedes(snFooBar1, pathFooBar1))
+	// only /foo supersedes /foo/bar1 w.r.t. /foo/bar2
+	rtest.Equals(t, false, snFooBar1.Supersedes(snFoo, pathFooBar2))
+	rtest.Equals(t, true, snFoo.Supersedes(snFooBar1, pathFooBar2))
+	// only /foo supersedes /foo/bar1 w.r.t. /foo
+	rtest.Equals(t, false, snFooBar1.Supersedes(snFoo, pathFoo))
+	rtest.Equals(t, true, snFoo.Supersedes(snFooBar1, pathFoo))
+	// only /foo supersedes /foo/bar1 w.r.t. [/foo/bar1,/foo/bar2]
+	rtest.Equals(t, false, snFooBar1.Supersedes(snFoo, pathFooBars))
+	rtest.Equals(t, true, snFoo.Supersedes(snFooBar1, pathFooBars))
+
+	// [/foo/bar1,/foo/bar2] and /foo supersede each other w.r.t. /foo/bar1
+	rtest.Equals(t, true, snFooBars.Supersedes(snFoo, pathFooBar1))
+	rtest.Equals(t, true, snFoo.Supersedes(snFooBars, pathFooBar1))
+	// [/foo/bar1,/foo/bar2] and /foo supersede each other w.r.t. /foo/bar2
+	rtest.Equals(t, true, snFooBars.Supersedes(snFoo, pathFooBar2))
+	rtest.Equals(t, true, snFoo.Supersedes(snFooBars, pathFooBar2))
+	// only /foo supersedes [/foo/bar1,/foo/bar2] w.r.t. /foo
+	rtest.Equals(t, false, snFooBars.Supersedes(snFoo, pathFoo))
+	rtest.Equals(t, true, snFoo.Supersedes(snFooBars, pathFoo))
+	// [/foo/bar1,/foo/bar2] and /foo supersede each other w.r.t. [/foo/bar1,/foo/bar2]
+	rtest.Equals(t, true, snFooBars.Supersedes(snFoo, pathFooBars))
+	rtest.Equals(t, true, snFoo.Supersedes(snFooBars, pathFooBars))
+
+	// /foo/bar1 and [/foo/bar1,/foo/bar2] supersede each other w.r.t. /foo/bar1
+	rtest.Equals(t, true, snFooBar1.Supersedes(snFooBars, pathFooBar1))
+	rtest.Equals(t, true, snFooBars.Supersedes(snFooBar1, pathFooBar1))
+	// only [/foo/bar1,/foo/bar2] supersedes /foo/bar1 w.r.t. /foo/bar2
+	rtest.Equals(t, false, snFooBar1.Supersedes(snFooBars, pathFooBar2))
+	rtest.Equals(t, true, snFooBars.Supersedes(snFooBar1, pathFooBar2))
+	// neither [/foo/bar1,/foo/bar2] nor /foo/bar1 supersede each other w.r.t. /foo
+	rtest.Equals(t, false, snFooBar1.Supersedes(snFooBars, pathFoo))
+	rtest.Equals(t, false, snFooBars.Supersedes(snFooBar1, pathFoo))
+	// only [/foo/bar1,/foo/bar2] supersedes /foo/bar1 w.r.t. [/foo/bar1,/foo/bar2]
+	rtest.Equals(t, false, snFooBar1.Supersedes(snFooBars, pathFooBars))
+	rtest.Equals(t, true, snFooBars.Supersedes(snFooBar1, pathFooBars))
 }

--- a/internal/ui/backup/json.go
+++ b/internal/ui/backup/json.go
@@ -102,7 +102,7 @@ func (b *JSONProgress) Error(item string, fi os.FileInfo, err error) error {
 
 // CompleteItem is the status callback function for the archiver when a
 // file/dir has been saved successfully.
-func (b *JSONProgress) CompleteItem(messageType, item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration) {
+func (b *JSONProgress) CompleteItem(messageType, item string, previous []*restic.Node, current *restic.Node, s archiver.ItemStats, d time.Duration) {
 	if b.v < 2 {
 		return
 	}

--- a/internal/ui/backup/text.go
+++ b/internal/ui/backup/text.go
@@ -135,7 +135,7 @@ func formatBytes(c uint64) string {
 
 // CompleteItem is the status callback function for the archiver when a
 // file/dir has been saved successfully.
-func (b *TextProgress) CompleteItem(messageType, item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration) {
+func (b *TextProgress) CompleteItem(messageType, item string, previous []*restic.Node, current *restic.Node, s archiver.ItemStats, d time.Duration) {
 	switch messageType {
 	case "dir new":
 		b.VV("new       %v, saved in %.3fs (%v added, %v metadata)", item, d.Seconds(), formatBytes(s.DataSize), formatBytes(s.TreeSize))


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This is a follow-up of #3229.
In this PR I made a PoC using the idea of user odin from the forum, see link below.

With this PR, restic writes a temporary file (in the cache dir to the selected repo, subdir /resume/) which contains the list of already finished directories and the tree ID where it is saved in the repo.
If the backup suceeds, the file is removed.

At the start of a backup, restic tries to read the temporary file (if existing) and uses the contained trees as "additional parent trees" for the given directories. This means that w.r.t. already saved trees, this resumed backup is as fast as a follow-up backup using a parent snapshot.

Note that this PR relies on #3121 which should be merged first.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
closes #2280
alternative to #2960

https://forum.restic.net/t/quicker-interrupted-backup-resumption/3470/6

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- I have not added documentation for the changes (in the manual) - there is also none for parent snapshots
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
