### PR TITLE
Prevent lock refresh from leaving behind lots of stale locks

### DIFF
--- a/changelog/unreleased/issue-2452
+++ b/changelog/unreleased/issue-2452
@@ -1,0 +1,11 @@
+Bugfix: Improve error handling of repository locking
+
+When the lock refresh failed to delete the old lock file, it forgot about the
+newly created one. Instead it continued trying to delete the old (usually no
+longer existing) lock file and thus over time lots of lock files accumulated.
+This has been fixed.
+
+https://github.com/restic/restic/issues/2452
+https://github.com/restic/restic/issues/2473
+https://github.com/restic/restic/issues/2562
+https://github.com/restic/restic/pull/3512

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -98,6 +98,8 @@ func init() {
 	var cancel context.CancelFunc
 	globalOptions.ctx, cancel = context.WithCancel(context.Background())
 	AddCleanupHandler(func() error {
+		// Must be called before the unlock cleanup handler to ensure that the latter is
+		// not blocked due to limited number of backend connections, see #1434
 		cancel()
 		return nil
 	})

--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -223,15 +223,11 @@ func (l *Lock) Refresh(ctx context.Context) error {
 		return err
 	}
 
-	err = l.repo.Backend().Remove(context.TODO(), Handle{Type: LockFile, Name: l.lockID.String()})
-	if err != nil {
-		return err
-	}
-
 	debug.Log("new lock ID %v", id)
+	oldLockID := l.lockID
 	l.lockID = &id
 
-	return nil
+	return l.repo.Backend().Remove(context.TODO(), Handle{Type: LockFile, Name: oldLockID.String()})
 }
 
 func (l Lock) String() string {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
When the lock refresh failed to delete the old lock file, it forgot about the new one. Instead it continued trying to delete the old (usually no longer existing) lock file and thus over time lots of lock files accumulate.

One way to trigger this is when a delete operation seems to fail for example due to a timeout although it actually succeeded.

The PR also contains a small initialization cleanup to ensure that the lock cleanup handler is called after the global context was canceled on interruptions.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #2473 
Fixes #2452 
Fixes #2562

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
