### PR TITLE
doc: Clarify setcap applying only to current binary

### DIFF
--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -338,6 +338,13 @@ attribute, interpret it and assign capabilities accordingly.
 
    root@a3e580b6369d:/# setcap cap_dac_read_search=+ep ~restic/bin/restic
 
+.. important:: The capabilities of the ``setcap`` command only applies to this
+    specific copy of the restic binary. If you run ``restic self-update`` or
+    in any other way replace or update the binary, the capabilities you added
+    above will not be in effect for the new binary. To mitigate this, simply
+    run the ``setcap`` command again, to make sure that the new binary has the
+    same and intended capabilities.
+
 From now on the user ``restic`` can run restic to backup the whole
 system.
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Clarifies in the documentation for full root/system backup that the `setcap` command only applies to the current restic binary and that the capabilities are lost when updating or replacing that binary.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #3322.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review