### PR TITLE
find: List missing pack files based on the index

### DIFF
--- a/changelog/unreleased/pull-3427
+++ b/changelog/unreleased/pull-3427
@@ -1,0 +1,13 @@
+Enhancement: `find --pack` fallback to index if data file is missing
+
+When investigating a repository with missing data files, it might be useful
+to determine affected snapshots before running `rebuild-index`.
+`restic find --pack pack-id` previously returned no data as it required
+accessing the data file. Now, if the necessary data is still available in the
+repository index, it gets retrieved from there.
+
+The command now also supports looking up multiple pack files in a single `find`
+run.
+
+https://github.com/restic/restic/pull/3427
+https://forum.restic.net/t/missing-packs-not-found/2600

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"fmt"
 	"sort"
 	"strings"
 	"time"
@@ -401,7 +400,7 @@ func (f *Finder) findIDs(ctx context.Context, sn *restic.Snapshot) error {
 	})
 }
 
-var errorAllPacksFound = fmt.Errorf("all packs found")
+var errAllPacksFound = errors.New("all packs found")
 
 // packsToBlobs converts the list of pack IDs to a list of blob IDs that
 // belong to those packs.
@@ -437,16 +436,16 @@ func (f *Finder) packsToBlobs(ctx context.Context, packs []string) error {
 		}
 		// Stop searching when all packs have been found
 		if len(packIDs) == 0 {
-			return errorAllPacksFound
+			return errAllPacksFound
 		}
 		return nil
 	})
 
-	if err != nil && err != errorAllPacksFound {
+	if err != nil && err != errAllPacksFound {
 		return err
 	}
 
-	if err != errorAllPacksFound {
+	if err != errAllPacksFound {
 		// try to resolve unknown pack ids from the index
 		packIDs = f.indexPacksToBlobs(ctx, packIDs)
 	}

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"sort"
 	"strings"
 	"time"
 
@@ -446,7 +447,13 @@ func (f *Finder) packsToBlobs(ctx context.Context, packs []string) error {
 	}
 
 	if err != errorAllPacksFound {
-		return errors.Fatal("unable to find all specified pack(s)")
+		list := make([]string, 0, len(packIDs))
+		for h := range packIDs {
+			list = append(list, h)
+		}
+
+		sort.Strings(list)
+		return errors.Fatalf("unable to find pack(s): %v", list)
 	}
 
 	debug.Log("%d blobs found", len(f.blobIDs))


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
When some pack files where lost, it would be useful to know which files/snapshots were affected without having to rebuild the index first. Currently `restic find --pack <pack-id>` returns nothing even if the pack file is still contained in the repository index. This PR introduces a fallback to resolve the blobs contained in a pack files from the repository index.

It is now also possible to specify multiple pack files in a single `restic find --pack` call.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
https://forum.restic.net/t/missing-packs-not-found/2600

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
~~- [ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
