### PR TITLE
rclone: extend timeout from 60s to 240s

### DIFF
--- a/changelog/unreleased/pull-3514
+++ b/changelog/unreleased/pull-3514
@@ -1,0 +1,7 @@
+Enhancement: Support timeout configurable for rclone backend
+
+A slow rclone backend could cause restic to time out while waiting for the repository to open.
+Restic now offers an `-o rclone.timeout` option to make this timeout configurable.
+
+https://github.com/restic/restic/issues/3511
+https://github.com/restic/restic/pull/3514

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -607,10 +607,11 @@ configuring a bandwidth limit for rclone can be achieved by setting the
 
 For debugging rclone, you can set the environment variable ``RCLONE_VERBOSE=2``.
 
-The rclone backend has two additional options:
+The rclone backend has three additional options:
 
  * ``-o rclone.program`` specifies the path to rclone, the default value is just ``rclone``
  * ``-o rclone.args`` allows setting the arguments passed to rclone, by default this is ``serve restic --stdio --b2-hard-delete``
+*  ``-o rclone.timeout`` specifies timeout for waiting on repository opening, the default value is ``1m``
 
 The reason for the ``--b2-hard-delete`` parameters can be found in the corresponding GitHub `issue #1657`_.
 

--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -222,7 +222,7 @@ func newBackend(cfg Config, lim limiter.Limiter) (*Backend, error) {
 	// send an HTTP request to the base URL, see if the server is there
 	client := &http.Client{
 		Transport: debug.RoundTripper(tr),
-		Timeout:   60 * time.Second,
+		Timeout:   cfg.Timeout * 60 * time.Second,
 	}
 
 	// request a random file which does not exist. we just want to test when

--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -222,7 +222,7 @@ func newBackend(cfg Config, lim limiter.Limiter) (*Backend, error) {
 	// send an HTTP request to the base URL, see if the server is there
 	client := &http.Client{
 		Transport: debug.RoundTripper(tr),
-		Timeout:   cfg.Timeout * 60 * time.Second,
+		Timeout:   cfg.Timeout,
 	}
 
 	// request a random file which does not exist. we just want to test when

--- a/internal/backend/rclone/config.go
+++ b/internal/backend/rclone/config.go
@@ -2,6 +2,7 @@ package rclone
 
 import (
 	"strings"
+	"time"
 
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/options"
@@ -12,13 +13,15 @@ type Config struct {
 	Program     string `option:"program" help:"path to rclone (default: rclone)"`
 	Args        string `option:"args"    help:"arguments for running rclone (default: serve restic --stdio --b2-hard-delete)"`
 	Remote      string
-	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	Connections uint          `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	Timeout     time.Duration `option:"timeout"     help:"set a timeout limit to wait for rclone to establish a connection (default: 1m)"`
 }
 
 var defaultConfig = Config{
 	Program:     "rclone",
 	Args:        "serve restic --stdio --b2-hard-delete",
 	Connections: 5,
+	Timeout:     "1m",
 }
 
 func init() {

--- a/internal/backend/rclone/config.go
+++ b/internal/backend/rclone/config.go
@@ -21,7 +21,7 @@ var defaultConfig = Config{
 	Program:     "rclone",
 	Args:        "serve restic --stdio --b2-hard-delete",
 	Connections: 5,
-	Timeout:     "1m",
+	Timeout:     time.Minute,
 }
 
 func init() {

--- a/internal/backend/rclone/config_test.go
+++ b/internal/backend/rclone/config_test.go
@@ -17,6 +17,7 @@ func TestParseConfig(t *testing.T) {
 				Program:     defaultConfig.Program,
 				Args:        defaultConfig.Args,
 				Connections: defaultConfig.Connections,
+				Timeout:     defaultConfig.Timeout,
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Resolves https://github.com/restic/restic/issues/3511
Timeout error when opening slow rclone backend (ex. MEGA)

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
I initially proposed adding a flag, but that would mean the flag only applies to rclone backend, so I just extended the hard-coded timeout for rclone.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
