### PR TITLE
internal/restic: Don't allocate in Tree.Insert

### DIFF
--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -107,7 +107,7 @@ func runRecover(gopts GlobalOptions) error {
 		return nil
 	}
 
-	tree := restic.NewTree()
+	tree := restic.NewTree(len(roots))
 	for id := range roots {
 		var subtreeID = id
 		node := restic.Node{

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -550,12 +550,13 @@ func (arch *Archiver) statDir(dir string) (os.FileInfo, error) {
 func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, previous *restic.Tree) (*restic.Tree, error) {
 	debug.Log("%v (%v nodes), parent %v", snPath, len(atree.Nodes), previous)
 
-	tree := restic.NewTree()
+	nodeNames := atree.NodeNames()
+	tree := restic.NewTree(len(nodeNames))
 
 	futureNodes := make(map[string]FutureNode)
 
 	// iterate over the nodes of atree in lexicographic (=deterministic) order
-	for _, name := range atree.NodeNames() {
+	for _, name := range nodeNames {
 		subatree := atree.Nodes[name]
 
 		// test if context has been cancelled

--- a/internal/archiver/tree_saver.go
+++ b/internal/archiver/tree_saver.go
@@ -103,7 +103,8 @@ type saveTreeResponse struct {
 func (s *TreeSaver) save(ctx context.Context, snPath string, node *restic.Node, nodes []FutureNode) (*restic.Node, ItemStats, error) {
 	var stats ItemStats
 
-	tree := restic.NewTree()
+	tree := restic.NewTree(len(nodes))
+
 	for _, fn := range nodes {
 		fn.wait(ctx)
 

--- a/internal/restic/tree.go
+++ b/internal/restic/tree.go
@@ -14,10 +14,10 @@ type Tree struct {
 	Nodes []*Node `json:"nodes"`
 }
 
-// NewTree creates a new tree object.
-func NewTree() *Tree {
+// NewTree creates a new tree object with the given initial capacity.
+func NewTree(capacity int) *Tree {
 	return &Tree{
-		Nodes: []*Node{},
+		Nodes: make([]*Node, 0, capacity),
 	}
 }
 
@@ -51,8 +51,8 @@ func (t *Tree) Insert(node *Node) error {
 		return errors.Errorf("node %q already present", node.Name)
 	}
 
-	// https://code.google.com/p/go-wiki/wiki/SliceTricks
-	t.Nodes = append(t.Nodes, &Node{})
+	// https://github.com/golang/go/wiki/SliceTricks
+	t.Nodes = append(t.Nodes, nil)
 	copy(t.Nodes[pos+1:], t.Nodes[pos:])
 	t.Nodes[pos] = node
 

--- a/internal/walker/walker_test.go
+++ b/internal/walker/walker_test.go
@@ -23,7 +23,7 @@ func BuildTreeMap(tree TestTree) (m TreeMap, root restic.ID) {
 }
 
 func buildTreeMap(tree TestTree, m TreeMap) restic.ID {
-	res := restic.NewTree()
+	res := restic.NewTree(0)
 
 	for name, item := range tree {
 		switch elem := item.(type) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

restic.Tree.Insert allocated a Node that was then immediately overwritten in every call. That's solved. Also, NewTree now takes a capacity argument to get rid of the remaining allocations. Results from the new benchmark:

```
name         old time/op    new time/op    delta
BuildTree-8    34.6µs ± 4%     7.0µs ± 3%  -79.68%  (p=0.000 n=18+19)

name         old alloc/op   new alloc/op   delta
BuildTree-8    34.0kB ± 0%     0.9kB ± 0%  -97.37%  (p=0.000 n=20+20)

name         old allocs/op  new allocs/op  delta
BuildTree-8       108 ± 0%         1 ± 0%  -99.07%  (p=0.000 n=20+20)
```

There are some more serious issues with tree construction, including that the one in restic recover takes quadratic time. I'm still looking for a proper solution to that problem. I've decided not to remove the unused Tree.Sort method, because it may come in useful.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

I don't think so.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
