### PR TITLE
Stream packs in `check --read-data` and during repacking

### DIFF
--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -2135,7 +2135,4 @@ func TestBackendLoadWriteTo(t *testing.T) {
 	firstSnapshot := testRunList(t, "snapshots", env.gopts)
 	rtest.Assert(t, len(firstSnapshot) == 1,
 		"expected one snapshot, got %v", firstSnapshot)
-
-	// test readData using the hashing.Reader
-	testRunCheck(t, env.gopts)
 }

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -160,7 +160,8 @@ const (
 	// HeaderSize is the header's constant overhead (independent of #entries)
 	HeaderSize = headerLengthSize + crypto.Extension
 
-	maxHeaderSize = 16 * 1024 * 1024
+	// MaxHeaderSize is the max size of header including header-length field
+	MaxHeaderSize = 16*1024*1024 + headerLengthSize
 	// number of header enries to download as part of header-length request
 	eagerEntries = 15
 )
@@ -199,7 +200,7 @@ func readRecords(rd io.ReaderAt, size int64, max int) ([]byte, int, error) {
 		err = InvalidFileError{Message: "header length is invalid"}
 	case int64(hlen) > size-int64(headerLengthSize):
 		err = InvalidFileError{Message: "header is larger than file"}
-	case int64(hlen) > maxHeaderSize:
+	case int64(hlen) > MaxHeaderSize-int64(headerLengthSize):
 		err = InvalidFileError{Message: "header is larger than maxHeaderSize"}
 	}
 	if err != nil {

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -2,13 +2,9 @@ package repository
 
 import (
 	"context"
-	"os"
 	"sync"
 
 	"github.com/restic/restic/internal/debug"
-	"github.com/restic/restic/internal/errors"
-	"github.com/restic/restic/internal/fs"
-	"github.com/restic/restic/internal/pack"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui/progress"
 
@@ -27,147 +23,63 @@ const numRepackWorkers = 8
 func Repack(ctx context.Context, repo restic.Repository, packs restic.IDSet, keepBlobs restic.BlobSet, p *progress.Counter) (obsoletePacks restic.IDSet, err error) {
 	debug.Log("repacking %d packs while keeping %d blobs", len(packs), len(keepBlobs))
 
+	var keepMutex sync.Mutex
 	wg, wgCtx := errgroup.WithContext(ctx)
 
-	downloadQueue := make(chan restic.ID)
+	downloadQueue := make(chan restic.PackBlobs)
 	wg.Go(func() error {
 		defer close(downloadQueue)
-		for packID := range packs {
-			select {
-			case downloadQueue <- packID:
-			case <-wgCtx.Done():
-				return wgCtx.Err()
-			}
-		}
-		return nil
-	})
-
-	type repackJob struct {
-		tempfile   *os.File
-		hash       restic.ID
-		packLength int64
-	}
-	processQueue := make(chan repackJob)
-	// used to close processQueue once all downloaders have finished
-	var downloadWG sync.WaitGroup
-
-	downloader := func() error {
-		defer downloadWG.Done()
-		for packID := range downloadQueue {
-			// load the complete pack into a temp file
-			h := restic.Handle{Type: restic.PackFile, Name: packID.String()}
-
-			tempfile, hash, packLength, err := DownloadAndHash(wgCtx, repo.Backend(), h)
-			if err != nil {
-				return errors.Wrap(err, "Repack")
-			}
-
-			debug.Log("pack %v loaded (%d bytes), hash %v", packID, packLength, hash)
-
-			if !packID.Equal(hash) {
-				return errors.Errorf("hash does not match id: want %v, got %v", packID, hash)
-			}
-
-			select {
-			case processQueue <- repackJob{tempfile, hash, packLength}:
-			case <-wgCtx.Done():
-				return wgCtx.Err()
-			}
-		}
-		return nil
-	}
-
-	downloadWG.Add(numRepackWorkers)
-	for i := 0; i < numRepackWorkers; i++ {
-		wg.Go(downloader)
-	}
-	wg.Go(func() error {
-		downloadWG.Wait()
-		close(processQueue)
-		return nil
-	})
-
-	var keepMutex sync.Mutex
-	worker := func() error {
-		for job := range processQueue {
-			tempfile, packID, packLength := job.tempfile, job.hash, job.packLength
-
-			blobs, _, err := pack.List(repo.Key(), tempfile, packLength)
-			if err != nil {
-				return err
-			}
-
-			debug.Log("processing pack %v, blobs: %v", packID, len(blobs))
-			var buf []byte
-			for _, entry := range blobs {
+		for pbs := range repo.Index().ListPacks(ctx, packs) {
+			var packBlobs []restic.Blob
+			keepMutex.Lock()
+			// filter out unnecessary blobs
+			for _, entry := range pbs.Blobs {
 				h := restic.BlobHandle{ID: entry.ID, Type: entry.Type}
-
-				keepMutex.Lock()
-				shouldKeep := keepBlobs.Has(h)
-				keepMutex.Unlock()
-
-				if !shouldKeep {
-					continue
+				if keepBlobs.Has(h) {
+					packBlobs = append(packBlobs, entry)
 				}
+			}
+			keepMutex.Unlock()
 
-				debug.Log("  process blob %v", h)
+			select {
+			case downloadQueue <- restic.PackBlobs{PackID: pbs.PackID, Blobs: packBlobs}:
+			case <-wgCtx.Done():
+				return wgCtx.Err()
+			}
+		}
+		return nil
+	})
 
-				if uint(cap(buf)) < entry.Length {
-					buf = make([]byte, entry.Length)
-				}
-				buf = buf[:entry.Length]
-
-				n, err := tempfile.ReadAt(buf, int64(entry.Offset))
-				if err != nil {
-					return errors.Wrap(err, "ReadAt")
-				}
-
-				if n != len(buf) {
-					return errors.Errorf("read blob %v from %v: not enough bytes read, want %v, got %v",
-						h, tempfile.Name(), len(buf), n)
-				}
-
-				nonce, ciphertext := buf[:repo.Key().NonceSize()], buf[repo.Key().NonceSize():]
-				plaintext, err := repo.Key().Open(ciphertext[:0], nonce, ciphertext, nil)
+	worker := func() error {
+		for t := range downloadQueue {
+			err := StreamPack(wgCtx, repo.Backend().Load, repo.Key(), t.PackID, t.Blobs, func(blob restic.BlobHandle, buf []byte, err error) error {
 				if err != nil {
 					return err
-				}
-
-				id := restic.Hash(plaintext)
-				if !id.Equal(entry.ID) {
-					debug.Log("read blob %v/%v from %v: wrong data returned, hash is %v",
-						h.Type, h.ID, tempfile.Name(), id)
-					return errors.Errorf("read blob %v from %v: wrong data returned, hash is %v",
-						h, tempfile.Name(), id)
 				}
 
 				keepMutex.Lock()
 				// recheck whether some other worker was faster
-				shouldKeep = keepBlobs.Has(h)
+				shouldKeep := keepBlobs.Has(blob)
 				if shouldKeep {
-					keepBlobs.Delete(h)
+					keepBlobs.Delete(blob)
 				}
 				keepMutex.Unlock()
 
 				if !shouldKeep {
-					continue
+					return nil
 				}
 
 				// We do want to save already saved blobs!
-				_, _, err = repo.SaveBlob(wgCtx, entry.Type, plaintext, entry.ID, true)
+				_, _, err = repo.SaveBlob(wgCtx, blob.Type, buf, blob.ID, true)
 				if err != nil {
 					return err
 				}
 
-				debug.Log("  saved blob %v", entry.ID)
-			}
-
-			if err = tempfile.Close(); err != nil {
-				return errors.Wrap(err, "Close")
-			}
-
-			if err = fs.RemoveIfExists(tempfile.Name()); err != nil {
-				return errors.Wrap(err, "Remove")
+				debug.Log("  saved blob %v", blob.ID)
+				return nil
+			})
+			if err != nil {
+				return err
 			}
 			p.Add(1)
 		}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -801,6 +801,11 @@ func StreamPack(ctx context.Context, beLoad BackendLoadFn, key *crypto.Key, pack
 			}
 			currentBlobEnd = entry.Offset + entry.Length
 
+			if int(entry.Length) <= key.NonceSize() {
+				debug.Log("%v", blobs)
+				return errors.Errorf("invalid blob length %v", entry)
+			}
+
 			// decryption errors are likely permanent, give the caller a chance to skip them
 			nonce, ciphertext := buf[:key.NonceSize()], buf[key.NonceSize():]
 			plaintext, err := key.Open(ciphertext[:0], nonce, ciphertext, nil)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -767,6 +767,7 @@ func StreamPack(ctx context.Context, beLoad BackendLoadFn, key *crypto.Key, pack
 		if bufferSize > MaxStreamBufferSize {
 			bufferSize = MaxStreamBufferSize
 		}
+		// create reader here to allow reusing the buffered reader from checker.checkData
 		bufRd := bufio.NewReaderSize(rd, bufferSize)
 		currentBlobEnd := dataStart
 		var buf []byte

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -27,7 +27,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-const maxStreamBufferSize = 4 * 1024 * 1024
+const MaxStreamBufferSize = 4 * 1024 * 1024
 
 // Repository is used to access a repository in a backend.
 type Repository struct {
@@ -808,8 +808,8 @@ func StreamPack(ctx context.Context, beLoad BackendLoadFn, key *crypto.Key, pack
 	// stream blobs in pack
 	err := beLoad(ctx, h, int(dataEnd-dataStart), int64(dataStart), func(rd io.Reader) error {
 		bufferSize := int(dataEnd - dataStart)
-		if bufferSize > maxStreamBufferSize {
-			bufferSize = maxStreamBufferSize
+		if bufferSize > MaxStreamBufferSize {
+			bufferSize = MaxStreamBufferSize
 		}
 		bufRd := bufio.NewReaderSize(rd, bufferSize)
 		currentBlobEnd := dataStart

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -11,6 +11,7 @@ import (
 	"sort"
 	"sync"
 
+	"github.com/cenkalti/backoff"
 	"github.com/restic/chunker"
 	"github.com/restic/restic/internal/backend/dryrun"
 	"github.com/restic/restic/internal/cache"
@@ -822,7 +823,7 @@ func StreamPack(ctx context.Context, beLoad BackendLoadFn, key *crypto.Key, pack
 
 			err = handleBlobFn(entry.BlobHandle, plaintext, err)
 			if err != nil {
-				return err
+				return backoff.Permanent(err)
 			}
 		}
 		return nil

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -798,7 +798,7 @@ func StreamPack(ctx context.Context, beLoad BackendLoadFn, key *crypto.Key, pack
 	sort.Slice(blobs, func(i, j int) bool {
 		return blobs[i].Offset < blobs[j].Offset
 	})
-	h := restic.Handle{Type: restic.PackFile, Name: packID.String()}
+	h := restic.Handle{Type: restic.PackFile, Name: packID.String(), ContainedBlobType: restic.DataBlob}
 
 	dataStart := blobs[0].Offset
 	dataEnd := blobs[len(blobs)-1].Offset + blobs[len(blobs)-1].Length

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -13,8 +13,6 @@ import (
 	"time"
 
 	"github.com/restic/restic/internal/archiver"
-	"github.com/restic/restic/internal/errors"
-	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
@@ -409,109 +407,5 @@ func TestRepositoryIncrementalIndex(t *testing.T) {
 		if len(ids) > 1 {
 			t.Errorf("pack %v listed in %d indexes\n", packID, len(ids))
 		}
-	}
-}
-
-type backend struct {
-	rd io.Reader
-}
-
-func (be backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	return fn(be.rd)
-}
-
-type retryBackend struct {
-	buf []byte
-}
-
-func (be retryBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	err := fn(bytes.NewReader(be.buf[:len(be.buf)/2]))
-	if err != nil {
-		return err
-	}
-
-	return fn(bytes.NewReader(be.buf))
-}
-
-func TestDownloadAndHash(t *testing.T) {
-	buf := make([]byte, 5*1024*1024+881)
-	_, err := io.ReadFull(rnd, buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	var tests = []struct {
-		be   repository.Loader
-		want []byte
-	}{
-		{
-			be:   backend{rd: bytes.NewReader(buf)},
-			want: buf,
-		},
-		{
-			be:   retryBackend{buf: buf},
-			want: buf,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			f, id, size, err := repository.DownloadAndHash(context.TODO(), test.be, restic.Handle{})
-			if err != nil {
-				t.Error(err)
-			}
-
-			want := restic.Hash(test.want)
-			if !want.Equal(id) {
-				t.Errorf("wrong hash returned, want %v, got %v", want.Str(), id.Str())
-			}
-
-			if size != int64(len(test.want)) {
-				t.Errorf("wrong size returned, want %v, got %v", test.want, size)
-			}
-
-			err = f.Close()
-			if err != nil {
-				t.Error(err)
-			}
-
-			err = fs.RemoveIfExists(f.Name())
-			if err != nil {
-				t.Fatal(err)
-			}
-		})
-	}
-}
-
-type errorReader struct {
-	err error
-}
-
-func (er errorReader) Read(p []byte) (n int, err error) {
-	return 0, er.err
-}
-
-func TestDownloadAndHashErrors(t *testing.T) {
-	var tests = []struct {
-		be  repository.Loader
-		err string
-	}{
-		{
-			be:  backend{rd: errorReader{errors.New("test error 1")}},
-			err: "test error 1",
-		},
-	}
-
-	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			_, _, _, err := repository.DownloadAndHash(context.TODO(), test.be, restic.Handle{})
-			if err == nil {
-				t.Fatalf("wanted error %q, got nil", test.err)
-			}
-
-			if errors.Cause(err).Error() != test.err {
-				t.Fatalf("wanted error %q, got %q", test.err, err)
-			}
-		})
 	}
 }

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -4,17 +4,22 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/restic/restic/internal/archiver"
+	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/test"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -408,4 +413,202 @@ func TestRepositoryIncrementalIndex(t *testing.T) {
 			t.Errorf("pack %v listed in %d indexes\n", packID, len(ids))
 		}
 	}
+
+}
+
+// buildPackfileWithoutHeader returns a manually built pack file without a header.
+func buildPackfileWithoutHeader(t testing.TB, blobSizes []int, key *crypto.Key) (blobs []restic.Blob, packfile []byte) {
+	var offset uint
+	for i, size := range blobSizes {
+		plaintext := test.Random(800+i, size)
+
+		// we use a deterministic nonce here so the whole process is
+		// deterministic, last byte is the blob index
+		var nonce = []byte{
+			0x15, 0x98, 0xc0, 0xf7, 0xb9, 0x65, 0x97, 0x74,
+			0x12, 0xdc, 0xd3, 0x62, 0xa9, 0x6e, 0x20, byte(i),
+		}
+
+		before := len(packfile)
+		packfile = append(packfile, nonce...)
+		packfile = key.Seal(packfile, nonce, plaintext, nil)
+		after := len(packfile)
+
+		ciphertextLength := after - before
+
+		blobs = append(blobs, restic.Blob{
+			BlobHandle: restic.BlobHandle{
+				ID:   restic.Hash(plaintext),
+				Type: restic.DataBlob,
+			},
+			Length: uint(ciphertextLength),
+			Offset: offset,
+		})
+
+		offset = uint(len(packfile))
+	}
+
+	return blobs, packfile
+}
+
+func TestStreamPack(t *testing.T) {
+	// always use the same key for deterministic output
+	const jsonKey = `{"mac":{"k":"eQenuI8adktfzZMuC8rwdA==","r":"k8cfAly2qQSky48CQK7SBA=="},"encrypt":"MKO9gZnRiQFl8mDUurSDa9NMjiu9MUifUrODTHS05wo="}`
+
+	var key crypto.Key
+	err := json.Unmarshal([]byte(jsonKey), &key)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	blobSizes := []int{
+		10,
+		5231,
+		18812,
+		123123,
+		12301,
+		892242,
+		28616,
+		13351,
+		252287,
+		188883,
+		2522811,
+		18883,
+	}
+
+	packfileBlobs, packfile := buildPackfileWithoutHeader(t, blobSizes, &key)
+
+	load := func(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+		data := packfile
+
+		if offset > int64(len(data)) {
+			offset = 0
+			length = 0
+		}
+		data = data[offset:]
+
+		if length > len(data) {
+			length = len(data)
+		}
+
+		data = data[:length]
+
+		return fn(bytes.NewReader(data))
+
+	}
+
+	// first, test regular usage
+	t.Run("regular", func(t *testing.T) {
+		tests := []struct {
+			blobs []restic.Blob
+		}{
+			{packfileBlobs[1:2]},
+			{packfileBlobs[2:5]},
+			{packfileBlobs[2:8]},
+			{[]restic.Blob{
+				packfileBlobs[0],
+				packfileBlobs[8],
+				packfileBlobs[4],
+			}},
+			{[]restic.Blob{
+				packfileBlobs[0],
+				packfileBlobs[len(packfileBlobs)-1],
+			}},
+		}
+
+		for _, test := range tests {
+			t.Run("", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				gotBlobs := make(map[restic.ID]int)
+
+				handleBlob := func(blob restic.BlobHandle, buf []byte, err error) error {
+					gotBlobs[blob.ID]++
+
+					id := restic.Hash(buf)
+					if !id.Equal(blob.ID) {
+						t.Fatalf("wrong id %v for blob %s returned", id, blob.ID)
+					}
+
+					return err
+				}
+
+				wantBlobs := make(map[restic.ID]int)
+				for _, blob := range test.blobs {
+					wantBlobs[blob.ID] = 1
+				}
+
+				err = repository.StreamPack(ctx, load, &key, restic.ID{}, test.blobs, handleBlob)
+				if err != nil {
+					t.Fatal(err)
+				}
+
+				if !cmp.Equal(wantBlobs, gotBlobs) {
+					t.Fatal(cmp.Diff(wantBlobs, gotBlobs))
+				}
+			})
+		}
+	})
+
+	// next, test invalid uses, which should return an error
+	t.Run("invalid", func(t *testing.T) {
+		tests := []struct {
+			blobs []restic.Blob
+			err   string
+		}{
+			{
+				// pass one blob several times
+				blobs: []restic.Blob{
+					packfileBlobs[3],
+					packfileBlobs[8],
+					packfileBlobs[3],
+					packfileBlobs[4],
+				},
+				err: "overlapping blobs in pack",
+			},
+
+			{
+				// pass something that's not a valid blob in the current pack file
+				blobs: []restic.Blob{
+					{
+						Offset: 123,
+						Length: 20000,
+					},
+				},
+				err: "ciphertext verification failed",
+			},
+
+			{
+				// pass a blob that's too small
+				blobs: []restic.Blob{
+					{
+						Offset: 123,
+						Length: 10,
+					},
+				},
+				err: "invalid blob length",
+			},
+		}
+
+		for _, test := range tests {
+			t.Run("", func(t *testing.T) {
+				ctx, cancel := context.WithCancel(context.Background())
+				defer cancel()
+
+				handleBlob := func(blob restic.BlobHandle, buf []byte, err error) error {
+					return err
+				}
+
+				err = repository.StreamPack(ctx, load, &key, restic.ID{}, test.blobs, handleBlob)
+				if err == nil {
+					t.Fatalf("wanted error %v, got nil", test.err)
+				}
+
+				if !strings.Contains(err.Error(), test.err) {
+					t.Fatalf("wrong error returned, it should contain %q but was %q", test.err, err)
+				}
+			})
+		}
+	})
 }

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -60,6 +60,11 @@ type Lister interface {
 	List(context.Context, FileType, func(FileInfo) error) error
 }
 
+type PackBlobs struct {
+	PackID ID
+	Blobs  []Blob
+}
+
 // MasterIndex keeps track of the blobs are stored within files.
 type MasterIndex interface {
 	Has(BlobHandle) bool
@@ -71,4 +76,5 @@ type MasterIndex interface {
 	// the context is cancelled, the background goroutine terminates. This
 	// blocks any modification of the index.
 	Each(ctx context.Context) <-chan PackedBlob
+	ListPacks(ctx context.Context, packs IDSet) <-chan PackBlobs
 }

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -1,12 +1,9 @@
 package restorer
 
 import (
-	"bufio"
 	"context"
-	"io"
 	"math"
 	"path/filepath"
-	"sort"
 	"sync"
 
 	"golang.org/x/sync/errgroup"
@@ -14,6 +11,7 @@ import (
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 )
 
@@ -52,7 +50,7 @@ type packInfo struct {
 type fileRestorer struct {
 	key        *crypto.Key
 	idx        func(restic.BlobHandle) []restic.PackedBlob
-	packLoader func(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error
+	packLoader repository.BackendLoadFn
 
 	filesWriter *filesWriter
 
@@ -62,7 +60,7 @@ type fileRestorer struct {
 }
 
 func newFileRestorer(dst string,
-	packLoader func(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error,
+	packLoader repository.BackendLoadFn,
 	key *crypto.Key,
 	idx func(restic.BlobHandle) []restic.PackedBlob) *fileRestorer {
 
@@ -175,17 +173,14 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 	return wg.Wait()
 }
 
-const maxBufferSize = 4 * 1024 * 1024
-
 func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 
 	// calculate pack byte range and blob->[]files->[]offsets mappings
 	start, end := int64(math.MaxInt64), int64(0)
 	blobs := make(map[restic.ID]struct {
-		offset int64                 // offset of the blob in the pack
-		length int                   // length of the blob
-		files  map[*fileInfo][]int64 // file -> offsets (plural!) of the blob in the file
+		files map[*fileInfo][]int64 // file -> offsets (plural!) of the blob in the file
 	})
+	var blobList []restic.Blob
 	for file := range pack.files {
 		addBlob := func(blob restic.Blob, fileOffset int64) {
 			if start > int64(blob.Offset) {
@@ -196,9 +191,8 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 			}
 			blobInfo, ok := blobs[blob.ID]
 			if !ok {
-				blobInfo.offset = int64(blob.Offset)
-				blobInfo.length = int(blob.Length)
 				blobInfo.files = make(map[*fileInfo][]int64)
+				blobList = append(blobList, blob)
 				blobs[blob.ID] = blobInfo
 			}
 			blobInfo.files[file] = append(blobInfo.files[file], fileOffset)
@@ -228,14 +222,6 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 		}
 	}
 
-	sortedBlobs := make([]restic.ID, 0, len(blobs))
-	for blobID := range blobs {
-		sortedBlobs = append(sortedBlobs, blobID)
-	}
-	sort.Slice(sortedBlobs, func(i, j int) bool {
-		return blobs[sortedBlobs[i]].offset < blobs[sortedBlobs[j]].offset
-	})
-
 	sanitizeError := func(file *fileInfo, err error) error {
 		if err != nil {
 			err = r.Error(file.location, err)
@@ -243,59 +229,39 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 		return err
 	}
 
-	h := restic.Handle{Type: restic.PackFile, Name: pack.id.String(), ContainedBlobType: restic.DataBlob}
-	err := r.packLoader(ctx, h, int(end-start), start, func(rd io.Reader) error {
-		bufferSize := int(end - start)
-		if bufferSize > maxBufferSize {
-			bufferSize = maxBufferSize
-		}
-		bufRd := bufio.NewReaderSize(rd, bufferSize)
-		currentBlobEnd := start
-		var blobData, buf []byte
-		for _, blobID := range sortedBlobs {
-			blob := blobs[blobID]
-			_, err := bufRd.Discard(int(blob.offset - currentBlobEnd))
-			if err != nil {
-				return err
-			}
-			buf, err = r.downloadBlob(bufRd, blobID, blob.length, buf)
-			if err != nil {
-				return err
-			}
-			blobData, err = r.decryptBlob(blobID, buf)
-			if err != nil {
-				for file := range blob.files {
-					if errFile := sanitizeError(file, err); errFile != nil {
-						return errFile
-					}
+	err := repository.StreamPack(ctx, r.packLoader, r.key, pack.id, blobList, func(h restic.BlobHandle, blobData []byte, err error) error {
+		blob := blobs[h.ID]
+		if err != nil {
+			for file := range blob.files {
+				if errFile := sanitizeError(file, err); errFile != nil {
+					return errFile
 				}
-				continue
 			}
-			currentBlobEnd = blob.offset + int64(blob.length)
-			for file, offsets := range blob.files {
-				for _, offset := range offsets {
-					writeToFile := func() error {
-						// this looks overly complicated and needs explanation
-						// two competing requirements:
-						// - must create the file once and only once
-						// - should allow concurrent writes to the file
-						// so write the first blob while holding file lock
-						// write other blobs after releasing the lock
-						createSize := int64(-1)
-						file.lock.Lock()
-						if file.inProgress {
-							file.lock.Unlock()
-						} else {
-							defer file.lock.Unlock()
-							file.inProgress = true
-							createSize = file.size
-						}
-						return r.filesWriter.writeToFile(r.targetPath(file.location), blobData, offset, createSize)
+			return nil
+		}
+		for file, offsets := range blob.files {
+			for _, offset := range offsets {
+				writeToFile := func() error {
+					// this looks overly complicated and needs explanation
+					// two competing requirements:
+					// - must create the file once and only once
+					// - should allow concurrent writes to the file
+					// so write the first blob while holding file lock
+					// write other blobs after releasing the lock
+					createSize := int64(-1)
+					file.lock.Lock()
+					if file.inProgress {
+						file.lock.Unlock()
+					} else {
+						defer file.lock.Unlock()
+						file.inProgress = true
+						createSize = file.size
 					}
-					err := sanitizeError(file, writeToFile())
-					if err != nil {
-						return err
-					}
+					return r.filesWriter.writeToFile(r.targetPath(file.location), blobData, offset, createSize)
+				}
+				err := sanitizeError(file, writeToFile())
+				if err != nil {
+					return err
 				}
 			}
 		}
@@ -311,42 +277,4 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 	}
 
 	return nil
-}
-
-func (r *fileRestorer) downloadBlob(rd io.Reader, blobID restic.ID, length int, buf []byte) ([]byte, error) {
-	// TODO reconcile with Repository#loadBlob implementation
-
-	if cap(buf) < length {
-		buf = make([]byte, length)
-	} else {
-		buf = buf[:length]
-	}
-
-	n, err := io.ReadFull(rd, buf)
-	if err != nil {
-		return nil, err
-	}
-
-	if n != length {
-		return nil, errors.Errorf("error loading blob %v: wrong length returned, want %d, got %d", blobID.Str(), length, n)
-	}
-	return buf, nil
-}
-
-func (r *fileRestorer) decryptBlob(blobID restic.ID, buf []byte) ([]byte, error) {
-	// TODO reconcile with Repository#loadBlob implementation
-
-	// decrypt
-	nonce, ciphertext := buf[:r.key.NonceSize()], buf[r.key.NonceSize():]
-	plaintext, err := r.key.Open(ciphertext[:0], nonce, ciphertext, nil)
-	if err != nil {
-		return nil, errors.Errorf("decrypting blob %v failed: %v", blobID, err)
-	}
-
-	// check hash
-	if !restic.Hash(plaintext).Equal(blobID) {
-		return nil, errors.Errorf("blob %v returned invalid hash", blobID)
-	}
-
-	return plaintext, nil
 }

--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
@@ -38,7 +39,7 @@ type TestRepo struct {
 	filesPathToContent map[string]string
 
 	//
-	loader func(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error
+	loader repository.BackendLoadFn
 }
 
 func (i *TestRepo) Lookup(bh restic.BlobHandle) []restic.PackedBlob {
@@ -267,7 +268,7 @@ func TestErrorRestoreFiles(t *testing.T) {
 	r.files = repo.files
 
 	err := r.restoreFiles(context.TODO())
-	rtest.Equals(t, loadError, err)
+	rtest.Assert(t, errors.Is(err, loadError), "got %v, expected contained error %v", err, loadError)
 }
 
 func TestDownloadError(t *testing.T) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
`check --read-data` and `prune` keep downloaded packs in temporary files which can end up being written to disk. This can cause a large amount of data being written to disk.

The PR converts both operations to stream the pack files directly from the backend without using temporary files. Note that for pack uploads during `prune` and `backup` temporary files are still used. The streaming operation is implemented using `StreamPack` which loads the requested blobs of a pack file and `ListPacks` in the MasterIndex which returns all blobs contained in a set of pack files, with the result being grouped by pack file.

The repack step of `prune` used `DownloadAndHash` to verify the pack and then extract blobs that should be kept. Now, only the relevant part of the pack file is loaded which reduces the amount of data downloaded during `prune`. Verifying the pack hash previously provided the assurance that the pack contains the list of blobs it was expected to have according the repository index. This assurance is now provided by directly accessing the pack file based on the index. As before each individual blob is checked to match the expected hash before any further processing.

The check read data implementation injects a special `Load` method into `StreamPack` to calculate the pack hash, verify individual blobs and extract the pack header for further processing in one pass.

In addition, the filerestorer code is switched to use `StreamPack` which removes the duplicate blob decryption implementation outside of `repository`.

`ListPacks` in the MasterIndex iterates multiple times over the repository index to keep the memory overhead low.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes  #3375
Related to #3465

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
