### PR TITLE
Fix typo in changelog

### DIFF
--- a/changelog/0.7.1_2017-07-22/issue-1081
+++ b/changelog/0.7.1_2017-07-22/issue-1081
@@ -1,4 +1,4 @@
-Enhancement: Clarify semantic for `--tasg` for the `forget` command
+Enhancement: Clarify semantic for `--tag` for the `forget` command
 
 https://github.com/restic/restic/issues/1081
 https://github.com/restic/restic/pull/1090


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Stumbled upon this when searching for something different, I guess this is a typo. 

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
