### PR TITLE
Display 'created new cache in ' message only if output is terminal

### DIFF
--- a/changelog/unreleased/issue-3334
+++ b/changelog/unreleased/issue-3334
@@ -1,0 +1,9 @@
+Bugfix: Print `created new cache` message only on a terminal
+
+`created new cache` message was outputed even when the output wasn't a
+terminal. That broke piping `restic dump` output to tar or zip
+if cache directory didn't exist. The message is now only printed on a
+terminal.
+
+https://github.com/restic/restic/issues/3334
+https://github.com/restic/restic/pull/3343

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -492,7 +492,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		return s, nil
 	}
 
-	if c.Created && !opts.JSON {
+	if c.Created && !opts.JSON && stdoutIsTerminal() {
 		Verbosef("created new cache in %v\n", c.Base)
 	}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.

You do not need to check all the boxes below all at once, feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Makes sure that `created new cache in ` is printed only in terminals. Fixes piping output to tar without existing cache directory.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
https://forum.restic.net/t/tar-dump-without-cache/3682
https://github.com/restic/restic/issues/3334

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
