### PR TITLE
Treat an empty password as a fatal error for repository init.

### DIFF
--- a/changelog/unreleased/issue-3214
+++ b/changelog/unreleased/issue-3214
@@ -6,3 +6,4 @@ an error with a stack trace. Now, if an empty password is provided, it is
 treated as a fatal error, and no repository is created.
 
 https://github.com/restic/restic/issues/3214
+https://github.com/restic/restic/pull/3283

--- a/changelog/unreleased/issue-3214
+++ b/changelog/unreleased/issue-3214
@@ -1,0 +1,8 @@
+Bugfix: Treat an empty password as a fatal error for repository init
+
+When attempting to initialize a new repository, if an empty password was
+supplied, the repository would be created but the init command would return
+an error with a stack trace. Now, if an empty password is provided, it is
+treated as a fatal error, and no repository is created.
+
+https://github.com/restic/restic/issues/3214

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -53,16 +53,16 @@ func runInit(opts InitOptions, gopts GlobalOptions, args []string) error {
 		return err
 	}
 
-	be, err := create(repo, gopts.extended)
-	if err != nil {
-		return errors.Fatalf("create repository at %s failed: %v\n", location.StripPassword(gopts.Repo), err)
-	}
-
 	gopts.password, err = ReadPasswordTwice(gopts,
 		"enter password for new repository: ",
 		"enter password again: ")
 	if err != nil {
 		return err
+	}
+
+	be, err := create(repo, gopts.extended)
+	if err != nil {
+		return errors.Fatalf("create repository at %s failed: %v\n", location.StripPassword(gopts.Repo), err)
 	}
 
 	s := repository.New(be)

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -364,7 +364,7 @@ func ReadPassword(opts GlobalOptions, prompt string) (string, error) {
 	}
 
 	if len(password) == 0 {
-		return "", errors.New("an empty password is not a password")
+		return "", errors.Fatal("an empty password is not a password")
 	}
 
 	return password, nil


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
<!--
Describe the changes and their purpose here, as detailed as needed.
-->
Addresses issue #3214

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
Closes issue #3214


Checklist
---------

- [x ] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [ x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x ] I have run `gofmt` on the code in all commits
- [x ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ x] I'm done, this Pull Request is ready for review
