### PR TITLE
archiver: Fix TestArchiverAbortEarlyOnError test

### DIFF
--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1998,7 +1998,6 @@ func TestArchiverAbortEarlyOnError(t *testing.T) {
 				filepath.FromSlash("dir/file2"): 1,
 				filepath.FromSlash("dir/file3"): 1,
 				filepath.FromSlash("dir/file4"): 1,
-				filepath.FromSlash("dir/file7"): 0,
 				filepath.FromSlash("dir/file8"): 0,
 				filepath.FromSlash("dir/file9"): 0,
 			},


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Fix the test failure reported in #3505.

The test failure can be caused when the test has uploaded four blobs, then queues two blobs for upload which are delayed. Then a seventh file can be opened which lead to a test failure.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3505

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
