### PR TITLE
Feature to match untagged snapshots only when listing or forgetting

### DIFF
--- a/changelog/unreleased/issue-3456
+++ b/changelog/unreleased/issue-3456
@@ -1,0 +1,9 @@
+Enhancement: Support filtering and specifying untagged snapshots
+
+It was previously not possible to specify an empty tag with the `--tag` and
+`--keep-tag` options. This has now been fixed, such that `--tag ''` and
+`--keep-tag ''` now matches snapshots without tags. This allows e.g. the
+`snapshots` and `forget` commands to only operate on untagged snapshots.
+
+https://github.com/restic/restic/issues/3456
+https://github.com/restic/restic/pull/3457

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -207,6 +207,8 @@ The ``forget`` command accepts the following parameters:
     boundaries and not relative to when you run the ``forget`` command. Weeks
     are Monday 00:00 -> Sunday 23:59, days 00:00 to 23:59, hours :00 to :59, etc.
 
+.. note:: Specifying ``--keep-tag ''`` will match untagged snapshots only.
+
 Multiple policies will be ORed together so as to be as inclusive as possible
 for keeping snapshots.
 
@@ -233,6 +235,13 @@ To only keep the last snapshot of all snapshots with both the tag ``foo`` and
 .. code-block:: console
 
    $ restic forget --tag foo,bar --keep-last 1
+
+To ensure only untagged snapshots are considered, specify the empty string '' as
+the tag.
+
+.. code-block:: console
+
+   $ restic forget --tag '' --keep-last 1
 
 All the ``--keep-*`` options above only count
 hours/days/weeks/months/years which have a snapshot, so those without a

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -165,12 +165,10 @@ command does that:
     create exclusive lock for repository
     modified tags on 1 snapshots
 
-Note the snapshot ID has changed, so between each change we need to look
-up the new ID of the snapshot. But there is an even better way, the
-``tag`` command accepts ``--tag`` for a filter, so we can filter
-snapshots based on the tag we just added.
-
-So we can add and remove tags incrementally like this:
+Note the snapshot ID has changed, so between each change we need to look up the
+new ID of the snapshot. But there is an even better way - the ``tag`` command
+accepts a filter using the ``--tag`` option, so we can filter snapshots based
+on the tag we just added. This way we can add and remove tags incrementally:
 
 .. code-block:: console
 
@@ -188,6 +186,14 @@ So we can add and remove tags incrementally like this:
 
     $ restic -r /srv/restic-repo tag --tag NL --add SOMETHING
     no snapshots were modified
+
+To operate on untagged snapshots only, specify the empty string ``''`` as the
+filter value to ``--tag``. The following command will add the tag ``OTHER``
+to all untagged snapshots:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo tag --tag '' --add OTHER
 
 Under the hood
 --------------

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -195,6 +195,9 @@ func (sn *Snapshot) hasTag(tag string) bool {
 // HasTags returns true if the snapshot has all the tags in l.
 func (sn *Snapshot) HasTags(l []string) bool {
 	for _, tag := range l {
+		if tag == "" && len(sn.Tags) == 0 {
+			return true
+		}
 		if !sn.hasTag(tag) {
 			return false
 		}

--- a/internal/restic/snapshot_test.go
+++ b/internal/restic/snapshot_test.go
@@ -14,3 +14,13 @@ func TestNewSnapshot(t *testing.T) {
 	_, err := restic.NewSnapshot(paths, nil, "foo", time.Now())
 	rtest.OK(t, err)
 }
+
+func TestTagList(t *testing.T) {
+	paths := []string{"/home/foobar"}
+	tags := []string{""}
+
+	sn, _ := restic.NewSnapshot(paths, nil, "foo", time.Now())
+
+	r := sn.HasTags(tags)
+	rtest.Assert(t, r, "Failed to match untagged snapshot")
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Add support for specifying an EMPTY tag for `--tag` and `--keep-tag` which implicitly matches all untagged snapshots.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://forum.restic.net/t/help-with-forgetting-untagged-snapshots/4173

See #3456

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
