### PR TITLE
Return s3.fileInfos by pointer

### DIFF
--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -186,12 +186,12 @@ type fileInfo struct {
 	isDir   bool
 }
 
-func (fi fileInfo) Name() string       { return fi.name }    // base name of the file
-func (fi fileInfo) Size() int64        { return fi.size }    // length in bytes for regular files; system-dependent for others
-func (fi fileInfo) Mode() os.FileMode  { return fi.mode }    // file mode bits
-func (fi fileInfo) ModTime() time.Time { return fi.modTime } // modification time
-func (fi fileInfo) IsDir() bool        { return fi.isDir }   // abbreviation for Mode().IsDir()
-func (fi fileInfo) Sys() interface{}   { return nil }        // underlying data source (can return nil)
+func (fi *fileInfo) Name() string       { return fi.name }    // base name of the file
+func (fi *fileInfo) Size() int64        { return fi.size }    // length in bytes for regular files; system-dependent for others
+func (fi *fileInfo) Mode() os.FileMode  { return fi.mode }    // file mode bits
+func (fi *fileInfo) ModTime() time.Time { return fi.modTime } // modification time
+func (fi *fileInfo) IsDir() bool        { return fi.isDir }   // abbreviation for Mode().IsDir()
+func (fi *fileInfo) Sys() interface{}   { return nil }        // underlying data source (can return nil)
 
 // ReadDir returns the entries for a directory.
 func (be *Backend) ReadDir(ctx context.Context, dir string) (list []os.FileInfo, err error) {
@@ -225,7 +225,7 @@ func (be *Backend) ReadDir(ctx context.Context, dir string) (list []os.FileInfo,
 		if name == "" {
 			continue
 		}
-		entry := fileInfo{
+		entry := &fileInfo{
 			name:    name,
 			size:    obj.Size,
 			modTime: obj.LastModified,


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Micro-optimization: since s3.fileInfos are returned in a []interface, they're already allocated on the heap. Making them pointers explicitly means the compiler doesn't need to generate fileInfo and *fileInfo versions of the methods on this type. The binary becomes about 7KiB smaller on Linux/amd64.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
