### PR TITLE
Add possibility to specify extra repo for "hot" data

### DIFF
--- a/changelog/unreleased/issue-3202
+++ b/changelog/unreleased/issue-3202
@@ -1,0 +1,13 @@
+Enhancement: Support cold storages
+
+Restic used to access the repository regularly for config, locks and
+metadata preventing it to work in combination with "cold storages".
+We've added an option to specify a "hot repository" which saves a copy
+of metadata, config and locks and is used to read those files.
+This allows many restic commands to work with cold storages. 
+
+https://github.com/restic/restic/issues/3202
+https://github.com/restic/restic/issues/2504
+https://github.com/restic/restic/issues/2611
+https://github.com/restic/restic/issues/2817
+https://github.com/restic/restic/pull/3235

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -1,10 +1,15 @@
 package main
 
 import (
+	"context"
+	"os"
+
 	"github.com/restic/chunker"
+	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/location"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
 
 	"github.com/spf13/cobra"
 )
@@ -30,6 +35,7 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 type InitOptions struct {
 	secondaryRepoOptions
 	CopyChunkerParameters bool
+	HotOnly               bool
 }
 
 var initOptions InitOptions
@@ -40,9 +46,17 @@ func init() {
 	f := cmdInit.Flags()
 	initSecondaryRepoOptions(f, &initOptions.secondaryRepoOptions, "secondary", "to copy chunker parameters from")
 	f.BoolVar(&initOptions.CopyChunkerParameters, "copy-chunker-params", false, "copy chunker parameters from the secondary repository (useful with the copy command)")
+	f.BoolVar(&initOptions.HotOnly, "hot-only", false, "initialize hot repo from existing repo (if --repo-hot is given)")
 }
 
 func runInit(opts InitOptions, gopts GlobalOptions, args []string) error {
+	if opts.HotOnly {
+		if gopts.RepoHot == "" {
+			return errors.Fatal("need to specify --repo-hot")
+		}
+		return runInitHotOnly(gopts)
+	}
+
 	chunkerPolynomial, err := maybeReadChunkerPolynomial(opts, gopts)
 	if err != nil {
 		return err
@@ -56,6 +70,15 @@ func runInit(opts InitOptions, gopts GlobalOptions, args []string) error {
 	be, err := create(repo, gopts.extended)
 	if err != nil {
 		return errors.Fatalf("create repository at %s failed: %v\n", location.StripPassword(gopts.Repo), err)
+	}
+
+	var beHot restic.Backend
+	if gopts.RepoHot != "" {
+		beHot, err = create(gopts.RepoHot, gopts.extended)
+		if err != nil {
+			return errors.Fatalf("create repository at %s failed: %v\n", location.StripPassword(gopts.RepoHot), err)
+		}
+		be = backend.NewHotColdBackend(beHot, be)
 	}
 
 	gopts.password, err = ReadPasswordTwice(gopts,
@@ -73,6 +96,21 @@ func runInit(opts InitOptions, gopts GlobalOptions, args []string) error {
 	}
 
 	Verbosef("created restic repository %v at %s\n", s.Config().ID[:10], location.StripPassword(gopts.Repo))
+	if gopts.RepoHot != "" {
+		sHot := repository.New(beHot)
+		sHot.InitFrom(s)
+		cfgHot := s.Config()
+		cfgHot.IsHot = true
+		err := beHot.Remove(gopts.ctx, restic.Handle{Type: restic.ConfigFile})
+		if err != nil {
+			return errors.Fatalf("modifying config files in hot repository part at %s failed: %v\n", location.StripPassword(gopts.RepoHot), err)
+		}
+		_, err = sHot.SaveJSONUnpacked(gopts.ctx, restic.ConfigFile, cfgHot)
+		if err != nil {
+			return errors.Fatalf("initializing hot repository part at %s failed: %v\n", location.StripPassword(gopts.RepoHot), err)
+		}
+		Verbosef("created restic hot repository part at %s\n", location.StripPassword(gopts.RepoHot))
+	}
 	Verbosef("\n")
 	Verbosef("Please note that knowledge of your password is required to access\n")
 	Verbosef("the repository. Losing your password means that your data is\n")
@@ -101,4 +139,96 @@ func maybeReadChunkerPolynomial(opts InitOptions, gopts GlobalOptions) (*chunker
 		return nil, errors.Fatal("Secondary repository must only be specified when copying the chunker parameters")
 	}
 	return nil, nil
+}
+
+func runInitHotOnly(gopts GlobalOptions) error {
+	ctx := gopts.ctx
+
+	beHot, err := create(gopts.RepoHot, gopts.extended)
+	if err != nil {
+		return errors.Fatalf("create repository at %s failed: %v\n", location.StripPassword(gopts.RepoHot), err)
+	}
+	has, err := beHot.Test(ctx, restic.Handle{Type: restic.ConfigFile})
+	if err != nil {
+		return err
+	}
+	if has {
+		return errors.Fatalf("hot repository at %sis already initialized", location.StripPassword(gopts.RepoHot))
+	}
+
+	gopts.RepoHot = ""
+	repo, err := OpenRepository(gopts)
+	if err != nil {
+		return err
+	}
+	lock, err := lockRepo(gopts.ctx, repo)
+	defer unlockRepo(lock)
+	if err != nil {
+		return err
+	}
+	be := repo.Backend()
+
+	sHot := repository.New(beHot)
+	sHot.InitFrom(repo)
+	cfgHot := repo.Config()
+	cfgHot.IsHot = true
+	_, err = sHot.SaveJSONUnpacked(gopts.ctx, restic.ConfigFile, cfgHot)
+	if err != nil {
+		return errors.Fatalf("initializing hot repository part at %s failed: %v\n", location.StripPassword(gopts.RepoHot), err)
+	}
+	Verbosef("created restic hot repository part at %s\n", location.StripPassword(gopts.RepoHot))
+
+	// copy tree packs
+	Verbosef("load index files\n")
+	err = repo.LoadIndex(gopts.ctx)
+	if err != nil {
+		return err
+	}
+	treepacks := restic.NewIDSet()
+	for pb := range repo.Index().Each(ctx) {
+		if pb.Type == restic.TreeBlob {
+			treepacks.Insert(pb.PackID)
+		}
+	}
+	Verbosef("copy tree pack files\n")
+	for id := range treepacks {
+		h := restic.Handle{Type: restic.PackFile, BT: restic.TreeBlob, Name: id.String()}
+		err = copyBackendFile(ctx, be, beHot, h)
+		if err != nil {
+			return err
+		}
+	}
+
+	// copy index, snapshots and keys
+	for _, t := range []restic.FileType{restic.IndexFile, restic.SnapshotFile, restic.KeyFile} {
+		Verbosef("copy %v files\n", t)
+		err = be.List(ctx, t, func(fi restic.FileInfo) error {
+			h := restic.Handle{Name: fi.Name, Type: t}
+			return copyBackendFile(ctx, be, beHot, h)
+		})
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func copyBackendFile(ctx context.Context, fromBe, toBe restic.Backend, h restic.Handle) error {
+	file, id, _, err := repository.DownloadAndHash(ctx, fromBe, h)
+	if err != nil {
+		return nil
+	}
+	defer os.Remove(file.Name())
+	defer file.Close()
+
+	if h.Name != id.String() {
+		return errors.Errorf("hash does not match id: want %v, got %v", h.Name, id.String())
+	}
+
+	rd, err := restic.NewFileReader(file)
+	if err != nil {
+		return err
+	}
+	return toBe.Save(ctx, h, rd)
 }

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -678,3 +678,38 @@ On MSYS2, you can install ``winpty`` as follows:
     $ pacman -S winpty
     $ winpty restic -r /srv/restic-repo init
 
+Saving hot data in a separate place
+*************************
+
+Some storage backends are not designed for standard read access to files, e.g. 
+some "cold cloud storages". Restic does not work well with such storage backends
+by default as it regularly needs to read config and metadata from the repository.
+
+However, you can specify another "hot repository" which only contains a copy of
+the config and metadata and is used to access those files. This "hot repository"
+should be stored in a regularly accessible storage backend and usually only needs
+a small fraction of the total space used by the full repository.
+If the "hot repository" is located on a fast local disc, an extra cache might
+not be useful, so consider using ``--no-cache`` in this case.
+To use a "hot repository", specify another storage url by giving the ``--repo-hot``
+option to all restic commands:
+
+.. code-block:: console
+
+    $ restc -r service:path/to/repo --repo-hot service:path/to/repo-hot init
+    $ restc -r service:path/to/repo --repo-hot service:path/to/repo-hot backup /data
+    ...
+
+Note that restic needs to read from ``service:path/to/repo`` whenever it needs to access
+the contents of the files that are backup'ed in the repository. This applies to:
+
+- ``restore``
+- ``mount`` if accessing file contents
+- ``dump``
+- ``cat`` for data blobs
+- ``copy`` if this is the source repository
+- ``check`` if ``--read-data`` or ``--read-data-subset`` is specified
+- ``rebuild-index``
+- ``prune`` if packs are repacked (but see the option ``--repack-cacheable-only``) 
+- ``forget --prune``, see above
+

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -63,7 +63,8 @@ like the following:
     {
       "version": 1,
       "id": "5956a3f67a6230d4a92cefb29529f10196c7d92582ec305fd71ff6d331d6271b",
-      "chunker_polynomial": "25b468838dcb75"
+      "chunker_polynomial": "25b468838dcb75",
+      "is_hot": true
     }
 
 After decryption, restic first checks that the version field contains a
@@ -73,6 +74,10 @@ which consists of 32 random bytes, encoded in hexadecimal. This uniquely
 identifies the repository, regardless if it is accessed via SFTP or
 locally. The field ``chunker_polynomial`` contains a parameter that is
 used for splitting large files into smaller chunks (see below).
+The field ``is_hot`` is optionally given for special repositories that 
+contain only hot parts (i.e. metadata) of the backup. Such a repository
+can only be used in combination with a standard repo which can then be 
+saved in some storage where reading is expensive.
 
 Repository Layout
 -----------------

--- a/internal/backend/backend_hotcold.go
+++ b/internal/backend/backend_hotcold.go
@@ -1,0 +1,158 @@
+package backend
+
+import (
+	"context"
+	"fmt"
+	"io"
+
+	"github.com/restic/restic/internal/restic"
+)
+
+// HotColdBackend uses a hot and a cold repository
+type HotColdBackend struct {
+	hot  restic.Backend
+	cold restic.Backend
+}
+
+// statically ensure that HotColdBackend implements restic.Backend.
+var _ restic.Backend = &HotColdBackend{}
+
+func NewHotColdBackend(hot restic.Backend, cold restic.Backend) *HotColdBackend {
+	return &HotColdBackend{
+		hot:  hot,
+		cold: cold,
+	}
+}
+
+// isCold returns whether the handle is cold or not
+func (be *HotColdBackend) isCold(h restic.Handle) bool {
+	return (h.Type == restic.PackFile && h.BT == restic.DataBlob)
+}
+
+// Save stores the data in the cold backend under the given handle.
+// If the handle is hot, it is additonally saved in the hot backend.
+func (be *HotColdBackend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
+	if err := be.cold.Save(ctx, h, rd); err != nil || be.isCold(h) {
+		return err
+	}
+	if err := rd.Rewind(); err != nil {
+		return err
+	}
+	return be.hot.Save(ctx, h, rd)
+}
+
+func (be *HotColdBackend) hasHot(ctx context.Context, h restic.Handle) (bool, error) {
+	if h.Type != restic.PackFile {
+		return true, nil
+	}
+	return be.hot.Test(ctx, h)
+}
+
+// Load tries to loads data from the hot backend and falls back to the cold backend for pack files.
+func (be *HotColdBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, consumer func(rd io.Reader) error) (err error) {
+	hasHot, err := be.hasHot(ctx, h)
+	if err != nil {
+		return err
+	}
+
+	if hasHot {
+		return be.hot.Load(ctx, h, length, offset, consumer)
+	}
+
+	return be.cold.Load(ctx, h, length, offset, consumer)
+}
+
+// Stat returns information about the File identified by h.
+func (be *HotColdBackend) Stat(ctx context.Context, h restic.Handle) (fi restic.FileInfo, err error) {
+	return be.cold.Stat(ctx, h)
+}
+
+// Remove removes a File with type t and name.
+func (be *HotColdBackend) Remove(ctx context.Context, h restic.Handle) (err error) {
+	hasHot, err := be.hasHot(ctx, h)
+	if err != nil {
+		return err
+	}
+
+	if !hasHot {
+		return be.cold.Remove(ctx, h)
+	}
+
+	errhot := be.hot.Remove(ctx, h)
+	errcold := be.cold.Remove(ctx, h)
+	if errhot == nil {
+		return errcold
+	}
+	return errhot
+}
+
+// Test returns a boolean value whether a File with the name and type exists.
+func (be *HotColdBackend) Test(ctx context.Context, h restic.Handle) (exists bool, err error) {
+	return be.cold.Test(ctx, h)
+}
+
+// List runs fn for each file in the backend which has the type t. When an
+// error is returned by the underlying backend, the request is retried. When fn
+// returns an error, the operation is aborted and the error is returned to the
+// caller.
+func (be *HotColdBackend) List(ctx context.Context, t restic.FileType, fn func(restic.FileInfo) error) error {
+	return be.cold.List(ctx, t, fn)
+}
+
+func (be *HotColdBackend) Close() error {
+	errhot := be.hot.Close()
+	errcold := be.cold.Close()
+	if errhot == nil {
+		return errcold
+	}
+	return errhot
+}
+
+func (be *HotColdBackend) Delete(ctx context.Context) error {
+	errhot := be.hot.Delete(ctx)
+	errcold := be.cold.Delete(ctx)
+	if errhot == nil {
+		return errcold
+	}
+	return errhot
+}
+
+func (be *HotColdBackend) IsNotExist(err error) bool {
+	return be.cold.IsNotExist(err)
+}
+
+func (be *HotColdBackend) Location() string {
+	return fmt.Sprintf("hot: %v cold: %v", be.hot.Location(), be.cold.Location())
+}
+
+func CheckSameFiles(ctx context.Context, be1 restic.Backend, be2 restic.Backend, t restic.FileType) (bool, error) {
+	files1 := make(map[string]int64)
+	err := be1.List(ctx, t, func(fi restic.FileInfo) error {
+		files1[fi.Name] = fi.Size
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	files2 := make(map[string]int64)
+	err = be2.List(ctx, t, func(fi restic.FileInfo) error {
+		files2[fi.Name] = fi.Size
+		return nil
+	})
+	if err != nil {
+		return false, err
+	}
+
+	if len(files1) != len(files2) {
+		return false, nil
+	}
+
+	for file, size := range files1 {
+		size2, ok := files2[file]
+		if !ok || size2 != size {
+			return false, nil
+		}
+	}
+	return true, nil
+}

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -68,6 +68,7 @@ func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd restic.Re
 	be.m.Lock()
 	defer be.m.Unlock()
 
+	h.BT = restic.InvalidBlob
 	if h.Type == restic.ConfigFile {
 		h.Name = ""
 	}
@@ -101,6 +102,7 @@ func (be *MemoryBackend) openReader(ctx context.Context, h restic.Handle, length
 	be.m.Lock()
 	defer be.m.Unlock()
 
+	h.BT = restic.InvalidBlob
 	if h.Type == restic.ConfigFile {
 		h.Name = ""
 	}
@@ -137,6 +139,7 @@ func (be *MemoryBackend) Stat(ctx context.Context, h restic.Handle) (restic.File
 		return restic.FileInfo{}, backoff.Permanent(err)
 	}
 
+	h.BT = restic.InvalidBlob
 	if h.Type == restic.ConfigFile {
 		h.Name = ""
 	}
@@ -158,6 +161,7 @@ func (be *MemoryBackend) Remove(ctx context.Context, h restic.Handle) error {
 
 	debug.Log("Remove %v", h)
 
+	h.BT = restic.InvalidBlob
 	if _, ok := be.data[h]; !ok {
 		return errNotFound
 	}

--- a/internal/cache/backend.go
+++ b/internal/cache/backend.go
@@ -21,7 +21,7 @@ type Backend struct {
 	inProgress      map[restic.Handle]chan struct{}
 }
 
-// ensure cachedBackend implements restic.Backend
+// ensure Backend implements restic.Backend
 var _ restic.Backend = &Backend{}
 
 func newBackend(be restic.Backend, c *Cache) *Backend {
@@ -43,14 +43,19 @@ func (b *Backend) Remove(ctx context.Context, h restic.Handle) error {
 	return b.Cache.remove(h)
 }
 
-var autoCacheTypes = map[restic.FileType]struct{}{
-	restic.IndexFile:    {},
-	restic.SnapshotFile: {},
+func autoCacheTypes(h restic.Handle) bool {
+	switch h.Type {
+	case restic.IndexFile, restic.SnapshotFile:
+		return true
+	case restic.PackFile:
+		return h.BT == restic.TreeBlob
+	}
+	return false
 }
 
 // Save stores a new file in the backend and the cache.
 func (b *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
-	if _, ok := autoCacheTypes[h.Type]; !ok {
+	if !autoCacheTypes(h) {
 		return b.Backend.Save(ctx, h, rd)
 	}
 
@@ -82,11 +87,6 @@ func (b *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRea
 	}
 
 	return nil
-}
-
-var autoCacheFiles = map[restic.FileType]bool{
-	restic.IndexFile:    true,
-	restic.SnapshotFile: true,
 }
 
 func (b *Backend) cacheFile(ctx context.Context, h restic.Handle) error {
@@ -174,25 +174,8 @@ func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset 
 		debug.Log("error loading %v from cache: %v", h, err)
 	}
 
-	// partial file requested
-	if offset != 0 || length != 0 {
-		if b.Cache.PerformReadahead(h) {
-			debug.Log("performing readahead for %v", h)
-
-			err := b.cacheFile(ctx, h)
-			if err == nil {
-				return b.loadFromCacheOrDelegate(ctx, h, length, offset, consumer)
-			}
-
-			debug.Log("error caching %v: %v", h, err)
-		}
-
-		debug.Log("Load(%v, %v, %v): partial file requested, delegating to backend", h, length, offset)
-		return b.Backend.Load(ctx, h, length, offset, consumer)
-	}
-
 	// if we don't automatically cache this file type, fall back to the backend
-	if _, ok := autoCacheFiles[h.Type]; !ok {
+	if !autoCacheTypes(h) {
 		debug.Log("Load(%v, %v, %v): delegating to backend", h, length, offset)
 		return b.Backend.Load(ctx, h, length, offset, consumer)
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -17,10 +17,9 @@ import (
 
 // Cache manages a local cache.
 type Cache struct {
-	path             string
-	Base             string
-	Created          bool
-	PerformReadahead func(restic.Handle) bool
+	path    string
+	Base    string
+	Created bool
 }
 
 const dirMode = 0700
@@ -152,10 +151,6 @@ func New(id string, basedir string) (c *Cache, err error) {
 		path:    cachedir,
 		Base:    basedir,
 		Created: created,
-		PerformReadahead: func(restic.Handle) bool {
-			// do not perform readahead by default
-			return false
-		},
 	}
 
 	return c, nil

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -99,6 +99,18 @@ func (mi *MasterIndex) Has(bh restic.BlobHandle) bool {
 	return false
 }
 
+func (mi *MasterIndex) IsMixedPack(packID restic.ID) bool {
+	mi.idxMutex.RLock()
+	defer mi.idxMutex.RUnlock()
+
+	for _, idx := range mi.idx {
+		if idx.MixedPacks().Has(packID) {
+			return true
+		}
+	}
+	return false
+}
+
 // Packs returns all packs that are covered by the index.
 // If packBlacklist is given, those packs are only contained in the
 // resulting IDSet if they are contained in a non-final (newly written) index.

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -100,7 +100,7 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packe
 	}
 
 	id := restic.IDFromHash(p.hw.Sum(nil))
-	h := restic.Handle{Type: restic.PackFile, Name: id.String()}
+	h := restic.Handle{Type: restic.PackFile, Name: id.String(), BT: t}
 
 	rd, err := restic.NewFileReader(p.tmpfile)
 	if err != nil {
@@ -114,20 +114,6 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packe
 	}
 
 	debug.Log("saved as %v", h)
-
-	if t == restic.TreeBlob && r.Cache != nil {
-		debug.Log("saving tree pack file in cache")
-
-		_, err = p.tmpfile.Seek(0, 0)
-		if err != nil {
-			return errors.Wrap(err, "Seek")
-		}
-
-		err := r.Cache.Save(h, p.tmpfile)
-		if err != nil {
-			return err
-		}
-	}
 
 	err = p.tmpfile.Close()
 	if err != nil {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -694,6 +694,15 @@ func (r *Repository) init(ctx context.Context, password string, cfg restic.Confi
 	return err
 }
 
+// InitFrom initializes a repo using key and config from another repo.
+func (r *Repository) InitFrom(r2 *Repository) {
+	r.key = r2.key
+	r.dataPM.key = r2.key
+	r.treePM.key = r2.key
+	r.keyName = r2.keyName
+	r.cfg = r2.cfg
+}
+
 // Key returns the current master key.
 func (r *Repository) Key() *crypto.Key {
 	return r.key

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -174,7 +174,11 @@ func (r *Repository) LoadBlob(ctx context.Context, t restic.BlobType, id restic.
 		}
 
 		// load blob from pack
-		h := restic.Handle{Type: restic.PackFile, Name: blob.PackID.String()}
+		bt := t
+		if r.idx.IsMixedPack(blob.PackID) {
+			bt = restic.InvalidBlob
+		}
+		h := restic.Handle{Type: restic.PackFile, Name: blob.PackID.String(), BT: bt}
 
 		switch {
 		case cap(buf) < int(blob.Length):
@@ -613,36 +617,6 @@ func (r *Repository) PrepareCache(indexIDs restic.IDSet) error {
 	err = r.Cache.Clear(restic.PackFile, packs)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error clearing pack files in cache: %v\n", err)
-	}
-
-	treePacks := restic.NewIDSet()
-	for _, idx := range r.idx.All() {
-		for _, id := range idx.TreePacks() {
-			treePacks.Insert(id)
-		}
-	}
-
-	// use readahead
-	debug.Log("using readahead")
-	cache := r.Cache
-	cache.PerformReadahead = func(h restic.Handle) bool {
-		if h.Type != restic.PackFile {
-			debug.Log("no readahead for %v, is not a pack file", h)
-			return false
-		}
-
-		id, err := restic.ParseID(h.Name)
-		if err != nil {
-			debug.Log("no readahead for %v, invalid ID", h)
-			return false
-		}
-
-		if treePacks.Has(id) {
-			debug.Log("perform readahead for %v", h)
-			return true
-		}
-		debug.Log("no readahead for %v, not tree file", h)
-		return false
 	}
 
 	return nil

--- a/internal/restic/config.go
+++ b/internal/restic/config.go
@@ -16,6 +16,7 @@ type Config struct {
 	Version           uint        `json:"version"`
 	ID                string      `json:"id"`
 	ChunkerPolynomial chunker.Pol `json:"chunker_polynomial"`
+	IsHot             bool        `json:"is_hot,omitempty"`
 }
 
 // RepoVersion is the version that is written to the config when a repository

--- a/internal/restic/file.go
+++ b/internal/restic/file.go
@@ -22,6 +22,7 @@ const (
 // Handle is used to store and access data in a backend.
 type Handle struct {
 	Type FileType
+	BT   BlobType
 	Name string
 }
 

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -245,7 +245,7 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) {
 		}
 	}
 
-	h := restic.Handle{Type: restic.PackFile, Name: pack.id.String()}
+	h := restic.Handle{Type: restic.PackFile, Name: pack.id.String(), BT: restic.DataBlob}
 	err := r.packLoader(ctx, h, int(end-start), start, func(rd io.Reader) error {
 		bufferSize := int(end - start)
 		if bufferSize > maxBufferSize {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds an option `--repo-hot` to specify a "hot repo" that is used for hot data, i.e. for all repository files except data pack files. The repo specified by `--repo` is still fully written and a complete restic repository, but only read if a pack data file is accessed. So, this can be stored in some "cold storage" or storage with very high latency while many restic commands still work. Usually the "hot repo" only takes a small fraction of the space used by the complete repository. See #3202 for the discussion. This PR implements the "cache-aproach".

The "hot repo" is marked by an extra data field in the Config file and some additional tests are added to check that only correct combiniations of "hot repo" and cold (i.e. standard) repo can be used. However, if a "hot repo" is openend by older restic versions, it will not give good errors, but seems like a broken repo.

Open points are:

- [ ] depends on #2856 which is not reviewed yet
- [x] add checks to the  `check` command that same files exist in hot and "complete" repo
- [x] add checks to the  `check --read-data` command that read and check all files from the "complete" repo
- [x] add some test case, especially test that the "complete" repo is not read except for data pack files
- [x] add ability to create a "hot repo" from an existing "complete" repo

Usage is:
```
restic -r <cold-repo> --repo-hot <hot-repo> init
restic -r <cold-repo> --repo-hot <hot-repo> backup /path/to/backup
restic -r <cold-repo> --repo-hot <hot-repo> backup /path/to/backup // follow-up backup
restic -r <cold-repo> --repo-hot <hot-repo> snapshots
restic -r <cold-repo> --repo-hot <hot-repo> check
restic -r <cold-repo> --repo-hot <hot-repo> forget --prune --repack-cacheable-only  <policy>
```
All the above commands do not read anything from `<cold-repo>`, just list the files therein or remove them during prune. In `<hot-repo>`, only the metadata is saved.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

see #3202 and the references therein.
IMO this closes #2504, closes #2611, closes #2817

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
