### PR TITLE
Clean up PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,8 +4,8 @@ fill out the following questions to make it easier for us to review your
 changes.
 -->
 
-What changes are made in this PR? What problem does it solve?
--------------------------------------------------------------
+What does this PR change? What problem does it solve?
+-----------------------------------------------------
 
 <!--
 Describe the changes and their purpose here, as detailed as needed.
@@ -25,17 +25,15 @@ Checklist
 ---------
 
 <!--
-Fill out this checklist by replacing [ ] with [x].
-
 You do not need to check all the boxes below all at once. Feel free to take
 your time and add more commits. If you're done and ready for review, please
-check the last box.
+check the last box. Enable a checkbox by replacing [ ] with [x].
 -->
 
 - [ ] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
-- [ ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for this PR.
-- [ ] I have added tests for all code changes in this PR.
-- [ ] I have added documentation for the those changes (in the manual).
+- [ ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
+- [ ] I have added tests for all code changes.
+- [ ] I have added documentation for relevant changes (in the manual).
 - [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
 - [ ] I have run `gofmt` on the code in all commits.
 - [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,8 +11,8 @@ What changes are made in this PR? What problem does it solve?
 Describe the changes and their purpose here, as detailed as needed.
 -->
 
-Was the change discussed in an issue or on the forum before?
-------------------------------------------------------------
+Was the change previously discussed in an issue or on the forum?
+----------------------------------------------------------------
 
 <!--
 Link issues and relevant forum posts here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -34,8 +34,8 @@ check the last box.
 
 - [ ] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
 - [ ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for this PR.
-- [ ] I have added tests for all changes in this PR.
-- [ ] I have added documentation for the changes (in the manual).
+- [ ] I have added tests for all code changes in this PR.
+- [ ] I have added documentation for the those changes (in the manual).
 - [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
 - [ ] I have run `gofmt` on the code in all commits.
 - [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,23 +1,17 @@
-
-
 <!--
 Thank you very much for contributing code or documentation to restic! Please
 fill out the following questions to make it easier for us to review your
 changes.
-
-You do not need to check all the boxes below all at once, feel free to take
-your time and add more commits. If you're done and ready for review, please
-check the last box.
 -->
 
-What does this PR change? What problem does it solve?
------------------------------------------------------
+What changes are made in this PR? What problem does it solve?
+-------------------------------------------------------------
 
 <!--
 Describe the changes and their purpose here, as detailed as needed.
 -->
 
-Was the change discussed in an issue or in the forum before?
+Was the change discussed in an issue or on the forum before?
 ------------------------------------------------------------
 
 <!--
@@ -30,11 +24,19 @@ is closed automatically when this PR is merged.
 Checklist
 ---------
 
-- [ ] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
-- [ ] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-- [ ] I have added tests for all changes in this PR
-- [ ] I have added documentation for the changes (in the manual)
-- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
-- [ ] I have run `gofmt` on the code in all commits
-- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
-- [ ] I'm done, this Pull Request is ready for review
+<!--
+Fill out this checklist by replacing [ ] with [x].
+
+You do not need to check all the boxes below all at once. Feel free to take
+your time and add more commits. If you're done and ready for review, please
+check the last box.
+-->
+
+- [ ] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
+- [ ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) for this PR.
+- [ ] I have added tests for all changes in this PR.
+- [ ] I have added documentation for the changes (in the manual).
+- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
+- [ ] I have run `gofmt` on the code in all commits.
+- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
+- [ ] I'm done! This pull request is ready for review.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This pull request modifies the PR template and makes the following changes:

- Clean up some writing style
- Remove extra blank lines

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review