### PR TITLE
Enable admin to decide group access to repository files

### DIFF
--- a/changelog/unreleased/pull-3419
+++ b/changelog/unreleased/pull-3419
@@ -1,0 +1,21 @@
+Enhancement: Use config file permissions to control file group access
+
+Previously files in a local/sftp restic repository would always end up with
+very restrictive access permissions allowing access only to the owner. This
+prevented a number of valid use-cases involving groups and ACLs.
+
+Now we use the config file permissions to decide whether group access
+should be given to newly created repository files or not. We arrange for
+repository files to be created group readable exactly when the repository
+config file is group readable.
+
+To opt-in to group readable repositories a simple `chmod -R g+r` or
+equivalent can be used. For repositories that should be writable by group
+members a tad more setup is required, see the docs.
+
+Posix ACLs can also be used now that the group permissions being forced to
+zero no longer masks the effect of ACL entries.
+
+https://github.com/restic/restic/issues/2351
+https://github.com/restic/restic/pull/3419
+https://forum.restic.net/t/change-permissions-on-repository-files/1391

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -699,3 +699,56 @@ On MSYS2, you can install ``winpty`` as follows:
 
     $ pacman -S winpty
     $ winpty restic -r /srv/restic-repo init
+
+
+Group accessible repositories
+*****************************
+
+Since restic version 0.14 local and SFTP repositories can be made
+accessible to members of a system group. To control this we have to change
+the group permissions of the top-level ``config`` file and restic will use
+this as a hint to determine what permissions to apply to newly created
+files. By default ``restic init`` sets repositories up to be group
+inaccessible.
+
+In order to give group members read-only access we simply add the read
+permission bit to all repository files with ``chmod``:
+
+.. code-block:: console
+
+    $ chmod -R g+r /srv/restic-repo
+
+This serves two purposes: 1) it sets the read permission bit on the
+repository config file triggering restic's logic to create new files as
+group accessible and 2) it actually allows the group read access to the
+files.
+
+.. note:: By default files on Unix systems are created with a user's
+          primary group as defined by the gid (group id) field in
+          ``/etc/passwd``. See `passwd(5)
+          <https://manpages.debian.org/latest/passwd/passwd.5.en.html>`_.
+
+For read-write access things are a bit more complicated. When users other
+than the repository creator add new files in the repository they will be
+group-owned by this user's primary group by default, not that of the
+original repository owner, meaning the original creator wouldn't have
+access to these files. That's hardly what you'd want.
+
+To make this work we can employ the help of the ``setgid`` permission bit
+available on Linux and most other Unix systems. This permission bit makes
+newly created directories inherit both the group owner (gid) and setgid bit
+from the parent directory. Setting this bit requires root but since it
+propagates down to any new directories we only have to do this priviledged
+setup once:
+
+.. code-block:: console
+
+    # find /srv/restic-repo -type d -exec chmod g+s '{}' \;
+    $ chmod -R g+rw /srv/restic-repo
+
+This sets the ``setgid`` bit on all existing directories in the repository
+and then grants read/write permissions for group access.
+
+.. note:: To manage who has access to the repository you can use
+          ``usermod`` on Linux systems, to change which group controls
+          repository access ``chgrp -R`` is your friend.

--- a/internal/backend/paths.go
+++ b/internal/backend/paths.go
@@ -21,6 +21,28 @@ var Paths = struct {
 	"config",
 }
 
-// Modes holds the default modes for directories and files for file-based
-// backends.
-var Modes = struct{ Dir, File os.FileMode }{0700, 0600}
+type Modes struct {
+	Dir  os.FileMode
+	File os.FileMode
+}
+
+// DefaultModes defines the default permissions to apply to new repository
+// files and directories stored on file-based backends.
+var DefaultModes = Modes{Dir: 0700, File: 0600}
+
+// DeriveModesFromFileInfo will, given the mode of a regular file, compute
+// the mode we should use for new files and directories. If the passed
+// error is non-nil DefaultModes are returned.
+func DeriveModesFromFileInfo(fi os.FileInfo, err error) Modes {
+	m := DefaultModes
+	if err != nil {
+		return m
+	}
+
+	if fi.Mode()&0040 != 0 { // Group has read access
+		m.Dir |= 0070
+		m.File |= 0060
+	}
+
+	return m
+}


### PR DESCRIPTION
This fixes #2351, see also https://github.com/restic/restic/issues/2351#issuecomment-855791064

Since the directory mode doesn't allow the execute bit (search permission)
to be set regardless of umask the files don't need to have empty group
permissions to disallow group access. By default the missing group execute
access on the containing directory will block any read/write attempt on the
files.

The upside of this is that the sysadmin can choose to change the directory
permissions to allow group execute access since all repo directories are
created at init time and not touched again after that. This will then allow
the group access to the files.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
