### PR TITLE
Update instructions for reproducing build

### DIFF
--- a/doc/developer_information.rst
+++ b/doc/developer_information.rst
@@ -12,27 +12,28 @@ depends on the following things:
  * The source code for the release
  * The exact version of the official `Go compiler <https://golang.org>`__ used to produce the binaries (running ``restic version`` will print this)
  * The architecture and operating system the Go compiler runs on (Linux, ``amd64``)
+ * The build tags (for official binaries, it's the tag ``selfupdate``)
  * The path where the source code is extracted to (``/restic``)
  * The path to the Go compiler (``/usr/local/go``)
- * The build tags (for official binaries, it's the tag ``selfupdate``)
- * The environment variables (mostly ``$GOOS``, ``$GOARCH``, ``$CGO_ENABLED``)
+ * The path to the Go workspace (``GOPATH=/home/build/go``)
+ * Other environment variables (mostly ``$GOOS``, ``$GOARCH``, ``$CGO_ENABLED``)
 
 In addition, The compressed ZIP files for Windows depends on the modification
 timestamp and filename of the binary contained in it. In order to reproduce the
 exact same ZIP file every time, we update the timestamp of the file ``VERSION``
 in the source code archive and set the timezone to Europe/Berlin.
 
-In the following example, we'll use the file ``restic-0.10.0.tar.gz`` and Go
-1.15.2 to reproduce the released binaries.
+In the following example, we'll use the file ``restic-0.12.1.tar.gz`` and Go
+1.16.6 to reproduce the released binaries.
 
 1. Determine the Go compiler version used to build the released binaries, then download and extract the Go compiler into ``/usr/local/go``:
 
 .. code::
 
     $ restic version
-    restic 0.10.0 compiled with go1.15.2 on linux/amd64
+    restic 0.12.1 compiled with go1.16.6 on linux/amd64
     $ cd /usr/local
-    $ curl -L https://dl.google.com/go/go1.15.2.linux-amd64.tar.gz | tar xz
+    $ curl -L https://dl.google.com/go/go1.16.6.linux-amd64.tar.gz | tar xz
 
 2. Extract the restic source code into ``/restic``
 
@@ -40,22 +41,23 @@ In the following example, we'll use the file ``restic-0.10.0.tar.gz`` and Go
 
     $ mkdir /restic
     $ cd /restic
-    $ TZ=Europe/Berlin curl -L https://github.com/restic/restic/releases/download/v0.10.0/restic-0.10.0.tar.gz | tar xz --strip-components=1
+    $ TZ=Europe/Berlin curl -L https://github.com/restic/restic/releases/download/v0.12.1/restic-0.12.1.tar.gz | tar xz --strip-components=1
 
 3. Build the binaries for Windows and Linux:
 
 .. code::
 
     $ export PATH=/usr/local/go/bin:$PATH
+    $ export GOPATH=/home/build/go
     $ go version
-    go version go1.15.2 linux/amd64
+    go version go1.16.6 linux/amd64
 
     $ GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -tags selfupdate -o restic_linux_amd64 ./cmd/restic
     $ bzip2 restic_linux_amd64
 
-    $ GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -tags selfupdate -o restic_0.10.0_windows_amd64.exe ./cmd/restic
-    $ touch --reference VERSION restic_0.10.0_windows_amd64.exe
-    $ TZ=Europe/Berlin zip -q -X restic_0.10.0_windows_amd64.zip restic_0.10.0_windows_amd64.exe
+    $ GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build -ldflags "-s -w" -tags selfupdate -o restic_0.12.1_windows_amd64.exe ./cmd/restic
+    $ touch --reference VERSION restic_0.12.1_windows_amd64.exe
+    $ TZ=Europe/Berlin zip -q -X restic_0.12.1_windows_amd64.zip restic_0.12.1_windows_amd64.exe
 
 Building the Official Binaries
 ******************************
@@ -83,7 +85,7 @@ The following steps are necessary to build the binaries:
 
 .. code::
 
-    tar xvzf restic-0.10.0.tar.gz
+    tar xvzf restic-0.12.1.tar.gz
 
 3. Create a directory to place the resulting binaries in:
 
@@ -96,20 +98,20 @@ The following steps are necessary to build the binaries:
 .. code::
 
     docker run --rm \
-        --volume "$PWD/restic-0.10.0:/restic" \
+        --volume "$PWD/restic-0.12.1:/restic" \
         --volume "$PWD/output:/output" \
         restic/builder \
-        go run helpers/build-release-binaries/main.go --version 0.10.0
+        go run helpers/build-release-binaries/main.go --version 0.12.1
 
 4. If anything goes wrong, you can enable debug output like this:
 
 .. code::
 
     docker run --rm \
-        --volume "$PWD/restic-0.10.0:/restic" \
+        --volume "$PWD/restic-0.12.1:/restic" \
         --volume "$PWD/output:/output" \
         restic/builder \
-        go run helpers/build-release-binaries/main.go --version 0.10.0 --verbose
+        go run helpers/build-release-binaries/main.go --version 0.12.1 --verbose
 
 Prepare a New Release
 *********************
@@ -122,6 +124,6 @@ required argument is the new version number (in `Semantic Versioning
 
 .. code::
 
-    go run helpers/prepare-release/main.go 0.10.0
+    go run helpers/prepare-release/main.go 0.12.1
 
 Checks can be skipped on demand via flags, please see ``--help`` for details.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The instructions for reproducing the build are incomplete. Dependencies are fetched at build time and stored in the GOPATH, which ends up in the final binary.

Also, it references an older version of restic, so I updated those references and the corresponding Go version too.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [N/A] I have added tests for all code changes.
- [N/A] I have added documentation for relevant changes (in the manual).
- [N/A] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [N/A] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
