### PR TITLE
Speed-up copy command

### DIFF
--- a/changelog/unreleased/pull-3513
+++ b/changelog/unreleased/pull-3513
@@ -1,0 +1,10 @@
+Enhancement: Improve speed of copy command
+
+The copy command could require a long time to copy snapshots for non-local
+backends. This has been improved to provide a throughput comparable to the
+restore command.
+
+In addition, the command now displays a progress bar.
+
+https://github.com/restic/restic/issues/2923
+https://github.com/restic/restic/pull/3513

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -500,7 +500,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 	if len(repackPacks) != 0 {
 		Verbosef("repacking packs\n")
 		bar := newProgressMax(!gopts.Quiet, uint64(len(repackPacks)), "packs repacked")
-		_, err := repository.Repack(ctx, repo, repackPacks, keepBlobs, bar)
+		_, err := repository.Repack(ctx, repo, repo, repackPacks, keepBlobs, bar)
 		bar.Done()
 		if err != nil {
 			return errors.Fatalf("%s", err)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The copy command currently proceeds blob by blob which can be very slow if there is any latency for backend accesses.

This PR reuses the repack operation used by prune to implement copy:
The repack operation copies all selected blobs from a set of pack files into new pack files. For prune the source and destination repositories are identical. To implement copy, just use a different source and destination repository.

This way the copy command gains all performance improvements made to the prune command, while also simplifying the implementation. The main change of this PR is the last commit, all other commits are part of #3484. Although this PR could be implemented standalone, I've decided to use #3484 as base as it only accesses the relevant parts of pack files instead of always downloading the full pack file.

The PR also adds a progress bar for the number of pack files copied for the current snapshot.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #2923.

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
