### PR TITLE
Fix `rebuild-index` for damaged index

### DIFF
--- a/changelog/unreleased/pull-3488
+++ b/changelog/unreleased/pull-3488
@@ -1,0 +1,7 @@
+Bugfix: rebuild-index failed if an index file was damaged
+
+The `rebuild-index` command failed with an error if an index file was damaged
+or truncated. This has been fixed. A (slow) workaround is to use
+`rebuild-index --read-all-packs` or to manually delete the damaged index.
+
+https://github.com/restic/restic/pull/3488

--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -73,7 +73,27 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 		}
 	} else {
 		Verbosef("loading indexes...\n")
-		err := repo.LoadIndex(gopts.ctx)
+		mi := repository.NewMasterIndex()
+		err := repository.ForAllIndexes(ctx, repo, func(id restic.ID, idx *repository.Index, oldFormat bool, err error) error {
+			if err != nil {
+				Warnf("removing invalid index %v: %v\n", id, err)
+				obsoleteIndexes = append(obsoleteIndexes, id)
+				return nil
+			}
+
+			mi.Insert(idx)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+
+		err = mi.MergeFinalIndexes()
+		if err != nil {
+			return err
+		}
+
+		err = repo.SetIndex(mi)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
`rebuild-index` now ignores broken index files instead of failing with an error. This allows benefiting from the much faster incremental index rebuild, while still removing broken files.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No. But the problem was mentioned in #1229.

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[x] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
