### PR TITLE
Use S3's proper product name, Amazon S3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -604,7 +604,7 @@ Details
    reduced.
 
    Restic used to rebuild the index from scratch after pruning. This could lead to missing packs in
-   the index in some cases for eventually consistent backends such as e.g. AWS S3. This behavior is
+   the index in some cases for eventually consistent backends such as e.g. Amazon S3. This behavior is
    now changed and the index rebuilding uses the information already known by `prune`.
 
    By default, the `prune` command no longer removes all unused data. This behavior can be

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Therefore, restic supports the following backends for storing backups natively:
 - [Local directory](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#local)
 - [sftp server (via SSH)](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#sftp)
 - [HTTP REST server](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#rest-server) ([protocol](https://restic.readthedocs.io/en/latest/100_references.html#rest-backend), [rest-server](https://github.com/restic/rest-server))
-- [AWS S3](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#amazon-s3) (either from Amazon or using the [Minio](https://minio.io) server)
+- [Amazon S3](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#amazon-s3) (either from Amazon or using the [Minio](https://minio.io) server)
 - [OpenStack Swift](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#openstack-swift)
 - [BackBlaze B2](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#backblaze-b2)
 - [Microsoft Azure Blob Storage](https://restic.readthedocs.io/en/latest/030_preparing_a_new_repo.html#microsoft-azure-blob-storage)

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -1744,7 +1744,7 @@ func testEdgeCaseRepo(t *testing.T, tarfile string, optionsCheck CheckOptions, o
 
 // a listOnceBackend only allows listing once per filetype
 // listing filetypes more than once may cause problems with eventually consistent
-// backends (like e.g. AWS S3) as the second listing may be inconsistent to what
+// backends (like e.g. Amazon S3) as the second listing may be inconsistent to what
 // is expected by the first listing + some operations.
 type listOnceBackend struct {
 	restic.Backend

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -257,7 +257,7 @@ Minio Server
 ************
 
 `Minio <https://www.minio.io>`__ is an Open Source Object Storage,
-written in Go and compatible with AWS S3 API.
+written in Go and compatible with Amazon S3 API.
 
 -  Download and Install `Minio
    Server <https://minio.io/downloads/#minio-server>`__.
@@ -287,7 +287,7 @@ this command.
 Wasabi
 ************
 
-`Wasabi <https://wasabi.com>`__ is a low cost AWS S3 conformant object storage provider.
+`Wasabi <https://wasabi.com>`__ is a low cost Amazon S3 conformant object storage provider.
 Due to it's S3 conformance, Wasabi can be used as a storage provider for a restic repository.
 
 -  Create a Wasabi bucket using the `Wasabi Console <https://console.wasabisys.com>`__.

--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -21,7 +21,7 @@ Setting up restic with Amazon S3
 Preface
 =======
 
-This tutorial will show you how to use restic with AWS S3. It will show you how
+This tutorial will show you how to use restic with Amazon S3. It will show you how
 to navigate the AWS web interface, create an S3 bucket, create a user with
 access to only this bucket, and finally how to connect restic to this bucket.
 
@@ -226,7 +226,7 @@ repository:
    the repository. Losing your password means that your data is
    irrecoverably lost.
 
-restic is now ready to be used with AWS S3. Try to create a backup:
+restic is now ready to be used with Amazon S3. Try to create a backup:
 
 .. code-block:: console
 
@@ -247,7 +247,7 @@ restic is now ready to be used with AWS S3. Try to create a backup:
    ----------------------------------------------------------------------
    10fdbace  2017-03-26 16:41:50  blackbox                /home/philip/restic-demo/test.bin
 
-A snapshot was created and stored in the S3 bucket. By default backups to AWS S3 will use the ``STANDARD`` storage class. Available storage classes include ``STANDARD``, ``STANDARD_IA``, ``ONEZONE_IA``, ``INTELLIGENT_TIERING``, and ``REDUCED_REDUNDANCY``. A different storage class could have been specified in the above command by using ``-o`` or ``--option``:
+A snapshot was created and stored in the S3 bucket. By default backups to Amazon S3 will use the ``STANDARD`` storage class. Available storage classes include ``STANDARD``, ``STANDARD_IA``, ``ONEZONE_IA``, ``INTELLIGENT_TIERING``, and ``REDUCED_REDUNDANCY``. A different storage class could have been specified in the above command by using ``-o`` or ``--option``:
 
 .. code-block:: console
 

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -125,7 +125,7 @@ s3 backend ``s3.layout``.
 S3 Legacy Layout
 ----------------
 
-Unfortunately during development the AWS S3 backend uses slightly different
+Unfortunately during development the Amazon S3 backend uses slightly different
 paths (directory names use singular instead of plural for ``key``,
 ``lock``, and ``snapshot`` files), and the pack files are stored directly below
 the ``data`` directory. The S3 Legacy repository layout looks like this:


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Per Amazon's product page [1], S3 is officially called "Amazon S3". The
restic project uses the phrase "AWS S3" in some places. This patch
corrects the product name.

[1]:https://aws.amazon.com/s3/

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
