### PR TITLE
backup: Fix total size for overlapping targets

### DIFF
--- a/changelog/unreleased/issue-3232
+++ b/changelog/unreleased/issue-3232
@@ -1,0 +1,11 @@
+Bugfix: Show correct statistics for overlapping targets
+
+A user reported that restic's statistics and progress information during backup
+is not correctly calculated when the backup targets (files/dirs to save)
+overlap. For example, consider a directory `foo` which contains (among others)
+a file `foo/bar`. When `restic backup foo foo/bar` is run, restic counted the
+size of the file `foo/bar` twice, so the completeness percentage as well as the
+number of files was wrong. This is now corrected.
+
+https://github.com/restic/restic/issues/3232
+https://github.com/restic/restic/pull/3243

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -548,13 +548,7 @@ func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, 
 	futureNodes := make(map[string]FutureNode)
 
 	// iterate over the nodes of atree in lexicographic (=deterministic) order
-	names := make([]string, 0, len(atree.Nodes))
-	for name := range atree.Nodes {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-
-	for _, name := range names {
+	for _, name := range atree.NodeNames() {
 		subatree := atree.Nodes[name]
 
 		// test if context has been cancelled
@@ -563,7 +557,7 @@ func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, 
 		}
 
 		// this is a leaf node
-		if subatree.Path != "" {
+		if subatree.Leaf() {
 			fn, excluded, err := arch.Save(ctx, join(snPath, name), subatree.Path, previous.Find(name))
 
 			if err != nil {

--- a/internal/archiver/scanner_test.go
+++ b/internal/archiver/scanner_test.go
@@ -40,8 +40,7 @@ func TestScanner(t *testing.T) {
 				filepath.FromSlash("work/subdir/other"):   {Files: 5, Bytes: 60},
 				filepath.FromSlash("work/subdir"):         {Files: 5, Dirs: 1, Bytes: 60},
 				filepath.FromSlash("work"):                {Files: 5, Dirs: 2, Bytes: 60},
-				filepath.FromSlash("."):                   {Files: 5, Dirs: 3, Bytes: 60},
-				filepath.FromSlash(""):                    {Files: 5, Dirs: 3, Bytes: 60},
+				filepath.FromSlash(""):                    {Files: 5, Dirs: 2, Bytes: 60},
 			},
 		},
 		{
@@ -72,8 +71,7 @@ func TestScanner(t *testing.T) {
 				filepath.FromSlash("work/subdir/bar.txt"): {Files: 2, Bytes: 30},
 				filepath.FromSlash("work/subdir"):         {Files: 2, Dirs: 1, Bytes: 30},
 				filepath.FromSlash("work"):                {Files: 2, Dirs: 2, Bytes: 30},
-				filepath.FromSlash("."):                   {Files: 2, Dirs: 3, Bytes: 30},
-				filepath.FromSlash(""):                    {Files: 2, Dirs: 3, Bytes: 30},
+				filepath.FromSlash(""):                    {Files: 2, Dirs: 2, Bytes: 30},
 			},
 		},
 	}
@@ -152,7 +150,7 @@ func TestScannerError(t *testing.T) {
 					},
 				},
 			},
-			result: ScanStats{Files: 5, Dirs: 3, Bytes: 60},
+			result: ScanStats{Files: 5, Dirs: 2, Bytes: 60},
 		},
 		{
 			name: "unreadable-dir",
@@ -168,7 +166,7 @@ func TestScannerError(t *testing.T) {
 					},
 				},
 			},
-			result: ScanStats{Files: 3, Dirs: 2, Bytes: 28},
+			result: ScanStats{Files: 3, Dirs: 1, Bytes: 28},
 			prepare: func(t testing.TB) {
 				err := os.Chmod(filepath.Join("work", "subdir"), 0000)
 				if err != nil {
@@ -191,7 +189,7 @@ func TestScannerError(t *testing.T) {
 				"foo":   TestFile{Content: "foo"},
 				"other": TestFile{Content: "other"},
 			},
-			result: ScanStats{Files: 3, Dirs: 1, Bytes: 11},
+			result: ScanStats{Files: 3, Dirs: 0, Bytes: 11},
 			resFn: func(t testing.TB, item string, s ScanStats) {
 				if item == "bar" {
 					err := os.Remove("foo")
@@ -289,7 +287,7 @@ func TestScannerCancel(t *testing.T) {
 		"other": TestFile{Content: "other"},
 	}
 
-	result := ScanStats{Files: 2, Dirs: 1, Bytes: 6}
+	result := ScanStats{Files: 2, Dirs: 0, Bytes: 6}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()

--- a/internal/archiver/tree.go
+++ b/internal/archiver/tree.go
@@ -2,6 +2,7 @@ package archiver
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
@@ -197,6 +198,24 @@ func (t *Tree) add(fs fs.FS, target, root string, pc []string) error {
 
 func (t Tree) String() string {
 	return formatTree(t, "")
+}
+
+// Leaf returns true if this is a leaf node, which means Path is set to a
+// non-empty string and the contents of Path should be inserted at this point
+// in the tree.
+func (t Tree) Leaf() bool {
+	return t.Path != ""
+}
+
+// NodeNames returns the sorted list of subtree names.
+func (t Tree) NodeNames() []string {
+	// iterate over the nodes of atree in lexicographic (=deterministic) order
+	names := make([]string, 0, len(t.Nodes))
+	for name := range t.Nodes {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	return names
 }
 
 // formatTree returns a text representation of the tree t.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Before, the scanner would could files twice if they were included in the list of backup targets twice, e.g. `restic backup foo foo/bar` would could the file `foo/bar` twice.

This commit uses the tree structure from the archiver to run the scanner, so both parts see the same files.


<!--
Describe the changes and their _purpose_ here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #3232
Closes #1356

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I'm done, this Pull Request is ready for review
