### PR TITLE
Build darwin/arm64 binaries for Apple M1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -200,7 +200,7 @@ jobs:
 
           - "freebsd/386 freebsd/amd64 freebsd/arm \
             aix/ppc64 \
-            darwin/amd64 \
+            darwin/amd64 darwin/arm64 \
             netbsd/386 netbsd/amd64 \
             windows/386 windows/amd64 \
             solaris/amd64"

--- a/changelog/unreleased/issue-3377
+++ b/changelog/unreleased/issue-3377
@@ -1,0 +1,6 @@
+Enhancement: Add release binaries for Apple Silicon
+
+We've added release binaries for macOS on Apple Silicon.
+
+https://github.com/restic/restic/issues/3377
+https://github.com/restic/restic/pull/3394

--- a/helpers/build-release-binaries/main.go
+++ b/helpers/build-release-binaries/main.go
@@ -224,7 +224,7 @@ func buildTargets(sourceDir, outputDir string, targets map[string][]string) {
 // ATTENTION: the list of architectures must be in sync with .github/workflows/tests.yml!
 var defaultBuildTargets = map[string][]string{
 	"aix":     {"ppc64"},
-	"darwin":  {"amd64"},
+	"darwin":  {"amd64", "arm64"},
 	"freebsd": {"386", "amd64", "arm"},
 	"linux":   {"386", "amd64", "arm", "arm64", "ppc64le", "mips", "mipsle", "mips64", "mips64le"},
 	"netbsd":  {"386", "amd64"},


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Go 1.16 has added support for macOS on arm64. Build native binaries for that platform.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
Fixes #3377

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~ No test coverage for these binaries for now.
- ~~[ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
