### PR TITLE
restore: Add --warmup option

### DIFF
--- a/cmd/restic/warmup.go
+++ b/cmd/restic/warmup.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"io"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/restic/restic/internal/restic"
+)
+
+const numWarmUpWorkers = 8
+
+// WarmUpFiles opens all files the given fileList in parallel in order to "warm" them up
+// This can be useful when accessing cold storage
+func WarmUpFiles(gopts GlobalOptions, fileList restic.IDSet, fileType restic.FileType) error {
+	totalCount := len(fileList)
+	fileChan := make(chan restic.ID)
+	go func() {
+		for id := range fileList {
+			fileChan <- id
+		}
+		close(fileChan)
+	}()
+
+	Verbosef("reopen repository\n")
+	// reopen the backend to get one without retries
+	be, err := open(gopts.Repo, gopts, gopts.extended)
+	if err != nil {
+		return err
+	}
+
+	bar := newProgressMax(!gopts.JSON && !gopts.Quiet, uint64(totalCount), "files warmed-up")
+	wg, ctx := errgroup.WithContext(gopts.ctx)
+	defer bar.Done()
+	for i := 0; i < numWarmUpWorkers; i++ {
+		wg.Go(func() error {
+			for id := range fileChan {
+				h := restic.Handle{Type: fileType, Name: id.String()}
+				// ignore errors, as we expect them for cold data loads
+				_ = be.Load(ctx, h, 1, 0, func(_ io.Reader) error { return nil })
+				if !gopts.JSON {
+					Verboseff("warmed up %v\n", h)
+				}
+				bar.Add(1)
+			}
+			return nil
+		})
+	}
+
+	return wg.Wait()
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds a dry run option to the `restore` command.
When called with `--dry-run`, `restore` only prints out which data pack files it needs to restore the data.

This allows to do some kind of warming-up for the data which will be needed for the actual `restore` run.

The two last commits extend the warm-up possibilities from #2881 to `restore`. I can also extract those to a separate PR, if wished (the discussion whether we should add the `--warm-up` option is not finished yet)

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

closes #2796 
see also #3202

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
