### PR TITLE
Honor RESTIC_CACHE_DIR environment variable

### DIFF
--- a/changelog/unreleased/issue-3382
+++ b/changelog/unreleased/issue-3382
@@ -1,0 +1,9 @@
+Change: honor RESTIC_CACHE_DIR environment variable in the check command
+
+--cache-dir option doesn't honor the RESTIC_CACHE_DIR environment variable by
+default. This fixes an issue with the restic check command that doesn't obey the
+RESTIC_CACHE_DIR environment variable. Extend the behavior of cache command to
+manage directories created by restic check.
+
+https://github.com/restic/restic/issues/3382
+https://github.com/restic/restic/pull/3474

--- a/cmd/restic/cmd_cache.go
+++ b/cmd/restic/cmd_cache.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/restic/restic/internal/cache"
@@ -140,8 +141,13 @@ func runCache(opts CacheOptions, gopts GlobalOptions, args []string) error {
 			size = fmt.Sprintf("%11s", formatBytes(uint64(bytes)))
 		}
 
+		name := entry.Name()
+		if !strings.HasPrefix(name, "restic-check-cache-") {
+			name = name[:10]
+		}
+
 		tab.AddRow(data{
-			entry.Name()[:10],
+			name,
 			fmt.Sprintf("%d days ago", uint(time.Since(entry.ModTime()).Hours()/24)),
 			old,
 			size,

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/restic/restic/internal/cache"
 	"github.com/restic/restic/internal/checker"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
@@ -146,6 +147,9 @@ func prepareCheckCache(opts CheckOptions, gopts *GlobalOptions) (cleanup func())
 	}
 
 	cachedir := gopts.CacheDir
+	if cachedir == "" {
+		cachedir = cache.EnvDir()
+	}
 
 	// use a cache in a temporary directory
 	tempdir, err := ioutil.TempDir(cachedir, "restic-check-cache-")

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -172,7 +172,7 @@ func updateTimestamp(d string) error {
 const MaxCacheAge = 30 * 24 * time.Hour
 
 func validCacheDirName(s string) bool {
-	r := regexp.MustCompile(`^[a-fA-F0-9]{64}$`)
+	r := regexp.MustCompile(`^[a-fA-F0-9]{64}$|^restic-check-cache-[0-9]+$`)
 	return r.MatchString(s)
 }
 

--- a/internal/cache/dir.go
+++ b/internal/cache/dir.go
@@ -6,10 +6,15 @@ import (
 	"path/filepath"
 )
 
+// EnvDir return $RESTIC_CACHE_DIR env
+func EnvDir() string {
+	return os.Getenv("RESTIC_CACHE_DIR")
+}
+
 // DefaultDir returns $RESTIC_CACHE_DIR, or the default cache directory
 // for the current OS if that variable is not set.
 func DefaultDir() (cachedir string, err error) {
-	cachedir = os.Getenv("RESTIC_CACHE_DIR")
+	cachedir = EnvDir()
 	if cachedir != "" {
 		return cachedir, nil
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->
CacheDir option doesn't honor the `RESTIC_CACHE_DIR` environment variable by default, this is done by default now.
This avoid checking for `gopts.CacheDir` and `RESTIC_CACHE_DIR` environment variable.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fix #3382: restic check doesn't obey the RESTIC_CACHE_DIR environment variable

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
