### PR TITLE
Use rclone.wrappedConn by pointer

### DIFF
--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -104,16 +104,16 @@ type wrappedConn struct {
 	io.Writer
 }
 
-func (c wrappedConn) Read(p []byte) (int, error) {
+func (c *wrappedConn) Read(p []byte) (int, error) {
 	return c.Reader.Read(p)
 }
 
-func (c wrappedConn) Write(p []byte) (int, error) {
+func (c *wrappedConn) Write(p []byte) (int, error) {
 	return c.Writer.Write(p)
 }
 
-func wrapConn(c *StdioConn, lim limiter.Limiter) wrappedConn {
-	wc := wrappedConn{
+func wrapConn(c *StdioConn, lim limiter.Limiter) *wrappedConn {
+	wc := &wrappedConn{
 		StdioConn: c,
 		Reader:    c,
 		Writer:    c,


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Like #3421, this saves a constant bit of space and compile time by using an interface implementation through a pointer.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
