### PR TITLE
Refactor backup progress

### DIFF
--- a/changelog/unreleased/issue-2738
+++ b/changelog/unreleased/issue-2738
@@ -1,0 +1,8 @@
+Bugfix: Don't print progress for `backup --json --quiet`
+
+Unlike the text output, the json output format still printed progress
+information even in quiet mode. This has been fixed by always disabling the
+progress output in quiet mode.
+
+https://github.com/restic/restic/issues/2738
+https://github.com/restic/restic/pull/3264

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -537,7 +537,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 
 	if opts.DryRun {
 		repo.SetDryRun()
-		progressPrinter.SetDryRun()
+		progressReporter.SetDryRun()
 	}
 
 	// use the terminal for stdout/stderr

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -527,39 +527,17 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		return err
 	}
 
-	type ArchiveProgressReporter interface {
-		CompleteItem(item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration)
-		StartFile(filename string)
-		CompleteBlob(filename string, bytes uint64)
-		ScannerError(item string, fi os.FileInfo, err error) error
-		ReportTotal(item string, s archiver.ScanStats)
-		SetMinUpdatePause(d time.Duration)
-		Run(ctx context.Context) error
-		Error(item string, fi os.FileInfo, err error) error
-		Finish(snapshotID restic.ID)
-		SetDryRun()
-
-		// ui.StdioWrapper
-		Stdout() io.WriteCloser
-		Stderr() io.WriteCloser
-
-		// ui.Message
-		E(msg string, args ...interface{})
-		P(msg string, args ...interface{})
-		V(msg string, args ...interface{})
-		VV(msg string, args ...interface{})
-	}
-
-	var p ArchiveProgressReporter
+	var progressPrinter ui.ProgressPrinter
 	if gopts.JSON {
-		p = json.NewBackup(term, gopts.verbosity)
+		progressPrinter = json.NewBackup(term, gopts.verbosity)
 	} else {
-		p = ui.NewBackup(term, gopts.verbosity)
+		progressPrinter = ui.NewBackup(term, gopts.verbosity)
 	}
+	progressReporter := ui.NewProgress(progressPrinter)
 
 	if opts.DryRun {
 		repo.SetDryRun()
-		p.SetDryRun()
+		progressPrinter.SetDryRun()
 	}
 
 	// use the terminal for stdout/stderr
@@ -567,14 +545,14 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	defer func() {
 		gopts.stdout, gopts.stderr = prevStdout, prevStderr
 	}()
-	gopts.stdout, gopts.stderr = p.Stdout(), p.Stderr()
+	gopts.stdout, gopts.stderr = progressPrinter.Stdout(), progressPrinter.Stderr()
 
-	p.SetMinUpdatePause(calculateProgressInterval(!gopts.Quiet))
+	progressReporter.SetMinUpdatePause(calculateProgressInterval(!gopts.Quiet))
 
-	t.Go(func() error { return p.Run(t.Context(gopts.ctx)) })
+	t.Go(func() error { return progressReporter.Run(t.Context(gopts.ctx)) })
 
 	if !gopts.JSON {
-		p.V("lock repository")
+		progressPrinter.V("lock repository")
 	}
 	lock, err := lockRepo(gopts.ctx, repo)
 	defer unlockRepo(lock)
@@ -595,7 +573,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	}
 
 	if !gopts.JSON {
-		p.V("load index files")
+		progressPrinter.V("load index files")
 	}
 	err = repo.LoadIndex(gopts.ctx)
 	if err != nil {
@@ -609,9 +587,9 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 
 	if !gopts.JSON {
 		if parentSnapshotID != nil {
-			p.P("using parent snapshot %v\n", parentSnapshotID.Str())
+			progressPrinter.P("using parent snapshot %v\n", parentSnapshotID.Str())
 		} else {
-			p.P("no parent snapshot found, will read all files\n")
+			progressPrinter.P("no parent snapshot found, will read all files\n")
 		}
 	}
 
@@ -640,12 +618,12 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		}
 
 		errorHandler := func(item string, err error) error {
-			return p.Error(item, nil, err)
+			return progressReporter.Error(item, nil, err)
 		}
 
 		messageHandler := func(msg string, args ...interface{}) {
 			if !gopts.JSON {
-				p.P(msg, args...)
+				progressPrinter.P(msg, args...)
 			}
 		}
 
