### PR TITLE
doc: Add note about bash completion path

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -316,3 +316,8 @@ Example for using sudo to write a bash completion script directly to the system-
 
     $ sudo ./restic generate --bash-completion /etc/bash_completion.d/restic
     writing bash completion file to /etc/bash_completion.d/restic
+
+.. note:: The path for the ``--bash-completion`` option may vary depending on
+   the operating system used, e.g. ``/usr/share/bash-completion/completions/restic``
+   in Debian and derivatives. Please look up the correct path in the appropriate
+   documentation.


### PR DESCRIPTION
Adds bash-completion example for Debian and derivatives

What does this PR change? What problem does it solve?
-----------------------------------------------------

Documentation had an example that was not applicable to Debian/Ubuntu/Devuan/..., this PR adds an additional example for those systems.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I'm done, this Pull Request is ready for review
