### PR TITLE
doc: Correct position of --verbose in backup docs

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -73,7 +73,7 @@ repository (since all data is already there). This is de-duplication at work!
 
 .. code-block:: console
 
-    $ restic -r /srv/restic-repo backup --verbose ~/work
+    $ restic -r /srv/restic-repo --verbose backup ~/work
     open repository
     enter password for repository:
     password is correct
@@ -107,7 +107,7 @@ restic encounters:
 
     $ echo 'more data foo bar' >> ~/work.txt
 
-    $ restic -r /srv/restic-repo backup --verbose --verbose ~/work.txt
+    $ restic -r /srv/restic-repo --verbose --verbose backup ~/work.txt
     open repository
     enter password for repository:
     password is correct


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Removes confusion about where to place the `--verbose` option when backing up.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

Yes, #3440.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
- [ ] I have added tests for all changes in this PR
- [x] I have added documentation for the changes (in the manual)
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [ ] I have run `gofmt` on the code in all commits
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review
