### PR TITLE
local: Ignore files in intermediate folders

### DIFF
--- a/changelog/unreleased/issue-3302
+++ b/changelog/unreleased/issue-3302
@@ -1,0 +1,8 @@
+Bugfix: Fix `fdopendir: not a directory` error for local backend
+
+The `check`, `list packs`, `prune` and `rebuild-index` commands failed
+for the local backend when the `data` folder in the repository contained
+files. This has been fixed.
+
+https://github.com/restic/restic/issues/3302
+https://github.com/restic/restic/pull/3308


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Since PR #3065 the list operation for the local backend only lists files in folders which are also accessed by other operations. For example the data directory has one level of sharding, e.g. `b912ddb81[...]` is expected to be located in `/data/b9/b912ddb81[...]`. A file located at an unexpected place like `/data/.DS_Store` caused unexpected errors like `fdopendir: not a directory`. As we can't prevent external tools from littering the data folder, such files should be ignored.

This PR adds a check to skip files in `/data/`.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #3302.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
