### PR TITLE
doc: Clarify dollar sign expansion in exclude files

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -229,9 +229,13 @@ see `filepath.Match <https://golang.org/pkg/path/filepath/#Match>`__ for
 syntax. Patterns are tested against the full path of a file/dir to be saved,
 even if restic is passed a relative path to save.
 
-Environment-variables in exclude files are expanded with `os.ExpandEnv <https://golang.org/pkg/os/#ExpandEnv>`__,
-so ``/home/$USER/foo`` will be expanded to ``/home/bob/foo`` for the user ``bob``.
-To get a literal dollar sign, write ``$$`` to the file. Note that tilde (``~``) expansion does not work, please use the ``$HOME`` environment variable instead.
+Environment variables in exclude files are expanded with `os.ExpandEnv
+<https://golang.org/pkg/os/#ExpandEnv>`__, so ``/home/$USER/foo`` will be
+expanded to ``/home/bob/foo`` for the user ``bob``. To get a literal dollar
+sign, write ``$$`` to the file - this has to be done even when there's no
+matching environment variable for the word following a single ``$``. Note
+that tilde (``~``) is not expanded, instead use the ``$HOME`` or equivalent
+environment variable (depending on your operating system).
 
 Patterns need to match on complete path components. For example, the pattern ``foo``:
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Clarifies how to write single dollar signs in exclude files (need to make them `$$`).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Closes #3329.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
