### PR TITLE
prune: Fix statistics for --repack-cacheable-only

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -434,11 +434,14 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 		}
 
 		switch {
-		case !reachedRepackSize && (p.duplicateBlobs > 0 || p.tpe != restic.DataBlob):
+		case reachedRepackSize:
+			keep(p.packInfo)
+
+		case p.duplicateBlobs > 0, p.tpe != restic.DataBlob:
 			// repacking duplicates/non-data is only limited by repackSize
 			repack(p.ID, p.packInfo)
 
-		case reachedUnusedSizeAfter, reachedRepackSize:
+		case reachedUnusedSizeAfter:
 			// for all other packs stop repacking if tolerated unused size is reached.
 			keep(p.packInfo)
 

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -298,6 +298,14 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 	repackPacks := restic.NewIDSet()
 
 	var repackCandidates []packInfoWithID
+	repackAllPacksWithDuplicates := true
+
+	keep := func(p packInfo) {
+		stats.packs.keep++
+		if p.duplicateBlobs > 0 {
+			repackAllPacksWithDuplicates = false
+		}
+	}
 
 	// loop over all packs and decide what to do
 	bar := newProgressMax(!gopts.Quiet, uint64(len(indexPack)), "packs processed")
@@ -341,11 +349,11 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 
 		case opts.RepackCachableOnly && p.tpe == restic.DataBlob:
 			// if this is a data pack and --repack-cacheable-only is set => keep pack!
-			stats.packs.keep++
+			keep(p)
 
 		case p.unusedBlobs == 0 && p.duplicateBlobs == 0 && p.tpe != restic.InvalidBlob:
 			// All blobs in pack are used and not duplicates/mixed => keep pack!
-			stats.packs.keep++
+			keep(p)
 
 		default:
 			// all other packs are candidates for repacking
@@ -384,8 +392,6 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 			Warnf("will forget missing pack file %v\n", id)
 		}
 	}
-
-	repackAllPacksWithDuplicates := true
 
 	// calculate limit for number of unused bytes in the repo after repacking
 	maxUnusedSizeAfter := opts.maxUnusedBytes(stats.size.used)
@@ -429,15 +435,12 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 
 		switch {
 		case !reachedRepackSize && (p.duplicateBlobs > 0 || p.tpe != restic.DataBlob):
-			// repacking duplicates/mixed is only limited by repackSize
+			// repacking duplicates/non-data is only limited by repackSize
 			repack(p.ID, p.packInfo)
 
 		case reachedUnusedSizeAfter, reachedRepackSize:
 			// for all other packs stop repacking if tolerated unused size is reached.
-			stats.packs.keep++
-			if p.duplicateBlobs > 0 {
-				repackAllPacksWithDuplicates = false
-			}
+			keep(p.packInfo)
 
 		default:
 			repack(p.ID, p.packInfo)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

`prune --repack-cacheable-only` may give strange statistics:

```
to repack:            0 blobs / 0 B
this removes        136 blobs / 511.814 KiB
```
(in fact nothing is repacked/removed)

This PR fixes this behavior and also slightly re-arranges the selection logic such that it is more intuitive readable.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No, I found it when testing #3235 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- I have not added tests for all changes in this PR
- I have not added documentation for the changes (in the manual)
- There's no new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
