### PR TITLE
Simplify internal/limiter

### DIFF
--- a/internal/limiter/static_limiter.go
+++ b/internal/limiter/static_limiter.go
@@ -57,19 +57,24 @@ func (rt roundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
 }
 
 func (l staticLimiter) roundTripper(rt http.RoundTripper, req *http.Request) (*http.Response, error) {
+	type readCloser struct {
+		io.Reader
+		io.Closer
+	}
+
 	if req.Body != nil {
-		req.Body = limitedReadCloser{
-			Reader:   l.Upstream(req.Body),
-			original: req.Body,
+		req.Body = &readCloser{
+			Reader: l.Upstream(req.Body),
+			Closer: req.Body,
 		}
 	}
 
 	res, err := rt.RoundTrip(req)
 
 	if res != nil && res.Body != nil {
-		res.Body = limitedReadCloser{
-			Reader:   l.Downstream(res.Body),
-			original: res.Body,
+		res.Body = &readCloser{
+			Reader: l.Downstream(res.Body),
+			Closer: res.Body,
 		}
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

internal/limiter has a limitedReadCloser that is used in two places, but only one of those needs to io.Closer functionality. This patch introduces an ad hoc readCloser type where needed so that the limitedReadWriteToCloser type can go.

When the Reader passed to newDownstreamLimitedReader does not implement io.WriterTo, its return value skips one level of indirection.

The existing test for io.WriterTo functionality passes.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
