### PR TITLE
filter: Fix crash for '**' pattern

### DIFF
--- a/changelog/unreleased/issue-3380
+++ b/changelog/unreleased/issue-3380
@@ -1,0 +1,7 @@
+Bugfix: Fix crash of `backup --exclude='**'`
+
+The exclude filter '**', which excludes all files, caused restic to crash. This
+has been fixed.
+
+https://github.com/restic/restic/issues/3380
+https://github.com/restic/restic/pull/3393

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -166,6 +166,11 @@ func match(patterns Pattern, strs []string) (matched bool, err error) {
 		return true, nil
 	}
 
+	// an empty pattern never matches a non-empty path
+	if len(patterns) == 0 {
+		return false, nil
+	}
+
 	if len(patterns) <= len(strs) {
 		minOffset := 0
 		maxOffset := len(strs) - len(patterns)

--- a/internal/filter/filter_test.go
+++ b/internal/filter/filter_test.go
@@ -23,6 +23,7 @@ var matchTests = []struct {
 	{"*.go", "/foo/bar/test.go", true},
 	{"*.c", "/foo/bar/test.go", false},
 	{"*", "/foo/bar/test.go", true},
+	{"**", "/foo/bar/test.go", true},
 	{"foo*", "/foo/bar/test.go", true},
 	{"bar*", "/foo/bar/test.go", true},
 	{"/bar*", "/foo/bar/test.go", false},


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
As reported by #3380 restic fails when run with `--exclude='**'`. '**' is iteratively expanded and on the first iteration expands to an empty pattern. Afterwards the pattern matching tries to access the first element of the pattern to determine whether it is an absolute path or not. As this pattern is empty this causes a crash. This is fixed by adding a special case to check for empty patterns.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #3380

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
