### PR TITLE
Print more details about possible repository damages

### DIFF
--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -394,7 +394,6 @@ func (f *Finder) findIDs(ctx context.Context, sn *restic.Snapshot) error {
 					delete(f.blobIDs, idStr[:shortStr])
 				}
 				f.out.PrintObject("blob", idStr, nodepath, parentTreeID.String(), sn)
-				break
 			}
 		}
 

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -378,7 +378,10 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 		return errorPacksMissing
 	}
 	if len(ignorePacks) != 0 {
-		Verbosef("missing but unneded pack files are referenced in the index, will be repaired\n")
+		Warnf("Missing but unneeded pack files are referenced in the index, will be repaired\n")
+		for id := range ignorePacks {
+			Warnf("will forget missing pack file %v\n", id)
+		}
 	}
 
 	repackAllPacksWithDuplicates := true

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -245,8 +245,9 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 
 	// Check if all used blobs have been found in index
 	if len(usedBlobs) != 0 {
-		Warnf("%v not found in the index\n"+
-			"Data blobs seem to be missing, aborting prune to prevent further data loss!\n"+
+		Warnf("%v not found in the index\n\n"+
+			"Integrity check failed: Data seems to be missing.\n"+
+			"Will not start prune to prevent (additional) data loss!\n"+
 			"Please report this error (along with the output of the 'prune' run) at\n"+
 			"https://github.com/restic/restic/issues/new/choose", usedBlobs)
 		return errorIndexIncomplete

--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -88,6 +88,11 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 			packSizeFromList[id] = packSize
 			removePacks.Insert(id)
 		}
+		if !ok {
+			Warnf("adding pack file to index %v\n", id)
+		} else if size != packSize {
+			Warnf("reindexing pack file %v with unexpected size %v instead of %v\n", id, packSize, size)
+		}
 		delete(packSizeFromIndex, id)
 		return nil
 	})
@@ -98,6 +103,7 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 		// forget pack files that are referenced in the index but do not exist
 		// when rebuilding the index
 		removePacks.Insert(id)
+		Warnf("removing not found pack file %v\n", id)
 	}
 
 	if len(packSizeFromList) > 0 {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Prune will now report missing pack files which are ignored as they are unneeded. rebuild-index prints added/removed/reindexed pack files when running an incremental index rebuild (which is the default). This should help with debugging damaged repositories.

I've reworded the message printed by prune when data blobs are missing, such that it doesn't sound like prune might just have broken the repository.

The find command will now also resolve multiple short blob ids within a file:
```
$ restic find  --show-pack-id --blob eec96b12 a7decf76
repository 86923eb5 opened successfully, password is correct
Found blob eec96b12fe5f511564d53360001caff605ebbeb4df6e759dcce28ac91bcd8353
 ... in file /restic/restic
     (tree f1c94f1e1c4da5643be80613cb50829fae655d073234bbe72e90ecfc8d725e4a)
 ... in snapshot 262ecd7a (2021-01-28 21:23:55)
Found blob a7decf76998b2c203d2ff4fce68044a16df7d76ae9f7f099a8f8f712049df3f6
 ... in file /restic/restic
     (tree f1c94f1e1c4da5643be80613cb50829fae655d073234bbe72e90ecfc8d725e4a)
 ... in snapshot 262ecd7a (2021-01-28 21:23:55)
Object eec96b12 not found in the index
Object a7decf76 not found in the index
```
Previously the output was
```
$ restic find  --show-pack-id --blob eec96b12 a7decf76
repository 86923eb5 opened successfully, password is correct
Found blob eec96b12fe5f511564d53360001caff605ebbeb4df6e759dcce28ac91bcd8353
 ... in file /restic/restic
     (tree f1c94f1e1c4da5643be80613cb50829fae655d073234bbe72e90ecfc8d725e4a)
 ... in snapshot 262ecd7a (2021-01-28 21:23:55)
Note: cannot find pack for object 'a7decf76', unable to parse ID: invalid length for hash
Object eec96b12 not found in the index
```

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
