### PR TITLE
Make Copy respect no lock

### DIFF
--- a/changelog/unreleased/issue-3518
+++ b/changelog/unreleased/issue-3518
@@ -1,0 +1,6 @@
+Bugfix: Make copy honor `--no-lock` for source repository
+
+When passing the `--no-lock` flag to the copy command, the source directory still attempted to issue a lock, causing failures on read-only source directories. `--no-lock` is now respected and copy no longer attempts a lock.
+
+https://github.com/restic/restic/issues/3518
+https://github.com/restic/restic/pull/3589

--- a/changelog/unreleased/issue-3518
+++ b/changelog/unreleased/issue-3518
@@ -1,6 +1,9 @@
-Bugfix: Make copy honor `--no-lock` for source repository
+Bugfix: Make copy command honor `--no-lock` for source repository
 
-When passing the `--no-lock` flag to the copy command, the source directory still attempted to issue a lock, causing failures on read-only source directories. `--no-lock` is now respected and copy no longer attempts a lock.
+When passing the `--no-lock` flag to the copy command, restic still attempted
+to lock the source repository, causing failures on read-only storage backends.
+`--no-lock` is now respected and copy then no longer creates a lock in the
+source repository.
 
 https://github.com/restic/restic/issues/3518
 https://github.com/restic/restic/pull/3589

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -73,10 +73,12 @@ func runCopy(opts CopyOptions, gopts GlobalOptions, args []string) error {
 		return err
 	}
 
-	srcLock, err := lockRepo(ctx, srcRepo)
-	defer unlockRepo(srcLock)
-	if err != nil {
-		return err
+	if !gopts.NoLock {
+		srcLock, err := lockRepo(ctx, srcRepo)
+		defer unlockRepo(srcLock)
+		if err != nil {
+			return err
+		}
 	}
 
 	dstLock, err := lockRepo(ctx, dstRepo)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This patch makes copy respect the `--no-lock` flag on the source repository.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3518
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
~~- [] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
