### PR TITLE
doc: Note only path-style URL support for S3

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -238,11 +238,12 @@ after the bucket name like this:
 For an S3-compatible server that is not Amazon (like Minio, see below),
 or is only available via HTTP, you can specify the URL to the server
 like this: ``s3:http://server:port/bucket_name``.
-
-.. note:: Currently, restic only supports defining the `path-style URLs <https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro>`__.           Virtual-hosted–style URLs, where the bucket name is in the 
-          hostname itself (like ``bucket_name.s3.us-west-2.amazonaws.com``), 
-          is not supported. It should be written in the path-style URL instead, 
-          for example ``s3.us-west-2.amazonaws.com/bucket_name``.
+          
+.. note:: restic expects `path-style URLs <https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro>`__
+          like for example ````s3.us-west-2.amazonaws.com/bucket_name``.
+          Virtual-hosted–style URLs like ``bucket_name.s3.us-west-2.amazonaws.com``,
+          where the bucket name is part of the hostname are not supported. These must
+          be converted to path-style URLs instead, for example ``s3.us-west-2.amazonaws.com/bucket_name``.
 
 .. note:: Certain S3-compatible servers do not properly implement the
           ``ListObjectsV2`` API, most notably Ceph versions before v14.2.5. On these

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -239,6 +239,10 @@ For an S3-compatible server that is not Amazon (like Minio, see below),
 or is only available via HTTP, you can specify the URL to the server
 like this: ``s3:http://server:port/bucket_name``.
 
+.. note:: Currently, restic only supports defining the `path-style URLs <https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro>`__.           Virtual-hosted–style URLs, where the bucket name is in the 
+          hostname itself (like ``bucket_name.s3.us-west-2.amazonaws.com``), 
+          is not supported. It should be written in the path-style URL instead, 
+          for example ``s3.us-west-2.amazonaws.com/bucket_name``.
 
 .. note:: Certain S3-compatible servers do not properly implement the
           ``ListObjectsV2`` API, most notably Ceph versions before v14.2.5. On these

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -240,7 +240,7 @@ or is only available via HTTP, you can specify the URL to the server
 like this: ``s3:http://server:port/bucket_name``.
           
 .. note:: restic expects `path-style URLs <https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro>`__
-          like for example ````s3.us-west-2.amazonaws.com/bucket_name``.
+          like for example ``s3.us-west-2.amazonaws.com/bucket_name``.
           Virtual-hosted–style URLs like ``bucket_name.s3.us-west-2.amazonaws.com``,
           where the bucket name is part of the hostname are not supported. These must
           be converted to path-style URLs instead, for example ``s3.us-west-2.amazonaws.com/bucket_name``.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
It alters the docs. This adds a note to mention that currently only path-style URL's are supported for S3, as per code at:
- https://github.com/restic/restic/blob/aa0faa8c7d7800b6ba7b11164fa2d3683f7f78aa/internal/backend/s3/config.go#L42-L45
- https://github.com/restic/restic/blob/aa0faa8c7d7800b6ba7b11164fa2d3683f7f78aa/internal/backend/s3/config.go#L48-L62


Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No. 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
