### PR TITLE
Backup docs: on Windows, the filesize must match for "unchanged"

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -183,9 +183,9 @@ Note that the device id of the containing mount point is never taken into
 account. Device numbers are not stable for removable devices and ZFS snapshots.
 If you want to force a re-scan in such a case, you can change the mountpoint.
 
-On **Windows**, a file is considered unchanged when its path and modification
-time match, and only ``--force`` has any effect. The other options are
-recognized but ignored.
+On **Windows**, a file is considered unchanged when its path, size
+and modification time match, and only ``--force`` has any effect.
+The other options are recognized but ignored.
 
 Excluding Files
 ***************


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The backup docs say that

> On Windows, a file is considered unchanged when its path and modification time match

I wrote that. I failed to mention that the size also has to match:

https://github.com/restic/restic/blob/efb10b3c4071ae218cede883c18e9f969491cec3/internal/archiver/archiver.go#L507-L508

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #3353.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
