### PR TITLE
rclone: Return one fewer value from run

### DIFF
--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -36,12 +36,12 @@ type Backend struct {
 }
 
 // run starts command with args and initializes the StdioConn.
-func run(command string, args ...string) (*StdioConn, *exec.Cmd, *sync.WaitGroup, func() error, error) {
+func run(command string, args ...string) (*StdioConn, *sync.WaitGroup, func() error, error) {
 	cmd := exec.Command(command, args...)
 
 	p, err := cmd.StderrPipe()
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	var wg sync.WaitGroup
@@ -58,7 +58,7 @@ func run(command string, args ...string) (*StdioConn, *exec.Cmd, *sync.WaitGroup
 
 	r, stdin, err := os.Pipe()
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	stdout, w, err := os.Pipe()
@@ -66,7 +66,7 @@ func run(command string, args ...string) (*StdioConn, *exec.Cmd, *sync.WaitGroup
 		// close first pipe and ignore subsequent errors
 		_ = r.Close()
 		_ = stdin.Close()
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	cmd.Stdin = r
@@ -84,7 +84,7 @@ func run(command string, args ...string) (*StdioConn, *exec.Cmd, *sync.WaitGroup
 		err = errW
 	}
 	if err != nil {
-		return nil, nil, nil, nil, err
+		return nil, nil, nil, err
 	}
 
 	c := &StdioConn{
@@ -93,7 +93,7 @@ func run(command string, args ...string) (*StdioConn, *exec.Cmd, *sync.WaitGroup
 		cmd:     cmd,
 	}
 
-	return c, cmd, &wg, bg, nil
+	return c, &wg, bg, nil
 }
 
 // wrappedConn adds bandwidth limiting capabilities to the StdioConn by
@@ -157,7 +157,7 @@ func newBackend(cfg Config, lim limiter.Limiter) (*Backend, error) {
 	arg0, args := args[0], args[1:]
 
 	debug.Log("running command: %v %v", arg0, args)
-	stdioConn, cmd, wg, bg, err := run(arg0, args...)
+	stdioConn, wg, bg, err := run(arg0, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -181,6 +181,7 @@ func newBackend(cfg Config, lim limiter.Limiter) (*Backend, error) {
 		},
 	}
 
+	cmd := stdioConn.cmd
 	waitCh := make(chan struct{})
 	be := &Backend{
 		tr:     tr,


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Cosmetic change: rclone.run returns five values, of which one is superfluous because it's a field on one of the others.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Unlikely :)

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
