### PR TITLE
backup: Correctly handle --quiet flag

### DIFF
--- a/changelog/unreleased/issue-3284
+++ b/changelog/unreleased/issue-3284
@@ -1,0 +1,11 @@
+Bugfix: `backup --quiet` no longer prints status information
+
+A regression in the latest restic version caused the output of `backup --quiet`
+to contain large amounts of backup progress information when run using an
+interactive terminal. This is fixed now.
+
+A workaround for this bug is to run restic as follows:
+`restic backup --quiet [..] | cat -`.
+
+https://github.com/restic/restic/issues/3184
+https://github.com/restic/restic/pull/3186

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -561,7 +561,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	}()
 	gopts.stdout, gopts.stderr = p.Stdout(), p.Stderr()
 
-	p.SetMinUpdatePause(calculateProgressInterval())
+	p.SetMinUpdatePause(calculateProgressInterval(!gopts.Quiet))
 
 	t.Go(func() error { return p.Run(t.Context(gopts.ctx)) })
 

--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -11,8 +11,8 @@ import (
 
 // calculateProgressInterval returns the interval configured via RESTIC_PROGRESS_FPS
 // or if unset returns an interval for 60fps on interactive terminals and 0 (=disabled)
-// for non-interactive terminals
-func calculateProgressInterval() time.Duration {
+// for non-interactive terminals or when run using the --quiet flag
+func calculateProgressInterval(show bool) time.Duration {
 	interval := time.Second / 60
 	fps, err := strconv.ParseFloat(os.Getenv("RESTIC_PROGRESS_FPS"), 64)
 	if err == nil && fps > 0 {
@@ -20,7 +20,7 @@ func calculateProgressInterval() time.Duration {
 			fps = 60
 		}
 		interval = time.Duration(float64(time.Second) / fps)
-	} else if !stdoutIsTerminal() {
+	} else if !stdoutIsTerminal() || !show {
 		interval = 0
 	}
 	return interval
@@ -31,7 +31,7 @@ func newProgressMax(show bool, max uint64, description string) *progress.Counter
 	if !show {
 		return nil
 	}
-	interval := calculateProgressInterval()
+	interval := calculateProgressInterval(show)
 
 	return progress.New(interval, max, func(v uint64, max uint64, d time.Duration, final bool) {
 		var status string


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
`restic backup --quiet` printed a lot of backup progress instead of printing nothing. This PR fixes this by explicitly setting the default progress output interval to 0, which properly disables the progress output.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #3284.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
