### PR TITLE
Make restore resumable

### DIFF
--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -118,10 +118,12 @@ func newTestRepo(content []TestFile) *TestRepo {
 	var files []*fileInfo
 	for _, file := range content {
 		content := restic.IDs{}
+		exists := []bool{}
 		for _, blob := range file.blobs {
 			content = append(content, restic.Hash([]byte(blob.data)))
+			exists = append(exists, false)
 		}
-		files = append(files, &fileInfo{location: file.name, blobs: content})
+		files = append(files, &fileInfo{location: file.name, blobs: content, exists: exists})
 	}
 
 	repo := &TestRepo{


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

With this PR, `restic resume` checks if existing files (partly) match the files to be restored. If matching blobs exist, they are no longer downloaded for restore.

With this change, `restic restore` is now resumable.

Note, that before checking the file contents of an existing file, it size is checked. This means if you use this PR on a platform that doesn't support pre-allocation of files, partly resumed files will need a complete download.
However fully restored files never need to be saved again.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

closes #407 
closes #2662
See https://forum.restic.net/t/22tb-restore-mistakes-were-made-lessons-learned/4042

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [ ] I'm done, this Pull Request is ready for review
