### PR TITLE
prune: Handle duplicate blobs more efficiently

### DIFF
--- a/changelog/unreleased/issue-3114
+++ b/changelog/unreleased/issue-3114
@@ -1,10 +1,10 @@
-Enhancement: Improve `prune` in presence of duplicate blobs
+Enhancement: Optimize handling of duplicate blobs in `prune`
 
-Restic `prune` always used to repack all pack files containing duplicate
-blobs. This effectively removed all duplicates during prune. However, one 
-of the consequences was that all those pack files were downloadeded and
-duplicate blobs did not contribute to the threshold for unused repository
-space.
+Restic `prune` always used to repack all data files containing duplicate
+blobs. This effectively removed all duplicates during prune. However, as a
+consequence all these data files were repacked even if the unused repository
+space threshold could be reached with less work.
+
 This is now changed and `prune` works nice and fast also if there are lots
 of duplicates.
 

--- a/changelog/unreleased/issue-3114
+++ b/changelog/unreleased/issue-3114
@@ -1,0 +1,12 @@
+Enhancement: Improve `prune` in presence of duplicate blobs
+
+Restic `prune` always used to repack all pack files containing duplicate
+blobs. This effectively removed all duplicates during prune. However, one 
+of the consequences was that all those pack files were downloadeded and
+duplicate blobs did not contribute to the threshold for unused repository
+space.
+This is now changed and `prune` works nice and fast also if there are lots
+of duplicates.
+
+https://github.com/restic/restic/issues/3114
+https://github.com/restic/restic/pull/3290


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Enhances treatment of duplicates during `prune`. Now an algorithm is implemented that marks each duplicate either as "used" or as "unused" (such that pack files containing only duplicates should be marked as completely unused and hence can be removed).
As a side effect, `prune` now can keep duplicates if unused space is allowed by `--max-unused` and the statistics are accurate even if not all packs with duplicates are repacked.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

closes #3114 (at least all points except the treatment of duplicates where one of the duplicates is damaged)

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
-  I have not added tests for all changes in this PR
- I have not added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
