### PR TITLE
doc: Polish exclude file documentation

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -227,7 +227,8 @@ This instructs restic to exclude files matching the following criteria:
 Patterns use `filepath.Glob <https://golang.org/pkg/path/filepath/#Glob>`__ internally,
 see `filepath.Match <https://golang.org/pkg/path/filepath/#Match>`__ for
 syntax. Patterns are tested against the full path of a file/dir to be saved,
-even if restic is passed a relative path to save.
+even if restic is passed a relative path to save. Empty lines and lines
+starting with a ``#`` are ignored.
 
 Environment variables in exclude files are expanded with `os.ExpandEnv
 <https://golang.org/pkg/os/#ExpandEnv>`__, so ``/home/$USER/foo`` will be
@@ -245,11 +246,10 @@ Patterns need to match on complete path components. For example, the pattern ``f
 A trailing ``/`` is ignored, a leading ``/`` anchors the pattern at the root directory.
 This means, ``/bin`` matches ``/bin/bash`` but does not match ``/usr/bin/restic``.
 
-Regular wildcards cannot be used to match over the directory separator ``/``.
-For example: ``b*ash`` matches ``/bin/bash`` but does not match ``/bin/ash``.
-
-For this, the special wildcard ``**`` can be used to match arbitrary
-sub-directories: The pattern ``foo/**/bar`` matches:
+Regular wildcards cannot be used to match over the directory separator ``/``,
+e.g. ``b*ash`` matches ``/bin/bash`` but does not match ``/bin/ash``. For this,
+the special wildcard ``**`` can be used to match arbitrary sub-directories: The
+pattern ``foo/**/bar`` matches:
 
  * ``/dir1/foo/dir2/bar/file``
  * ``/foo/bar/file``


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds info about empty lines and lines starting with `#` in the docs for `backup` exclude files.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
