### PR TITLE
rest: Workaround Http2 zero-length reply bug

### DIFF
--- a/changelog/unreleased/issue-2742
+++ b/changelog/unreleased/issue-2742
@@ -1,0 +1,15 @@
+Bugfix: Improve error handling for rclone and rest backend over HTTP2
+
+When retrieving data from the rclone / rest backend while also using HTTP2
+restic did not detect when no data was returned at all. This could cause
+for example the `check` command to report the following error:
+```
+Pack ID does not match, want xxxxxxxx, got e3b0c442
+```
+
+This has been fixed by correctly detecting the incomplete download and
+retrying the download.
+
+https://github.com/restic/restic/issues/2742
+https://github.com/restic/restic/pull/3453
+https://forum.restic.net/t/http2-stream-closed-connection-reset-context-canceled/3743/10

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/textproto"
 	"net/url"
 	"path"
 	"strconv"
@@ -198,6 +199,44 @@ func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset 
 	return err
 }
 
+// checkContentLength returns an error if the server returned a value in the
+// Content-Length header in an HTTP2 connection, but closed the connection
+// before any data was sent.
+//
+// This is a workaround for https://github.com/golang/go/issues/46071
+//
+// See also https://forum.restic.net/t/http2-stream-closed-connection-reset-context-canceled/3743/10
+func checkContentLength(resp *http.Response) error {
+	// the following code is based on
+	// https://github.com/golang/go/blob/b7a85e0003cedb1b48a1fd3ae5b746ec6330102e/src/net/http/h2_bundle.go#L8646
+
+	if resp.ContentLength != 0 {
+		return nil
+	}
+
+	if resp.ProtoMajor != 2 && resp.ProtoMinor != 0 {
+		return nil
+	}
+
+	if len(resp.Header[textproto.CanonicalMIMEHeaderKey("Content-Length")]) != 1 {
+		return nil
+	}
+
+	// make sure that if the server returned a content length and we can
+	// parse it, it is really zero, otherwise return an error
+	contentLength := resp.Header.Get("Content-Length")
+	cl, err := strconv.ParseUint(contentLength, 10, 63)
+	if err != nil {
+		return fmt.Errorf("unable to parse Content-Length %q: %w", contentLength, err)
+	}
+
+	if cl != 0 {
+		return errors.Errorf("unexpected EOF: got 0 instead of %v bytes", cl)
+	}
+
+	return nil
+}
+
 func (b *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
@@ -249,16 +288,10 @@ func (b *Backend) openReader(ctx context.Context, h restic.Handle, length int, o
 
 	// workaround https://github.com/golang/go/issues/46071
 	// see also https://forum.restic.net/t/http2-stream-closed-connection-reset-context-canceled/3743/10
-	if resp.ContentLength == 0 && resp.ProtoMajor == 2 && resp.ProtoMinor == 0 {
-		if clens := resp.Header["Content-Length"]; len(clens) == 1 {
-			if cl, err := strconv.ParseUint(clens[0], 10, 63); err == nil {
-				resp.ContentLength = int64(cl)
-			}
-			if resp.ContentLength != 0 {
-				_ = resp.Body.Close()
-				return nil, errors.Errorf("unexpected EOF got 0 instead of %v bytes", resp.ContentLength)
-			}
-		}
+	err = checkContentLength(resp)
+	if err != nil {
+		_ = resp.Body.Close()
+		return nil, err
 	}
 
 	return resp.Body, nil

--- a/internal/backend/rest/rest_int_go114_test.go
+++ b/internal/backend/rest/rest_int_go114_test.go
@@ -1,0 +1,94 @@
+// +build go1.14
+
+package rest_test
+
+import (
+	"context"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/restic/restic/internal/backend/rest"
+	"github.com/restic/restic/internal/restic"
+)
+
+func TestZeroLengthRead(t *testing.T) {
+	// Test workaround for https://github.com/golang/go/issues/46071. Can be removed once this is fixed in Go
+	// and the minimum golang version supported by restic includes the fix.
+	numRequests := 0
+	srv := httptest.NewUnstartedServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		numRequests++
+		t.Logf("req %v %v", req.Method, req.URL.Path)
+		if req.Method == "GET" {
+			res.Header().Set("Content-Length", "42")
+			// Now the handler fails for some reason and is unable to send data
+			return
+		}
+
+		t.Errorf("unhandled request %v %v", req.Method, req.URL.Path)
+	}))
+	srv.EnableHTTP2 = true
+	srv.StartTLS()
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := rest.Config{
+		Connections: 5,
+		URL:         srvURL,
+	}
+	be, err := rest.Open(cfg, srv.Client().Transport)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		err = be.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	err = be.Load(context.TODO(), restic.Handle{Type: restic.ConfigFile}, 0, 0, func(rd io.Reader) error {
+		_, err := ioutil.ReadAll(rd)
+		if err == nil {
+			t.Fatal("ReadAll should have returned an 'Unexpected EOF' error")
+		}
+		return nil
+	})
+	if err == nil {
+		t.Fatal("Got no unexpected EOF error")
+	}
+}
+
+func TestGolangZeroLengthRead(t *testing.T) {
+	// This test is intended to fail once the underlying issue has been fixed in Go
+	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Length", "42")
+		// Now the handler fails for some reason and is unable to send data
+	}))
+	ts.EnableHTTP2 = true
+	ts.StartTLS()
+	defer ts.Close()
+
+	res, err := ts.Client().Get(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = ioutil.ReadAll(res.Body)
+	defer func() {
+		err = res.Body.Close()
+		if err != nil {
+			t.Fatal(err)
+		}
+	}()
+	if err != nil {
+		// This should fail with an 'Unexpected EOF' error
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The golang http client does not return an error when a HTTP2 reply includes a non-zero content length but does not return any data at all. This scenario can occur e.g. when using rclone when a file stored in a backend seems to be accessible but then fails to download.

This can cause errors like "Pack ID does not match, want $HASH, got e3b0c44" as reported in #2742.

The underlying issue is a bug in the go http client, which is also tracked as https://github.com/golang/go/issues/46071 . However, it is unknown when a fix will be available and I don't expect it to be backported to all go versions still supported by restic.  I've added a test that will fail once the underlying issue in the http.client has been fixed, to allow us to eventually remove the workaround again.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #2742 .
See also https://forum.restic.net/t/http2-stream-closed-connection-reset-context-canceled/3743/10 .

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
