### PR TITLE
restore: Correctly handle partial pack download errors

### DIFF
--- a/changelog/unreleased/pull-3449
+++ b/changelog/unreleased/pull-3449
@@ -1,0 +1,8 @@
+Bugfix: Correctly handle download errors during `restore`
+
+Due to a regression in restic 0.12.0 the `restore` command in some cases
+did not retry download errors and only printed a warning. This has been
+fixed by retrying incomplete data downloads.
+
+https://github.com/restic/restic/issues/3439
+https://github.com/restic/restic/pull/3449

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -258,7 +258,11 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 			if err != nil {
 				return err
 			}
-			blobData, buf, err = r.loadBlob(bufRd, blobID, blob.length, buf)
+			buf, err = r.downloadBlob(bufRd, blobID, blob.length, buf)
+			if err != nil {
+				return err
+			}
+			blobData, err = r.decryptBlob(blobID, buf)
 			if err != nil {
 				for file := range blob.files {
 					if errFile := sanitizeError(file, err); errFile != nil {
@@ -309,7 +313,7 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 	return nil
 }
 
-func (r *fileRestorer) loadBlob(rd io.Reader, blobID restic.ID, length int, buf []byte) ([]byte, []byte, error) {
+func (r *fileRestorer) downloadBlob(rd io.Reader, blobID restic.ID, length int, buf []byte) ([]byte, error) {
 	// TODO reconcile with Repository#loadBlob implementation
 
 	if cap(buf) < length {
@@ -320,24 +324,29 @@ func (r *fileRestorer) loadBlob(rd io.Reader, blobID restic.ID, length int, buf 
 
 	n, err := io.ReadFull(rd, buf)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	if n != length {
-		return nil, nil, errors.Errorf("error loading blob %v: wrong length returned, want %d, got %d", blobID.Str(), length, n)
+		return nil, errors.Errorf("error loading blob %v: wrong length returned, want %d, got %d", blobID.Str(), length, n)
 	}
+	return buf, nil
+}
+
+func (r *fileRestorer) decryptBlob(blobID restic.ID, buf []byte) ([]byte, error) {
+	// TODO reconcile with Repository#loadBlob implementation
 
 	// decrypt
 	nonce, ciphertext := buf[:r.key.NonceSize()], buf[r.key.NonceSize():]
 	plaintext, err := r.key.Open(ciphertext[:0], nonce, ciphertext, nil)
 	if err != nil {
-		return nil, nil, errors.Errorf("decrypting blob %v failed: %v", blobID, err)
+		return nil, errors.Errorf("decrypting blob %v failed: %v", blobID, err)
 	}
 
 	// check hash
 	if !restic.Hash(plaintext).Equal(blobID) {
-		return nil, nil, errors.Errorf("blob %v returned invalid hash", blobID)
+		return nil, errors.Errorf("blob %v returned invalid hash", blobID)
 	}
 
-	return plaintext, buf, nil
+	return plaintext, nil
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
As reported in #3439 download errors can lead to incompletely `restore`d data. Download errors were only passed to `sanitizeError` which only prints the error and then continues. This prevented retrying download errors.

This PR splits the blob download function into two parts which separately download a blob and then decrypt it. This allows retrying failed downloads, while still allowing the restore command to skip blobs which fail to decrypt.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See #3439. I've named the changelog after the PR as the related issue also reports a different problem.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
