### PR TITLE
doc: Add note about scheduling to backup section

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -483,6 +483,16 @@ The tags can later be used to keep (or forget) snapshots with the ``forget``
 command. The command ``tag`` can be used to modify tags on an existing
 snapshot.
 
+Scheduling backups
+******************
+
+Restic does not have a built-in way of scheduling backups, as it's a tool
+that runs when executed rather than a daemon. There are plenty of different
+ways to schedule backup runs on various different platforms, e.g. systemd
+and cron on Linux/BSD and Task Scheduler in Windows, depending on one's
+needs and requirements. When scheduling restic to run recurringly, please
+make sure to detect already running instances before starting the backup.
+
 Space requirements
 ******************
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Explains that restic doesn't have built-in scheduling
and mentions a few keywords one can search for.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Yes, issue #519.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.