### PR TITLE
b2: Successful delete if file does not exist

### DIFF
--- a/changelog/unreleased/issue-3541
+++ b/changelog/unreleased/issue-3541
@@ -1,0 +1,9 @@
+Bugfix: Improve handling of temporary B2 delete errors
+
+Deleting files on B2 can sometimes fail temporarily, which requires restic to
+retry the delete operation. In some cases the file was deleted nevertheless
+causing the retries and ultimately the restic command to fail. This has been
+fixed.
+
+https://github.com/restic/restic/issues/3541
+https://github.com/restic/restic/pull/3544

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -265,7 +265,13 @@ func (be *b2Backend) Remove(ctx context.Context, h restic.Handle) error {
 	defer be.sem.ReleaseToken()
 
 	obj := be.bucket.Object(be.Filename(h))
-	return errors.Wrap(obj.Delete(ctx), "Delete")
+	err := obj.Delete(ctx)
+	// consider a file as removed if b2 informs us that it does not exist
+	if b2.IsNotExist(err) {
+		return nil
+	}
+
+	return errors.Wrap(err, "Delete")
 }
 
 type semLocker struct {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
When deleting a file, B2 sometimes returns a "500 Service Unavailable" error but nevertheless correctly deletes the file. Due to retries in the B2 library blazer, we sometimes also see a "400 File not present" error. The retries of restic for the delete request then fail with "404 File with such name does not exist.".

As we have to rely on request retries in a distributed system to handle temporary errors, also consider a delete request to be successful if the file is reported as not existing. This should be safe as B2 claims to provide a strongly consistent bucket listing and thus a missing file shouldn't mysteriously show up again later on.

This PR only makes the Remove operation of the B2 backend idempotent and not that of other backends. I'm not yet sure whether we could run into issues with reappearing files on other backends, which especially for index files could lead to data loss. To also include other backends we should probably finish #2839 first.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3541.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
