### PR TITLE
Put blobs read by dump into LRU cache to speed up reuse

### DIFF
--- a/changelog/unreleased/pull-3508
+++ b/changelog/unreleased/pull-3508
@@ -1,0 +1,10 @@
+Enhancement: Cache blobs read by the dump command
+
+When dumping a file using the `restic dump` command, restic did not cache blobs
+in any way, so even consecutive runs of the same blob did get loaded from the
+repository again and again, slowing down the dump.
+
+Now, the caching mechanism already used by the `fuse` command is also used by
+the `dump` command. This makes dumping much faster, especially for sparse files.
+
+https://github.com/restic/restic/pull/3508

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -96,7 +96,7 @@ func (f *file) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenR
 
 func (f *openFile) getBlobAt(ctx context.Context, i int) (blob []byte, err error) {
 
-	blob, ok := f.root.blobCache.get(f.node.Content[i])
+	blob, ok := f.root.blobCache.Get(f.node.Content[i])
 	if ok {
 		return blob, nil
 	}
@@ -107,7 +107,7 @@ func (f *openFile) getBlobAt(ctx context.Context, i int) (blob []byte, err error
 		return nil, err
 	}
 
-	f.root.blobCache.add(f.node.Content[i], blob)
+	f.root.blobCache.Add(f.node.Content[i], blob)
 
 	return blob, nil
 }

--- a/internal/fuse/fuse_test.go
+++ b/internal/fuse/fuse_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/restic/restic/internal/blobcache"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 
@@ -27,10 +28,10 @@ func TestCache(t *testing.T) {
 
 	const (
 		kiB       = 1 << 10
-		cacheSize = 64*kiB + 3*cacheOverhead
+		cacheSize = 64*kiB + 3*blobcache.CacheOverhead
 	)
 
-	c := newBlobCache(cacheSize)
+	c := blobcache.New(cacheSize)
 
 	addAndCheck := func(id restic.ID, exp []byte) {
 		c.add(id, exp)
@@ -156,7 +157,7 @@ func TestFuseFile(t *testing.T) {
 		Size:    filesize,
 		Content: content,
 	}
-	root := &Root{repo: repo, blobCache: newBlobCache(blobCacheSize)}
+	root := &Root{repo: repo, blobCache: blobcache.New(blobCacheSize)}
 
 	inode := fs.GenerateDynamicInode(1, "foo")
 	f, err := newFile(context.TODO(), root, inode, node)
@@ -191,7 +192,7 @@ func TestFuseDir(t *testing.T) {
 	repo, cleanup := repository.TestRepository(t)
 	defer cleanup()
 
-	root := &Root{repo: repo, blobCache: newBlobCache(blobCacheSize)}
+	root := &Root{repo: repo, blobCache: blobcache.New(blobCacheSize)}
 
 	node := &restic.Node{
 		Mode:       0755,

--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/restic/restic/internal/blobcache"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/restic"
 
@@ -27,7 +28,7 @@ type Root struct {
 	cfg       Config
 	inode     uint64
 	snapshots restic.Snapshots
-	blobCache *blobCache
+	blobCache *blobcache.BlobCache
 
 	snCount   int
 	lastCheck time.Time
@@ -54,7 +55,7 @@ func NewRoot(repo restic.Repository, cfg Config) *Root {
 		repo:      repo,
 		inode:     rootInode,
 		cfg:       cfg,
-		blobCache: newBlobCache(blobCacheSize),
+		blobCache: blobcache.New(blobCacheSize),
 	}
 
 	if !cfg.OwnerIsRoot {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

In upstream restic, the dump command does not cache any blobs. This is especially bad for consecutive runs of the same data, for example sparse files, where the same blobs are read from the repository over and over again. 

This PR moves the already-existing blobcache mechanism out of the `fuse` command/package into its own `blobcache` package and then makes the `dump` command/package also use the blobcache mechanism.

While the cache size is not configurable yet, for my test data, the `restic dump` command of a sparse vm image with about 70% usage takes only about 0.7x of the vanilla restic's time and network load.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

As far as I know, this change was only discussed in the #restic IRC channel on 2021-08-03.
It might be a solution to #3406, although the fix proposed there is totally different.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
