### PR TITLE
Failing to remove temporary file will result in debug warning

### DIFF
--- a/VERSION
+++ b/VERSION
@@ -1,1 +1,1 @@
-0.12.1
+0.12.1 for Firma Chrobok

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -136,7 +136,7 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packe
 
 	err = fs.RemoveIfExists(p.tmpfile.Name())
 	if err != nil {
-		return errors.Wrap(err, "Remove")
+		debug.Log("Could not remove file: %s\n", p.tmpfile.Name())
 	}
 
 	// update blobs in the index


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR fixes errors when creating backups on windows. 
Sometimes another process (typically antivirus software) would block deleting temporary files, causing error, which should just be warnings.
This PR degrades those errors to warnings.

I have successfully tested this solution on multiple windows machines, which previously could not finish creating backup.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Issues was discussed in #1551 
https://forum.restic.net/t/temp-file-errors-on-windows-10/380/12

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added documentation for the changes (in the manual)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
