### PR TITLE
s3: Add warning if key ID or secret is empty

### DIFF
--- a/changelog/unreleased/issue-2388
+++ b/changelog/unreleased/issue-2388
@@ -1,0 +1,7 @@
+Enhancement: Add warning for S3 if partial credentials are provided
+
+Check if both the AWS key ID and secret environment variables are set
+before connecting to the remote server and report an error if not.
+
+https://github.com/restic/restic/issues/2388
+https://github.com/restic/restic/pull/3532

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -554,6 +554,12 @@ func parseConfig(loc location.Location, opts options.Options) (interface{}, erro
 			cfg.Secret = os.Getenv("AWS_SECRET_ACCESS_KEY")
 		}
 
+		if cfg.KeyID == "" && cfg.Secret != "" {
+			return nil, errors.Fatalf("unable to open S3 backend: Key ID ($AWS_ACCESS_KEY_ID) is empty")
+		} else if cfg.KeyID != "" && cfg.Secret == "" {
+			return nil, errors.Fatalf("unable to open S3 backend: Secret ($AWS_SECRET_ACCESS_KEY) is empty")
+		}
+
 		if cfg.Region == "" {
 			cfg.Region = os.Getenv("AWS_DEFAULT_REGION")
 		}

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -69,6 +69,15 @@ func open(ctx context.Context, cfg Config, rt http.RoundTripper) (*Backend, erro
 		},
 	})
 
+	c, err := creds.Get()
+	if err != nil {
+		return nil, errors.Wrap(err, "creds.Get")
+	}
+
+	if c.SignerType == credentials.SignatureAnonymous {
+		debug.Log("using anonymous access for %#v", cfg.Endpoint)
+	}
+
 	options := &minio.Options{
 		Creds:     creds,
 		Secure:    !cfg.UseHTTP,


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Add warning for S3/GS/Azure if credentials are not set.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #2388

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
