### PR TITLE
Support for specifying amount of data in read-data-subset

### DIFF
--- a/changelog/unreleased/issue-3490
+++ b/changelog/unreleased/issue-3490
@@ -1,0 +1,9 @@
+Enhancement: Support for specifying file size in `check --read-data-subset`
+
+To check a subset of repository files, the `check --read-data-subset` command
+used to support two ways to select a subset - A specific range of pack files, 
+or random percentage of pack files. We have added a third method to select pack 
+files - By specifying file size. This new option is available with the 'restic check' command.
+
+https://github.com/restic/restic/issues/3490
+https://github.com/restic/restic/pull/3548

--- a/cmd/restic/cmd_check_test.go
+++ b/cmd/restic/cmd_check_test.go
@@ -129,3 +129,37 @@ func TestSelectNoRandomPacksByPercentage(t *testing.T) {
 	selectedPacks := selectRandomPacksByPercentage(testPacks, 10.0)
 	rtest.Assert(t, len(selectedPacks) == 0, "Expected 0 selected packs")
 }
+
+func TestSelectRandomPacksByFileSize(t *testing.T) {
+	var testPacks = make(map[restic.ID]int64)
+	for i := 1; i <= 10; i++ {
+		id := restic.NewRandomID()
+		// ensure unique ids
+		id[0] = byte(i)
+		testPacks[id] = 0
+	}
+
+	selectedPacks := selectRandomPacksByFileSize(testPacks, 10, 500)
+	rtest.Assert(t, len(selectedPacks) == 1, "Expected 1 selected packs")
+
+	selectedPacks = selectRandomPacksByFileSize(testPacks, 10240, 51200)
+	rtest.Assert(t, len(selectedPacks) == 2, "Expected 2 selected packs")
+	for pack := range selectedPacks {
+		_, ok := testPacks[pack]
+		rtest.Assert(t, ok, "Unexpected selection")
+	}
+
+	selectedPacks = selectRandomPacksByFileSize(testPacks, 500, 500)
+	rtest.Assert(t, len(selectedPacks) == 10, "Expected 10 selected packs")
+	for pack := range selectedPacks {
+		_, ok := testPacks[pack]
+		rtest.Assert(t, ok, "Unexpected item in selection")
+	}
+}
+
+func TestSelectNoRandomPacksByFileSize(t *testing.T) {
+	// that the a repository without pack files works
+	var testPacks = make(map[restic.ID]int64)
+	selectedPacks := selectRandomPacksByFileSize(testPacks, 10, 500)
+	rtest.Assert(t, len(selectedPacks) == 0, "Expected 0 selected packs")
+}

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -249,9 +249,9 @@ integrity of the pack files in the repository, use the ``--read-data`` flag:
     and also that it takes more time than the default ``check``.
 
 Alternatively, use the ``--read-data-subset`` parameter to check only a
-subset of the repository pack files at a time. It supports two ways to select a
-subset. One selects a specific range of pack files, the other selects a random
-percentage of pack files.
+subset of the repository pack files at a time. It supports three ways to select a
+subset. One selects a specific range of pack files, the second selects a random
+percentage of pack files, and the third selects pack files of the specified size.
 
 Use ``--read-data-subset=n/t`` to check only a subset of the repository pack
 files at a time. The parameter takes two values, ``n`` and ``t``. When the check
@@ -285,3 +285,16 @@ integer:
 .. code-block:: console
 
     $ restic -r /srv/restic-repo check --read-data-subset=10%
+
+Use ``--read-data-subset=NS`` to check a randomly chosen subset of the repository pack files. 
+It takes one parameter, ``NS``, where 'N' is a whole number representing file size and 'S' is the unit 
+of file size (B/K/M/G/T) of pack files to check. Behind the scenes, the specified size will be converted 
+to percentage of the total repository size. The behaviour of the check command following this conversion 
+will be the same as the percentage option above. For a file size value the following command may be used:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo check --read-data-subset=50M
+    $ restic -r /srv/restic-repo check --read-data-subset=10G
+
+


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
To check the data users have to use `restic check --read-data-subset=`. The read-data-subset flag does not currently support specifying a random subset of X bytes. This PR adds support for the same. 
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3490 
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [ ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
