### PR TITLE
internal/ui/termstatus: Use Fprintln to get a newline

### DIFF
--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -210,9 +210,8 @@ func (t *Terminal) runWithoutStatus(ctx context.Context) {
 
 		case stat := <-t.status:
 			for _, line := range stat.lines {
-				// ensure that each line ends with newline
-				withNewline := strings.TrimRight(line, "\n") + "\n"
-				fmt.Fprint(t.wr, withNewline)
+				// Ensure that each message ends with exactly one newline.
+				fmt.Fprintln(t.wr, strings.TrimRight(line, "\n"))
 			}
 			if err := t.wr.Flush(); err != nil {
 				fmt.Fprintf(os.Stderr, "flush failed: %v\n", err)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Cosmetic fixup for some code added in #3199. Instead of adding a newline to a message "manually", let fmt.Fprintln do that.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
