### PR TITLE
check: Fix crash of --read-data-subset=x% on empty repository

### DIFF
--- a/changelog/unreleased/issue-3296
+++ b/changelog/unreleased/issue-3296
@@ -1,0 +1,7 @@
+Bugfix: Fix crash of `check --read-data-subset=x%` run for an empty repository
+
+`check --read-data-subset=x%` crashed when run for an empty repository. This
+has been fixed.
+
+https://github.com/restic/restic/issues/3296
+https://github.com/restic/restic/pull/3309

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -331,7 +331,7 @@ func selectPacksByBucket(allPacks map[restic.ID]int64, bucket, totalBuckets uint
 func selectRandomPacksByPercentage(allPacks map[restic.ID]int64, percentage float64) map[restic.ID]int64 {
 	packCount := len(allPacks)
 	packsToCheck := int(float64(packCount) * (percentage / 100.0))
-	if packsToCheck < 1 {
+	if packCount > 0 && packsToCheck < 1 {
 		packsToCheck = 1
 	}
 	timeNs := time.Now().UnixNano()

--- a/cmd/restic/cmd_check_test.go
+++ b/cmd/restic/cmd_check_test.go
@@ -122,3 +122,10 @@ func TestSelectRandomPacksByPercentage(t *testing.T) {
 		rtest.Assert(t, ok, "Expected input and output to be equal")
 	}
 }
+
+func TestSelectNoRandomPacksByPercentage(t *testing.T) {
+	// that the a repository without pack files works
+	var testPacks = make(map[restic.ID]int64)
+	selectedPacks := selectRandomPacksByPercentage(testPacks, 10.0)
+	rtest.Assert(t, len(selectedPacks) == 0, "Expected 0 selected packs")
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
`check --read-data-subset=x%` crashed when run for an empty repository. This PR fixes this by correctly handling that special case.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #3296.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
