### PR TITLE
Make restic.{lchown,mknod} regular functions

### DIFF
--- a/internal/restic/mknod_unix.go
+++ b/internal/restic/mknod_unix.go
@@ -1,0 +1,9 @@
+// +build !freebsd,!windows
+
+package restic
+
+import "golang.org/x/sys/unix"
+
+func mknod(path string, mode uint32, dev uint64) (err error) {
+	return unix.Mknod(path, mode, int(dev))
+}

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -188,8 +188,6 @@ func (node Node) restoreMetadata(path string) error {
 	if err := lchown(path, int(node.UID), int(node.GID)); err != nil {
 		// Like "cp -a" and "rsync -a" do, we only report lchown permission errors
 		// if we run as root.
-		// On Windows, Geteuid always returns -1, and we always report lchown
-		// permission errors.
 		if os.Geteuid() > 0 && os.IsPermission(err) {
 			debug.Log("not running as root, ignoring lchown permission error for %v: %v",
 				path, err)
@@ -310,11 +308,11 @@ func (node Node) createSymlinkAt(path string) error {
 }
 
 func (node *Node) createDevAt(path string) error {
-	return mknod(path, syscall.S_IFBLK|0600, node.device())
+	return mknod(path, syscall.S_IFBLK|0600, node.Device)
 }
 
 func (node *Node) createCharDevAt(path string) error {
-	return mknod(path, syscall.S_IFCHR|0600, node.device())
+	return mknod(path, syscall.S_IFCHR|0600, node.Device)
 }
 
 func (node *Node) createFifoAt(path string) error {

--- a/internal/restic/node_aix.go
+++ b/internal/restic/node_aix.go
@@ -8,10 +8,6 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
-func (node Node) device() int {
-	return int(node.Device)
-}
-
 // AIX has a funny timespec type in syscall, with 32-bit nanoseconds.
 // golang.org/x/sys/unix handles this cleanly, but we're stuck with syscall
 // because os.Stat returns a syscall type in its os.FileInfo.Sys().

--- a/internal/restic/node_darwin.go
+++ b/internal/restic/node_darwin.go
@@ -6,10 +6,6 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
-func (node Node) device() int {
-	return int(node.Device)
-}
-
 func (s statT) atim() syscall.Timespec { return s.Atimespec }
 func (s statT) mtim() syscall.Timespec { return s.Mtimespec }
 func (s statT) ctim() syscall.Timespec { return s.Ctimespec }

--- a/internal/restic/node_freebsd.go
+++ b/internal/restic/node_freebsd.go
@@ -8,8 +8,8 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
-func (node Node) device() uint64 {
-	return node.Device
+func mknod(path string, mode uint32, dev uint64) (err error) {
+	return syscall.Mknod(path, mode, dev)
 }
 
 func (s statT) atim() syscall.Timespec { return s.Atimespec }

--- a/internal/restic/node_linux.go
+++ b/internal/restic/node_linux.go
@@ -32,10 +32,6 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return dir.Close()
 }
 
-func (node Node) device() int {
-	return int(node.Device)
-}
-
 func (s statT) atim() syscall.Timespec { return s.Atim }
 func (s statT) mtim() syscall.Timespec { return s.Mtim }
 func (s statT) ctim() syscall.Timespec { return s.Ctim }

--- a/internal/restic/node_netbsd.go
+++ b/internal/restic/node_netbsd.go
@@ -6,10 +6,6 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
-func (node Node) device() int {
-	return int(node.Device)
-}
-
 func (s statT) atim() syscall.Timespec { return s.Atimespec }
 func (s statT) mtim() syscall.Timespec { return s.Mtimespec }
 func (s statT) ctim() syscall.Timespec { return s.Ctimespec }

--- a/internal/restic/node_openbsd.go
+++ b/internal/restic/node_openbsd.go
@@ -6,10 +6,6 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
-func (node Node) device() int {
-	return int(node.Device)
-}
-
 func (s statT) atim() syscall.Timespec { return s.Atim }
 func (s statT) mtim() syscall.Timespec { return s.Mtim }
 func (s statT) ctim() syscall.Timespec { return s.Ctim }

--- a/internal/restic/node_solaris.go
+++ b/internal/restic/node_solaris.go
@@ -6,10 +6,6 @@ func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespe
 	return nil
 }
 
-func (node Node) device() int {
-	return int(node.Device)
-}
-
 func (s statT) atim() syscall.Timespec { return s.Atim }
 func (s statT) mtim() syscall.Timespec { return s.Mtim }
 func (s statT) ctim() syscall.Timespec { return s.Ctim }

--- a/internal/restic/node_unix.go
+++ b/internal/restic/node_unix.go
@@ -5,12 +5,11 @@ package restic
 import (
 	"os"
 	"syscall"
-
-	"golang.org/x/sys/unix"
 )
 
-var mknod = unix.Mknod
-var lchown = os.Lchown
+func lchown(name string, uid, gid int) error {
+	return os.Lchown(name, uid, gid)
+}
 
 type statT syscall.Stat_t
 

--- a/internal/restic/node_windows.go
+++ b/internal/restic/node_windows.go
@@ -6,24 +6,18 @@ import (
 	"github.com/restic/restic/internal/errors"
 )
 
-// mknod() creates a filesystem node (file, device
-// special file, or named pipe) named pathname, with attributes
-// specified by mode and dev.
-var mknod = func(path string, mode uint32, dev int) (err error) {
+// mknod is not supported on Windows.
+func mknod(path string, mode uint32, dev uint64) (err error) {
 	return errors.New("device nodes cannot be created on windows")
 }
 
 // Windows doesn't need lchown
-var lchown = func(path string, uid int, gid int) (err error) {
+func lchown(path string, uid int, gid int) (err error) {
 	return nil
 }
 
 func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
 	return nil
-}
-
-func (node Node) device() int {
-	return int(node.Device)
 }
 
 // Getxattr retrieves extended attribute data associated with path.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

restic.lchown and restic.mknod are changed into regular functions rather than function-typed variables. This allows the compiler to inline them and remove some dead code. The binary becomes about 2.5 KiB smaller on Windows, 3 KiB on Linux.

To pull this off, I had to write a specialized mknod wrapper for FreeBSD, the only platform where its dev argument is uint64. The old code cast the Node.Device field to int everywhere, meaning that the behavior on 32-bit FreeBSD was possibly incorrect (though I haven't been able to test this).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
