### PR TITLE
Backend code and test cleanups

### DIFF
--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -81,13 +81,13 @@ func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd restic.Re
 		return err
 	}
 
-	be.data[h] = buf
-	debug.Log("saved %v bytes at %v", len(buf), h)
-
 	// sanity check
 	if int64(len(buf)) != rd.Length() {
 		return errors.Errorf("wrote %d bytes instead of the expected %d bytes", len(buf), rd.Length())
 	}
+
+	be.data[h] = buf
+	debug.Log("saved %v bytes at %v", len(buf), h)
 
 	return ctx.Err()
 }

--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -577,13 +577,15 @@ func (s *Suite) TestSaveError(t *testing.T) {
 	}()
 
 	length := rand.Intn(1<<23) + 200000
-	data := test.Random(23, length)
+	data := test.Random(24, length)
 	var id restic.ID
 	copy(id[:], data)
 
 	// test that incomplete uploads fail
 	h := restic.Handle{Type: restic.PackFile, Name: id.String()}
 	err := b.Save(context.TODO(), h, &incompleteByteReader{ByteReader: *restic.NewByteReader(data)})
+	// try to delete possible leftovers
+	_ = s.delayedRemove(t, b, h)
 	if err == nil {
 		t.Fatal("incomplete upload did not fail")
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This is in parts a follow-up to #3176. TestSaveError now uses a separate filename and tries to clean after itself. This should prevent accidentally triggering a "file already exists"-error instead of the error due to an incomplete upload.

The mem backend now checks the upload size before verifying its size. This prevents leftover files. The local / sftp backend still keep failed uploads and only return an error. That way the three backends together offer both ways how incomplete uploads could be handled by backends.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No. I've noticed these problems while testing #3246.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~ Already covered by tests
- ~~[ ] I have added documentation for the changes (in the manual)~~ Not user visible
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~ Not user visible
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
