### PR TITLE
sftp: Implement atomic uploads

### DIFF
--- a/changelog/unreleased/issue-3003
+++ b/changelog/unreleased/issue-3003
@@ -1,0 +1,10 @@
+Enhancement: Atomic uploads for SFTP
+
+The SFTP backend did not upload files atomically. An interrupted upload could
+leave an incomplete file behind which could prevent restic from accessing the
+repository.
+
+Uploads in the SFTP backend are now done atomically.
+
+https://github.com/restic/restic/issues/3003
+https://github.com/restic/restic/pull/3524


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Most backends except sftp (and to some extent rclone) upload files atomically. This has two benefits: an interrupted upload won't leave incomplete files behind and additionally files that are still uploading are not visible to other processes.

This PR implements atomic upload for SFTP. The idea is to create a file with a sufficiently random temporary name that the chance of collisions is essentially zero and then rename the file to its final name once the upload is complete.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3003

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
