### PR TITLE
prune --max-unused does not limit metadata repacking

### DIFF
--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -341,7 +341,7 @@ The ``prune`` command accepts the following options:
       unused files. This means that as long as some data is still used within
       a file stored in the repo, restic will just leave it there. Use this if
       you want to minimize the time and bandwidth used by the ``prune``
-      operation.
+      operation. Note that metadata will still be repacked.
 
    Restic tries to repack as little data as possible while still ensuring this 
    limit for unused data.


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Adding minor clarification to documentation of `prune --max-unused` to indicate it does not limit metadata repacking. The referenced PR indicates `max-repack-size` CAN limit metadata repacking.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

https://forum.restic.net/t/max-unused-unlimited-still-repacks/3661
https://github.com/restic/restic/pull/3228

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
