### PR TITLE
Streamline progress printing in cmd/restic

### DIFF
--- a/cmd/restic/cleanup.go
+++ b/cmd/restic/cleanup.go
@@ -58,7 +58,7 @@ func RunCleanupHandlers() {
 func CleanupHandler(c <-chan os.Signal) {
 	for s := range c {
 		debug.Log("signal %v received, cleaning up", s)
-		Warnf("%ssignal %v received, cleaning up\n", ClearLine(), s)
+		Warnf("%ssignal %v received, cleaning up\n", clearLine(0), s)
 
 		code := 0
 

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -119,18 +119,6 @@ func verifyPruneOptions(opts *PruneOptions) error {
 	return nil
 }
 
-func shortenStatus(maxLength int, s string) string {
-	if len(s) <= maxLength {
-		return s
-	}
-
-	if maxLength < 3 {
-		return s[:maxLength]
-	}
-
-	return s[:maxLength-3] + "..."
-}
-
 func runPrune(opts PruneOptions, gopts GlobalOptions) error {
 	err := verifyPruneOptions(&opts)
 	if err != nil {

--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -4,9 +4,11 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/restic/restic/internal/ui/progress"
+	"github.com/restic/restic/internal/ui/termstatus"
 )
 
 // calculateProgressInterval returns the interval configured via RESTIC_PROGRESS_FPS
@@ -32,6 +34,7 @@ func newProgressMax(show bool, max uint64, description string) *progress.Counter
 		return nil
 	}
 	interval := calculateProgressInterval(show)
+	canUpdateStatus := stdoutCanUpdateStatus()
 
 	return progress.New(interval, max, func(v uint64, max uint64, d time.Duration, final bool) {
 		var status string
@@ -42,13 +45,36 @@ func newProgressMax(show bool, max uint64, description string) *progress.Counter
 				formatDuration(d), formatPercent(v, max), v, max, description)
 		}
 
-		if w := stdoutTerminalWidth(); w > 0 {
-			status = shortenStatus(w, status)
-		}
-
-		PrintProgress("%s", status)
+		printProgress(status, canUpdateStatus)
 		if final {
 			fmt.Print("\n")
 		}
 	})
+}
+
+func printProgress(status string, canUpdateStatus bool) {
+	w := stdoutTerminalWidth()
+	if w > 0 {
+		if w < 3 {
+			status = termstatus.Truncate(status, w)
+		} else {
+			status = termstatus.Truncate(status, w-3) + "..."
+		}
+	}
+
+	var carriageControl, clear string
+
+	if canUpdateStatus {
+		clear = clearLine(w)
+	}
+
+	if !(strings.HasSuffix(status, "\r") || strings.HasSuffix(status, "\n")) {
+		if canUpdateStatus {
+			carriageControl = "\r"
+		} else {
+			carriageControl = "\n"
+		}
+	}
+
+	_, _ = os.Stdout.Write([]byte(clear + status + carriageControl))
 }

--- a/internal/ui/termstatus/status_test.go
+++ b/internal/ui/termstatus/status_test.go
@@ -19,17 +19,41 @@ func TestTruncate(t *testing.T) {
 		{"foo", 0, ""},
 		{"foo", -1, ""},
 		{"Löwen", 4, "Löwe"},
-		{"あああああああああ/data", 10, "あああああ"},
-		{"あああああああああ/data", 11, "あああああ"},
+		{"あああああ/data", 7, "あああ"},
+		{"あああああ/data", 10, "あああああ"},
+		{"あああああ/data", 11, "あああああ/"},
 	}
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			out := truncate(test.input, test.width)
+			out := Truncate(test.input, test.width)
 			if out != test.output {
 				t.Fatalf("wrong output for input %v, width %d: want %q, got %q",
 					test.input, test.width, test.output, out)
 			}
 		})
 	}
+}
+
+func benchmarkTruncate(b *testing.B, s string, w int) {
+	for i := 0; i < b.N; i++ {
+		Truncate(s, w)
+	}
+}
+
+func BenchmarkTruncateASCII(b *testing.B) {
+	s := "This is an ASCII-only status message...\r\n"
+	benchmarkTruncate(b, s, len(s)-1)
+}
+
+func BenchmarkTruncateUnicode(b *testing.B) {
+	s := "Hello World or Καλημέρα κόσμε or こんにちは 世界"
+	w := 0
+	for _, r := range s {
+		w++
+		if wideRune(r) {
+			w++
+		}
+	}
+	benchmarkTruncate(b, s, w-1)
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It changes the progress printing in cmd/restic, with the following main features:

* PrintProgress no longer does unnecessary Sprintf calls
* newProgressMax's callback checks whether the terminal supports line updates once instead of once per call
* the callback looks up the terminal width once per call instead of twice (on Windows)
* the status shortening now uses the Unicode-aware version from internal/ui/termstatus; it doesn't need this, so consider this code reuse and future-proofing
* ASCII handling in termstatus.Truncate has been optimized

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
