### PR TITLE
Use LRU cache in restic dump

### DIFF
--- a/changelog/unreleased/pull-3508
+++ b/changelog/unreleased/pull-3508
@@ -1,0 +1,10 @@
+Enhancement: Cache blobs read by the dump command
+
+When dumping a file using the `restic dump` command, restic did not cache blobs
+in any way, so even consecutive runs of the same blob did get loaded from the
+repository again and again, slowing down the dump.
+
+Now, the caching mechanism already used by the `fuse` command is also used by
+the `dump` command. This makes dumping much faster, especially for sparse files.
+
+https://github.com/restic/restic/pull/3508

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -95,7 +95,8 @@ func printFromTree(ctx context.Context, tree *restic.Tree, repo restic.Repositor
 		if node.Name == pathComponents[0] {
 			switch {
 			case l == 1 && dump.IsFile(node):
-				return dump.GetNodeData(ctx, os.Stdout, repo, node)
+				cache := dump.NewCache()
+				return dump.WriteNodeData(ctx, os.Stdout, repo, node, cache)
 			case l > 1 && dump.IsDir(node):
 				subtree, err := repo.LoadTree(ctx, *node.Subtree)
 				if err != nil {

--- a/internal/bloblru/cache_test.go
+++ b/internal/bloblru/cache_test.go
@@ -1,0 +1,50 @@
+package bloblru
+
+import (
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestCache(t *testing.T) {
+	var id1, id2, id3 restic.ID
+	id1[0] = 1
+	id2[0] = 2
+	id3[0] = 3
+
+	const (
+		kiB       = 1 << 10
+		cacheSize = 64*kiB + 3*overhead
+	)
+
+	c := New(cacheSize)
+
+	addAndCheck := func(id restic.ID, exp []byte) {
+		c.Add(id, exp)
+		blob, ok := c.Get(id)
+		rtest.Assert(t, ok, "blob %v added but not found in cache", id)
+		rtest.Equals(t, &exp[0], &blob[0])
+		rtest.Equals(t, exp, blob)
+	}
+
+	addAndCheck(id1, make([]byte, 32*kiB))
+	addAndCheck(id2, make([]byte, 30*kiB))
+	addAndCheck(id3, make([]byte, 10*kiB))
+
+	_, ok := c.Get(id2)
+	rtest.Assert(t, ok, "blob %v not present", id2)
+	_, ok = c.Get(id1)
+	rtest.Assert(t, !ok, "blob %v present, but should have been evicted", id1)
+
+	c.Add(id1, make([]byte, 1+c.size))
+	_, ok = c.Get(id1)
+	rtest.Assert(t, !ok, "blob %v too large but still added to cache")
+
+	c.c.Remove(id1)
+	c.c.Remove(id3)
+	c.c.Remove(id2)
+
+	rtest.Equals(t, cacheSize, c.size)
+	rtest.Equals(t, cacheSize, c.free)
+}

--- a/internal/dump/common.go
+++ b/internal/dump/common.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"path"
 
+	"github.com/restic/restic/internal/bloblru"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/walker"
@@ -14,6 +15,14 @@ import (
 type dumper interface {
 	io.Closer
 	dumpNode(ctx context.Context, node *restic.Node, repo restic.Repository) error
+}
+
+// WriteDump will write the contents of the given tree to the given destination.
+// It will loop over all nodes in the tree and dump them recursively.
+type WriteDump func(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error
+
+func NewCache() *bloblru.Cache {
+	return bloblru.New(64 << 20)
 }
 
 func writeDump(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dmp dumper) error {
@@ -67,20 +76,24 @@ func dumpTree(ctx context.Context, repo restic.Repository, rootNode *restic.Node
 	return err
 }
 
-// GetNodeData will write the contents of the node to the given output.
-func GetNodeData(ctx context.Context, output io.Writer, repo restic.Repository, node *restic.Node) error {
+// WriteNodeData writes the contents of the node to the given Writer.
+func WriteNodeData(ctx context.Context, w io.Writer, repo restic.Repository, node *restic.Node, cache *bloblru.Cache) error {
 	var (
 		buf []byte
 		err error
 	)
 	for _, id := range node.Content {
-		buf, err = repo.LoadBlob(ctx, restic.DataBlob, id, buf)
-		if err != nil {
-			return err
+		blob, ok := cache.Get(id)
+		if !ok {
+			blob, err = repo.LoadBlob(ctx, restic.DataBlob, id, buf)
+			if err != nil {
+				return err
+			}
+
+			buf = cache.Add(id, blob) // Reuse evicted buffer.
 		}
 
-		_, err = output.Write(buf)
-		if err != nil {
+		if _, err := w.Write(blob); err != nil {
 			return errors.Wrap(err, "Write")
 		}
 	}

--- a/internal/dump/common.go
+++ b/internal/dump/common.go
@@ -16,11 +16,7 @@ type dumper interface {
 	dumpNode(ctx context.Context, node *restic.Node, repo restic.Repository) error
 }
 
-// WriteDump will write the contents of the given tree to the given destination.
-// It will loop over all nodes in the tree and dump them recursively.
-type WriteDump func(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error
-
-func writeDump(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dmp dumper, dst io.Writer) error {
+func writeDump(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dmp dumper) error {
 	for _, rootNode := range tree.Nodes {
 		rootNode.Path = rootPath
 		err := dumpTree(ctx, repo, rootNode, rootPath, dmp)

--- a/internal/dump/common_test.go
+++ b/internal/dump/common_test.go
@@ -3,7 +3,6 @@ package dump
 import (
 	"bytes"
 	"context"
-	"io"
 	"testing"
 
 	"github.com/restic/restic/internal/archiver"
@@ -28,7 +27,6 @@ func prepareTempdirRepoSrc(t testing.TB, src archiver.TestDir) (tempdir string, 
 }
 
 type CheckDump func(t *testing.T, testDir string, testDump *bytes.Buffer) error
-type WriteDump func(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error
 
 func WriteTest(t *testing.T, wd WriteDump, cd CheckDump) {
 	tests := []struct {

--- a/internal/dump/common_test.go
+++ b/internal/dump/common_test.go
@@ -3,6 +3,7 @@ package dump
 import (
 	"bytes"
 	"context"
+	"io"
 	"testing"
 
 	"github.com/restic/restic/internal/archiver"
@@ -27,6 +28,7 @@ func prepareTempdirRepoSrc(t testing.TB, src archiver.TestDir) (tempdir string, 
 }
 
 type CheckDump func(t *testing.T, testDir string, testDump *bytes.Buffer) error
+type WriteDump func(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error
 
 func WriteTest(t *testing.T, wd WriteDump, cd CheckDump) {
 	tests := []struct {

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -23,7 +23,7 @@ var _ dumper = tarDumper{}
 func WriteTar(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error {
 	dmp := tarDumper{w: tar.NewWriter(dst)}
 
-	return writeDump(ctx, repo, tree, rootPath, dmp, dst)
+	return writeDump(ctx, repo, tree, rootPath, dmp)
 }
 
 func (dmp tarDumper) Close() error {

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -8,25 +8,29 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/restic/restic/internal/bloblru"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 )
 
 type tarDumper struct {
-	w *tar.Writer
+	cache *bloblru.Cache
+	w     *tar.Writer
 }
 
 // Statically ensure that tarDumper implements dumper.
-var _ dumper = tarDumper{}
+var _ dumper = &tarDumper{}
 
 // WriteTar will write the contents of the given tree, encoded as a tar to the given destination.
 func WriteTar(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error {
-	dmp := tarDumper{w: tar.NewWriter(dst)}
-
+	dmp := &tarDumper{
+		cache: NewCache(),
+		w:     tar.NewWriter(dst),
+	}
 	return writeDump(ctx, repo, tree, rootPath, dmp)
 }
 
-func (dmp tarDumper) Close() error {
+func (dmp *tarDumper) Close() error {
 	return dmp.w.Close()
 }
 
@@ -39,7 +43,7 @@ const (
 	cISVTX = 0o1000 // Save text (sticky bit)
 )
 
-func (dmp tarDumper) dumpNode(ctx context.Context, node *restic.Node, repo restic.Repository) error {
+func (dmp *tarDumper) dumpNode(ctx context.Context, node *restic.Node, repo restic.Repository) error {
 	relPath, err := filepath.Rel("/", node.Path)
 	if err != nil {
 		return err
@@ -90,7 +94,7 @@ func (dmp tarDumper) dumpNode(ctx context.Context, node *restic.Node, repo resti
 		return errors.Wrap(err, "TarHeader")
 	}
 
-	return GetNodeData(ctx, dmp.w, repo, node)
+	return WriteNodeData(ctx, dmp.w, repo, node, dmp.cache)
 }
 
 func parseXattrs(xattrs []restic.ExtendedAttribute) map[string]string {

--- a/internal/dump/zip.go
+++ b/internal/dump/zip.go
@@ -21,7 +21,7 @@ var _ dumper = zipDumper{}
 func WriteZip(ctx context.Context, repo restic.Repository, tree *restic.Tree, rootPath string, dst io.Writer) error {
 	dmp := zipDumper{w: zip.NewWriter(dst)}
 
-	return writeDump(ctx, repo, tree, rootPath, dmp, dst)
+	return writeDump(ctx, repo, tree, rootPath, dmp)
 }
 
 func (dmp zipDumper) Close() error {

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -96,7 +96,7 @@ func (f *file) Open(ctx context.Context, req *fuse.OpenRequest, resp *fuse.OpenR
 
 func (f *openFile) getBlobAt(ctx context.Context, i int) (blob []byte, err error) {
 
-	blob, ok := f.root.blobCache.get(f.node.Content[i])
+	blob, ok := f.root.blobCache.Get(f.node.Content[i])
 	if ok {
 		return blob, nil
 	}
@@ -107,7 +107,7 @@ func (f *openFile) getBlobAt(ctx context.Context, i int) (blob []byte, err error
 		return nil, err
 	}
 
-	f.root.blobCache.add(f.node.Content[i], blob)
+	f.root.blobCache.Add(f.node.Content[i], blob)
 
 	return blob, nil
 }

--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || linux
 // +build darwin freebsd linux
 
 package fuse
@@ -6,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/restic/restic/internal/bloblru"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/restic"
 
@@ -27,7 +29,7 @@ type Root struct {
 	cfg       Config
 	inode     uint64
 	snapshots restic.Snapshots
-	blobCache *blobCache
+	blobCache *bloblru.Cache
 
 	snCount   int
 	lastCheck time.Time
@@ -54,7 +56,7 @@ func NewRoot(repo restic.Repository, cfg Config) *Root {
 		repo:      repo,
 		inode:     rootInode,
 		cfg:       cfg,
-		blobCache: newBlobCache(blobCacheSize),
+		blobCache: bloblru.New(blobCacheSize),
 	}
 
 	if !cfg.OwnerIsRoot {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

restic dump now uses an LRU cache to suppress repeated loads of the same blob. This is essentially #3508 with fixes (and two of the commits are ascribed to @youam). I renamed the cache package internal/bloblru to prevent confusion with internal/cache.

To prove that an LRU cache is more useful than just remembering the last id, I dumped a directory of 18.8GiB of source code to /dev/null. I found that 51022/437420 = 11.66% of blob loads were skipped, accounting for 377MiB (1.96%) of the bytes written. When only the last id is remembered, only 1470 loads were skipped, or 44.41MiB.

The code is a bit of a mess because knowledge of caches is now spread all over. I have a plan to refactor internal/dump, but I'd like to keep it outside the scope of this PR.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Updates #3406. Closes  #3508.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
