### PR TITLE
Use FcntlFstore to preallocate on Mac

### DIFF
--- a/internal/restorer/preallocate_darwin.go
+++ b/internal/restorer/preallocate_darwin.go
@@ -2,8 +2,6 @@ package restorer
 
 import (
 	"os"
-	"runtime"
-	"unsafe"
 
 	"golang.org/x/sys/unix"
 )
@@ -16,7 +14,7 @@ func preallocateFile(wr *os.File, size int64) error {
 		Offset:  0,
 		Length:  size,
 	}
-	_, err := unix.FcntlInt(wr.Fd(), unix.F_PREALLOCATE, int(uintptr(unsafe.Pointer(&fst))))
+	err := unix.FcntlFstore(wr.Fd(), unix.F_PREALLOCATE, &fst)
 
 	if err == nil {
 		return nil
@@ -24,10 +22,7 @@ func preallocateFile(wr *os.File, size int64) error {
 
 	// just take preallocation in any form, but still ask for everything
 	fst.Flags = unix.F_ALLOCATEALL
-	_, err = unix.FcntlInt(wr.Fd(), unix.F_PREALLOCATE, int(uintptr(unsafe.Pointer(&fst))))
-
-	// Keep struct alive until fcntl has returned
-	runtime.KeepAlive(fst)
+	err = unix.FcntlFstore(wr.Fd(), unix.F_PREALLOCATE, &fst)
 
 	return err
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Replace unix.FcntlInt + runtime.KeepAlive by unix.FcntlFstore. Keeping fst alive is now x/sys/unix's responsibility.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Figured out that this function exists while investigating runtime.KeepAlive for #3360.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
