### PR TITLE
Prevent local backend file fragmentation by file preallocation.

### DIFF
--- a/changelog/unreleased/pull-3261
+++ b/changelog/unreleased/pull-3261
@@ -1,0 +1,8 @@
+Enhancement: Reduce file fragmentation for local backend
+
+Before this change, local backend files could become fragmented.
+Now restic will try to preallocate space for pack files to avoid
+their fragmentation.
+
+https://github.com/restic/restic/issues/2679
+https://github.com/restic/restic/pull/3261

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -148,6 +148,13 @@ func (b *Local) Save(_ context.Context, h restic.Handle, rd restic.RewindReader)
 		}
 	}(f)
 
+	// preallocate disk space
+	if size := rd.Length(); size > 0 {
+		if err := fs.PreallocateFile(f, size); err != nil {
+			debug.Log("Failed to preallocate %v with size %v: %v", finalname, size, err)
+		}
+	}
+
 	// save data, then sync
 	wbytes, err := io.Copy(f, rd)
 	if err != nil {

--- a/internal/fs/preallocate_darwin.go
+++ b/internal/fs/preallocate_darwin.go
@@ -1,4 +1,4 @@
-package restorer
+package fs
 
 import (
 	"os"
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func preallocateFile(wr *os.File, size int64) error {
+func PreallocateFile(wr *os.File, size int64) error {
 	// try contiguous first
 	fst := unix.Fstore_t{
 		Flags:   unix.F_ALLOCATECONTIG | unix.F_ALLOCATEALL,

--- a/internal/fs/preallocate_linux.go
+++ b/internal/fs/preallocate_linux.go
@@ -1,4 +1,4 @@
-package restorer
+package fs
 
 import (
 	"os"
@@ -6,7 +6,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func preallocateFile(wr *os.File, size int64) error {
+func PreallocateFile(wr *os.File, size int64) error {
 	if size <= 0 {
 		return nil
 	}

--- a/internal/fs/preallocate_other.go
+++ b/internal/fs/preallocate_other.go
@@ -1,11 +1,11 @@
 //go:build !linux && !darwin
 // +build !linux,!darwin
 
-package restorer
+package fs
 
 import "os"
 
-func preallocateFile(wr *os.File, size int64) error {
+func PreallocateFile(wr *os.File, size int64) error {
 	// Maybe truncate can help?
 	// Windows: This calls SetEndOfFile which preallocates space on disk
 	return wr.Truncate(size)

--- a/internal/fs/preallocate_test.go
+++ b/internal/fs/preallocate_test.go
@@ -1,4 +1,4 @@
-package restorer
+package fs
 
 import (
 	"os"
@@ -7,7 +7,6 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/test"
 )
 
@@ -23,7 +22,7 @@ func TestPreallocate(t *testing.T) {
 				test.OK(t, wr.Close())
 			}()
 
-			err = preallocateFile(wr, i)
+			err = PreallocateFile(wr, i)
 			if err == syscall.ENOTSUP {
 				t.SkipNow()
 			}
@@ -32,7 +31,7 @@ func TestPreallocate(t *testing.T) {
 			fi, err := wr.Stat()
 			test.OK(t, err)
 
-			efi := fs.ExtendedStat(fi)
+			efi := ExtendedStat(fi)
 			test.Assert(t, efi.Size == i || efi.Blocks > 0, "Preallocated size of %v, got size %v block %v", i, efi.Size, efi.Blocks)
 		})
 	}

--- a/internal/restorer/fileswriter.go
+++ b/internal/restorer/fileswriter.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/fs"
 )
 
 // writes blobs to target files.
@@ -72,7 +73,7 @@ func (w *filesWriter) writeToFile(path string, blob []byte, offset int64, create
 					return nil, err
 				}
 			} else {
-				err := preallocateFile(wr.File, createSize)
+				err := fs.PreallocateFile(wr.File, createSize)
 				if err != nil {
 					// Just log the preallocate error but don't let it cause the restore process to fail.
 					// Preallocate might return an error if the filesystem (implementation) does not


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

File preallocation has already been added to the restorer, but not to the local backend.
This PR moves preallocation code from `restorer` to the `fs` package and adds preallocation to the local backend.

Before this PR:
```
restic init --copy-chunker-params 
created restic repository f0e0af3f2f at repo2

restic backup "C:\Program Files" 
no parent snapshot found, will read all files

Files:       94897 new,     0 changed,     0 unmodified
Dirs:         9490 new,     0 changed,     0 unmodified
Added to the repo: 9.117 GiB

processed 94897 files, 10.011 GiB in 5:04
snapshot 5b287af7 saved

contig /a /s repo2

...
repo2\data\0d\0da13caef4a1746608248a8d1286dbddd20ef89dc524c6c2adb8da5c9e4a8a41 is in 16 fragments
repo2\data\0e\0eaa27e755e25a65f45327e400d058df6b426cdefa0b083c54a743d10fb90db9 is in 14 fragments
repo2\data\2c\2cb9a6bc2645656f8f288d131f251edcf5a76314f46cb67f2300febea6b61aaf is in 13 fragments
repo2\data\34\34a9dfd06cc971ef6d5768471245ae8ad26572942133d54313baa6484d116bb6 is in 12 fragments
repo2\data\74\74cfcbf057fc7af25b4fe930b766d95e2a96f1c0a166d66dff9812da85f8df30 is in 12 fragments
repo2\data\85\854e876ad694fcff94b5927520ac1aeb85dd555cf47f5d2525212047de4f0a7c is in 17 fragments
repo2\data\be\be958f56d448fe766f6fd7289d015c831f730678529d7355bb5b2ed790741a0b is in 16 fragments
repo2\data\bf\bfd119b20a3a4cdc7831d126f551f0211aaa9c56ae06603365a31365c6e4d3e9 is in 12 fragments
...

Summary:
     Number of files processed:      2322
     Number unsuccessfully procesed: 0
     Average fragmentation       : 2.9186 frags/file
```

Many files are split into 10-20 fragments.

After this PR:
```
restic init --copy-chunker-params 
created restic repository 665523814e at repo2

restic backup "C:\Program Files" 
no parent snapshot found, will read all files

Files:       94897 new,     0 changed,     0 unmodified
Dirs:         9490 new,     0 changed,     0 unmodified
Added to the repo: 9.117 GiB

processed 94897 files, 10.011 GiB in 4:55
snapshot f97d7203 saved

contig /a /s repo2

...
repo2\data is in 8 fragments
...

Summary:
     Number of files processed:      2317
     Number unsuccessfully procesed: 0
     Average fragmentation       : 1.00388 frags/file
```
Only the `data` dir (containing 256 subdirs) is fragmented.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://github.com/restic/restic/issues/2679
https://github.com/restic/restic/pull/2893

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review