### PR TITLE
Calculate content hashes during upload

### DIFF
--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"encoding/base64"
+	"hash"
 	"io"
 	"net/http"
 	"os"
@@ -110,6 +111,11 @@ func (be *Backend) Join(p ...string) string {
 // Location returns this backend's location (the container name).
 func (be *Backend) Location() string {
 	return be.Join(be.container.Name, be.prefix)
+}
+
+// Hasher may return a hash function for calculating a content hash for the backend
+func (be *Backend) Hasher() hash.Hash {
+	return nil
 }
 
 // Path returns the path in the bucket that is used for this backend.

--- a/internal/backend/azure/azure_test.go
+++ b/internal/backend/azure/azure_test.go
@@ -172,7 +172,7 @@ func TestUploadLargeFile(t *testing.T) {
 
 	t.Logf("hash of %d bytes: %v", len(data), id)
 
-	err = be.Save(ctx, h, restic.NewByteReader(data))
+	err = be.Save(ctx, h, restic.NewByteReader(data, be.Hasher()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -200,6 +200,7 @@ func (be *b2Backend) Save(ctx context.Context, h restic.Handle, rd restic.Rewind
 	debug.Log("Save %v, name %v", h, name)
 	obj := be.bucket.Object(name)
 
+	// b2 always requires sha1 checksums for uploaded file parts
 	w := obj.NewWriter(ctx)
 	n, err := io.Copy(w, rd)
 	debug.Log("  saved %d bytes, err %v", n, err)

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -2,6 +2,7 @@ package b2
 
 import (
 	"context"
+	"hash"
 	"io"
 	"net/http"
 	"path"
@@ -135,6 +136,11 @@ func (be *b2Backend) SetListMaxItems(i int) {
 // Location returns the location for the backend.
 func (be *b2Backend) Location() string {
 	return be.cfg.Bucket
+}
+
+// Hasher may return a hash function for calculating a content hash for the backend
+func (be *b2Backend) Hasher() hash.Hash {
+	return nil
 }
 
 // IsNotExist returns true if the error is caused by a non-existing file.

--- a/internal/backend/backend_retry_test.go
+++ b/internal/backend/backend_retry_test.go
@@ -36,7 +36,7 @@ func TestBackendSaveRetry(t *testing.T) {
 	retryBackend := NewRetryBackend(be, 10, nil)
 
 	data := test.Random(23, 5*1024*1024+11241)
-	err := retryBackend.Save(context.TODO(), restic.Handle{}, restic.NewByteReader(data))
+	err := retryBackend.Save(context.TODO(), restic.Handle{}, restic.NewByteReader(data, be.Hasher()))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -256,7 +256,7 @@ func TestBackendCanceledContext(t *testing.T) {
 	_, err = retryBackend.Stat(ctx, h)
 	assertIsCanceled(t, err)
 
-	err = retryBackend.Save(ctx, h, restic.NewByteReader([]byte{}))
+	err = retryBackend.Save(ctx, h, restic.NewByteReader([]byte{}, nil))
 	assertIsCanceled(t, err)
 	err = retryBackend.Remove(ctx, h)
 	assertIsCanceled(t, err)

--- a/internal/backend/dryrun/dry_backend.go
+++ b/internal/backend/dryrun/dry_backend.go
@@ -2,6 +2,7 @@ package dryrun
 
 import (
 	"context"
+	"hash"
 	"io"
 
 	"github.com/restic/restic/internal/debug"
@@ -56,6 +57,10 @@ func (be *Backend) Delete(ctx context.Context) error {
 
 func (be *Backend) Close() error {
 	return be.b.Close()
+}
+
+func (be *Backend) Hasher() hash.Hash {
+	return be.b.Hasher()
 }
 
 func (be *Backend) IsNotExist(err error) bool {

--- a/internal/backend/dryrun/dry_backend_test.go
+++ b/internal/backend/dryrun/dry_backend_test.go
@@ -71,7 +71,7 @@ func TestDry(t *testing.T) {
 		handle := restic.Handle{Type: restic.PackFile, Name: step.fname}
 		switch step.op {
 		case "save":
-			err = step.be.Save(ctx, handle, restic.NewByteReader([]byte(step.content)))
+			err = step.be.Save(ctx, handle, restic.NewByteReader([]byte(step.content), step.be.Hasher()))
 		case "test":
 			boolRes, err = step.be.Test(ctx, handle)
 			if boolRes != (step.content != "") {

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -3,6 +3,7 @@ package gs
 
 import (
 	"context"
+	"crypto/md5"
 	"hash"
 	"io"
 	"net/http"
@@ -191,7 +192,7 @@ func (be *Backend) Location() string {
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (be *Backend) Hasher() hash.Hash {
-	return nil
+	return md5.New()
 }
 
 // Path returns the path in the bucket that is used for this backend.
@@ -240,6 +241,7 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 	// uploads are not providing significant benefit anyways.
 	w := be.bucket.Object(objName).NewWriter(ctx)
 	w.ChunkSize = 0
+	w.MD5 = rd.Hash()
 	wbytes, err := io.Copy(w, rd)
 	cerr := w.Close()
 	if err == nil {

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -3,6 +3,7 @@ package gs
 
 import (
 	"context"
+	"hash"
 	"io"
 	"net/http"
 	"os"
@@ -186,6 +187,11 @@ func (be *Backend) Join(p ...string) string {
 // Location returns this backend's location (the bucket name).
 func (be *Backend) Location() string {
 	return be.Join(be.bucketName, be.prefix)
+}
+
+// Hasher may return a hash function for calculating a content hash for the backend
+func (be *Backend) Hasher() hash.Hash {
+	return nil
 }
 
 // Path returns the path in the bucket that is used for this backend.

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -2,6 +2,7 @@ package local
 
 import (
 	"context"
+	"hash"
 	"io"
 	"io/ioutil"
 	"os"
@@ -75,6 +76,11 @@ func Create(ctx context.Context, cfg Config) (*Local, error) {
 // Location returns this backend's location (the directory name).
 func (b *Local) Location() string {
 	return b.Path
+}
+
+// Hasher may return a hash function for calculating a content hash for the backend
+func (b *Local) Hasher() hash.Hash {
+	return nil
 }
 
 // IsNotExist returns true if the error is caused by a non existing file.

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -3,6 +3,7 @@ package mem
 import (
 	"bytes"
 	"context"
+	"hash"
 	"io"
 	"io/ioutil"
 	"sync"
@@ -212,6 +213,11 @@ func (be *MemoryBackend) List(ctx context.Context, t restic.FileType, fn func(re
 // Location returns the location of the backend (RAM).
 func (be *MemoryBackend) Location() string {
 	return "RAM"
+}
+
+// Hasher may return a hash function for calculating a content hash for the backend
+func (be *MemoryBackend) Hasher() hash.Hash {
+	return nil
 }
 
 // Delete removes all data in the backend.

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -3,6 +3,8 @@ package mem
 import (
 	"bytes"
 	"context"
+	"crypto/md5"
+	"encoding/base64"
 	"hash"
 	"io"
 	"io/ioutil"
@@ -85,6 +87,16 @@ func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd restic.Re
 	// sanity check
 	if int64(len(buf)) != rd.Length() {
 		return errors.Errorf("wrote %d bytes instead of the expected %d bytes", len(buf), rd.Length())
+	}
+
+	beHash := be.Hasher()
+	// must never fail according to interface
+	_, _ = beHash.Write(buf)
+	if !bytes.Equal(beHash.Sum(nil), rd.Hash()) {
+		return errors.Errorf("invalid file hash or content, got %s expected %s",
+			base64.RawStdEncoding.EncodeToString(beHash.Sum(nil)),
+			base64.RawStdEncoding.EncodeToString(rd.Hash()),
+		)
 	}
 
 	be.data[h] = buf
@@ -217,7 +229,7 @@ func (be *MemoryBackend) Location() string {
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (be *MemoryBackend) Hasher() hash.Hash {
-	return nil
+	return md5.New()
 }
 
 // Delete removes all data in the backend.

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -91,7 +91,10 @@ func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd restic.Re
 
 	beHash := be.Hasher()
 	// must never fail according to interface
-	_, _ = beHash.Write(buf)
+	_, err = beHash.Write(buf)
+	if err != nil {
+		panic(err)
+	}
 	if !bytes.Equal(beHash.Sum(nil), rd.Hash()) {
 		return errors.Errorf("invalid file hash or content, got %s expected %s",
 			base64.RawStdEncoding.EncodeToString(beHash.Sum(nil)),

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -107,6 +108,11 @@ func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (*Backend, er
 // Location returns this backend's location (the server's URL).
 func (b *Backend) Location() string {
 	return b.url.String()
+}
+
+// Hasher may return a hash function for calculating a content hash for the backend
+func (b *Backend) Hasher() hash.Hash {
+	return nil
 }
 
 // Save stores data in the backend at the handle.

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -3,6 +3,7 @@ package s3
 import (
 	"context"
 	"fmt"
+	"hash"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -248,6 +249,11 @@ func (be *Backend) ReadDir(ctx context.Context, dir string) (list []os.FileInfo,
 // Location returns this backend's location (the bucket name).
 func (be *Backend) Location() string {
 	return be.Join(be.cfg.Bucket, be.cfg.Prefix)
+}
+
+// Hasher may return a hash function for calculating a content hash for the backend
+func (be *Backend) Hasher() hash.Hash {
+	return nil
 }
 
 // Path returns the path in the bucket that is used for this backend.

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -270,6 +270,8 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 
 	opts := minio.PutObjectOptions{StorageClass: be.cfg.StorageClass}
 	opts.ContentType = "application/octet-stream"
+	// the only option with the high-level api is to let the library handle the checksum computation
+	opts.SendContentMd5 = true
 
 	debug.Log("PutObject(%v, %v, %v)", be.cfg.Bucket, objName, rd.Length())
 	info, err := be.client.PutObject(ctx, be.cfg.Bucket, objName, ioutil.NopCloser(rd), int64(rd.Length()), opts)

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"fmt"
+	"hash"
 	"io"
 	"os"
 	"os/exec"
@@ -238,6 +239,11 @@ func Create(ctx context.Context, cfg Config) (*SFTP, error) {
 // Location returns this backend's location (the directory name).
 func (r *SFTP) Location() string {
 	return r.p
+}
+
+// Hasher may return a hash function for calculating a content hash for the backend
+func (r *SFTP) Hasher() hash.Hash {
+	return nil
 }
 
 // Join joins the given paths and cleans them afterwards. This always uses

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -2,6 +2,8 @@ package swift
 
 import (
 	"context"
+	"crypto/md5"
+	"encoding/hex"
 	"fmt"
 	"hash"
 	"io"
@@ -118,7 +120,7 @@ func (be *beSwift) Location() string {
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (be *beSwift) Hasher() hash.Hash {
-	return nil
+	return md5.New()
 }
 
 // Load runs fn with a reader that yields the contents of the file at h at the
@@ -184,7 +186,7 @@ func (be *beSwift) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 
 	debug.Log("PutObject(%v, %v, %v)", be.container, objName, encoding)
 	hdr := swift.Headers{"Content-Length": strconv.FormatInt(rd.Length(), 10)}
-	_, err := be.conn.ObjectPut(be.container, objName, rd, true, "", encoding, hdr)
+	_, err := be.conn.ObjectPut(be.container, objName, rd, true, hex.EncodeToString(rd.Hash()), encoding, hdr)
 	// swift does not return the upload length
 	debug.Log("%v, err %#v", objName, err)
 

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -3,6 +3,7 @@ package swift
 import (
 	"context"
 	"fmt"
+	"hash"
 	"io"
 	"net/http"
 	"path"
@@ -113,6 +114,11 @@ func (be *beSwift) createContainer(policy string) error {
 // Location returns this backend's location (the container name).
 func (be *beSwift) Location() string {
 	return be.container
+}
+
+// Hasher may return a hash function for calculating a content hash for the backend
+func (be *beSwift) Hasher() hash.Hash {
+	return nil
 }
 
 // Load runs fn with a reader that yields the contents of the file at h at the

--- a/internal/backend/test/benchmarks.go
+++ b/internal/backend/test/benchmarks.go
@@ -14,7 +14,7 @@ func saveRandomFile(t testing.TB, be restic.Backend, length int) ([]byte, restic
 	data := test.Random(23, length)
 	id := restic.Hash(data)
 	handle := restic.Handle{Type: restic.PackFile, Name: id.String()}
-	err := be.Save(context.TODO(), handle, restic.NewByteReader(data))
+	err := be.Save(context.TODO(), handle, restic.NewByteReader(data, be.Hasher()))
 	if err != nil {
 		t.Fatalf("Save() error: %+v", err)
 	}
@@ -148,7 +148,7 @@ func (s *Suite) BenchmarkSave(t *testing.B) {
 	id := restic.Hash(data)
 	handle := restic.Handle{Type: restic.PackFile, Name: id.String()}
 
-	rd := restic.NewByteReader(data)
+	rd := restic.NewByteReader(data, be.Hasher())
 	t.SetBytes(int64(length))
 	t.ResetTimer()
 

--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -84,7 +84,7 @@ func (s *Suite) TestConfig(t *testing.T) {
 		t.Fatalf("did not get expected error for non-existing config")
 	}
 
-	err = b.Save(context.TODO(), restic.Handle{Type: restic.ConfigFile}, restic.NewByteReader([]byte(testString)))
+	err = b.Save(context.TODO(), restic.Handle{Type: restic.ConfigFile}, restic.NewByteReader([]byte(testString), b.Hasher()))
 	if err != nil {
 		t.Fatalf("Save() error: %+v", err)
 	}
@@ -134,7 +134,7 @@ func (s *Suite) TestLoad(t *testing.T) {
 	id := restic.Hash(data)
 
 	handle := restic.Handle{Type: restic.PackFile, Name: id.String()}
-	err = b.Save(context.TODO(), handle, restic.NewByteReader(data))
+	err = b.Save(context.TODO(), handle, restic.NewByteReader(data, b.Hasher()))
 	if err != nil {
 		t.Fatalf("Save() error: %+v", err)
 	}
@@ -253,7 +253,7 @@ func (s *Suite) TestList(t *testing.T) {
 		data := test.Random(rand.Int(), rand.Intn(100)+55)
 		id := restic.Hash(data)
 		h := restic.Handle{Type: restic.PackFile, Name: id.String()}
-		err := b.Save(context.TODO(), h, restic.NewByteReader(data))
+		err := b.Save(context.TODO(), h, restic.NewByteReader(data, b.Hasher()))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -343,7 +343,7 @@ func (s *Suite) TestListCancel(t *testing.T) {
 		data := []byte(fmt.Sprintf("random test blob %v", i))
 		id := restic.Hash(data)
 		h := restic.Handle{Type: restic.PackFile, Name: id.String()}
-		err := b.Save(context.TODO(), h, restic.NewByteReader(data))
+		err := b.Save(context.TODO(), h, restic.NewByteReader(data, b.Hasher()))
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -447,6 +447,7 @@ type errorCloser struct {
 	io.ReadSeeker
 	l int64
 	t testing.TB
+	h []byte
 }
 
 func (ec errorCloser) Close() error {
@@ -456,6 +457,10 @@ func (ec errorCloser) Close() error {
 
 func (ec errorCloser) Length() int64 {
 	return ec.l
+}
+
+func (ec errorCloser) Hash() []byte {
+	return ec.h
 }
 
 func (ec errorCloser) Rewind() error {
@@ -486,7 +491,7 @@ func (s *Suite) TestSave(t *testing.T) {
 			Type: restic.PackFile,
 			Name: fmt.Sprintf("%s-%d", id, i),
 		}
-		err := b.Save(context.TODO(), h, restic.NewByteReader(data))
+		err := b.Save(context.TODO(), h, restic.NewByteReader(data, b.Hasher()))
 		test.OK(t, err)
 
 		buf, err := backend.LoadAll(context.TODO(), nil, b, h)
@@ -538,7 +543,19 @@ func (s *Suite) TestSave(t *testing.T) {
 
 	// wrap the tempfile in an errorCloser, so we can detect if the backend
 	// closes the reader
-	err = b.Save(context.TODO(), h, errorCloser{t: t, l: int64(length), ReadSeeker: tmpfile})
+	var beHash []byte
+	if b.Hasher() != nil {
+		beHasher := b.Hasher()
+		// must never fail according to interface
+		_, _ = beHasher.Write(data)
+		beHash = beHasher.Sum(nil)
+	}
+	err = b.Save(context.TODO(), h, errorCloser{
+		t:          t,
+		l:          int64(length),
+		ReadSeeker: tmpfile,
+		h:          beHash,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -583,7 +600,7 @@ func (s *Suite) TestSaveError(t *testing.T) {
 
 	// test that incomplete uploads fail
 	h := restic.Handle{Type: restic.PackFile, Name: id.String()}
-	err := b.Save(context.TODO(), h, &incompleteByteReader{ByteReader: *restic.NewByteReader(data)})
+	err := b.Save(context.TODO(), h, &incompleteByteReader{ByteReader: *restic.NewByteReader(data, b.Hasher())})
 	// try to delete possible leftovers
 	_ = s.delayedRemove(t, b, h)
 	if err == nil {
@@ -610,7 +627,7 @@ func (s *Suite) TestSaveFilenames(t *testing.T) {
 
 	for i, test := range filenameTests {
 		h := restic.Handle{Name: test.name, Type: restic.PackFile}
-		err := b.Save(context.TODO(), h, restic.NewByteReader([]byte(test.data)))
+		err := b.Save(context.TODO(), h, restic.NewByteReader([]byte(test.data), b.Hasher()))
 		if err != nil {
 			t.Errorf("test %d failed: Save() returned %+v", i, err)
 			continue
@@ -647,7 +664,7 @@ var testStrings = []struct {
 func store(t testing.TB, b restic.Backend, tpe restic.FileType, data []byte) restic.Handle {
 	id := restic.Hash(data)
 	h := restic.Handle{Name: id.String(), Type: tpe}
-	err := b.Save(context.TODO(), h, restic.NewByteReader([]byte(data)))
+	err := b.Save(context.TODO(), h, restic.NewByteReader([]byte(data), b.Hasher()))
 	test.OK(t, err)
 	return h
 }
@@ -801,7 +818,7 @@ func (s *Suite) TestBackend(t *testing.T) {
 		test.Assert(t, !ok, "removed blob still present")
 
 		// create blob
-		err = b.Save(context.TODO(), h, restic.NewByteReader([]byte(ts.data)))
+		err = b.Save(context.TODO(), h, restic.NewByteReader([]byte(ts.data), b.Hasher()))
 		test.OK(t, err)
 
 		// list items

--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -547,7 +547,10 @@ func (s *Suite) TestSave(t *testing.T) {
 	if b.Hasher() != nil {
 		beHasher := b.Hasher()
 		// must never fail according to interface
-		_, _ = beHasher.Write(data)
+		_, err := beHasher.Write(data)
+		if err != nil {
+			panic(err)
+		}
 		beHash = beHasher.Sum(nil)
 	}
 	err = b.Save(context.TODO(), h, errorCloser{

--- a/internal/backend/utils_test.go
+++ b/internal/backend/utils_test.go
@@ -26,7 +26,7 @@ func TestLoadAll(t *testing.T) {
 
 		id := restic.Hash(data)
 		h := restic.Handle{Name: id.String(), Type: restic.PackFile}
-		err := b.Save(context.TODO(), h, restic.NewByteReader(data))
+		err := b.Save(context.TODO(), h, restic.NewByteReader(data, b.Hasher()))
 		rtest.OK(t, err)
 
 		buf, err := backend.LoadAll(context.TODO(), buf, b, restic.Handle{Type: restic.PackFile, Name: id.String()})
@@ -47,7 +47,7 @@ func TestLoadAll(t *testing.T) {
 func save(t testing.TB, be restic.Backend, buf []byte) restic.Handle {
 	id := restic.Hash(buf)
 	h := restic.Handle{Name: id.String(), Type: restic.PackFile}
-	err := be.Save(context.TODO(), h, restic.NewByteReader(buf))
+	err := be.Save(context.TODO(), h, restic.NewByteReader(buf, be.Hasher()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cache/backend_test.go
+++ b/internal/cache/backend_test.go
@@ -32,7 +32,7 @@ func loadAndCompare(t testing.TB, be restic.Backend, h restic.Handle, data []byt
 }
 
 func save(t testing.TB, be restic.Backend, h restic.Handle, data []byte) {
-	err := be.Save(context.TODO(), h, restic.NewByteReader(data))
+	err := be.Save(context.TODO(), h, restic.NewByteReader(data, be.Hasher()))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/limiter/limiter_backend_test.go
+++ b/internal/limiter/limiter_backend_test.go
@@ -39,7 +39,7 @@ func TestLimitBackendSave(t *testing.T) {
 	limiter := NewStaticLimiter(42*1024, 42*1024)
 	limbe := LimitBackend(be, limiter)
 
-	rd := restic.NewByteReader(data)
+	rd := restic.NewByteReader(data, nil)
 	err := limbe.Save(context.TODO(), testHandle, rd)
 	rtest.OK(t, err)
 }

--- a/internal/mock/backend.go
+++ b/internal/mock/backend.go
@@ -2,6 +2,7 @@ package mock
 
 import (
 	"context"
+	"hash"
 	"io"
 
 	"github.com/restic/restic/internal/errors"
@@ -20,6 +21,7 @@ type Backend struct {
 	TestFn       func(ctx context.Context, h restic.Handle) (bool, error)
 	DeleteFn     func(ctx context.Context) error
 	LocationFn   func() string
+	HasherFn     func() hash.Hash
 }
 
 // NewBackend returns new mock Backend instance
@@ -44,6 +46,15 @@ func (m *Backend) Location() string {
 	}
 
 	return m.LocationFn()
+}
+
+// Hasher may return a hash function for calculating a content hash for the backend
+func (m *Backend) Hasher() hash.Hash {
+	if m.HasherFn == nil {
+		return nil
+	}
+
+	return m.HasherFn()
 }
 
 // IsNotExist returns true if the error is caused by a missing file.

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -127,7 +127,7 @@ func TestUnpackReadSeeker(t *testing.T) {
 	id := restic.Hash(packData)
 
 	handle := restic.Handle{Type: restic.PackFile, Name: id.String()}
-	rtest.OK(t, b.Save(context.TODO(), handle, restic.NewByteReader(packData)))
+	rtest.OK(t, b.Save(context.TODO(), handle, restic.NewByteReader(packData, b.Hasher())))
 	verifyBlobs(t, bufs, k, restic.ReaderAt(context.TODO(), b, handle), packSize)
 }
 
@@ -140,6 +140,6 @@ func TestShortPack(t *testing.T) {
 	id := restic.Hash(packData)
 
 	handle := restic.Handle{Type: restic.PackFile, Name: id.String()}
-	rtest.OK(t, b.Save(context.TODO(), handle, restic.NewByteReader(packData)))
+	rtest.OK(t, b.Save(context.TODO(), handle, restic.NewByteReader(packData, b.Hasher())))
 	verifyBlobs(t, bufs, k, restic.ReaderAt(context.TODO(), b, handle), packSize)
 }

--- a/internal/repository/key.go
+++ b/internal/repository/key.go
@@ -279,7 +279,7 @@ func AddKey(ctx context.Context, s *Repository, password, username, hostname str
 		Name: restic.Hash(buf).String(),
 	}
 
-	err = s.be.Save(ctx, h, restic.NewByteReader(buf))
+	err = s.be.Save(ctx, h, restic.NewByteReader(buf, s.be.Hasher()))
 	if err != nil {
 		return nil, err
 	}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -322,7 +322,7 @@ func (r *Repository) SaveUnpacked(ctx context.Context, t restic.FileType, p []by
 	}
 	h := restic.Handle{Type: t, Name: id.String()}
 
-	err = r.be.Save(ctx, h, restic.NewByteReader(ciphertext))
+	err = r.be.Save(ctx, h, restic.NewByteReader(ciphertext, r.be.Hasher()))
 	if err != nil {
 		debug.Log("error saving blob %v: %v", h, err)
 		return restic.ID{}, err

--- a/internal/restic/backend.go
+++ b/internal/restic/backend.go
@@ -2,6 +2,7 @@ package restic
 
 import (
 	"context"
+	"hash"
 	"io"
 )
 
@@ -16,6 +17,9 @@ type Backend interface {
 	// Location returns a string that describes the type and location of the
 	// repository.
 	Location() string
+
+	// Hasher may return a hash function for calculating a content hash for the backend
+	Hasher() hash.Hash
 
 	// Test a boolean value whether a File with the name and type exists.
 	Test(ctx context.Context, h Handle) (bool, error)

--- a/internal/restic/rewind_reader.go
+++ b/internal/restic/rewind_reader.go
@@ -56,7 +56,10 @@ func NewByteReader(buf []byte, hasher hash.Hash) *ByteReader {
 	var hash []byte
 	if hasher != nil {
 		// must never fail according to interface
-		_, _ = hasher.Write(buf)
+		_, err := hasher.Write(buf)
+		if err != nil {
+			panic(err)
+		}
 		hash = hasher.Sum(nil)
 	}
 	return &ByteReader{

--- a/internal/restic/rewind_reader.go
+++ b/internal/restic/rewind_reader.go
@@ -2,6 +2,7 @@ package restic
 
 import (
 	"bytes"
+	"hash"
 	"io"
 
 	"github.com/restic/restic/internal/errors"
@@ -18,12 +19,16 @@ type RewindReader interface {
 	// Length returns the number of bytes that can be read from the Reader
 	// after calling Rewind.
 	Length() int64
+
+	// Hash return a hash of the data if requested by the backed.
+	Hash() []byte
 }
 
 // ByteReader implements a RewindReader for a byte slice.
 type ByteReader struct {
 	*bytes.Reader
-	Len int64
+	Len  int64
+	hash []byte
 }
 
 // Rewind restarts the reader from the beginning of the data.
@@ -38,14 +43,26 @@ func (b *ByteReader) Length() int64 {
 	return b.Len
 }
 
+// Hash return a hash of the data if requested by the backed.
+func (b *ByteReader) Hash() []byte {
+	return b.hash
+}
+
 // statically ensure that *ByteReader implements RewindReader.
 var _ RewindReader = &ByteReader{}
 
 // NewByteReader prepares a ByteReader that can then be used to read buf.
-func NewByteReader(buf []byte) *ByteReader {
+func NewByteReader(buf []byte, hasher hash.Hash) *ByteReader {
+	var hash []byte
+	if hasher != nil {
+		// must never fail according to interface
+		_, _ = hasher.Write(buf)
+		hash = hasher.Sum(nil)
+	}
 	return &ByteReader{
 		Reader: bytes.NewReader(buf),
 		Len:    int64(len(buf)),
+		hash:   hash,
 	}
 }
 
@@ -55,7 +72,8 @@ var _ RewindReader = &FileReader{}
 // FileReader implements a RewindReader for an open file.
 type FileReader struct {
 	io.ReadSeeker
-	Len int64
+	Len  int64
+	hash []byte
 }
 
 // Rewind seeks to the beginning of the file.
@@ -69,8 +87,13 @@ func (f *FileReader) Length() int64 {
 	return f.Len
 }
 
+// Hash return a hash of the data if requested by the backed.
+func (f *FileReader) Hash() []byte {
+	return f.hash
+}
+
 // NewFileReader wraps f in a *FileReader.
-func NewFileReader(f io.ReadSeeker) (*FileReader, error) {
+func NewFileReader(f io.ReadSeeker, hash []byte) (*FileReader, error) {
 	pos, err := f.Seek(0, io.SeekEnd)
 	if err != nil {
 		return nil, errors.Wrap(err, "Seek")
@@ -79,6 +102,7 @@ func NewFileReader(f io.ReadSeeker) (*FileReader, error) {
 	fr := &FileReader{
 		ReadSeeker: f,
 		Len:        pos,
+		hash:       hash,
 	}
 
 	err = fr.Rewind()

--- a/internal/restic/rewind_reader_test.go
+++ b/internal/restic/rewind_reader_test.go
@@ -2,6 +2,8 @@ package restic
 
 import (
 	"bytes"
+	"crypto/md5"
+	"hash"
 	"io"
 	"io/ioutil"
 	"math/rand"
@@ -15,10 +17,12 @@ import (
 
 func TestByteReader(t *testing.T) {
 	buf := []byte("foobar")
-	fn := func() RewindReader {
-		return NewByteReader(buf)
+	for _, hasher := range []hash.Hash{nil, md5.New()} {
+		fn := func() RewindReader {
+			return NewByteReader(buf, hasher)
+		}
+		testRewindReader(t, fn, buf)
 	}
-	testRewindReader(t, fn, buf)
 }
 
 func TestFileReader(t *testing.T) {
@@ -28,7 +32,7 @@ func TestFileReader(t *testing.T) {
 	defer cleanup()
 
 	filename := filepath.Join(d, "file-reader-test")
-	err := ioutil.WriteFile(filename, []byte("foobar"), 0600)
+	err := ioutil.WriteFile(filename, buf, 0600)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -45,15 +49,23 @@ func TestFileReader(t *testing.T) {
 		}
 	}()
 
-	fn := func() RewindReader {
-		rd, err := NewFileReader(f)
-		if err != nil {
-			t.Fatal(err)
+	for _, hasher := range []hash.Hash{nil, md5.New()} {
+		fn := func() RewindReader {
+			var hash []byte
+			if hasher != nil {
+				// must never fail according to interface
+				_, _ = hasher.Write(buf)
+				hash = hasher.Sum(nil)
+			}
+			rd, err := NewFileReader(f, hash)
+			if err != nil {
+				t.Fatal(err)
+			}
+			return rd
 		}
-		return rd
-	}
 
-	testRewindReader(t, fn, buf)
+		testRewindReader(t, fn, buf)
+	}
 }
 
 func testRewindReader(t *testing.T, fn func() RewindReader, data []byte) {
@@ -103,6 +115,15 @@ func testRewindReader(t *testing.T, fn func() RewindReader, data []byte) {
 
 			if rd.Length() != int64(len(data)) {
 				t.Fatalf("wrong length returned, want %d, got %d", int64(len(data)), rd.Length())
+			}
+
+			if rd.Hash() != nil {
+				hasher := md5.New()
+				// must never fail according to interface
+				_, _ = hasher.Write(buf2)
+				if !bytes.Equal(rd.Hash(), hasher.Sum(nil)) {
+					t.Fatal("hash does not match data")
+				}
 			}
 		},
 		func(t testing.TB, rd RewindReader, data []byte) {

--- a/internal/restic/rewind_reader_test.go
+++ b/internal/restic/rewind_reader_test.go
@@ -54,7 +54,10 @@ func TestFileReader(t *testing.T) {
 			var hash []byte
 			if hasher != nil {
 				// must never fail according to interface
-				_, _ = hasher.Write(buf)
+				_, err := hasher.Write(buf)
+				if err != nil {
+					panic(err)
+				}
 				hash = hasher.Sum(nil)
 			}
 			rd, err := NewFileReader(f, hash)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Supersedes #3178, I've switched the repository to run the cloud backend tests.

Up to now only the B2 backend and to a lesser extend the Swift backend have checked the integrity of uploaded files. For B2 the blazer library calculates SHA1 hashes for the uploaded files and provides that information to B2. The server-side of B2 then verifies that the uploaded data matches the hashes and rejects the upload in case of a mismatch. This effectively rules out any data corruption during upload _and_ storage. The latter point probably needs some explanation. As the backend now knows the correct hash of a file it is able to check the integrity of the stored data from time to time. The hash also allows detecting hardware problems causing bitflips within the storage system or data corruption before it is stored.

For Swift the library was calculating the MD5 hash of the data during the upload and compared it with the value returned by the server. Compared to the variant used for B2 it has the benefit of being simpler to calculate on-the-fly but has several drawbacks: It is necessary to delete the broken upload after detecting the problem. This could be impossible when e.g. using an append-only backend or when the delete operation fails due to network problems. Depending on the consistency guarantees of a backend (and bugs) it could be possible that the broken upload can show up again for some time. This cannot happen, if the broken upload is rejected right from the start.

This PR enables (among others) the calculation of the content hash for S3 in the minio library. The calculation happens inside the library which could increase the memory usage a bit compared to before. As the content hash is included in the request authenticator, this also prevents any intermediate load balancers etc. from damaging the upload.

The main change of this PR is that it enhances the `RewindReader` to also return the hash for the uploaded data when requested by the backend. For that the backends can return a `hash.Hash` object via a new `Hasher()` method which is then used during pack assembly to calculate the content hash. Calculating the hash during pack assembly has the big benefit that it calculates the hash at the earliest point in time possible, and thus would also detect a damaged temporary pack file.

The azure, gs, swift and mem (for testing) backends now use that mechanism with the MD5 hash to ensure the integrity of the uploaded data.

The content hash also effectively prevents the creation of incomplete pack files due to interrupted upload for all supported backends.

The following backends are not affected by this PR:
- REST / rclone: The REST server could easily check the sha256 hash of the uploaded data. It would also be possible to provide the md5 content hash, but that probably not too useful. For rclone that could be useful however.
- local / sftp: As there is no "smart" storage system on the other side there's not much that can be done here. I mean it would be possible to check that the generated pack file data matches the data which is later on written to the repository. However, I'm not sure whether that's worth the trouble.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #2202.
Fixes #2700.
Fixes #3023.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
