### PR TITLE
rebuild-index: Add missing bar.Done()

### DIFF
--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -110,6 +110,7 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 		Verbosef("reading pack files\n")
 		bar := newProgressMax(!globalOptions.Quiet, uint64(len(packSizeFromList)), "packs")
 		invalidFiles, err := repo.CreateIndexFromPacks(ctx, packSizeFromList, bar)
+		bar.Done()
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Finishes the reporting bar when reading pack files by `rebuild-index`.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

no.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
