### PR TITLE
Refactor internal/dump + concurrent load/write

### DIFF
--- a/internal/dump/common_test.go
+++ b/internal/dump/common_test.go
@@ -28,7 +28,7 @@ func prepareTempdirRepoSrc(t testing.TB, src archiver.TestDir) (tempdir string, 
 
 type CheckDump func(t *testing.T, testDir string, testDump *bytes.Buffer) error
 
-func WriteTest(t *testing.T, wd WriteDump, cd CheckDump) {
+func WriteTest(t *testing.T, format string, cd CheckDump) {
 	tests := []struct {
 		name   string
 		args   archiver.TestDir
@@ -92,8 +92,9 @@ func WriteTest(t *testing.T, wd WriteDump, cd CheckDump) {
 			rtest.OK(t, err)
 
 			dst := &bytes.Buffer{}
-			if err := wd(ctx, repo, tree, tt.target, dst); err != nil {
-				t.Fatalf("WriteDump() error = %v", err)
+			d := New(format, repo, dst)
+			if err := d.DumpTree(ctx, tree, tt.target); err != nil {
+				t.Fatalf("Dumper.Run error = %v", err)
 			}
 			if err := cd(t, tmpdir, dst); err != nil {
 				t.Errorf("WriteDump() = does not match: %v", err)

--- a/internal/dump/tar_test.go
+++ b/internal/dump/tar_test.go
@@ -16,7 +16,7 @@ import (
 )
 
 func TestWriteTar(t *testing.T) {
-	WriteTest(t, WriteTar, checkTar)
+	WriteTest(t, "tar", checkTar)
 }
 
 func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {

--- a/internal/dump/zip_test.go
+++ b/internal/dump/zip_test.go
@@ -15,7 +15,7 @@ import (
 )
 
 func TestWriteZip(t *testing.T) {
-	WriteTest(t, WriteZip, checkZip)
+	WriteTest(t, "zip", checkZip)
 }
 
 func readZipFile(f *zip.File) ([]byte, error) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Package internal/dump has been reworked so its API consists of a single type Dumper that handles tar and zip formats. Loading trees, loading blobs and writing blobs out happen concurrently. Parallel blob loading has not been implemented, but should not be too hard to add.

Tests pass with minimal changes.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

This cleans up the mess I left behind in #3522.
Updates #3406.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
