### PR TITLE
rest: Adjust http2-missing-eof test to golang >= 1.17.3

### DIFF
--- a/internal/backend/rest/rest_int_go114_test.go
+++ b/internal/backend/rest/rest_int_go114_test.go
@@ -1,4 +1,9 @@
-// +build go1.14
+//go:build go1.14 && !go1.18
+// +build go1.14,!go1.18
+
+// missing eof error is fixed in golang >= 1.17.3 or >= 1.16.10
+// remove the workaround from rest.go when the minimum golang version
+// supported by restic reaches 1.18.
 
 package rest_test
 
@@ -63,32 +68,5 @@ func TestZeroLengthRead(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("Got no unexpected EOF error")
-	}
-}
-
-func TestGolangZeroLengthRead(t *testing.T) {
-	// This test is intended to fail once the underlying issue has been fixed in Go
-	ts := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Length", "42")
-		// Now the handler fails for some reason and is unable to send data
-	}))
-	ts.EnableHTTP2 = true
-	ts.StartTLS()
-	defer ts.Close()
-
-	res, err := ts.Client().Get(ts.URL)
-	if err != nil {
-		t.Fatal(err)
-	}
-	_, err = ioutil.ReadAll(res.Body)
-	defer func() {
-		err = res.Body.Close()
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-	if err != nil {
-		// This should fail with an 'Unexpected EOF' error
-		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The http2 client did not return an eof error when the response included a content-length but no data was received. This has been fixed in golang 1.17.3/1.16.10. Therefore just drop the canary check and disable the whole test starting from go 1.18.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Follow-up to #3453.

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
