### PR TITLE
Redownload files with wrong hash

### DIFF
--- a/changelog/unreleased/issue-2533
+++ b/changelog/unreleased/issue-2533
@@ -1,0 +1,13 @@
+Enhancement: Redownload cached data if invalid
+
+In rare situations, like for example after a system crash, the data stored
+in the cache might be corrupted. This could cause restic to fail and
+required manually deleting the cache.
+
+Restic now automatically removes broken data from the cache, allowing it
+to recover from such a situation without user intervention. In addition,
+restic retries downloads which return corrupt data in order to handle
+temporary download problems.
+
+https://github.com/restic/restic/issues/2533
+https://github.com/restic/restic/pull/3521

--- a/internal/backend/utils.go
+++ b/internal/backend/utils.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 )
 
@@ -13,6 +15,7 @@ import (
 // buffer, which is truncated. If the buffer is not large enough or nil, a new
 // one is allocated.
 func LoadAll(ctx context.Context, buf []byte, be restic.Backend, h restic.Handle) ([]byte, error) {
+	retriedInvalidData := false
 	err := be.Load(ctx, h, 0, 0, func(rd io.Reader) error {
 		// make sure this is idempotent, in case an error occurs this function may be called multiple times!
 		wr := bytes.NewBuffer(buf[:0])
@@ -21,6 +24,18 @@ func LoadAll(ctx context.Context, buf []byte, be restic.Backend, h restic.Handle
 			return cerr
 		}
 		buf = wr.Bytes()
+
+		// retry loading damaged data only once. If a file fails to download correctly
+		// the second time, then it  is likely corrupted at the backend. Return the data
+		// to the caller in that case to let it decide what to do with the data.
+		if !retriedInvalidData && h.Type != restic.ConfigFile {
+			id, err := restic.ParseID(h.Name)
+			if err == nil && !restic.Hash(buf).Equal(id) {
+				debug.Log("retry loading broken blob %v", h)
+				retriedInvalidData = true
+				return errors.Errorf("loadAll(%v): invalid data returned", h)
+			}
+		}
 		return nil
 	})
 

--- a/internal/backend/utils_test.go
+++ b/internal/backend/utils_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"testing"
 
@@ -54,6 +55,47 @@ func save(t testing.TB, be restic.Backend, buf []byte) restic.Handle {
 		t.Fatal(err)
 	}
 	return h
+}
+
+type quickRetryBackend struct {
+	restic.Backend
+}
+
+func (be *quickRetryBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+	err := be.Backend.Load(ctx, h, length, offset, fn)
+	if err != nil {
+		// retry
+		err = be.Backend.Load(ctx, h, length, offset, fn)
+	}
+	return err
+}
+
+func TestLoadAllBroken(t *testing.T) {
+	b := mock.NewBackend()
+
+	data := rtest.Random(23, rand.Intn(MiB)+500*KiB)
+	id := restic.Hash(data)
+	// damage buffer
+	data[0] ^= 0xff
+
+	b.OpenReaderFn = func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+		return ioutil.NopCloser(bytes.NewReader(data)), nil
+	}
+
+	// must fail on first try
+	_, err := backend.LoadAll(context.TODO(), nil, b, restic.Handle{Type: restic.PackFile, Name: id.String()})
+	if err == nil {
+		t.Fatalf("missing expected error")
+	}
+
+	// must return the broken data after a retry
+	be := &quickRetryBackend{Backend: b}
+	buf, err := backend.LoadAll(context.TODO(), nil, be, restic.Handle{Type: restic.PackFile, Name: id.String()})
+	rtest.OK(t, err)
+
+	if !bytes.Equal(buf, data) {
+		t.Fatalf("wrong data returned")
+	}
 }
 
 func TestLoadAllAppend(t *testing.T) {

--- a/internal/cache/backend.go
+++ b/internal/cache/backend.go
@@ -131,21 +131,19 @@ func (b *Backend) cacheFile(ctx context.Context, h restic.Handle) error {
 	return nil
 }
 
-// loadFromCacheOrDelegate will try to load the file from the cache, and fall
-// back to the backend if that fails.
-func (b *Backend) loadFromCacheOrDelegate(ctx context.Context, h restic.Handle, length int, offset int64, consumer func(rd io.Reader) error) error {
+// loadFromCache will try to load the file from the cache.
+func (b *Backend) loadFromCache(ctx context.Context, h restic.Handle, length int, offset int64, consumer func(rd io.Reader) error) (bool, error) {
 	rd, err := b.Cache.load(h, length, offset)
 	if err != nil {
-		debug.Log("error caching %v: %v, falling back to backend", h, err)
-		return b.Backend.Load(ctx, h, length, offset, consumer)
+		return false, err
 	}
 
 	err = consumer(rd)
 	if err != nil {
 		_ = rd.Close() // ignore secondary errors
-		return err
+		return true, err
 	}
-	return rd.Close()
+	return true, rd.Close()
 }
 
 // Load loads a file from the cache or the backend.
@@ -161,14 +159,9 @@ func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset 
 	}
 
 	// try loading from cache without checking that the handle is actually cached
-	rd, err := b.Cache.load(h, length, offset)
-	if err == nil {
-		err = consumer(rd)
-		if err != nil {
-			_ = rd.Close() // ignore secondary errors
-			return err
-		}
-		return rd.Close()
+	inCache, err := b.loadFromCache(ctx, h, length, offset, consumer)
+	if inCache {
+		return err
 	}
 	debug.Log("error loading %v from cache: %v", h, err)
 
@@ -181,7 +174,10 @@ func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset 
 	debug.Log("auto-store %v in the cache", h)
 	err = b.cacheFile(ctx, h)
 	if err == nil {
-		return b.loadFromCacheOrDelegate(ctx, h, length, offset, consumer)
+		inCache, err = b.loadFromCache(ctx, h, length, offset, consumer)
+		if inCache {
+			return err
+		}
 	}
 
 	debug.Log("error caching %v: %v, falling back to backend", h, err)

--- a/internal/cache/backend.go
+++ b/internal/cache/backend.go
@@ -161,7 +161,12 @@ func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset 
 	// try loading from cache without checking that the handle is actually cached
 	inCache, err := b.loadFromCache(ctx, h, length, offset, consumer)
 	if inCache {
-		return err
+		if err == nil {
+			return nil
+		}
+
+		// drop from cache and retry once
+		_ = b.Cache.remove(h)
 	}
 	debug.Log("error loading %v from cache: %v", h, err)
 

--- a/internal/cache/backend_test.go
+++ b/internal/cache/backend_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"io/ioutil"
 	"math/rand"
 	"sync"
 	"testing"
@@ -170,4 +171,38 @@ func TestErrorBackend(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestBackendRemoveBroken(t *testing.T) {
+	be := mem.New()
+
+	c, cleanup := TestNewCache(t)
+	defer cleanup()
+
+	h, data := randomData(5234142)
+	// save directly in backend
+	save(t, be, h, data)
+
+	// prime cache with broken copy
+	broken := append([]byte{}, data...)
+	broken[0] ^= 0xff
+	err := c.Save(h, bytes.NewReader(broken))
+	test.OK(t, err)
+
+	// loadall retries if broken data was returned
+	buf, err := backend.LoadAll(context.TODO(), nil, c.Wrap(be), h)
+	test.OK(t, err)
+
+	if !bytes.Equal(buf, data) {
+		t.Fatalf("wrong data returned")
+	}
+
+	// check that the cache now contains the correct data
+	rd, err := c.load(h, 0, 0)
+	test.OK(t, err)
+	cached, err := ioutil.ReadAll(rd)
+	test.OK(t, err)
+	if !bytes.Equal(cached, data) {
+		t.Fatalf("wrong data cache")
+	}
 }

--- a/internal/cache/backend_test.go
+++ b/internal/cache/backend_test.go
@@ -48,7 +48,6 @@ func remove(t testing.TB, be restic.Backend, h restic.Handle) {
 func randomData(n int) (restic.Handle, []byte) {
 	data := test.Random(rand.Int(), n)
 	id := restic.Hash(data)
-	copy(id[:], data)
 	h := restic.Handle{
 		Type: restic.IndexFile,
 		Name: id.String(),


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
restic currently retries downloading files if the overall operation fails. However, there's only rudimentary support for handling corrupted downloads or incomplete files in the cache. Only pack files are accessed using an explicitly set length, which allows the cache to remove cached pack files that are shorter.

However, this mechanism does not support index, lock and snapshot files. This can lead to a situation where users have to manually delete incomplete files form the cache. While it would be possible to determine the size of those files, in many cases an additional list call would be necessary along with passing the length information along everywhere.

This PR takes a different route: for index, lock and snapshot files it is possible to verify their hash while downloading. This allows to simply fail and retry downloading. As corrupted downloads or incomplete files are expected to be rare, limit this to a single retry. Files that are already cached need special handling. For these the cache entry is removed, before trying to redownload the file.

This PR is currently in a request for comment state. There are no new test yet.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #2533.
Conflicts with #2619.

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
~~- [ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
