### PR TITLE
Fix runtime.KeepAlive usage in preallocateFile

### DIFF
--- a/internal/restorer/preallocate_darwin.go
+++ b/internal/restorer/preallocate_darwin.go
@@ -10,13 +10,13 @@ import (
 
 func preallocateFile(wr *os.File, size int64) error {
 	// try contiguous first
-	fst := unix.Fstore_t{
+	fst := &unix.Fstore_t{
 		Flags:   unix.F_ALLOCATECONTIG | unix.F_ALLOCATEALL,
 		Posmode: unix.F_PEOFPOSMODE,
 		Offset:  0,
 		Length:  size,
 	}
-	_, err := unix.FcntlInt(wr.Fd(), unix.F_PREALLOCATE, int(uintptr(unsafe.Pointer(&fst))))
+	_, err := unix.FcntlInt(wr.Fd(), unix.F_PREALLOCATE, int(uintptr(unsafe.Pointer(fst))))
 
 	if err == nil {
 		return nil
@@ -24,7 +24,7 @@ func preallocateFile(wr *os.File, size int64) error {
 
 	// just take preallocation in any form, but still ask for everything
 	fst.Flags = unix.F_ALLOCATEALL
-	_, err = unix.FcntlInt(wr.Fd(), unix.F_PREALLOCATE, int(uintptr(unsafe.Pointer(&fst))))
+	_, err = unix.FcntlInt(wr.Fd(), unix.F_PREALLOCATE, int(uintptr(unsafe.Pointer(fst))))
 
 	// Keep struct alive until fcntl has returned
 	runtime.KeepAlive(fst)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

When fst is a struct, what runtime.KeepAlive receives is a copy pointed to by an interface{}. If I've got the unsafe.Pointer rules right, the compiler is allowed to decide that neither FcntlInt call can see the struct because all they get is an int. It's then allowed to reorder the code to first copy the struct, then drop the memory for the original, then call FcntlInt.

In any case, this matches the [example](https://golang.org/pkg/runtime/#KeepAlive) in the runtime package more closely.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
