### PR TITLE
Asynchronously upload pack files

### DIFF
--- a/changelog/unreleased/issue-2696
+++ b/changelog/unreleased/issue-2696
@@ -1,0 +1,13 @@
+Enhancement: Improve backup speed with many small files
+
+We have restructured the backup pipeline to continue reading files while all
+upload connections are busy. This allows the backup to already prepare the next
+data file such that the upload can continue right once the last one has
+completed. This can especially improve the backup performance for high latency
+backends.
+
+The upload concurrency is now controlled using the `-o <backend-name>.connections=5`
+option.
+
+https://github.com/restic/restic/issues/2696
+https://github.com/restic/restic/pull/3489

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -89,10 +89,6 @@ func changeTags(ctx context.Context, repo *repository.Repository, sn *restic.Sna
 
 		debug.Log("new snapshot saved as %v", id)
 
-		if err = repo.Flush(ctx); err != nil {
-			return false, err
-		}
-
 		// Remove the old snapshot.
 		h := restic.Handle{Type: restic.SnapshotFile, Name: sn.ID().String()}
 		if err = repo.Backend().Remove(ctx, h); err != nil {

--- a/doc/047_tuning_backup_parameters.rst
+++ b/doc/047_tuning_backup_parameters.rst
@@ -1,0 +1,40 @@
+..
+  Normally, there are no heading levels assigned to certain characters as the structure is
+  determined from the succession of headings. However, this convention is used in Python’s
+  Style Guide for documenting which you may follow:
+  # with overline, for parts
+  * for chapters
+  = for sections
+  - for subsections
+  ^ for subsubsections
+  " for paragraphs
+########################
+Tuning Backup Parameters
+########################
+
+Restic offers a few parameters that allow tuning the backup. The default values should
+work well in general although specific use cases can benefit from different non-default
+values. As the restic commands evolve over time, the optimal value for each parameter
+can also change across restic versions.
+
+
+Backend Connections
+===================
+
+Restic uses a global limit for the number of concurrent connections to a backend.
+This limit can be configured using ``-o <backend-name>.connections=5``, for example for
+the REST backend the parameter would be ``-o rest.connections=5``. By default restic uses
+``5`` connections for each backend, except for the local backend which uses a limit of ``2``.
+The defaults should work well in most cases. For high-latency backends it can be beneficial
+to increase the number of connections. Please be aware that this increases the resource
+consumption of restic and that a too high connection count *will degrade performace*.
+
+
+Compression
+===========
+
+For a repository using a least repository format version 2, you can configure how data
+is compressed with the option ``--compression``. It can be set to ```auto``` (the default,
+which will compress very fast), ``max`` (which will trade backup speed and CPU usage for
+slightly better compression), or ``off`` (which disables compression). Each setting is
+only applied for the single run of restic.

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,6 +9,7 @@ Restic Documentation
    030_preparing_a_new_repo
    040_backup
    045_working_with_repos
+   047_tuning_backup_parameters
    050_restore
    060_forget
    070_encryption

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -122,7 +122,9 @@ func (o Options) ApplyDefaults() Options {
 	}
 
 	if o.SaveBlobConcurrency == 0 {
-		o.SaveBlobConcurrency = uint(runtime.NumCPU())
+		// blob saving is CPU bound due to hash checking and encryption
+		// the actual upload is handled by the repository itself
+		o.SaveBlobConcurrency = uint(runtime.GOMAXPROCS(0))
 	}
 
 	if o.SaveTreeConcurrency == 0 {

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -128,9 +128,12 @@ func (o Options) ApplyDefaults() Options {
 	}
 
 	if o.SaveTreeConcurrency == 0 {
-		// use a relatively high concurrency here, having multiple SaveTree
-		// workers is cheap
-		o.SaveTreeConcurrency = o.SaveBlobConcurrency * 20
+		// can either wait for a file, wait for a tree, serialize a tree or wait for saveblob
+		// the last two are cpu-bound and thus mutually exclusive.
+		// Also allow waiting for FileReadConcurrency files, this is the maximum of FutureFiles
+		// which currently can be in progress. The main backup loop blocks when trying to queue
+		// more files to read.
+		o.SaveTreeConcurrency = uint(runtime.GOMAXPROCS(0)) + o.FileReadConcurrency
 	}
 
 	return o

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -42,6 +42,7 @@ func prepareTempdirRepoSrc(t testing.TB, src TestDir) (tempdir string, repo rest
 
 func saveFile(t testing.TB, repo restic.Repository, filename string, filesystem fs.FS) (*restic.Node, ItemStats) {
 	wg, ctx := errgroup.WithContext(context.TODO())
+	repo.StartPackUploader(ctx, wg)
 
 	arch := New(repo, filesystem, Options{})
 	arch.runWorkers(ctx, wg)
@@ -213,6 +214,7 @@ func TestArchiverSave(t *testing.T) {
 			defer cleanup()
 
 			wg, ctx := errgroup.WithContext(ctx)
+			repo.StartPackUploader(ctx, wg)
 
 			arch := New(repo, fs.Track{FS: fs.Local{}}, Options{})
 			arch.Error = func(item string, fi os.FileInfo, err error) error {
@@ -281,6 +283,7 @@ func TestArchiverSaveReaderFS(t *testing.T) {
 			defer cleanup()
 
 			wg, ctx := errgroup.WithContext(ctx)
+			repo.StartPackUploader(ctx, wg)
 
 			ts := time.Now()
 			filename := "xx"
@@ -830,6 +833,7 @@ func TestArchiverSaveDir(t *testing.T) {
 			defer cleanup()
 
 			wg, ctx := errgroup.WithContext(context.Background())
+			repo.StartPackUploader(ctx, wg)
 
 			arch := New(repo, fs.Track{FS: fs.Local{}}, Options{})
 			arch.runWorkers(ctx, wg)
@@ -914,6 +918,7 @@ func TestArchiverSaveDirIncremental(t *testing.T) {
 	// archiver did save the same tree several times
 	for i := 0; i < 5; i++ {
 		wg, ctx := errgroup.WithContext(context.TODO())
+		repo.StartPackUploader(ctx, wg)
 
 		arch := New(repo, fs.Track{FS: fs.Local{}}, Options{})
 		arch.runWorkers(ctx, wg)
@@ -1097,6 +1102,7 @@ func TestArchiverSaveTree(t *testing.T) {
 			}
 
 			wg, ctx := errgroup.WithContext(context.TODO())
+			repo.StartPackUploader(ctx, wg)
 
 			arch.runWorkers(ctx, wg)
 
@@ -2239,6 +2245,7 @@ func TestRacyFileSwap(t *testing.T) {
 	defer cancel()
 
 	wg, ctx := errgroup.WithContext(ctx)
+	repo.StartPackUploader(ctx, wg)
 
 	arch := New(repo, fs.Track{FS: statfs}, Options{})
 	arch.Error = func(item string, fi os.FileInfo, err error) error {

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/test"
+	"golang.org/x/sync/errgroup"
 )
 
 var checkerTestData = filepath.Join("testdata", "checker-test-repo.tar.gz")
@@ -476,6 +477,8 @@ func TestCheckerBlobTypeConfusion(t *testing.T) {
 		Nodes: []*restic.Node{damagedNode},
 	}
 
+	wg, wgCtx := errgroup.WithContext(ctx)
+	repo.StartPackUploader(wgCtx, wg)
 	id, err := repo.SaveTree(ctx, damagedTree)
 	test.OK(t, repo.Flush(ctx))
 	test.OK(t, err)
@@ -483,6 +486,8 @@ func TestCheckerBlobTypeConfusion(t *testing.T) {
 	buf, err := repo.LoadBlob(ctx, restic.TreeBlob, id, nil)
 	test.OK(t, err)
 
+	wg, wgCtx = errgroup.WithContext(ctx)
+	repo.StartPackUploader(wgCtx, wg)
 	_, _, _, err = repo.SaveBlob(ctx, restic.DataBlob, buf, id, false)
 	test.OK(t, err)
 

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -42,7 +42,7 @@ func newPack(t testing.TB, k *crypto.Key, lengths []int) ([]Buf, []byte, uint) {
 		rtest.OK(t, err)
 	}
 
-	_, err := p.Finalize()
+	err := p.Finalize()
 	rtest.OK(t, err)
 
 	return bufs, buf.Bytes(), p.Size()

--- a/internal/repository/fuzz_test.go
+++ b/internal/repository/fuzz_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/restic/restic/internal/backend/mem"
 	"github.com/restic/restic/internal/restic"
+	"golang.org/x/sync/errgroup"
 )
 
 // Test saving a blob and loading it again, with varying buffer sizes.
@@ -22,6 +23,9 @@ func FuzzSaveLoadBlob(f *testing.F) {
 
 		id := restic.Hash(blob)
 		repo, _ := TestRepositoryWithBackend(t, mem.New(), 2)
+
+		var wg errgroup.Group
+		repo.StartPackUploader(context.TODO(), &wg)
 
 		_, _, _, err := repo.SaveBlob(context.TODO(), restic.DataBlob, blob, id, false)
 		if err != nil {

--- a/internal/repository/packer_uploader.go
+++ b/internal/repository/packer_uploader.go
@@ -1,0 +1,63 @@
+package repository
+
+import (
+	"context"
+
+	"github.com/restic/restic/internal/restic"
+	"golang.org/x/sync/errgroup"
+)
+
+// SavePacker implements saving a pack in the repository.
+type SavePacker interface {
+	savePacker(ctx context.Context, t restic.BlobType, p *Packer) error
+}
+
+type uploadTask struct {
+	packer *Packer
+	tpe    restic.BlobType
+}
+
+type packerUploader struct {
+	uploadQueue chan uploadTask
+}
+
+func newPackerUploader(ctx context.Context, wg *errgroup.Group, repo SavePacker, connections uint) *packerUploader {
+	pu := &packerUploader{
+		uploadQueue: make(chan uploadTask),
+	}
+
+	for i := 0; i < int(connections); i++ {
+		wg.Go(func() error {
+			for {
+				select {
+				case t, ok := <-pu.uploadQueue:
+					if !ok {
+						return nil
+					}
+					err := repo.savePacker(ctx, t.tpe, t.packer)
+					if err != nil {
+						return err
+					}
+				case <-ctx.Done():
+					return ctx.Err()
+				}
+			}
+		})
+	}
+
+	return pu
+}
+
+func (pu *packerUploader) QueuePacker(ctx context.Context, t restic.BlobType, p *Packer) (err error) {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case pu.uploadQueue <- uploadTask{tpe: t, packer: p}:
+	}
+
+	return nil
+}
+
+func (pu *packerUploader) TriggerShutdown() {
+	close(pu.uploadQueue)
+}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -520,8 +520,8 @@ func (r *Repository) StartPackUploader(ctx context.Context, wg *errgroup.Group) 
 	innerWg, ctx := errgroup.WithContext(ctx)
 	r.packerWg = innerWg
 	r.uploader = newPackerUploader(ctx, innerWg, r, r.be.Connections())
-	r.treePM = newPackerManager(r.key, r.be.Hasher, restic.TreeBlob, r.uploader.QueuePacker)
-	r.dataPM = newPackerManager(r.key, r.be.Hasher, restic.DataBlob, r.uploader.QueuePacker)
+	r.treePM = newPackerManager(r.key, restic.TreeBlob, r.uploader.QueuePacker)
+	r.dataPM = newPackerManager(r.key, restic.DataBlob, r.uploader.QueuePacker)
 
 	wg.Go(func() error {
 		return innerWg.Wait()

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/ui/progress"
+	"golang.org/x/sync/errgroup"
 )
 
 // Repository stores data in a backend. It provides high-level functions and
@@ -34,6 +35,10 @@ type Repository interface {
 	// the the pack header.
 	ListPack(context.Context, ID, int64) ([]Blob, uint32, error)
 
+	// StartPackUploader start goroutines to upload new pack files. The errgroup
+	// is used to immediately notify about an upload error. Flush() will also return
+	// that error.
+	StartPackUploader(ctx context.Context, wg *errgroup.Group)
 	Flush(context.Context) error
 
 	SaveUnpacked(context.Context, FileType, []byte) (ID, error)

--- a/internal/restic/tree_test.go
+++ b/internal/restic/tree_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
+	"golang.org/x/sync/errgroup"
 )
 
 var testFiles = []struct {
@@ -98,6 +99,8 @@ func TestLoadTree(t *testing.T) {
 	repo, cleanup := repository.TestRepository(t)
 	defer cleanup()
 
+	var wg errgroup.Group
+	repo.StartPackUploader(context.TODO(), &wg)
 	// save tree
 	tree := restic.NewTree(0)
 	id, err := repo.SaveTree(context.TODO(), tree)

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
+	"golang.org/x/sync/errgroup"
 )
 
 type Node interface{}
@@ -122,8 +123,9 @@ func saveSnapshot(t testing.TB, repo restic.Repository, snapshot Snapshot) (*res
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
+	wg, wgCtx := errgroup.WithContext(ctx)
+	repo.StartPackUploader(wgCtx, wg)
 	treeID := saveDir(t, repo, snapshot.Nodes, 1000)
-
 	err := repo.Flush(ctx)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The backup pipeline can stall if lots of small files are backed up while using a high-latency backend, see #2696. This is caused by the fileSaver and blobSaver having to wait until a pack file is uploaded, if a blob filled up the pack file. By blocking the fileSaver this prevents processing further files and thus effectively limits the upload concurrency to 2 for small files.

This PR lets the repository upload finished packs in the background (in SaveAndEncrypt), without blocking the caller. The caller is only blocked if all uploader goroutines are busy. That way the fileSaver is no longer blocked when backing up small files. The archiver concurrency has been adapted to remove excess goroutines.

The concurrency of the pack uploader is based on the number of connections configured for each backend. For `local` a default of 2 and for `sftp` a default of 5 connections is used. Configurable connections for these two backends are implemented in #3475.

To keep the number of temporary pack files low, despite the increased upload concurrency, the packer manager now only maintains a single not-completed pack file. The pack file hash calculation is deferred to the uploader goroutines as otherwise the single pack file would become a bottleneck. Simply dumping data chunks into the temporary pack file is rather fast: for me `BenchmarkPackerManager` which measures the pack assembly step reports a throughput of 3GB/s.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #2696

Should be combined with #3475.

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes. **Only the pack uploader has no own tests. Everything else is already covered by existing tests**
- [ ] I have added documentation for relevant changes (in the manual). **I think we should document the `-o <backend>.connections=42` parameter somewhere**
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
