### PR TITLE
Add release binaries for linux/s390x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -195,7 +195,7 @@ jobs:
       matrix:
         # run cross-compile in two batches parallel so the overall tests run faster
         targets:
-          - "linux/386 linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/mips linux/mipsle linux/mips64 linux/mips64le \
+          - "linux/386 linux/amd64 linux/arm linux/arm64 linux/ppc64le linux/mips linux/mipsle linux/mips64 linux/mips64le linux/s390x \
             openbsd/386 openbsd/amd64"
 
           - "freebsd/386 freebsd/amd64 freebsd/arm \

--- a/changelog/unreleased/issue-2780
+++ b/changelog/unreleased/issue-2780
@@ -1,0 +1,6 @@
+Enhancement: Add release binaries for s390x architecture on Linux
+
+We've added release binaries for Linux using the s390x architecture.
+
+https://github.com/restic/restic/issues/2780
+https://github.com/restic/restic/pull/3452

--- a/helpers/build-release-binaries/main.go
+++ b/helpers/build-release-binaries/main.go
@@ -226,7 +226,7 @@ var defaultBuildTargets = map[string][]string{
 	"aix":     {"ppc64"},
 	"darwin":  {"amd64", "arm64"},
 	"freebsd": {"386", "amd64", "arm"},
-	"linux":   {"386", "amd64", "arm", "arm64", "ppc64le", "mips", "mipsle", "mips64", "mips64le"},
+	"linux":   {"386", "amd64", "arm", "arm64", "ppc64le", "mips", "mipsle", "mips64", "mips64le", "s390x"},
 	"netbsd":  {"386", "amd64"},
 	"openbsd": {"386", "amd64"},
 	"windows": {"386", "amd64"},


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR add automated CI builds for linux/s390x and adds release builds for it. Note that there is no (automatic) test coverage for that platform.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #2780

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
