### PR TITLE
Add RepositoryFile2 Option for secondary repository

### DIFF
--- a/changelog/unreleased/issue-3293
+++ b/changelog/unreleased/issue-3293
@@ -1,0 +1,14 @@
+Enhancement: Add `--repository-file2` option to `init` and `copy` command
+
+The `init` and `copy` command can now be used with the `--repository-file2`
+option or the `$RESTIC_REPOSITORY_FILE2` environment variable.
+These to options are in addition to the `--repo2` flag and allow you to read
+the destination repository from a file.
+
+Using both `--repository-file` and `--repo2` options resulted in an error for
+the `copy` or `init` command. The handling of this combination of options has
+been fixed. A workaround for this issue is to only use `--repo` or `-r` and
+`--repo2` for `init` or `copy`.
+
+https://github.com/restic/restic/issues/3293
+https://github.com/restic/restic/pull/3294

--- a/cmd/restic/secondary_repo.go
+++ b/cmd/restic/secondary_repo.go
@@ -9,6 +9,7 @@ import (
 
 type secondaryRepoOptions struct {
 	Repo            string
+	RepositoryFile  string
 	password        string
 	PasswordFile    string
 	PasswordCommand string
@@ -17,18 +18,25 @@ type secondaryRepoOptions struct {
 
 func initSecondaryRepoOptions(f *pflag.FlagSet, opts *secondaryRepoOptions, repoPrefix string, repoUsage string) {
 	f.StringVarP(&opts.Repo, "repo2", "", os.Getenv("RESTIC_REPOSITORY2"), repoPrefix+" `repository` "+repoUsage+" (default: $RESTIC_REPOSITORY2)")
+	f.StringVarP(&opts.RepositoryFile, "repository-file2", "", os.Getenv("RESTIC_REPOSITORY_FILE2"), "`file` from which to read the "+repoPrefix+" repository location "+repoUsage+" (default: $RESTIC_REPOSITORY_FILE2)")
 	f.StringVarP(&opts.PasswordFile, "password-file2", "", os.Getenv("RESTIC_PASSWORD_FILE2"), "`file` to read the "+repoPrefix+" repository password from (default: $RESTIC_PASSWORD_FILE2)")
 	f.StringVarP(&opts.KeyHint, "key-hint2", "", os.Getenv("RESTIC_KEY_HINT2"), "key ID of key to try decrypting the "+repoPrefix+" repository first (default: $RESTIC_KEY_HINT2)")
 	f.StringVarP(&opts.PasswordCommand, "password-command2", "", os.Getenv("RESTIC_PASSWORD_COMMAND2"), "shell `command` to obtain the "+repoPrefix+" repository password from (default: $RESTIC_PASSWORD_COMMAND2)")
 }
 
 func fillSecondaryGlobalOpts(opts secondaryRepoOptions, gopts GlobalOptions, repoPrefix string) (GlobalOptions, error) {
-	if opts.Repo == "" {
-		return GlobalOptions{}, errors.Fatal("Please specify a " + repoPrefix + " repository location (--repo2)")
+	if opts.Repo == "" && opts.RepositoryFile == "" {
+		return GlobalOptions{}, errors.Fatal("Please specify a " + repoPrefix + " repository location (--repo2 or --repository-file2)")
 	}
+
+	if opts.Repo != "" && opts.RepositoryFile != "" {
+		return GlobalOptions{}, errors.Fatal("Options --repo2 and --repository-file2 are mutually exclusive, please specify only one")
+	}
+
 	var err error
 	dstGopts := gopts
 	dstGopts.Repo = opts.Repo
+	dstGopts.RepositoryFile = opts.RepositoryFile
 	dstGopts.PasswordFile = opts.PasswordFile
 	dstGopts.PasswordCommand = opts.PasswordCommand
 	dstGopts.KeyHint = opts.KeyHint

--- a/cmd/restic/secondary_repo_test.go
+++ b/cmd/restic/secondary_repo_test.go
@@ -42,7 +42,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 			},
 		},
 		{
-			// Test if RepositoryFile and PasswordFile are parsed correctly.
+			// Test if RepositoryFile and PasswordCommand are parsed correctly.
 			Opts: secondaryRepoOptions{
 				RepositoryFile:  "backupDst",
 				PasswordCommand: "echo secretDst",
@@ -69,7 +69,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 			},
 		},
 		{
-			// Test must fail on no repo given.
+			// Test must fail as PasswordFile and PasswordCommand are both given
 			Opts: secondaryRepoOptions{
 				Repo:            "backupDst",
 				PasswordFile:    "passwordFileDst",
@@ -77,21 +77,21 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 			},
 		},
 		{
-			// Test must fail on no repo given.
+			// Test must fail as PasswordFile does not exist
 			Opts: secondaryRepoOptions{
 				Repo:         "backupDst",
 				PasswordFile: "NonExistingFile",
 			},
 		},
 		{
-			// Test must fail on no repo given.
+			// Test must fail as PasswordCommand does not exist
 			Opts: secondaryRepoOptions{
 				Repo:            "backupDst",
 				PasswordCommand: "notEmpty",
 			},
 		},
 		{
-			// Test must fail on no repo given.
+			// Test must fail as no password is given.
 			Opts: secondaryRepoOptions{
 				Repo: "backupDst",
 			},

--- a/cmd/restic/secondary_repo_test.go
+++ b/cmd/restic/secondary_repo_test.go
@@ -1,0 +1,132 @@
+package main
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+//TestFillSecondaryGlobalOpts tests valid and invalid data on fillSecondaryGlobalOpts-function
+func TestFillSecondaryGlobalOpts(t *testing.T) {
+	//secondaryRepoTestCase defines a struct for test cases
+	type secondaryRepoTestCase struct {
+		Opts     secondaryRepoOptions
+		DstGOpts GlobalOptions
+	}
+
+	//validSecondaryRepoTestCases is a list with test cases that must pass
+	var validSecondaryRepoTestCases = []secondaryRepoTestCase{
+		{
+			// Test if Repo and Password are parsed correctly.
+			Opts: secondaryRepoOptions{
+				Repo:     "backupDst",
+				password: "secretDst",
+			},
+			DstGOpts: GlobalOptions{
+				Repo:     "backupDst",
+				password: "secretDst",
+			},
+		},
+		{
+			// Test if RepositoryFile and PasswordFile are parsed correctly.
+			Opts: secondaryRepoOptions{
+				RepositoryFile: "backupDst",
+				PasswordFile:   "passwordFileDst",
+			},
+			DstGOpts: GlobalOptions{
+				RepositoryFile: "backupDst",
+				password:       "secretDst",
+				PasswordFile:   "passwordFileDst",
+			},
+		},
+		{
+			// Test if RepositoryFile and PasswordFile are parsed correctly.
+			Opts: secondaryRepoOptions{
+				RepositoryFile:  "backupDst",
+				PasswordCommand: "echo secretDst",
+			},
+			DstGOpts: GlobalOptions{
+				RepositoryFile:  "backupDst",
+				password:        "secretDst",
+				PasswordCommand: "echo secretDst",
+			},
+		},
+	}
+
+	//invalidSecondaryRepoTestCases is a list with test cases that must fail
+	var invalidSecondaryRepoTestCases = []secondaryRepoTestCase{
+		{
+			// Test must fail on no repo given.
+			Opts: secondaryRepoOptions{},
+		},
+		{
+			// Test must fail as Repo and RepositoryFile are both given
+			Opts: secondaryRepoOptions{
+				Repo:           "backupDst",
+				RepositoryFile: "backupDst",
+			},
+		},
+		{
+			// Test must fail on no repo given.
+			Opts: secondaryRepoOptions{
+				Repo:            "backupDst",
+				PasswordFile:    "passwordFileDst",
+				PasswordCommand: "notEmpty",
+			},
+		},
+		{
+			// Test must fail on no repo given.
+			Opts: secondaryRepoOptions{
+				Repo:         "backupDst",
+				PasswordFile: "NonExistingFile",
+			},
+		},
+		{
+			// Test must fail on no repo given.
+			Opts: secondaryRepoOptions{
+				Repo:            "backupDst",
+				PasswordCommand: "notEmpty",
+			},
+		},
+		{
+			// Test must fail on no repo given.
+			Opts: secondaryRepoOptions{
+				Repo: "backupDst",
+			},
+		},
+	}
+
+	//gOpts defines the Global options used in the secondary repository tests
+	var gOpts = GlobalOptions{
+		Repo:           "backupSrc",
+		RepositoryFile: "backupSrc",
+		password:       "secretSrc",
+		PasswordFile:   "passwordFileSrc",
+	}
+
+	//Create temp dir to create password file.
+	dir, cleanup := rtest.TempDir(t)
+	defer cleanup()
+
+	cleanup = rtest.Chdir(t, dir)
+	defer cleanup()
+
+	//Create temporary password file
+	err := ioutil.WriteFile(filepath.Join(dir, "passwordFileDst"), []byte("secretDst"), 0666)
+	rtest.OK(t, err)
+
+	// Test all valid cases
+	for _, testCase := range validSecondaryRepoTestCases {
+		DstGOpts, err := fillSecondaryGlobalOpts(testCase.Opts, gOpts, "destination")
+		rtest.OK(t, err)
+		rtest.Equals(t, DstGOpts, testCase.DstGOpts)
+	}
+
+	// Test all invalid cases
+	for _, testCase := range invalidSecondaryRepoTestCases {
+		_, err := fillSecondaryGlobalOpts(testCase.Opts, gOpts, "destination")
+		rtest.Assert(t, err != nil, "Expected error, but function did not return an error")
+	}
+}

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -117,8 +117,12 @@ be skipped by later copy runs.
     both the source and destination repository, *may occupy up to twice their
     space* in the destination repository. See below for how to avoid this.
 
-For the destination repository ``--repo2`` the password can be read from
-a file ``--password-file2`` or from a command ``--password-command2``.
+The destination repository is specified with ``--repo2`` or can be read 
+from a file specified via ``--repository-file2``. Both of these options
+can also set as environment variables ``$RESTIC_REPOSITORY2`` or
+``$RESTIC_REPOSITORY_FILE2`` respectively. For the destination repository 
+the password can be read from a file ``--password-file2`` or from a command 
+``--password-command2``.
 Alternatively the environment variables ``$RESTIC_PASSWORD_COMMAND2`` and
 ``$RESTIC_PASSWORD_FILE2`` can be used. It is also possible to directly
 pass the password via ``$RESTIC_PASSWORD2``. The key which should be used


### PR DESCRIPTION
I ran into issues with combining the `--repository-file` and `--repo2` on a `restic copy`.

I do think that the copy could support `--repository-file2` flag. This requires to review this section anyways.
Furthermore, to get to this section of code, the `Repo`-key must be **not** empty, and therefore, the `RepositoryFile`-key must be an empty string.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
On initialisation of the options for the secondary repository, all
options are copied from the primary repository. This includes the
repository-file key, this one is not cleared. Resulting in both primary
and secondary options having the same value for repository-file.

Then the Repo-key is set from the repo2 flag.
Resulting in an fatal error as the Repo and Repo File key are set.

Solved it by clearing the Repo File Key for the secondary repository
options.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
This pull request fixes #3293
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
