### PR TITLE
prune: Add missing newlines in error descriptions

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -249,7 +249,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 			"Integrity check failed: Data seems to be missing.\n"+
 			"Will not start prune to prevent (additional) data loss!\n"+
 			"Please report this error (along with the output of the 'prune' run) at\n"+
-			"https://github.com/restic/restic/issues/new/choose", usedBlobs)
+			"https://github.com/restic/restic/issues/new/choose\n", usedBlobs)
 		return errorIndexIncomplete
 	}
 
@@ -324,7 +324,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 			// Pack size does not fit and pack is needed => error
 			// If the pack is not needed, this is no error, the pack can
 			// and will be simply removed, see below.
-			Warnf("pack %s: calculated size %d does not match real size %d\nRun 'restic rebuild-index'.",
+			Warnf("pack %s: calculated size %d does not match real size %d\nRun 'restic rebuild-index'.\n",
 				id.Str(), p.unusedSize+p.usedSize, packSize)
 			return errorSizeNotMatching
 		}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The error messages printed by prune, when blobs are missing from the index or the index does not accurately reflect the pack file size, were missing a new line at the end. This can lead to garbled ouput (see https://github.com/restic/restic/issues/3400#issuecomment-862288023 for the full output):
```
https://github.com/restic/restic/issues/new/chooseFatal: index is not complete
```

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- ~~[ ] I have added tests for all changes in this PR~~
- ~~[ ] I have added documentation for the changes (in the manual)~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))~~
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
