### PR TITLE
Don't search for long IDs

### DIFF
--- a/internal/restic/backend_find.go
+++ b/internal/restic/backend_find.go
@@ -24,7 +24,13 @@ func (e *NoIDByPrefixError) Error() string {
 // Find loads the list of all files of type t and searches for names which
 // start with prefix. If none is found, nil and ErrNoIDPrefixFound is returned.
 // If more than one is found, nil and ErrMultipleIDMatches is returned.
+// If prefix in fact is a full filename, it is simply returned
 func Find(ctx context.Context, be Lister, t FileType, prefix string) (string, error) {
+
+	if len(prefix) == 2*idSize {
+		return prefix, nil
+	}
+
 	match := ""
 
 	ctx, cancel := context.WithCancel(ctx)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Don't search for IDs if a long (i.e. complete) ID is given. This should mainly affect snapshot IDs given on the command line which now no longer need to run a backend 'List' for each long snapshot ID given.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

see #3392 

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
