### PR TITLE
gs: Don't drop error when finishing upload

### DIFF
--- a/changelog/unreleased/pull-3249
+++ b/changelog/unreleased/pull-3249
@@ -1,0 +1,7 @@
+Bugfix: Better error handling for gs backend
+
+The gs backend did not notice when the last steep of completing a file upload
+failed. Under rare circumstance, this might be able to cause missing files in
+the backup repository. This has been fixed.
+
+https://github.com/restic/restic/pull/3249

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -235,7 +235,10 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 	w := be.bucket.Object(objName).NewWriter(ctx)
 	w.ChunkSize = 0
 	wbytes, err := io.Copy(w, rd)
-	w.Close()
+	cerr := w.Close()
+	if err == nil {
+		err = cerr
+	}
 
 	be.sem.ReleaseToken()
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The error returned when finishing the upload of an object was dropped. This could cause silent upload failures and thus data loss in certain cases. When a MD5 hash for the uploaded blob is specified, a wrong hash/damaged upload would return its error via the Close() whose error was dropped.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
The problem showed up while testing #3246. I've split the fix into a separate PR to allow merging it independently of the other changes in #3246 as this bug might possibly cause data loss.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR -> The failing test is in #3246, I'm not sure how to reliably test this otherwise.
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
