### PR TITLE
Allow HTTP/2

### DIFF
--- a/changelog/unreleased/pull-3254
+++ b/changelog/unreleased/pull-3254
@@ -1,0 +1,8 @@
+Enhancement: Enable HTTP/2 for backend connections
+
+Go's HTTP library usually automatically chooses between HTTP/1.x and HTTP/2
+depending on what the server supports. But for compatibility this mechanism
+is disabled if DialContext is used (which is the case for restic). This change
+allows restic's HTTP client to negotiate HTTP/2 if supported by the server.
+
+https://github.com/restic/restic/pull/3254

--- a/internal/backend/http_transport.go
+++ b/internal/backend/http_transport.go
@@ -70,6 +70,7 @@ func Transport(opts TransportOptions) (http.RoundTripper, error) {
 			KeepAlive: 30 * time.Second,
 			DualStack: true,
 		}).DialContext,
+		ForceAttemptHTTP2:     true,
 		MaxIdleConns:          100,
 		MaxIdleConnsPerHost:   100,
 		IdleConnTimeout:       90 * time.Second,


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Allows Go to use HTTP/2 for backend conections. This is automatically disabled when using DialContext for compatibility with older versions of Go. Setting `ForceAttemptHTTP2` opts in to the new behavior.
This makes restic much faster with certain backends supporting HTTP/2.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
