### PR TITLE
Add changelog for #3426

### DIFF
--- a/changelog/unreleased/pull-3426
+++ b/changelog/unreleased/pull-3426
@@ -1,0 +1,7 @@
+Enhancement: Optimize read performance of mount command
+
+Reading large files in a mounted repository may be up to five times faster.
+This improvement primarily applies to repositories stored at a backend that can
+be accessed with low latency, like e.g. the local backend.
+
+https://github.com/restic/restic/pull/3426


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Adds a changelog for PR #3426 (prune readahead option).

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
~~- [ ] I have added tests for all changes in this PR~~
~~- [ ] I have added documentation for the changes (in the manual)~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
