### PR TITLE
Modernize error handling in local backend

### DIFF
--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -27,6 +27,8 @@ var Wrapf = errors.Wrapf
 // returns nil.
 var WithMessage = errors.WithMessage
 
+var WithStack = errors.WithStack
+
 // Cause returns the cause of an error. It will also unwrap certain errors,
 // e.g. *url.Error returned by the net/http client.
 func Cause(err error) error {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

* Stop prepending the operation name: it's already part of os.PathError, leading to repetitive errors like "Chmod: chmod /foo/bar: operation not permitted".

* Use errors.Is to check for specific errors.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Follow-up to #2980.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
