### PR TITLE
docs: Fix link to "help wanted" issues

### DIFF
--- a/doc/090_participating.rst
+++ b/doc/090_participating.rst
@@ -83,10 +83,9 @@ back end is contained in `Design <https://restic.readthedocs.io/en/latest/design
 If you'd like to start contributing to restic, but don't know exactly
 what do to, have a look at this great article by Dave Cheney:
 `Suggestions for contributing to an Open Source
-project <https://dave.cheney.net/2016/03/12/suggestions-for-contributing-to-an-open-source-project>`__
+project <https://dave.cheney.net/2016/03/12/suggestions-for-contributing-to-an-open-source-project>`__.
 A few issues have been tagged with the label ``help wanted``, you can
-start looking at those:
-https://github.com/restic/restic/labels/help%20wanted
+start looking at `those <https://github.com/restic/restic/labels/help%3A%20wanted>`_.
 
 ********
 Security


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

I noticed that the [Contributing](https://restic.readthedocs.io/en/stable/090_participating.html#contributing) section of the docs has a broken link. In particular, the link to the [`help wanted` issues](https://github.com/restic/restic/labels/help%20wanted) is missing a colon, and so GitHub returns an empty search. This change fixes this link, and also cleans up the formatting slightly.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

I didn't think it was necessary, given it's a trivial change to the docs.

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
[N/A] I have added tests for all code changes.
[N/A] I have added documentation for relevant changes (in the manual).
[N/A] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
[N/A] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
