### PR TITLE
Update Backblaze B2 blazer module

### DIFF
--- a/changelog/unreleased/issue-3556
+++ b/changelog/unreleased/issue-3556
@@ -1,0 +1,8 @@
+Bugfix: Fix hang with Backblaze B2 if SSL certificate authority error
+
+If a request failed with an SSL unknown certificate authority error, the
+B2 backend retried indefinitely and restic would appear to hang.
+It now returns the error and restic fails with an error message.
+
+https://github.com/restic/restic/issues/3556
+https://github.com/restic/restic/issues/2355

--- a/changelog/unreleased/issue-3556
+++ b/changelog/unreleased/issue-3556
@@ -6,3 +6,4 @@ It now returns the error and restic fails with an error message.
 
 https://github.com/restic/restic/issues/3556
 https://github.com/restic/restic/issues/2355
+https://github.com/restic/restic/pull/3571

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/google/go-cmp v0.5.6
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/juju/ratelimit v1.0.1
-	github.com/kurin/blazer v0.5.3
+	github.com/kurin/blazer v0.5.4-0.20211030221322-ba894c124ac6
 	github.com/minio/minio-go/v7 v7.0.14
 	github.com/minio/sha256-simd v1.0.0
 	github.com/ncw/swift/v2 v2.0.0

--- a/go.sum
+++ b/go.sum
@@ -243,8 +243,8 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0 h1:45sCR5RtlFHMR4UwH9sdQ5TC8v0qDQCHnXt+kaKSTVE=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
-github.com/kurin/blazer v0.5.3 h1:SAgYv0TKU0kN/ETfO5ExjNAPyMt2FocO2s/UlCHfjAk=
-github.com/kurin/blazer v0.5.3/go.mod h1:4FCXMUWo9DllR2Do4TtBd377ezyAJ51vB5uTBjt0pGU=
+github.com/kurin/blazer v0.5.4-0.20211030221322-ba894c124ac6 h1:nz7i1au+nDzgExfqW5Zl6q85XNTvYoGnM5DHiQC0yYs=
+github.com/kurin/blazer v0.5.4-0.20211030221322-ba894c124ac6/go.mod h1:4FCXMUWo9DllR2Do4TtBd377ezyAJ51vB5uTBjt0pGU=
 github.com/magiconair/properties v1.8.5/go.mod h1:y3VJvCyxH9uVvJTWEGAELF3aiYNyPKd5NZ3oSwXrF60=
 github.com/mattn/go-colorable v0.0.9/go.mod h1:9vuHe8Xs5qXnSaW/c/ABM9alt+Vo+STaOChaDxuIBZU=
 github.com/mattn/go-isatty v0.0.3/go.mod h1:M+lRXTBqGeGNdLjl/ufCoiOlB5xdOkqRJdNxMWT7Zi4=


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

With the latest version of blazer if a request fails with an SSL unknown certificate authority error, it returns the error without retrying the request and the restic command fails with error message "Fatal: create repository at b2:***** failed: b2.NewClient: x509: certificate signed by unknown authority".


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #3556
Closes #2355


Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
