### PR TITLE
Fix rest backend tests

### DIFF
--- a/internal/backend/rest/rest_test.go
+++ b/internal/backend/rest/rest_test.go
@@ -50,7 +50,7 @@ func runRESTServer(ctx context.Context, t testing.TB, dir string) (*url.URL, fun
 		return nil, nil
 	}
 
-	url, err := url.Parse("http://localhost:8000/restic-test")
+	url, err := url.Parse("http://localhost:8000/restic-test/")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/minio/sha256-simd"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 
@@ -484,12 +485,11 @@ func (s *Suite) TestSave(t *testing.T) {
 	for i := 0; i < saveTests; i++ {
 		length := rand.Intn(1<<23) + 200000
 		data := test.Random(23, length)
-		// use the first 32 byte as the ID
-		copy(id[:], data)
+		id = sha256.Sum256(data)
 
 		h := restic.Handle{
 			Type: restic.PackFile,
-			Name: fmt.Sprintf("%s-%d", id, i),
+			Name: id.String(),
 		}
 		err := b.Save(context.TODO(), h, restic.NewByteReader(data, b.Hasher()))
 		test.OK(t, err)
@@ -529,7 +529,7 @@ func (s *Suite) TestSave(t *testing.T) {
 
 	length := rand.Intn(1<<23) + 200000
 	data := test.Random(23, length)
-	copy(id[:], data)
+	id = sha256.Sum256(data)
 
 	if _, err = tmpfile.Write(data); err != nil {
 		t.Fatal(err)

--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -657,49 +657,6 @@ func (s *Suite) TestSaveWrongHash(t *testing.T) {
 	}
 }
 
-var filenameTests = []struct {
-	name string
-	data string
-}{
-	{"1dfc6bc0f06cb255889e9ea7860a5753e8eb9665c9a96627971171b444e3113e", "x"},
-	{"f00b4r", "foobar"},
-	{
-		"1dfc6bc0f06cb255889e9ea7860a5753e8eb9665c9a96627971171b444e3113e4bf8f2d9144cc5420a80f04a4880ad6155fc58903a4fb6457c476c43541dcaa6-5",
-		"foobar content of data blob",
-	},
-}
-
-// TestSaveFilenames tests saving data with various file names in the backend.
-func (s *Suite) TestSaveFilenames(t *testing.T) {
-	b := s.open(t)
-	defer s.close(t, b)
-
-	for i, test := range filenameTests {
-		h := restic.Handle{Name: test.name, Type: restic.PackFile}
-		err := b.Save(context.TODO(), h, restic.NewByteReader([]byte(test.data), b.Hasher()))
-		if err != nil {
-			t.Errorf("test %d failed: Save() returned %+v", i, err)
-			continue
-		}
-
-		buf, err := backend.LoadAll(context.TODO(), nil, b, h)
-		if err != nil {
-			t.Errorf("test %d failed: Load() returned %+v", i, err)
-			continue
-		}
-
-		if !bytes.Equal(buf, []byte(test.data)) {
-			t.Errorf("test %d: returned wrong bytes", i)
-		}
-
-		err = b.Remove(context.TODO(), h)
-		if err != nil {
-			t.Errorf("test %d failed: Remove() returned %+v", i, err)
-			continue
-		}
-	}
-}
-
 var testStrings = []struct {
 	id   string
 	data string


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
With the recently merged restic/rest-server#112 and restic/rest-server#130 the REST backend tests are failing now. This PR makes the necessary changes to fix the test failures:

- With the path parsing changes `POST http://localhost:8000/restic-test?create=true` no longer works. Instead `POST http://localhost:8000/restic-test/?create=true` must be used. This is also the variant which is used by `restic init`. That is the change fixes the test to match the normal behavior of restic.
- Filenames in the backend are expected to match the sha256 sum of the file content. As the rest-server now enforces this rule, some tests require changes. This obsoletes the `TestSaveFilenames` test.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes. Sort of ^^ .
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
