### PR TITLE
docs/example: useradd: restic now system account

### DIFF
--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -309,7 +309,7 @@ the backups:
 
 .. code-block:: console
 
-   root@a3e580b6369d:/# useradd -m restic
+   root@a3e580b6369d:/# useradd --system --create-home --shell /sbin/nologin restic
 
 Then we download and install the restic binary into the user's home 
 directory (please adjust the URL to refer to the latest restic version).
@@ -317,7 +317,7 @@ directory (please adjust the URL to refer to the latest restic version).
 .. code-block:: console
 
    root@a3e580b6369d:/# mkdir ~restic/bin
-   root@a3e580b6369d:/# curl -L https://github.com/restic/restic/releases/download/v0.9.6/restic_0.9.6_linux_amd64.bz2 | bunzip2 > ~restic/bin/restic
+   root@a3e580b6369d:/# curl -L https://github.com/restic/restic/releases/download/v0.12.1/restic_0.12.1_linux_amd64.bz2 | bunzip2 > ~restic/bin/restic
 
 Before we assign any special capability to the restic binary we
 restrict its permissions so that only root and the newly created


### PR DESCRIPTION
Weakly Closes #2408
and: use /sbin/nologin
and: use long flags (self-documenting) in the useradd command
and: download v0.12.1 instead of v0.9.6

What does this PR change? What problem does it solve?
-----------------------------------------------------
\~Docs\~ and [\~Secuwurity\~](https://pl.c7.ee/memes/bill_wurtz_wavy_means_society.mp4)


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No, Yes, in my head, ???

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
