### PR TITLE
Dynamically increase pack size with repository size

### DIFF
--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -153,6 +153,19 @@ func (mi *MasterIndex) Count(t restic.BlobType) (n uint) {
 	return sum
 }
 
+// TotalSize returns the total size referenced by the index.
+func (mi *MasterIndex) TotalSize() (n uint) {
+	mi.idxMutex.RLock()
+	defer mi.idxMutex.RUnlock()
+
+	var sum uint
+	for _, idx := range mi.idx {
+		sum += idx.TotalSize()
+	}
+
+	return sum
+}
+
 // Insert adds a new index to the MasterIndex.
 func (mi *MasterIndex) Insert(idx *Index) {
 	mi.idxMutex.Lock()

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -37,7 +37,7 @@ type packerManager struct {
 	packers []*Packer
 }
 
-const minPackSize = 4 * 1024 * 1024
+const maxBlobsPerPack = 100000
 
 // newPackerManager returns an new packer manager which writes temporary files
 // to a temporary directory

--- a/internal/repository/packer_manager_test.go
+++ b/internal/repository/packer_manager_test.go
@@ -56,6 +56,8 @@ func saveFile(t testing.TB, be Saver, length int, f *os.File, id restic.ID) {
 	}
 }
 
+const minPackSize = 4 * 1024 * 1024
+
 func fillPacks(t testing.TB, rnd *rand.Rand, be Saver, pm *packerManager, buf []byte) (bytes int) {
 	for i := 0; i < 100; i++ {
 		l := rnd.Intn(maxBlobSize)

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -515,3 +515,22 @@ func TestDownloadAndHashErrors(t *testing.T) {
 		})
 	}
 }
+
+func TestMinPackSize(t *testing.T) {
+	const MiB = 1024 * 1024
+	const GiB = 1024 * MiB
+	const TiB = 1024 * GiB
+	const PiB = 1024 * TiB
+
+	smallestPackSize := uint(4 * MiB)
+	largestPackSize := uint(4076 * MiB)
+
+	rtest.Equals(t, smallestPackSize, repository.MinPackSize(0))
+	rtest.Equals(t, smallestPackSize, repository.MinPackSize(50*MiB))
+	rtest.Equals(t, smallestPackSize, repository.MinPackSize(GiB))
+	rtest.Equals(t, 2*smallestPackSize, repository.MinPackSize(4*GiB))
+	rtest.Equals(t, 32*smallestPackSize, repository.MinPackSize(TiB))
+	rtest.Equals(t, 512*smallestPackSize, repository.MinPackSize(256*TiB))
+	rtest.Equals(t, largestPackSize, repository.MinPackSize(PiB))
+	rtest.Equals(t, largestPackSize, repository.MinPackSize(2*PiB))
+}

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -66,6 +66,7 @@ type MasterIndex interface {
 	Lookup(BlobHandle) []PackedBlob
 	Count(BlobType) uint
 	PackSize(ctx context.Context, onlyHdr bool) map[ID]int64
+	TotalSize() uint
 
 	// Each returns a channel that yields all blobs known to the index. When
 	// the context is cancelled, the background goroutine terminates. This


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Currently packs are written once they reach the size of 4MB. In practice this leads to average pack sizes of around 4.7 MiB.
This means that large repositories contain of a large amount of pack files, e.g.
1 GiB -> ~200 pack files
1 TiB -> ~205,000 pack files (!)
1 PB -> ~215,000,000 pack files (!!!) 

Lots of small pack files pose problems in some cases, e.g. performance issues or high costs with some storage providers. Moreover with a lower number of pack files memory usage is a bit reduced.

In #2750 it is proposed to let users specify the pack size. A sensible choice would be to choose a pack size of `sqrt(reposize in GB) * 4 MiB`. This would lead to 
1 GiB -> ~256 pack files a 4 MiB
1 TiB -> ~8,200 pack files a 128 MiB
1 PiB -> ~260,000 pack files a 4 GiB
This would however need a priori knowledge of the repository size.

Hence this PR uses the current reposize to determine the pack size by the above formula and therefore dynamically increases the pack size with growing repo size.
This dynamic increase roughly doubles the number of the pack files compared to the table above.

For very small repos a pack size of 4MiB is still targeted and for very large repos (> 1 PiB) the pack size is limited to 4076 MiB such that including pack headers the total pack will not exceed 4 GiB.
Moreover, the number of blobs per pack is limited such that no problems with large pack headers or index files occur.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
see #2750 and the references therein.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
