### PR TITLE
ls: Check for non-nil error before calling panic()

### DIFF
--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -165,7 +165,9 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 				ShortID:    sn.ID().Str(),
 				StructType: "snapshot",
 			})
-			panic(err)
+			if err != nil {
+				Warnf("JSON encode failed: %v\n", err)
+			}
 		}
 
 		printNode = func(path string, node *restic.Node) {
@@ -182,7 +184,9 @@ func runLs(opts LsOptions, gopts GlobalOptions, args []string) error {
 				ChangeTime: node.ChangeTime,
 				StructType: "node",
 			})
-			panic(err)
+			if err != nil {
+				Warnf("JSON encode failed: %v\n", err)
+			}
 		}
 	} else {
 		printSnapshot = func(sn *restic.Snapshot) {


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Don't panic when `restic ls --json` is called. It was accidentally included in the error checking cleanup PR #3250.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I'm done, this Pull Request is ready for review
