### PR TITLE
prune: Handle --max-repack-size=0 as expected

### DIFF
--- a/changelog/unreleased/pull-3591
+++ b/changelog/unreleased/pull-3591
@@ -1,0 +1,8 @@
+Bugfix: Fix handling of `prune --max-repack-size=0`
+
+Restic ignored the `--max-repack-size` option when passing a value of 0. This
+has been fixed.
+
+As a workaround, `--max-repack-size=1` can be used with older versions of restic.
+
+https://github.com/restic/restic/pull/3591

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -66,6 +66,7 @@ func addPruneOptions(c *cobra.Command) {
 }
 
 func verifyPruneOptions(opts *PruneOptions) error {
+	opts.MaxRepackBytes = math.MaxUint64
 	if len(opts.MaxRepackSize) > 0 {
 		size, err := parseSizeStr(opts.MaxRepackSize)
 		if err != nil {
@@ -418,11 +419,7 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 
 	for _, p := range repackCandidates {
 		reachedUnusedSizeAfter := (stats.size.unused-stats.size.remove-stats.size.repackrm < maxUnusedSizeAfter)
-
-		reachedRepackSize := false
-		if opts.MaxRepackBytes > 0 {
-			reachedRepackSize = stats.size.repack+p.unusedSize+p.usedSize > opts.MaxRepackBytes
-		}
+		reachedRepackSize := stats.size.repack+p.unusedSize+p.usedSize >= opts.MaxRepackBytes
 
 		switch {
 		case reachedRepackSize:


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Previously the flag was ignored and `--max-repack-size=1` had to be
used instead.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Mentioned in #1153.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
