### PR TITLE
backup: add flag --summary-filename

### DIFF
--- a/internal/ui/backup/json.go
+++ b/internal/ui/backup/json.go
@@ -172,7 +172,12 @@ func (b *JSONProgress) ReportTotal(item string, start time.Time, s archiver.Scan
 
 // Finish prints the finishing messages.
 func (b *JSONProgress) Finish(snapshotID restic.ID, start time.Time, summary *Summary, dryRun bool) {
-	b.print(summaryOutput{
+	b.print(b.FinishSummary(snapshotID, start, summary, dryRun))
+}
+
+// FinishSummary returns the summary as a struct
+func (b *JSONProgress) FinishSummary(snapshotID restic.ID, start time.Time, summary *Summary, dryRun bool) summaryOutput {
+	return summaryOutput{
 		MessageType:         "summary",
 		FilesNew:            summary.Files.New,
 		FilesChanged:        summary.Files.Changed,
@@ -188,7 +193,7 @@ func (b *JSONProgress) Finish(snapshotID restic.ID, start time.Time, summary *Su
 		TotalDuration:       time.Since(start).Seconds(),
 		SnapshotID:          snapshotID.Str(),
 		DryRun:              dryRun,
-	})
+	}
 }
 
 // Reset no-op
@@ -225,20 +230,3 @@ type verboseUpdate struct {
 	TotalFiles   uint    `json:"total_files"`
 }
 
-type summaryOutput struct {
-	MessageType         string  `json:"message_type"` // "summary"
-	FilesNew            uint    `json:"files_new"`
-	FilesChanged        uint    `json:"files_changed"`
-	FilesUnmodified     uint    `json:"files_unmodified"`
-	DirsNew             uint    `json:"dirs_new"`
-	DirsChanged         uint    `json:"dirs_changed"`
-	DirsUnmodified      uint    `json:"dirs_unmodified"`
-	DataBlobs           int     `json:"data_blobs"`
-	TreeBlobs           int     `json:"tree_blobs"`
-	DataAdded           uint64  `json:"data_added"`
-	TotalFilesProcessed uint    `json:"total_files_processed"`
-	TotalBytesProcessed uint64  `json:"total_bytes_processed"`
-	TotalDuration       float64 `json:"total_duration"` // in seconds
-	SnapshotID          string  `json:"snapshot_id"`
-	DryRun              bool    `json:"dry_run,omitempty"`
-}

--- a/internal/ui/backup/text.go
+++ b/internal/ui/backup/text.go
@@ -186,3 +186,25 @@ func (b *TextProgress) Finish(snapshotID restic.ID, start time.Time, summary *Su
 		formatDuration(time.Since(start)),
 	)
 }
+
+// Return finishing stats in a struct.
+func (b *TextProgress) FinishSummary(snapshotID restic.ID, start time.Time, summary *Summary, dryRun bool) summaryOutput {
+	return summaryOutput{
+		MessageType:         "summary",
+		FilesNew:            summary.Files.New,
+		FilesChanged:        summary.Files.Changed,
+		FilesUnmodified:     summary.Files.Unchanged,
+		DirsNew:             summary.Dirs.New,
+		DirsChanged:         summary.Dirs.Changed,
+		DirsUnmodified:      summary.Dirs.Unchanged,
+		DataBlobs:           summary.ItemStats.DataBlobs,
+		TreeBlobs:           summary.ItemStats.TreeBlobs,
+		DataAdded:           summary.ItemStats.DataSize + summary.ItemStats.TreeSize,
+		TotalFilesProcessed: summary.Files.New + summary.Files.Changed + summary.Files.Unchanged,
+		TotalBytesProcessed: summary.ProcessedBytes,
+		TotalDuration:       time.Since(start).Seconds(),
+		SnapshotID:          snapshotID.Str(),
+		DryRun:              dryRun,
+	}
+}
+


### PR DESCRIPTION
The summary statistics in JSON form will be appended to the specified
filename.  This works independently of verbosity level and reporter
(json or text) chosen.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Collecting statistics from the jobs which have run is currently relatively awkward.  This patch allows statistics and metadata to be collected and processed by other scripts.

It uses append mode and prepares the JSON string so it is written atomically to the file, so no locking should be required.

A simple example run:

```log
[kjetilho@scribus ~/git/github.com/restic/restic]; ./restic backup doc --summary-filename /tmp/restic-log.json
repository fff7b667 opened successfully, password is correct
no parent snapshot found, will read all files

Files:          75 new,     0 changed,     0 unmodified
Dirs:            8 new,     0 changed,     0 unmodified
Added to the repo: 2.506 MiB

processed 75 files, 2.466 MiB in 0:00
snapshot 53fafae6 saved
: [kjetilho@scribus ~/git/github.com/restic/restic]; cat /tmp/restic-log.json
{"message_type":"summary","files_new":75,"files_changed":0,"files_unmodified":0,"dirs_new":8,"dirs_changed":0,"dirs_unmodified":0,"data_blobs":75,"tree_blobs":9,"data_added":2627290,"total_files_processed":75,"total_bytes_processed":2585467,"total_duration":0.348978869,"snapshot_id":"53fafae6"}
: [kjetilho@scribus ~/git/github.com/restic/restic]; date > doc/new-file
: [kjetilho@scribus ~/git/github.com/restic/restic]; ./restic backup doc --summary-filename /tmp/restic-log.json
repository fff7b667 opened successfully, password is correct
using parent snapshot 53fafae6

Files:           1 new,     0 changed,    75 unmodified
Dirs:            0 new,     1 changed,     7 unmodified
Added to the repo: 16.688 KiB

processed 76 files, 2.466 MiB in 0:00
snapshot dc5ef1b8 saved
: [kjetilho@scribus ~/git/github.com/restic/restic]; cat /tmp/restic-log.json
{"message_type":"summary","files_new":75,"files_changed":0,"files_unmodified":0,"dirs_new":8,"dirs_changed":0,"dirs_unmodified":0,"data_blobs":75,"tree_blobs":9,"data_added":2627290,"total_files_processed":75,"total_bytes_processed":2585467,"total_duration":0.348978869,"snapshot_id":"53fafae6"}
{"message_type":"summary","files_new":1,"files_changed":0,"files_unmodified":75,"dirs_new":0,"dirs_changed":1,"dirs_unmodified":7,"data_blobs":1,"tree_blobs":2,"data_added":17088,"total_files_processed":76,"total_bytes_processed":2585500,"total_duration":0.286814645,"snapshot_id":"dc5ef1b8"}
```

If this idea is accepted, I would like to add the timestamp for when the backup job started to the metadata.

Ideally this metadata would be available from the snapshot sub-command, but it seems like a chicken and egg problem to add that information as part of the snapshot, so I gave up on that idea.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

It has been discussed loosely on IRC from time to time.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [ ] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [ ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
