### PR TITLE
Sanitize debug log

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -555,13 +555,13 @@ func parseConfig(loc location.Location, opts options.Options) (interface{}, erro
 			cfg.KeyID = os.Getenv("AWS_ACCESS_KEY_ID")
 		}
 
-		if cfg.Secret == "" {
-			cfg.Secret = os.Getenv("AWS_SECRET_ACCESS_KEY")
+		if cfg.Secret.String() == "" {
+			cfg.Secret = options.NewSecretString(os.Getenv("AWS_SECRET_ACCESS_KEY"))
 		}
 
-		if cfg.KeyID == "" && cfg.Secret != "" {
+		if cfg.KeyID == "" && cfg.Secret.String() != "" {
 			return nil, errors.Fatalf("unable to open S3 backend: Key ID ($AWS_ACCESS_KEY_ID) is empty")
-		} else if cfg.KeyID != "" && cfg.Secret == "" {
+		} else if cfg.KeyID != "" && cfg.Secret.String() == "" {
 			return nil, errors.Fatalf("unable to open S3 backend: Secret ($AWS_SECRET_ACCESS_KEY) is empty")
 		}
 
@@ -595,8 +595,8 @@ func parseConfig(loc location.Location, opts options.Options) (interface{}, erro
 			cfg.AccountName = os.Getenv("AZURE_ACCOUNT_NAME")
 		}
 
-		if cfg.AccountKey == "" {
-			cfg.AccountKey = os.Getenv("AZURE_ACCOUNT_KEY")
+		if cfg.AccountKey.String() == "" {
+			cfg.AccountKey = options.NewSecretString(os.Getenv("AZURE_ACCOUNT_KEY"))
 		}
 
 		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
@@ -631,11 +631,11 @@ func parseConfig(loc location.Location, opts options.Options) (interface{}, erro
 			return nil, errors.Fatalf("unable to open B2 backend: Account ID ($B2_ACCOUNT_ID) is empty")
 		}
 
-		if cfg.Key == "" {
-			cfg.Key = os.Getenv("B2_ACCOUNT_KEY")
+		if cfg.Key.String() == "" {
+			cfg.Key = options.NewSecretString(os.Getenv("B2_ACCOUNT_KEY"))
 		}
 
-		if cfg.Key == "" {
+		if cfg.Key.String() == "" {
 			return nil, errors.Fatalf("unable to open B2 backend: Key ($B2_ACCOUNT_KEY) is empty")
 		}
 

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -39,7 +39,7 @@ var _ restic.Backend = &Backend{}
 func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 	debug.Log("open, config %#v", cfg)
 
-	client, err := storage.NewBasicClient(cfg.AccountName, cfg.AccountKey)
+	client, err := storage.NewBasicClient(cfg.AccountName, cfg.AccountKey.Unwrap())
 	if err != nil {
 		return nil, errors.Wrap(err, "NewBasicClient")
 	}

--- a/internal/backend/azure/azure_test.go
+++ b/internal/backend/azure/azure_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/restic/restic/internal/backend/azure"
 	"github.com/restic/restic/internal/backend/test"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/options"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
@@ -36,7 +37,7 @@ func newAzureTestSuite(t testing.TB) *test.Suite {
 
 			cfg := azcfg.(azure.Config)
 			cfg.AccountName = os.Getenv("RESTIC_TEST_AZURE_ACCOUNT_NAME")
-			cfg.AccountKey = os.Getenv("RESTIC_TEST_AZURE_ACCOUNT_KEY")
+			cfg.AccountKey = options.NewSecretString(os.Getenv("RESTIC_TEST_AZURE_ACCOUNT_KEY"))
 			cfg.Prefix = fmt.Sprintf("test-%d", time.Now().UnixNano())
 			return cfg, nil
 		},
@@ -146,7 +147,7 @@ func TestUploadLargeFile(t *testing.T) {
 
 	cfg := azcfg.(azure.Config)
 	cfg.AccountName = os.Getenv("RESTIC_TEST_AZURE_ACCOUNT_NAME")
-	cfg.AccountKey = os.Getenv("RESTIC_TEST_AZURE_ACCOUNT_KEY")
+	cfg.AccountKey = options.NewSecretString(os.Getenv("RESTIC_TEST_AZURE_ACCOUNT_KEY"))
 	cfg.Prefix = fmt.Sprintf("test-upload-large-%d", time.Now().UnixNano())
 
 	tr, err := backend.Transport(backend.TransportOptions{})

--- a/internal/backend/azure/config.go
+++ b/internal/backend/azure/config.go
@@ -12,7 +12,7 @@ import (
 // server.
 type Config struct {
 	AccountName string
-	AccountKey  string
+	AccountKey  options.SecretString
 	Container   string
 	Prefix      string
 

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -34,7 +34,7 @@ var _ restic.Backend = &b2Backend{}
 func newClient(ctx context.Context, cfg Config, rt http.RoundTripper) (*b2.Client, error) {
 	opts := []b2.ClientOption{b2.Transport(rt)}
 
-	c, err := b2.NewClient(ctx, cfg.AccountID, cfg.Key, opts...)
+	c, err := b2.NewClient(ctx, cfg.AccountID, cfg.Key.Unwrap(), opts...)
 	if err != nil {
 		return nil, errors.Wrap(err, "b2.NewClient")
 	}

--- a/internal/backend/b2/b2_test.go
+++ b/internal/backend/b2/b2_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/b2"
 	"github.com/restic/restic/internal/backend/test"
+	"github.com/restic/restic/internal/options"
 	"github.com/restic/restic/internal/restic"
 
 	rtest "github.com/restic/restic/internal/test"
@@ -37,7 +38,7 @@ func newB2TestSuite(t testing.TB) *test.Suite {
 
 			cfg := b2cfg.(b2.Config)
 			cfg.AccountID = os.Getenv("RESTIC_TEST_B2_ACCOUNT_ID")
-			cfg.Key = os.Getenv("RESTIC_TEST_B2_ACCOUNT_KEY")
+			cfg.Key = options.NewSecretString(os.Getenv("RESTIC_TEST_B2_ACCOUNT_KEY"))
 			cfg.Prefix = fmt.Sprintf("test-%d", time.Now().UnixNano())
 			return cfg, nil
 		},

--- a/internal/backend/b2/config.go
+++ b/internal/backend/b2/config.go
@@ -13,7 +13,7 @@ import (
 // server.
 type Config struct {
 	AccountID string
-	Key       string
+	Key       options.SecretString
 	Bucket    string
 	Prefix    string
 

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -12,13 +12,14 @@ import (
 // Config contains all configuration necessary to connect to an s3 compatible
 // server.
 type Config struct {
-	Endpoint      string
-	UseHTTP       bool
-	KeyID, Secret string
-	Bucket        string
-	Prefix        string
-	Layout        string `option:"layout" help:"use this backend layout (default: auto-detect)"`
-	StorageClass  string `option:"storage-class" help:"set S3 storage class (STANDARD, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING or REDUCED_REDUNDANCY)"`
+	Endpoint     string
+	UseHTTP      bool
+	KeyID        string
+	Secret       options.SecretString
+	Bucket       string
+	Prefix       string
+	Layout       string `option:"layout" help:"use this backend layout (default: auto-detect)"`
+	StorageClass string `option:"storage-class" help:"set S3 storage class (STANDARD, STANDARD_IA, ONEZONE_IA, INTELLIGENT_TIERING or REDUCED_REDUNDANCY)"`
 
 	Connections   uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
 	MaxRetries    uint   `option:"retries" help:"set the number of retries attempted"`

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -56,7 +56,7 @@ func open(ctx context.Context, cfg Config, rt http.RoundTripper) (*Backend, erro
 		&credentials.Static{
 			Value: credentials.Value{
 				AccessKeyID:     cfg.KeyID,
-				SecretAccessKey: cfg.Secret,
+				SecretAccessKey: cfg.Secret.Unwrap(),
 			},
 		},
 		&credentials.EnvMinio{},

--- a/internal/backend/s3/s3_test.go
+++ b/internal/backend/s3/s3_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/s3"
 	"github.com/restic/restic/internal/backend/test"
+	"github.com/restic/restic/internal/options"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
@@ -141,7 +142,7 @@ func newMinioTestSuite(ctx context.Context, t testing.TB) *test.Suite {
 			cfg.Config.Prefix = fmt.Sprintf("test-%d", time.Now().UnixNano())
 			cfg.Config.UseHTTP = true
 			cfg.Config.KeyID = key
-			cfg.Config.Secret = secret
+			cfg.Config.Secret = options.NewSecretString(secret)
 			return cfg, nil
 		},
 
@@ -239,7 +240,7 @@ func newS3TestSuite(t testing.TB) *test.Suite {
 
 			cfg := s3cfg.(s3.Config)
 			cfg.KeyID = os.Getenv("RESTIC_TEST_S3_KEY")
-			cfg.Secret = os.Getenv("RESTIC_TEST_S3_SECRET")
+			cfg.Secret = options.NewSecretString(os.Getenv("RESTIC_TEST_S3_SECRET"))
 			cfg.Prefix = fmt.Sprintf("test-%d", time.Now().UnixNano())
 			return cfg, nil
 		},

--- a/internal/backend/swift/config.go
+++ b/internal/backend/swift/config.go
@@ -24,12 +24,12 @@ type Config struct {
 	TrustID        string
 
 	StorageURL string
-	AuthToken  string
+	AuthToken  options.SecretString
 
 	// auth v3 only
 	ApplicationCredentialID     string
 	ApplicationCredentialName   string
-	ApplicationCredentialSecret string
+	ApplicationCredentialSecret options.SecretString
 
 	Container              string
 	Prefix                 string
@@ -111,16 +111,25 @@ func ApplyEnvironment(prefix string, cfg interface{}) error {
 		// Application Credential auth
 		{&c.ApplicationCredentialID, prefix + "OS_APPLICATION_CREDENTIAL_ID"},
 		{&c.ApplicationCredentialName, prefix + "OS_APPLICATION_CREDENTIAL_NAME"},
-		{&c.ApplicationCredentialSecret, prefix + "OS_APPLICATION_CREDENTIAL_SECRET"},
 
 		// Manual authentication
 		{&c.StorageURL, prefix + "OS_STORAGE_URL"},
-		{&c.AuthToken, prefix + "OS_AUTH_TOKEN"},
 
 		{&c.DefaultContainerPolicy, prefix + "SWIFT_DEFAULT_CONTAINER_POLICY"},
 	} {
 		if *val.s == "" {
 			*val.s = os.Getenv(val.env)
+		}
+	}
+	for _, val := range []struct {
+		s   *options.SecretString
+		env string
+	}{
+		{&c.ApplicationCredentialSecret, prefix + "OS_APPLICATION_CREDENTIAL_SECRET"},
+		{&c.AuthToken, prefix + "OS_AUTH_TOKEN"},
+	} {
+		if val.s.String() == "" {
+			*val.s = options.NewSecretString(os.Getenv(val.env))
 		}
 	}
 	return nil

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -60,10 +60,10 @@ func Open(ctx context.Context, cfg Config, rt http.RoundTripper) (restic.Backend
 			TenantDomainId:              cfg.TenantDomainID,
 			TrustId:                     cfg.TrustID,
 			StorageUrl:                  cfg.StorageURL,
-			AuthToken:                   cfg.AuthToken,
+			AuthToken:                   cfg.AuthToken.Unwrap(),
 			ApplicationCredentialId:     cfg.ApplicationCredentialID,
 			ApplicationCredentialName:   cfg.ApplicationCredentialName,
-			ApplicationCredentialSecret: cfg.ApplicationCredentialSecret,
+			ApplicationCredentialSecret: cfg.ApplicationCredentialSecret.Unwrap(),
 			ConnectTimeout:              time.Minute,
 			Timeout:                     time.Minute,
 

--- a/internal/debug/round_tripper_debug_test.go
+++ b/internal/debug/round_tripper_debug_test.go
@@ -1,0 +1,46 @@
+// +build debug
+
+package debug
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/restic/restic/internal/test"
+)
+
+func TestRedactHeader(t *testing.T) {
+	secretHeaders := []string{
+		"Authorization",
+		"X-Auth-Token",
+		"X-Auth-Key",
+	}
+
+	header := make(http.Header)
+	header["Authorization"] = []string{"123"}
+	header["X-Auth-Token"] = []string{"1234"}
+	header["X-Auth-Key"] = []string{"12345"}
+	header["Host"] = []string{"my.host"}
+
+	origHeaders := redactHeader(header)
+
+	for _, hdr := range secretHeaders {
+		test.Equals(t, "**redacted**", header[hdr][0])
+	}
+	test.Equals(t, "my.host", header["Host"][0])
+
+	restoreHeader(header, origHeaders)
+	test.Equals(t, "123", header["Authorization"][0])
+	test.Equals(t, "1234", header["X-Auth-Token"][0])
+	test.Equals(t, "12345", header["X-Auth-Key"][0])
+	test.Equals(t, "my.host", header["Host"][0])
+
+	delete(header, "X-Auth-Key")
+	origHeaders = redactHeader(header)
+	_, hasHeader := header["X-Auth-Key"]
+	test.Assert(t, !hasHeader, "Unexpected header: %v", header["X-Auth-Key"])
+
+	restoreHeader(header, origHeaders)
+	_, hasHeader = header["X-Auth-Key"]
+	test.Assert(t, !hasHeader, "Unexpected header: %v", header["X-Auth-Key"])
+}

--- a/internal/options/secret_string.go
+++ b/internal/options/secret_string.go
@@ -1,0 +1,24 @@
+package options
+
+type SecretString struct {
+	s *string
+}
+
+func NewSecretString(s string) SecretString {
+	return SecretString{s: &s}
+}
+
+func (s SecretString) GoString() string {
+	return `"` + s.String() + `"`
+}
+
+func (s SecretString) String() string {
+	if len(*s.s) == 0 {
+		return ``
+	}
+	return `**redacted**`
+}
+
+func (s *SecretString) Unwrap() string {
+	return *s.s
+}

--- a/internal/options/secret_string_test.go
+++ b/internal/options/secret_string_test.go
@@ -1,0 +1,55 @@
+package options_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/restic/restic/internal/options"
+	"github.com/restic/restic/internal/test"
+)
+
+type secretTest struct {
+	str options.SecretString
+}
+
+func assertNotIn(t *testing.T, str string, substr string) {
+	if strings.Contains(str, substr) {
+		t.Fatalf("'%s' should not contain '%s'", str, substr)
+	}
+}
+
+func TestSecretString(t *testing.T) {
+	keyStr := "secret-key"
+	secret := options.NewSecretString(keyStr)
+
+	test.Equals(t, "**redacted**", secret.String())
+	test.Equals(t, `"**redacted**"`, secret.GoString())
+	test.Equals(t, "**redacted**", fmt.Sprint(secret))
+	test.Equals(t, "**redacted**", fmt.Sprintf("%v", secret))
+	test.Equals(t, `"**redacted**"`, fmt.Sprintf("%#v", secret))
+	test.Equals(t, keyStr, secret.Unwrap())
+}
+
+func TestSecretStringStruct(t *testing.T) {
+	keyStr := "secret-key"
+	secretStruct := &secretTest{
+		str: options.NewSecretString(keyStr),
+	}
+
+	assertNotIn(t, fmt.Sprint(secretStruct), keyStr)
+	assertNotIn(t, fmt.Sprintf("%v", secretStruct), keyStr)
+	assertNotIn(t, fmt.Sprintf("%#v", secretStruct), keyStr)
+}
+
+func TestSecretStringEmpty(t *testing.T) {
+	keyStr := ""
+	secret := options.NewSecretString(keyStr)
+
+	test.Equals(t, "", secret.String())
+	test.Equals(t, `""`, secret.GoString())
+	test.Equals(t, "", fmt.Sprint(secret))
+	test.Equals(t, "", fmt.Sprintf("%v", secret))
+	test.Equals(t, `""`, fmt.Sprintf("%#v", secret))
+	test.Equals(t, keyStr, secret.Unwrap())
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The debug log currently contains authentication credentials which can cause them to leak accidentally. This PR redacts the two most obvious leaks:
- The dumped http request headers often contain a secret `Authorization` header.
- The backend config often contains the secret part of an access token.

Quite likely neither information is required for debugging, so just replace these with `**redacted**`.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No. But it was prompted by #3450.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~ Not visible for normal users.
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