@@ -655,7 +633,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	}
 	if opts.Stdin {
 		if !gopts.JSON {
-			p.V("read data from stdin")
+			progressPrinter.V("read data from stdin")
 		}
 		filename := path.Join("/", opts.StdinFilename)
 		targetFS = &fs.Reader{
@@ -670,11 +648,11 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	sc := archiver.NewScanner(targetFS)
 	sc.SelectByName = selectByNameFilter
 	sc.Select = selectFilter
-	sc.Error = p.ScannerError
-	sc.Result = p.ReportTotal
+	sc.Error = progressReporter.ScannerError
+	sc.Result = progressReporter.ReportTotal
 
 	if !gopts.JSON {
-		p.V("start scan on %v", targets)
+		progressPrinter.V("start scan on %v", targets)
 	}
 	t.Go(func() error { return sc.Scan(t.Context(gopts.ctx), targets) })
 
@@ -685,11 +663,11 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	success := true
 	arch.Error = func(item string, fi os.FileInfo, err error) error {
 		success = false
-		return p.Error(item, fi, err)
+		return progressReporter.Error(item, fi, err)
 	}
-	arch.CompleteItem = p.CompleteItem
-	arch.StartFile = p.StartFile
-	arch.CompleteBlob = p.CompleteBlob
+	arch.CompleteItem = progressReporter.CompleteItem
+	arch.StartFile = progressReporter.StartFile
+	arch.CompleteBlob = progressReporter.CompleteBlob
 
 	if opts.IgnoreInode {
 		// --ignore-inode implies --ignore-ctime: on FUSE, the ctime is not
@@ -713,7 +691,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	}
 
 	if !gopts.JSON {
-		p.V("start backup on %v", targets)
+		progressPrinter.V("start backup on %v", targets)
 	}
 	_, id, err := arch.Snapshot(gopts.ctx, targets, snapshotOpts)
 
@@ -729,9 +707,9 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	}
 
 	// Report finished execution
-	p.Finish(id)
+	progressReporter.Finish(id)
 	if !gopts.JSON && !opts.DryRun {
-		p.P("snapshot %s saved\n", id.Str())
+		progressPrinter.P("snapshot %s saved\n", id.Str())
 	}
 	if !success {
 		return ErrInvalidSourceData

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -547,7 +547,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	}()
 	gopts.stdout, gopts.stderr = progressPrinter.Stdout(), progressPrinter.Stderr()
 
-	progressReporter.SetMinUpdatePause(calculateProgressInterval(!gopts.Quiet))
+	progressReporter.SetMinUpdatePause(calculateProgressInterval(!gopts.Quiet, gopts.JSON))
 
 	t.Go(func() error { return progressReporter.Run(t.Context(gopts.ctx)) })
 

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -24,8 +24,7 @@ import (
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/textfile"
-	"github.com/restic/restic/internal/ui"
-	"github.com/restic/restic/internal/ui/json"
+	"github.com/restic/restic/internal/ui/backup"
 	"github.com/restic/restic/internal/ui/termstatus"
 )
 
@@ -527,13 +526,13 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		return err
 	}
 
-	var progressPrinter ui.ProgressPrinter
+	var progressPrinter backup.ProgressPrinter
 	if gopts.JSON {
-		progressPrinter = json.NewBackup(term, gopts.verbosity)
+		progressPrinter = backup.NewJSONProgress(term, gopts.verbosity)
 	} else {
-		progressPrinter = ui.NewBackup(term, gopts.verbosity)
+		progressPrinter = backup.NewTextProgress(term, gopts.verbosity)
 	}
