### PR TITLE
backup: In case of error also Wait() for terminal goroutine

### DIFF
--- a/changelog/unreleased/pull-3305
+++ b/changelog/unreleased/pull-3305
@@ -1,0 +1,7 @@
+Bugfix: In case of error also Wait() for terminal goroutine
+
+This prevents a race condition where the final summary message is
+lost.  When using --json output it happened from time to time that the
+summary output was missing.
+
+https://github.com/restic/restic/pull/3305

--- a/changelog/unreleased/pull-3305
+++ b/changelog/unreleased/pull-3305
@@ -1,7 +1,6 @@
-Bugfix: In case of error also Wait() for terminal goroutine
+Bugfix: Fix possibly missing backup summary of json output in case of error
 
-This prevents a race condition where the final summary message is
-lost.  When using --json output it happened from time to time that the
-summary output was missing.
+When using --json output it happened from time to time that the summary output
+was missing in case an error occurred. This has been fixed.
 
 https://github.com/restic/restic/pull/3305

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -60,11 +60,11 @@ Exit status is 3 if some source data could not be read (incomplete snapshot crea
 		t.Go(func() error { term.Run(t.Context(globalOptions.ctx)); return nil })
 
 		err := runBackup(backupOptions, globalOptions, term, args)
-		if err != nil {
-			return err
-		}
 		t.Kill(nil)
-		return t.Wait()
+		if werr := t.Wait(); werr != nil {
+			panic(fmt.Sprintf("term.Run() returned err: %v", err))
+		}
+		return err
 	},
 }
 


### PR DESCRIPTION
This prevents a race condition where the final summary message can get lost.


What does this PR change? What problem does it solve?
-----------------------------------------------------

When using  `--json` output it happens from time to time that the summary output is missing.

Especially likely is this case if the standard output of restic is a pipe and therefore buffered (I use a tool to parse the JSON output of restic).

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
