### PR TITLE
Improve snapshot filter warning message

### DIFF
--- a/cmd/restic/find.go
+++ b/cmd/restic/find.go
@@ -31,7 +31,7 @@ func FindFilteredSnapshots(ctx context.Context, repo *repository.Repository, hos
 				} else {
 					id, err = restic.FindSnapshot(ctx, repo, s)
 					if err != nil {
-						Warnf("Ignoring %q, it is not a snapshot id\n", s)
+						Warnf("Ignoring %q: %v\n", s, err)
 						continue
 					}
 				}

--- a/internal/restic/backend_find.go
+++ b/internal/restic/backend_find.go
@@ -10,7 +10,7 @@ import (
 type MultipleIDMatchesError struct{ prefix string }
 
 func (e *MultipleIDMatchesError) Error() string {
-	return fmt.Sprintf("multiple IDs with prefix %s found", e.prefix)
+	return fmt.Sprintf("multiple IDs with prefix %q found", e.prefix)
 }
 
 // A NoIDByPrefixError is returned by Find() when no ID for a given prefix


### PR DESCRIPTION
Include the root-cause why the snapshot prefix is ignored.

What does this PR change? What problem does it solve?
-----------------------------------------------------

I was confused by the following error message (2 snapshots have the same 2-char prefix):
```
sudo -E restic forget --verbose --prune --dry-run  c1
Ignoring "c1", it is not a snapshot id
```
Describe the changes and their purpose here, as detailed as needed.
--------------------------------------------------------------------------------------------
Improved error-messages:

```
Ignoring "c1": multiple IDs with prefix c1 found
```
and

```
sudo -E restic forget --verbose --prune --dry-run  cxx
Ignoring "cxx": no matching ID found for prefix "cxx"
```

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
