### PR TITLE
Fix windows terminal output for mintty

### DIFF
--- a/changelog/unreleased/issue-3111
+++ b/changelog/unreleased/issue-3111
@@ -1,0 +1,11 @@
+Bugfix: Fix terminal output redirection for powershell
+
+When redirecting the output of restic using powershell on Windows, the
+output contained terminal escape characters. This has been fixed by
+properly detecting the terminal type.
+
+In addition, the mintty terminal now shows progress output for the backup
+command.
+
+https://github.com/restic/restic/issues/3111
+https://github.com/restic/restic/pull/3325

--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -20,7 +20,7 @@ func calculateProgressInterval(show bool) time.Duration {
 			fps = 60
 		}
 		interval = time.Duration(float64(time.Second) / fps)
-	} else if !stdoutIsTerminal() || !show {
+	} else if !stdoutCanUpdateStatus() || !show {
 		interval = 0
 	}
 	return interval

--- a/go.mod
+++ b/go.mod
@@ -37,7 +37,7 @@ require (
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73
 	golang.org/x/oauth2 v0.0.0-20200902213428-5d25da1a8d43
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
-	golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4
+	golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b
 	golang.org/x/text v0.3.4
 	google.golang.org/api v0.32.0
 	gopkg.in/check.v1 v1.0.0-20200902074654-038fdea0a05b // indirect

--- a/go.sum
+++ b/go.sum
@@ -379,8 +379,9 @@ golang.org/x/sys v0.0.0-20200803210538-64077c9b5642/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20200828194041-157a740278f4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200905004654-be1d3432aa8f/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20201101102859-da207088b7d1/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4 h1:myAQVi0cGEoqQVR5POX+8RR2mrocKqNN1hmeMqhX27k=
 golang.org/x/sys v0.0.0-20210119212857-b64e53b001e4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b h1:ggRgirZABFolTmi3sn6Ivd9SipZwLedQ5wR0aAKnFxU=
+golang.org/x/sys v0.0.0-20210305230114-8fe3ee5dd75b/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221 h1:/ZHdbVpdR/jk3g30/d4yUL0JU9kksj8+F/bnQUVLGDM=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -67,7 +67,7 @@ func New(wr io.Writer, errWriter io.Writer, disableStatus bool) *Terminal {
 		return t
 	}
 
-	if d, ok := wr.(fder); ok && canUpdateStatus(d.Fd()) {
+	if d, ok := wr.(fder); ok && CanUpdateStatus(d.Fd()) {
 		// only use the fancy status code when we're running on a real terminal.
 		t.canUpdateStatus = true
 		t.fd = d.Fd()

--- a/internal/ui/termstatus/terminal_unix.go
+++ b/internal/ui/termstatus/terminal_unix.go
@@ -20,9 +20,9 @@ func moveCursorUp(wr io.Writer, fd uintptr) func(io.Writer, uintptr, int) {
 	return posixMoveCursorUp
 }
 
-// canUpdateStatus returns true if status lines can be printed, the process
+// CanUpdateStatus returns true if status lines can be printed, the process
 // output is not redirected to a file or pipe.
-func canUpdateStatus(fd uintptr) bool {
+func CanUpdateStatus(fd uintptr) bool {
 	if !terminal.IsTerminal(int(fd)) {
 		return false
 	}

--- a/internal/ui/termstatus/terminal_windows.go
+++ b/internal/ui/termstatus/terminal_windows.go
@@ -80,9 +80,9 @@ func isPipe(fd uintptr) bool {
 	return err == nil && typ == windows.FILE_TYPE_PIPE
 }
 
-// canUpdateStatus returns true if status lines can be printed, the process
+// CanUpdateStatus returns true if status lines can be printed, the process
 // output is not redirected to a file or pipe.
-func canUpdateStatus(fd uintptr) bool {
+func CanUpdateStatus(fd uintptr) bool {
 	// easy case, the terminal is cmd or psh, without redirection
 	if isWindowsTerminal(fd) {
 		return true

--- a/internal/ui/termstatus/terminal_windows.go
+++ b/internal/ui/termstatus/terminal_windows.go
@@ -4,6 +4,7 @@ package termstatus
 
 import (
 	"io"
+	"strings"
 	"syscall"
 	"unsafe"
 
@@ -80,6 +81,22 @@ func isPipe(fd uintptr) bool {
 	return err == nil && typ == windows.FILE_TYPE_PIPE
 }
 
+func getFileNameByHandle(fd uintptr) (string, error) {
+	type FILE_NAME_INFO struct {
+		FileNameLength int32
+		FileName       [windows.MAX_LONG_PATH]uint16
+	}
+
+	var fi FILE_NAME_INFO
+	err := windows.GetFileInformationByHandleEx(windows.Handle(fd), windows.FileNameInfo, (*byte)(unsafe.Pointer(&fi)), uint32(unsafe.Sizeof(fi)))
+	if err != nil {
+		return "", err
+	}
+
+	filename := syscall.UTF16ToString(fi.FileName[:])
+	return filename, nil
+}
+
 // CanUpdateStatus returns true if status lines can be printed, the process
 // output is not redirected to a file or pipe.
 func CanUpdateStatus(fd uintptr) bool {
@@ -88,11 +105,23 @@ func CanUpdateStatus(fd uintptr) bool {
 		return true
 	}
 
-	// check that the output file type is a pipe (0x0003)
+	// pipes require special handling
 	if !isPipe(fd) {
 		return false
 	}
 
-	// assume we're running in mintty/cygwin
-	return true
+	fn, err := getFileNameByHandle(fd)
+	if err != nil {
+		return false
+	}
+
+	// inspired by https://github.com/RyanGlScott/mintty/blob/master/src/System/Console/MinTTY/Win32.hsc
+	// terminal: \msys-dd50a72ab4668b33-pty0-to-master
+	// pipe to cat: \msys-dd50a72ab4668b33-13244-pipe-0x16
+	if (strings.HasPrefix(fn, "\\cygwin-") || strings.HasPrefix(fn, "\\msys-")) &&
+		strings.Contains(fn, "-pty") && strings.HasSuffix(fn, "-master") {
+		return true
+	}
+
+	return false
 }

--- a/internal/ui/termstatus/terminal_windows_test.go
+++ b/internal/ui/termstatus/terminal_windows_test.go
@@ -1,0 +1,30 @@
+package termstatus
+
+import (
+	"syscall"
+	"testing"
+
+	"golang.org/x/sys/windows"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestIsMinTTY(t *testing.T) {
+	for _, test := range []struct {
+		path   string
+		result bool
+	}{
+		{`\\.\pipe\msys-dd50a72ab4668b33-pty0-to-master`, true},
+		{`\\.\pipe\msys-dd50a72ab4668b33-13244-pipe-0x16`, false},
+	} {
+		filename, err := syscall.UTF16FromString(test.path)
+		rtest.OK(t, err)
+		handle, err := windows.CreateNamedPipe(&filename[0], windows.PIPE_ACCESS_DUPLEX,
+			windows.PIPE_TYPE_BYTE, 1, 1024, 1024, 0, nil)
+		rtest.OK(t, err)
+		defer windows.CloseHandle(handle)
+
+		rtest.Assert(t, CanUpdateStatus(uintptr(handle)) == test.result,
+			"expected CanUpdateStatus(%v) == %v", test.path, test.result)
+	}
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Redirecting the output of restic to a file when using powershell currently results in terminal control characters being printed.

restic tries to detect whether mintty is used on windows and switches to posix terminal control characters. This check was done by testing whether stdout is a pipe. However, the latter is also the case when piping the output of restic between commands or on powershell when redirecting the output to a file. This PR makes the mintty terminal detection more robust by checking the filename of the connected pipe which must match `\\(cygwin-|msys-).+-pty.+-master`. This avoids false positives and ensures that piping the output to another command also works as expected.

In addition the interactive terminal output on mintty is repaired: Since #3199 restic only shows progress output for the backup command and all others on regular terminals, which does not include the mintty special case. This is fixed by introducing `stdoutCanUpdateStatus` which uses the same logic also used for the terminal type detection by the backup command. `stdoutIsTerminal` is extended to also return true for mintty terminals.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
fixes #3111
Alternative to #3301

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
