### PR TITLE
restorer: Check dropped error

### DIFF
--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -205,12 +205,16 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 		}
 		if fileBlobs, ok := file.blobs.(restic.IDs); ok {
 			fileOffset := int64(0)
-			r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob) {
+			err := r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob) {
 				if packID.Equal(pack.id) {
 					addBlob(blob, fileOffset)
 				}
 				fileOffset += int64(blob.Length) - crypto.Extension
 			})
+			if err != nil {
+				// restoreFiles should have caught this error before
+				panic(err)
+			}
 		} else if packsMap, ok := file.blobs.(map[restic.ID][]fileBlobInfo); ok {
 			for _, blob := range packsMap[pack.id] {
 				idxPacks := r.idx(restic.BlobHandle{ID: blob.id, Type: restic.DataBlob})


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This fixes the last warning reported by golangci-lint. `restoreFiles` currently aborts if a file with missing blobs should be restored. Thus `forEachBlob` in `downloadPack` should never see missing blobs.

And implementation alternative would be to modify both functions to just report the file as broken an to continue restoring everything else.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
This is a follow-up to #3150.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
