### PR TITLE
s3: Fix sanity check

### DIFF
--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -277,7 +277,7 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 	debug.Log("%v -> %v bytes, err %#v: %v", objName, info.Size, err, err)
 
 	// sanity check
-	if err != nil && info.Size != rd.Length() {
+	if err == nil && info.Size != rd.Length() {
 		return errors.Errorf("wrote %d bytes instead of the expected %d bytes", info.Size, rd.Length())
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The sanity check shouldn't replace the error message if there is already one.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Notices this in the error log in https://github.com/restic/restic/issues/3265#issuecomment-792723601 .

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
