### PR TITLE
Save files under temporary name in local backend

### DIFF
--- a/changelog/unreleased/pull-3436
+++ b/changelog/unreleased/pull-3436
@@ -1,0 +1,12 @@
+Enhancement: Improve local backend's resilience to (system) crashes
+
+Restic now ensures that files stored using the `local` backend are created
+atomically (that is, files are either stored completely or not at all). This
+ensures that no incomplete files are left behind even if restic is terminated
+while writing a file.
+
+In addition, restic now tries to ensure that the directory in the repository
+which contains a newly uploaded file is also written to disk. This can prevent
+missing files if the system crashes or the disk is not properly unmounted.
+
+https://github.com/restic/restic/pull/3436

--- a/internal/backend/local/local_internal_test.go
+++ b/internal/backend/local/local_internal_test.go
@@ -3,6 +3,7 @@ package local
 import (
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"syscall"
 	"testing"
@@ -14,15 +15,13 @@ import (
 )
 
 func TestNoSpacePermanent(t *testing.T) {
-	oldOpenFile := openFile
+	oldTempFile := tempFile
 	defer func() {
-		openFile = oldOpenFile
+		tempFile = oldTempFile
 	}()
 
-	openFile = func(name string, flags int, mode os.FileMode) (*os.File, error) {
-		// The actual error from os.OpenFile is *os.PathError.
-		// Other functions called inside Save may return *os.SyscallError.
-		return nil, os.NewSyscallError("open", syscall.ENOSPC)
+	tempFile = func(_, _ string) (*os.File, error) {
+		return nil, fmt.Errorf("not creating tempfile, %w", syscall.ENOSPC)
 	}
 
 	dir, cleanup := rtest.TempDir(t)

--- a/internal/backend/local/local_unix.go
+++ b/internal/backend/local/local_unix.go
@@ -3,10 +3,32 @@
 package local
 
 import (
+	"errors"
 	"os"
+	"syscall"
 
 	"github.com/restic/restic/internal/fs"
 )
+
+// fsyncDir flushes changes to the directory dir.
+func fsyncDir(dir string) error {
+	d, err := os.Open(dir)
+	if err != nil {
+		return err
+	}
+
+	err = d.Sync()
+	if errors.Is(err, syscall.ENOTSUP) {
+		err = nil
+	}
+
+	cerr := d.Close()
+	if err == nil {
+		err = cerr
+	}
+
+	return err
+}
 
 // set file to readonly
 func setFileReadonly(f string, mode os.FileMode) error {

--- a/internal/backend/local/local_windows.go
+++ b/internal/backend/local/local_windows.go
@@ -4,6 +4,9 @@ import (
 	"os"
 )
 
+// Can't explicitly flush directory changes on Windows.
+func fsyncDir(dir string) error { return nil }
+
 // We don't modify read-only on windows,
 // since it will make us unable to delete the file,
 // and this isn't common practice on this platform.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Files in local backends are written to a temporary file first, then sync'd, then renamed. In case of a crash or network disconnect, broken pack files will end up with names of the form `*-tmp-*` and will not be picked up by other restic commands.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Fixes #3435.

This patch includes #3420 to avoid merge conflicts.

The code is similar to #2838, but does not take into account writing to a single repo from multiple sources (the repo is assumed to be locked).

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [x] I have added tests for all changes in this PR
- [ ] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