-	progressReporter := ui.NewProgress(progressPrinter)
+	progressReporter := backup.NewProgress(progressPrinter)
 
 	if opts.DryRun {
 		repo.SetDryRun()

--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -14,7 +14,7 @@ import (
 // calculateProgressInterval returns the interval configured via RESTIC_PROGRESS_FPS
 // or if unset returns an interval for 60fps on interactive terminals and 0 (=disabled)
 // for non-interactive terminals or when run using the --quiet flag
-func calculateProgressInterval(show bool) time.Duration {
+func calculateProgressInterval(show bool, json bool) time.Duration {
 	interval := time.Second / 60
 	fps, err := strconv.ParseFloat(os.Getenv("RESTIC_PROGRESS_FPS"), 64)
 	if err == nil && fps > 0 {
@@ -22,7 +22,7 @@ func calculateProgressInterval(show bool) time.Duration {
 			fps = 60
 		}
 		interval = time.Duration(float64(time.Second) / fps)
-	} else if !stdoutCanUpdateStatus() || !show {
+	} else if !json && !stdoutCanUpdateStatus() || !show {
 		interval = 0
 	}
 	return interval
@@ -33,7 +33,7 @@ func newProgressMax(show bool, max uint64, description string) *progress.Counter
 	if !show {
 		return nil
 	}
-	interval := calculateProgressInterval(show)
+	interval := calculateProgressInterval(show, false)
 	canUpdateStatus := stdoutCanUpdateStatus()
 
 	return progress.New(interval, max, func(v uint64, max uint64, d time.Duration, final bool) {

--- a/internal/ui/backup.go
+++ b/internal/ui/backup.go
@@ -17,7 +17,6 @@ type Backup struct {
 	*StdioWrapper
 
 	term *termstatus.Terminal
-	dry  bool // true if writes are faked
 }
 
 // NewBackup returns a new backup progress reporter.
@@ -165,14 +164,14 @@ func (b *Backup) Reset() {
 }
 
 // Finish prints the finishing messages.
-func (b *Backup) Finish(snapshotID restic.ID, start time.Time, summary *Summary) {
+func (b *Backup) Finish(snapshotID restic.ID, start time.Time, summary *Summary, dryRun bool) {
 	b.P("\n")
 	b.P("Files:       %5d new, %5d changed, %5d unmodified\n", summary.Files.New, summary.Files.Changed, summary.Files.Unchanged)
 	b.P("Dirs:        %5d new, %5d changed, %5d unmodified\n", summary.Dirs.New, summary.Dirs.Changed, summary.Dirs.Unchanged)
 	b.V("Data Blobs:  %5d new\n", summary.ItemStats.DataBlobs)
 	b.V("Tree Blobs:  %5d new\n", summary.ItemStats.TreeBlobs)
 	verb := "Added"
-	if b.dry {
+	if dryRun {
 		verb = "Would add"
 	}
 	b.P("%s to the repo: %-5s\n", verb, formatBytes(summary.ItemStats.DataSize+summary.ItemStats.TreeSize))
@@ -182,8 +181,4 @@ func (b *Backup) Finish(snapshotID restic.ID, start time.Time, summary *Summary)
 		formatBytes(summary.ProcessedBytes),
 		formatDuration(time.Since(start)),
 	)
-}
-
-func (b *Backup) SetDryRun() {
-	b.dry = true
 }

--- a/internal/ui/backup.go
+++ b/internal/ui/backup.go
@@ -19,6 +19,9 @@ type Backup struct {
 	term *termstatus.Terminal
 }
 
+// assert that Backup implements the ProgressPrinter interface
+var _ ProgressPrinter = &Backup{}
+
 // NewBackup returns a new backup progress reporter.
 func NewBackup(term *termstatus.Terminal, verbosity uint) *Backup {
 	return &Backup{

--- a/internal/ui/backup.go
+++ b/internal/ui/backup.go
@@ -151,12 +151,10 @@ func (b *Backup) CompleteItem(messageType, item string, previous, current *resti
 
 // ReportTotal sets the total stats up to now
 func (b *Backup) ReportTotal(item string, start time.Time, s archiver.ScanStats) {
-	if item == "" {
-		b.V("scan finished in %.3fs: %v files, %s",
-			time.Since(start).Seconds(),
-			s.Files, formatBytes(s.Bytes),
-		)
-	}
+	b.V("scan finished in %.3fs: %v files, %s",
+		time.Since(start).Seconds(),
+		s.Files, formatBytes(s.Bytes),
+	)
 }
 
 // Reset status

--- a/internal/ui/backup.go
+++ b/internal/ui/backup.go
@@ -1,58 +1,23 @@
 package ui
 
 import (
-	"context"
 	"fmt"
 	"os"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/restic/restic/internal/archiver"
 	"github.com/restic/restic/internal/restic"
-	"github.com/restic/restic/internal/ui/signals"
 	"github.com/restic/restic/internal/ui/termstatus"
 )
-
-type counter struct {
-	Files, Dirs uint
-	Bytes       uint64
-}
-
-type fileWorkerMessage struct {
-	filename string
-	done     bool
-}
 
 // Backup reports progress for the `backup` command.
 type Backup struct {
 	*Message
 	*StdioWrapper
 
-	MinUpdatePause time.Duration
-
-	term  *termstatus.Terminal
-	start time.Time
-
-	totalBytes uint64
-	dry        bool // true if writes are faked
-
-	totalCh     chan counter
-	processedCh chan counter
-	errCh       chan struct{}
-	workerCh    chan fileWorkerMessage
-	closed      chan struct{}
-
-	summary struct {
-		sync.Mutex
-		Files, Dirs struct {
-			New       uint
-			Changed   uint
-			Unchanged uint
-		}
-		ProcessedBytes uint64
-		archiver.ItemStats
-	}
+	term *termstatus.Terminal
+	dry  bool // true if writes are faked
 }
 
 // NewBackup returns a new backup progress reporter.
@@ -61,102 +26,16 @@ func NewBackup(term *termstatus.Terminal, verbosity uint) *Backup {
 		Message:      NewMessage(term, verbosity),
 		StdioWrapper: NewStdioWrapper(term),
 		term:         term,
-		start:        time.Now(),
-
-		// limit to 60fps by default
-		MinUpdatePause: time.Second / 60,
-
-		totalCh:     make(chan counter),
-		processedCh: make(chan counter),
-		errCh:       make(chan struct{}),
-		workerCh:    make(chan fileWorkerMessage),
-		closed:      make(chan struct{}),
-	}
-}
-
-// Run regularly updates the status lines. It should be called in a separate
-// goroutine.
-func (b *Backup) Run(ctx context.Context) error {
-	var (
-		lastUpdate       time.Time
-		total, processed counter
-		errors           uint
-		started          bool
-		currentFiles     = make(map[string]struct{})
-		secondsRemaining uint64
-	)
-
-	t := time.NewTicker(time.Second)
-	signalsCh := signals.GetProgressChannel()
-	defer t.Stop()
-	defer close(b.closed)
-	// Reset status when finished
-	defer func() {
-		if b.term.CanUpdateStatus() {
-			b.term.SetStatus([]string{""})
-		}
-	}()
-
-	for {
-		forceUpdate := false
-
-		select {
-		case <-ctx.Done():
-			return nil
-		case t, ok := <-b.totalCh:
-			if ok {
-				total = t
-				started = true
-			} else {
-				// scan has finished
-				b.totalCh = nil
-				b.totalBytes = total.Bytes
-			}
-		case s := <-b.processedCh:
-			processed.Files += s.Files
-			processed.Dirs += s.Dirs
-			processed.Bytes += s.Bytes
-			started = true
-		case <-b.errCh:
-			errors++
-			started = true
-		case m := <-b.workerCh:
-			if m.done {
-				delete(currentFiles, m.filename)
-			} else {
-				currentFiles[m.filename] = struct{}{}
-			}
-		case <-t.C:
-			if !started {
-				continue
-			}
-
-			if b.totalCh == nil {
-				secs := float64(time.Since(b.start) / time.Second)
-				todo := float64(total.Bytes - processed.Bytes)
-				secondsRemaining = uint64(secs / float64(processed.Bytes) * todo)
-			}
-		case <-signalsCh:
-			forceUpdate = true
-		}
-
-		// limit update frequency
-		if !forceUpdate && (time.Since(lastUpdate) < b.MinUpdatePause || b.MinUpdatePause == 0) {
-			continue
-		}
-		lastUpdate = time.Now()
-
-		b.update(total, processed, errors, currentFiles, secondsRemaining)
 	}
 }
 
 // update updates the status lines.
-func (b *Backup) update(total, processed counter, errors uint, currentFiles map[string]struct{}, secs uint64) {
+func (b *Backup) Update(total, processed Counter, errors uint, currentFiles map[string]struct{}, start time.Time, secs uint64) {
 	var status string
 	if total.Files == 0 && total.Dirs == 0 {
 		// no total count available yet
 		status = fmt.Sprintf("[%s] %v files, %s, %d errors",
-			formatDuration(time.Since(b.start)),
+			formatDuration(time.Since(start)),
 			processed.Files, formatBytes(processed.Bytes), errors,
 		)
 	} else {
@@ -170,7 +49,7 @@ func (b *Backup) update(total, processed counter, errors uint, currentFiles map[
 
 		// include totals
 		status = fmt.Sprintf("[%s] %s%v files %s, total %v files %v, %d errors%s",
-			formatDuration(time.Since(b.start)),
+			formatDuration(time.Since(start)),
 			percent,
 			processed.Files,
 			formatBytes(processed.Bytes),
@@ -201,27 +80,7 @@ func (b *Backup) ScannerError(item string, fi os.FileInfo, err error) error {
 // Error is the error callback function for the archiver, it prints the error and returns nil.
 func (b *Backup) Error(item string, fi os.FileInfo, err error) error {
 	b.E("error: %v\n", err)
-	select {
-	case b.errCh <- struct{}{}:
-	case <-b.closed:
-	}
 	return nil
-}
-
-// StartFile is called when a file is being processed by a worker.
-func (b *Backup) StartFile(filename string) {
-	select {
-	case b.workerCh <- fileWorkerMessage{filename: filename}:
-	case <-b.closed:
-	}
-}
-
-// CompleteBlob is called for all saved blobs for files.
-func (b *Backup) CompleteBlob(filename string, bytes uint64) {
-	select {
-	case b.processedCh <- counter{Bytes: bytes}:
-	case <-b.closed:
-	}
 }
 
 func formatPercent(numerator uint64, denominator uint64) string {
@@ -273,136 +132,58 @@ func formatBytes(c uint64) string {
 
 // CompleteItem is the status callback function for the archiver when a
 // file/dir has been saved successfully.
-func (b *Backup) CompleteItem(item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration) {
-	b.summary.Lock()
-	b.summary.ItemStats.Add(s)
-
-	// for the last item "/", current is nil
-	if current != nil {
-		b.summary.ProcessedBytes += current.Size
-	}
-
-	b.summary.Unlock()
-
-	if current == nil {
-		// error occurred, tell the status display to remove the line
-		select {
-		case b.workerCh <- fileWorkerMessage{filename: item, done: true}:
-		case <-b.closed:
-		}
-		return
-	}
-
-	switch current.Type {
-	case "file":
-		select {
-		case b.processedCh <- counter{Files: 1}:
-		case <-b.closed:
-		}
-		select {
-		case b.workerCh <- fileWorkerMessage{filename: item, done: true}:
-		case <-b.closed:
-		}
-	case "dir":
-		select {
-		case b.processedCh <- counter{Dirs: 1}:
-		case <-b.closed:
-		}
-	}
-
-	if current.Type == "dir" {
-		if previous == nil {
-			b.VV("new       %v, saved in %.3fs (%v added, %v metadata)", item, d.Seconds(), formatBytes(s.DataSize), formatBytes(s.TreeSize))
-			b.summary.Lock()
-			b.summary.Dirs.New++
-			b.summary.Unlock()
-			return
-		}
-
-		if previous.Equals(*current) {
-			b.VV("unchanged %v", item)
-			b.summary.Lock()
-			b.summary.Dirs.Unchanged++
-			b.summary.Unlock()
-		} else {
-			b.VV("modified  %v, saved in %.3fs (%v added, %v metadata)", item, d.Seconds(), formatBytes(s.DataSize), formatBytes(s.TreeSize))
-			b.summary.Lock()
-			b.summary.Dirs.Changed++
-			b.summary.Unlock()
-		}
-
-	} else if current.Type == "file" {
-		select {
-		case b.workerCh <- fileWorkerMessage{done: true, filename: item}:
-		case <-b.closed:
-		}
-
-		if previous == nil {
-			b.VV("new       %v, saved in %.3fs (%v added)", item, d.Seconds(), formatBytes(s.DataSize))
-			b.summary.Lock()
-			b.summary.Files.New++
-			b.summary.Unlock()
-			return
-		}
-
-		if previous.Equals(*current) {
-			b.VV("unchanged %v", item)
-			b.summary.Lock()
-			b.summary.Files.Unchanged++
-			b.summary.Unlock()
-		} else {
-			b.VV("modified  %v, saved in %.3fs (%v added)", item, d.Seconds(), formatBytes(s.DataSize))
-			b.summary.Lock()
-			b.summary.Files.Changed++
-			b.summary.Unlock()
-		}
+func (b *Backup) CompleteItem(messageType, item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration) {
+	switch messageType {
+	case "dir new":
+		b.VV("new       %v, saved in %.3fs (%v added, %v metadata)", item, d.Seconds(), formatBytes(s.DataSize), formatBytes(s.TreeSize))
+	case "dir unchanged":
+		b.VV("unchanged %v", item)
+	case "dir modified":
+		b.VV("modified  %v, saved in %.3fs (%v added, %v metadata)", item, d.Seconds(), formatBytes(s.DataSize), formatBytes(s.TreeSize))
+	case "file new":
+		b.VV("new       %v, saved in %.3fs (%v added)", item, d.Seconds(), formatBytes(s.DataSize))
+	case "file unchanged":
+		b.VV("unchanged %v", item)
+	case "file modified":
+		b.VV("modified  %v, saved in %.3fs (%v added)", item, d.Seconds(), formatBytes(s.DataSize))
 	}
 }
 
 // ReportTotal sets the total stats up to now
-func (b *Backup) ReportTotal(item string, s archiver.ScanStats) {
-	select {
-	case b.totalCh <- counter{Files: s.Files, Dirs: s.Dirs, Bytes: s.Bytes}:
-	case <-b.closed:
-	}
-
+func (b *Backup) ReportTotal(item string, start time.Time, s archiver.ScanStats) {
 	if item == "" {
 		b.V("scan finished in %.3fs: %v files, %s",
-			time.Since(b.start).Seconds(),
+			time.Since(start).Seconds(),
 			s.Files, formatBytes(s.Bytes),
 		)
-		close(b.totalCh)
-		return
+	}
+}
+
+// Reset status
+func (b *Backup) Reset() {
+	if b.term.CanUpdateStatus() {
+		b.term.SetStatus([]string{""})
 	}
 }
 
 // Finish prints the finishing messages.
-func (b *Backup) Finish(snapshotID restic.ID) {
-	// wait for the status update goroutine to shut down
-	<-b.closed
-
+func (b *Backup) Finish(snapshotID restic.ID, start time.Time, summary *Summary) {
 	b.P("\n")
-	b.P("Files:       %5d new, %5d changed, %5d unmodified\n", b.summary.Files.New, b.summary.Files.Changed, b.summary.Files.Unchanged)
-	b.P("Dirs:        %5d new, %5d changed, %5d unmodified\n", b.summary.Dirs.New, b.summary.Dirs.Changed, b.summary.Dirs.Unchanged)
-	b.V("Data Blobs:  %5d new\n", b.summary.ItemStats.DataBlobs)
-	b.V("Tree Blobs:  %5d new\n", b.summary.ItemStats.TreeBlobs)
+	b.P("Files:       %5d new, %5d changed, %5d unmodified\n", summary.Files.New, summary.Files.Changed, summary.Files.Unchanged)
+	b.P("Dirs:        %5d new, %5d changed, %5d unmodified\n", summary.Dirs.New, summary.Dirs.Changed, summary.Dirs.Unchanged)
+	b.V("Data Blobs:  %5d new\n", summary.ItemStats.DataBlobs)
+	b.V("Tree Blobs:  %5d new\n", summary.ItemStats.TreeBlobs)
 	verb := "Added"
 	if b.dry {
 		verb = "Would add"
 	}
-	b.P("%s to the repo: %-5s\n", verb, formatBytes(b.summary.ItemStats.DataSize+b.summary.ItemStats.TreeSize))
+	b.P("%s to the repo: %-5s\n", verb, formatBytes(summary.ItemStats.DataSize+summary.ItemStats.TreeSize))
 	b.P("\n")
 	b.P("processed %v files, %v in %s",
-		b.summary.Files.New+b.summary.Files.Changed+b.summary.Files.Unchanged,
-		formatBytes(b.summary.ProcessedBytes),
-		formatDuration(time.Since(b.start)),
+		summary.Files.New+summary.Files.Changed+summary.Files.Unchanged,
+		formatBytes(summary.ProcessedBytes),
+		formatDuration(time.Since(start)),
 	)
-}
-
-// SetMinUpdatePause sets b.MinUpdatePause. It satisfies the
-// ArchiveProgressReporter interface.
-func (b *Backup) SetMinUpdatePause(d time.Duration) {
-	b.MinUpdatePause = d
 }
 
 func (b *Backup) SetDryRun() {

--- a/internal/ui/backup/progress.go
+++ b/internal/ui/backup/progress.go
@@ -1,4 +1,4 @@
-package ui
+package backup
 
 import (
 	"context"

--- a/internal/ui/json/backup.go
+++ b/internal/ui/json/backup.go
@@ -171,8 +171,21 @@ func (b *Backup) ReportTotal(item string, start time.Time, s archiver.ScanStats)
 // Finish prints the finishing messages.
 func (b *Backup) Finish(snapshotID restic.ID, start time.Time, summary *ui.Summary) {
 	b.print(summaryOutput{
-		MessageType: "summary",
-		SnapshotID:  snapshotID.Str(),
+		MessageType:         "summary",
+		FilesNew:            summary.Files.New,
+		FilesChanged:        summary.Files.Changed,
+		FilesUnmodified:     summary.Files.Unchanged,
+		DirsNew:             summary.Dirs.New,
+		DirsChanged:         summary.Dirs.Changed,
+		DirsUnmodified:      summary.Dirs.Unchanged,
+		DataBlobs:           summary.ItemStats.DataBlobs,
+		TreeBlobs:           summary.ItemStats.TreeBlobs,
+		DataAdded:           summary.ItemStats.DataSize + summary.ItemStats.TreeSize,
+		TotalFilesProcessed: summary.Files.New + summary.Files.Changed + summary.Files.Unchanged,
+		TotalBytesProcessed: summary.ProcessedBytes,
+		TotalDuration:       time.Since(start).Seconds(),
+		SnapshotID:          snapshotID.Str(),
+		DryRun:              b.dry,
 	})
 }
 

--- a/internal/ui/json/backup.go
+++ b/internal/ui/json/backup.go
@@ -22,6 +22,9 @@ type Backup struct {
 	v    uint
 }
 
+// assert that Backup implements the ProgressPrinter interface
+var _ ui.ProgressPrinter = &Backup{}
+
 // NewBackup returns a new backup progress reporter.
 func NewBackup(term *termstatus.Terminal, verbosity uint) *Backup {
 	return &Backup{

--- a/internal/ui/json/backup.go
+++ b/internal/ui/json/backup.go
@@ -157,17 +157,14 @@ func (b *Backup) CompleteItem(messageType, item string, previous, current *resti
 
 // ReportTotal sets the total stats up to now
 func (b *Backup) ReportTotal(item string, start time.Time, s archiver.ScanStats) {
-	if item == "" {
-		if b.v >= 2 {
-			b.print(verboseUpdate{
-				MessageType: "status",
-				Action:      "scan_finished",
-				Duration:    time.Since(start).Seconds(),
-				DataSize:    s.Bytes,
-				TotalFiles:  s.Files,
-			})
-		}
-		return
+	if b.v >= 2 {
+		b.print(verboseUpdate{
+			MessageType: "status",
+			Action:      "scan_finished",
+			Duration:    time.Since(start).Seconds(),
+			DataSize:    s.Bytes,
+			TotalFiles:  s.Files,
+		})
 	}
 }
 

--- a/internal/ui/json/backup.go
+++ b/internal/ui/json/backup.go
@@ -20,7 +20,6 @@ type Backup struct {
 
 	term *termstatus.Terminal
 	v    uint
-	dry  bool
 }
 
 // NewBackup returns a new backup progress reporter.
@@ -169,7 +168,7 @@ func (b *Backup) ReportTotal(item string, start time.Time, s archiver.ScanStats)
 }
 
 // Finish prints the finishing messages.
-func (b *Backup) Finish(snapshotID restic.ID, start time.Time, summary *ui.Summary) {
+func (b *Backup) Finish(snapshotID restic.ID, start time.Time, summary *ui.Summary, dryRun bool) {
 	b.print(summaryOutput{
 		MessageType:         "summary",
 		FilesNew:            summary.Files.New,
@@ -185,17 +184,12 @@ func (b *Backup) Finish(snapshotID restic.ID, start time.Time, summary *ui.Summa
 		TotalBytesProcessed: summary.ProcessedBytes,
 		TotalDuration:       time.Since(start).Seconds(),
 		SnapshotID:          snapshotID.Str(),
-		DryRun:              b.dry,
+		DryRun:              dryRun,
 	})
 }
 
 // Reset no-op
 func (b *Backup) Reset() {
-}
-
-// SetDryRun marks the backup as a "dry run".
-func (b *Backup) SetDryRun() {
-	b.dry = true
 }
 
 type statusUpdate struct {

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -61,7 +61,6 @@ type Summary struct {
 		Unchanged uint
 	}
 	ProcessedBytes uint64
-	TotalErrors    uint
 	archiver.ItemStats
 }
 
@@ -141,9 +140,6 @@ func (p *Progress) Run(ctx context.Context) error {
 			started = true
 		case <-p.errCh:
 			errors++
-			p.summary.Lock()
-			p.summary.TotalErrors = errors
-			p.summary.Unlock()
 			started = true
 		case m := <-p.workerCh:
 			if m.done {

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -1,0 +1,321 @@
+package ui
+
+import (
+	"context"
+	"io"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/restic/restic/internal/archiver"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/ui/signals"
+)
+
+type ProgressPrinter interface {
+	Update(total, processed Counter, errors uint, currentFiles map[string]struct{}, start time.Time, secs uint64)
+	Error(item string, fi os.FileInfo, err error) error
+	ScannerError(item string, fi os.FileInfo, err error) error
+	CompleteItem(messageType string, item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration)
+	ReportTotal(item string, start time.Time, s archiver.ScanStats)
+	Finish(snapshotID restic.ID, start time.Time, summary *Summary)
+	Reset()
+	SetDryRun()
+
+	// ui.StdioWrapper
+	Stdout() io.WriteCloser
+	Stderr() io.WriteCloser
+
+	E(msg string, args ...interface{})
+	P(msg string, args ...interface{})
+	V(msg string, args ...interface{})
+	VV(msg string, args ...interface{})
+}
+
+type Counter struct {
+	Files, Dirs, Bytes uint64
+}
+
+type fileWorkerMessage struct {
+	filename string
+	done     bool
+}
+
+type ProgressReporter interface {
+	CompleteItem(item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration)
+	StartFile(filename string)
+	CompleteBlob(filename string, bytes uint64)
+	ScannerError(item string, fi os.FileInfo, err error) error
+	ReportTotal(item string, s archiver.ScanStats)
+	SetMinUpdatePause(d time.Duration)
+	Run(ctx context.Context) error
+	Error(item string, fi os.FileInfo, err error) error
+	Finish(snapshotID restic.ID)
+}
+
+type Summary struct {
+	sync.Mutex
+	Files, Dirs struct {
+		New       uint
+		Changed   uint
+		Unchanged uint
+	}
+	ProcessedBytes uint64
+	TotalErrors    uint
+	archiver.ItemStats
+}
+
+type Progress struct {
+	MinUpdatePause time.Duration
+
+	start time.Time
+
+	totalBytes uint64
+
+	totalCh     chan Counter
+	processedCh chan Counter
+	errCh       chan struct{}
+	workerCh    chan fileWorkerMessage
+	closed      chan struct{}
+
+	summary *Summary
+	printer ProgressPrinter
+}
+
+func NewProgress(printer ProgressPrinter) *Progress {
+	return &Progress{
+		// limit to 60fps by default
+		MinUpdatePause: time.Second / 60,
+		start:          time.Now(),
+
+		totalCh:     make(chan Counter),
+		processedCh: make(chan Counter),
+		errCh:       make(chan struct{}),
+		workerCh:    make(chan fileWorkerMessage),
+		closed:      make(chan struct{}),
+
+		summary: &Summary{},
+
+		printer: printer,
+	}
+}
+
+func (p *Progress) Run(ctx context.Context) error {
+	var (
+		lastUpdate       time.Time
+		total, processed Counter
+		errors           uint
+		started          bool
+		currentFiles     = make(map[string]struct{})
+		secondsRemaining uint64
+	)
+
+	t := time.NewTicker(time.Second)
+	signalsCh := signals.GetProgressChannel()
+	defer t.Stop()
+	defer close(p.closed)
+	// Reset status when finished
+	defer p.printer.Reset()
+
+	for {
+		forceUpdate := false
+		select {
+		case <-ctx.Done():
+			return nil
+		case t, ok := <-p.totalCh:
+			if ok {
+				total = t
+				started = true
+			} else {
+				// scan has finished
+				p.totalCh = nil
+				p.totalBytes = total.Bytes
+			}
+		case s := <-p.processedCh:
+			processed.Files += s.Files
+			processed.Dirs += s.Dirs
+			processed.Bytes += s.Bytes
+			started = true
+		case <-p.errCh:
+			errors++
+			p.summary.Lock()
+			p.summary.TotalErrors = errors
+			p.summary.Unlock()
+			started = true
+		case m := <-p.workerCh:
+			if m.done {
+				delete(currentFiles, m.filename)
+			} else {
+				currentFiles[m.filename] = struct{}{}
+			}
+		case <-t.C:
+			if !started {
+				continue
+			}
+
+			if p.totalCh == nil {
+				secs := float64(time.Since(p.start) / time.Second)
+				todo := float64(total.Bytes - processed.Bytes)
+				secondsRemaining = uint64(secs / float64(processed.Bytes) * todo)
+			}
+		case <-signalsCh:
+			forceUpdate = true
+		}
+
+		// limit update frequency
+		if !forceUpdate && (time.Since(lastUpdate) < p.MinUpdatePause || p.MinUpdatePause == 0) {
+			continue
+		}
+		lastUpdate = time.Now()
+
+		p.printer.Update(total, processed, errors, currentFiles, p.start, secondsRemaining)
+	}
+}
+
+// ScannerError is the error callback function for the scanner, it prints the
+// error in verbose mode and returns nil.
+func (p *Progress) ScannerError(item string, fi os.FileInfo, err error) error {
+	return p.printer.ScannerError(item, fi, err)
+}
+
+// Error is the error callback function for the archiver, it prints the error and returns nil.
+func (p *Progress) Error(item string, fi os.FileInfo, err error) error {
+	cbErr := p.printer.Error(item, fi, err)
+
+	select {
+	case p.errCh <- struct{}{}:
+	case <-p.closed:
+	}
+	return cbErr
+}
+
+// StartFile is called when a file is being processed by a worker.
+func (p *Progress) StartFile(filename string) {
+	select {
+	case p.workerCh <- fileWorkerMessage{filename: filename}:
+	case <-p.closed:
+	}
+}
+
+// CompleteBlob is called for all saved blobs for files.
+func (p *Progress) CompleteBlob(filename string, bytes uint64) {
+	select {
+	case p.processedCh <- Counter{Bytes: bytes}:
+	case <-p.closed:
+	}
+}
+
+// CompleteItem is the status callback function for the archiver when a
+// file/dir has been saved successfully.
+func (p *Progress) CompleteItem(item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration) {
+	p.summary.Lock()
+	p.summary.ItemStats.Add(s)
+
+	// for the last item "/", current is nil
+	if current != nil {
+		p.summary.ProcessedBytes += current.Size
+	}
+
+	p.summary.Unlock()
+
+	if current == nil {
+		// error occurred, tell the status display to remove the line
+		select {
+		case p.workerCh <- fileWorkerMessage{filename: item, done: true}:
+		case <-p.closed:
+		}
+		return
+	}
+
+	switch current.Type {
+	case "file":
+		select {
+		case p.processedCh <- Counter{Files: 1}:
+		case <-p.closed:
+		}
+		select {
+		case p.workerCh <- fileWorkerMessage{filename: item, done: true}:
+		case <-p.closed:
+		}
+	case "dir":
+		select {
+		case p.processedCh <- Counter{Dirs: 1}:
+		case <-p.closed:
+		}
+	}
+
+	if current.Type == "dir" {
+		if previous == nil {
+			p.printer.CompleteItem("dir new", item, previous, current, s, d)
+			p.summary.Lock()
+			p.summary.Dirs.New++
+			p.summary.Unlock()
+			return
+		}
+
+		if previous.Equals(*current) {
+			p.printer.CompleteItem("dir unchanged", item, previous, current, s, d)
+			p.summary.Lock()
+			p.summary.Dirs.Unchanged++
+			p.summary.Unlock()
+		} else {
+			p.printer.CompleteItem("dir modified", item, previous, current, s, d)
+			p.summary.Lock()
+			p.summary.Dirs.Changed++
+			p.summary.Unlock()
+		}
+
+	} else if current.Type == "file" {
+		select {
+		case p.workerCh <- fileWorkerMessage{done: true, filename: item}:
+		case <-p.closed:
+		}
+
+		if previous == nil {
+			p.printer.CompleteItem("file new", item, previous, current, s, d)
+			p.summary.Lock()
+			p.summary.Files.New++
+			p.summary.Unlock()
+			return
+		}
+
+		if previous.Equals(*current) {
+			p.printer.CompleteItem("file unchanged", item, previous, current, s, d)
+			p.summary.Lock()
+			p.summary.Files.Unchanged++
+			p.summary.Unlock()
+		} else {
+			p.printer.CompleteItem("file modified", item, previous, current, s, d)
+			p.summary.Lock()
+			p.summary.Files.Changed++
+			p.summary.Unlock()
+		}
+	}
+}
+
+// ReportTotal sets the total stats up to now
+func (p *Progress) ReportTotal(item string, s archiver.ScanStats) {
+	select {
+	case p.totalCh <- Counter{Files: uint64(s.Files), Dirs: uint64(s.Dirs), Bytes: s.Bytes}:
+	case <-p.closed:
+	}
+
+	if item == "" {
+		p.printer.ReportTotal(item, p.start, s)
+		close(p.totalCh)
+		return
+	}
+}
+
+// Finish prints the finishing messages.
+func (p *Progress) Finish(snapshotID restic.ID) {
+	<-p.closed
+	summary := p.summary
+	p.printer.Finish(snapshotID, p.start, summary)
+}
+
+// SetMinUpdatePause sets b.MinUpdatePause. It satisfies the
+// ArchiveProgressReporter interface.
+func (p *Progress) SetMinUpdatePause(d time.Duration) {
+	p.MinUpdatePause = d
+}

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -65,6 +65,7 @@ type Summary struct {
 	archiver.ItemStats
 }
 
+// Progress reports progress for the `backup` command.
 type Progress struct {
 	MinUpdatePause time.Duration
 
@@ -100,6 +101,8 @@ func NewProgress(printer ProgressPrinter) *Progress {
 	}
 }
 
+// Run regularly updates the status lines. It should be called in a separate
+// goroutine.
 func (p *Progress) Run(ctx context.Context) error {
 	var (
 		lastUpdate       time.Time
@@ -309,9 +312,9 @@ func (p *Progress) ReportTotal(item string, s archiver.ScanStats) {
 
 // Finish prints the finishing messages.
 func (p *Progress) Finish(snapshotID restic.ID) {
+	// wait for the status update goroutine to shut down
 	<-p.closed
-	summary := p.summary
-	p.printer.Finish(snapshotID, p.start, summary)
+	p.printer.Finish(snapshotID, p.start, p.summary)
 }
 
 // SetMinUpdatePause sets b.MinUpdatePause. It satisfies the


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
`ui/backup.go` and `ui/json/backup.go` are almost identical to one another (copy paste). 

This change refactors the shared logic into `progress.go`. 

`ui/backup.go` and `ui/json/backup.go` have already begun to diverge, for example
```
// for the last item "/", current is nil
if current != nil { 
   p.summary.ProcessedBytes += current.Size
}
```
`p.summary.ProcessedBytes += current.Size` was done outside of the lock in json/backup.go , but ui/backup.go had the above

This will continue to be a "hope we don't forget to update the other place" problem..

This change also allows the progress reporting/printing to be shared with restore status (forth coming after this is merged).

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No it wasn't
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [X] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [X] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [X] I have run `gofmt` on the code in all commits
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [X] I'm done, this Pull Request is ready for review
