### PR TITLE
Fork process for background mounting

### DIFF
--- a/changelog/unreleased/issue-2743
+++ b/changelog/unreleased/issue-2743
@@ -1,3 +1,5 @@
 Enhancement: Allow folders to be mounted in the background.
 
 Restic currently requires the process to be open continously for the folder to be mounted. By offloading this, we can keep the mount alive while restic does not have to be open.
+
+https://github.com/restic/restic/issues/2743

--- a/changelog/unreleased/issue-2743
+++ b/changelog/unreleased/issue-2743
@@ -1,0 +1,3 @@
+Enhancement: Allow folders to be mounted in the background.
+
+Restic currently requires the process to be open continously for the folder to be mounted. By offloading this, we can keep the mount alive while restic does not have to be open.

--- a/changelog/unreleased/issue-2743
+++ b/changelog/unreleased/issue-2743
@@ -1,5 +1,5 @@
-Enhancement: Allow folders to be mounted in the background.
+Enhancement: Allow folders to be mounted in the background
 
-Restic currently requires the process to be open continously for the folder to be mounted. By offloading this, we can keep the mount alive while restic does not have to be open.
+Restic currently requires the process to be open continously for the folder to be mounted. By offloading this, we can keep the mount alive while restic does not have to be open
 
 https://github.com/restic/restic/issues/2743

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -84,12 +84,31 @@ func init() {
 	mountFlags.BoolVar(&mountOptions.DaemonMode, "daemon", false, "run this mount in background like a daemon")
 }
 
+func linearSearch(args []string, search string) int {
+	for i, n := range args {
+		if n == search {
+			return i
+		}
+	}
+	return -1
+}
+
+func removeElement(args []string, search string) []string {
+	index := linearSearch(args, search)
+	if index != -1 {
+		return append(args[:index], args[index+1:]...)
+	} else {
+		return args
+	}
+}
+
 func runMount(opts MountOptions, gopts GlobalOptions, args []string) error {
 	if opts.DaemonMode {
 		filename := os.Args[0]
 		attr := new(syscall.ProcAttr)
-		pid, err := syscall.ForkExec(filename, args, attr)
-		Println("Mount is now running as a daemon. PID: %d", pid)
+		argx := removeElement(args, "daemon")
+		pid, err := syscall.ForkExec(filename, argx, attr)
+		Println("Mount is now running as a daemon. PID: ", pid)
 		if err != nil {
 			panic(err)
 		}

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"time"
+	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -85,6 +86,13 @@ func init() {
 
 func runMount(opts MountOptions, gopts GlobalOptions, args []string) error {
 	if opts.DaemonMode {
+		filename := os.Args[0]
+		attr := new(syscall.ProcAttr)
+		pid, err := syscall.ForkExec(filename, args, attr)
+		Println("Mount is now running as a daemon. PID: %d", pid)
+		if err != nil {
+			panic(err)
+		}
 		go runMount(opts, gopts, args)
 		return errors.New("Daemon mode running in background")
 	}

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -97,9 +97,8 @@ func removeElement(args []string, search string) []string {
 	index := linearSearch(args, search)
 	if index != -1 {
 		return append(args[:index], args[index+1:]...)
-	} else {
-		return args
 	}
+	return args
 }
 
 func runMount(opts MountOptions, gopts GlobalOptions, args []string) error {

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -93,7 +93,6 @@ func runMount(opts MountOptions, gopts GlobalOptions, args []string) error {
 		if err != nil {
 			panic(err)
 		}
-		go runMount(opts, gopts, args)
 		return errors.New("Daemon mode running in background")
 	}
 	if opts.SnapshotTemplate == "" {

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -5,8 +5,8 @@ package main
 import (
 	"os"
 	"strings"
-	"time"
 	"syscall"
+	"time"
 
 	"github.com/spf13/cobra"
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This allows restic to be forked and put into the background for mounts to continue running even when restic closes.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Issue #2743 discusses this.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
