### PR TITLE
Check for ENOSPC and remove broken files in SFTP

### DIFF
--- a/changelog/unreleased/issue-3336
+++ b/changelog/unreleased/issue-3336
@@ -1,0 +1,8 @@
+Enhancement: SFTP backend now checks for disk space
+
+Backing up over SFTP previously spewed multiple generic "failure" messages
+when the remote disk was full. It now checks for disk space before writing
+a file and fails immediately with a "no space left on device" message.
+
+https://github.com/restic/restic/issues/3336
+https://github.com/restic/restic/pull/3345


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The SFTP backend now checks whether an error in Save is ENOSPC. It also does a Chmod earlier and tries to remove broken files when an error occurs. Tested by backing up into a tiny loopback device over SFTP:

```
$ mount | grep loop
/dev/loop121 on /mnt type ext4 (rw,relatime)
$ ./restic init -r /mnt/r
created restic repository 1b0bf898e0 at /mnt/r

Please note that knowledge of your password is required to access
the repository. Losing your password means that your data is
irrecoverably lost.
$ ./restic -r sftp://localhost//mnt/r backup .
repository 1b0bf898 opened successfully, password is correct
created new cache in /home/me/.cache/restic
no parent snapshot found, will read all files
Fatal: unable to save snapshot: sftp: no space left on device
```

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes #3336.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
