### PR TITLE
Check cap instead of len in bloblru

### DIFF
--- a/internal/bloblru/cache.go
+++ b/internal/bloblru/cache.go
@@ -47,7 +47,7 @@ func New(size int) *Cache {
 func (c *Cache) Add(id restic.ID, blob []byte) (old []byte) {
 	debug.Log("bloblru.Cache: add %v", id)
 
-	size := len(blob) + overhead
+	size := cap(blob) + overhead
 	if size > c.size {
 		return
 	}
@@ -66,7 +66,7 @@ func (c *Cache) Add(id restic.ID, blob []byte) (old []byte) {
 	for size > c.free {
 		_, val, _ := c.c.RemoveOldest()
 		b := val.([]byte)
-		if len(b) > len(old) {
+		if cap(b) > cap(old) {
 			// We can only return one buffer, so pick the largest.
 			old = b
 		}
@@ -91,6 +91,6 @@ func (c *Cache) Get(id restic.ID) ([]byte, bool) {
 
 func (c *Cache) evict(key, value interface{}) {
 	blob := value.([]byte)
-	debug.Log("bloblru.Cache: evict %v, %d bytes", key, len(blob))
-	c.free += len(blob) + overhead
+	debug.Log("bloblru.Cache: evict %v, %d bytes", key, cap(blob))
+	c.free += cap(blob) + overhead
 }

--- a/internal/bloblru/cache_test.go
+++ b/internal/bloblru/cache_test.go
@@ -28,9 +28,11 @@ func TestCache(t *testing.T) {
 		rtest.Equals(t, exp, blob)
 	}
 
-	addAndCheck(id1, make([]byte, 32*kiB))
-	addAndCheck(id2, make([]byte, 30*kiB))
-	addAndCheck(id3, make([]byte, 10*kiB))
+	// Our blobs have len 1 but larger cap. The cache should check the cap,
+	// since it more reliably indicates the amount of memory kept alive.
+	addAndCheck(id1, make([]byte, 1, 32*kiB))
+	addAndCheck(id2, make([]byte, 1, 30*kiB))
+	addAndCheck(id3, make([]byte, 1, 10*kiB))
 
 	_, ok := c.Get(id2)
 	rtest.Assert(t, ok, "blob %v not present", id2)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

restic dump uses bloblru.Cache to keep buffers alive, but also reuses evicted buffers. That means large buffers may be used to store small blobs, causing the cache to think it's using less memory than it actually does.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
