### PR TITLE
local: Fix fd leak when encountering files directly inside data/

### DIFF
--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -322,6 +322,8 @@ func visitFiles(ctx context.Context, dir string, fn func(restic.FileInfo) error,
 	if ignoreNotADirectory {
 		fi, err := d.Stat()
 		if err != nil || !fi.IsDir() {
+			// ignore subsequent errors
+			_ = d.Close()
 			return err
 		}
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
restic currently leaks file descriptors when listing a `data/` folder which directly contains files instead of in the subfolders. This PR adds the missing call to `Close()`.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://forum.restic.net/t/too-many-open-files/4503/12

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes. **I don't see how that would be possible.** 
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
