### PR TITLE
Add --device-map flag to allow remapping DeviceIDs

### DIFF
--- a/cmd/restic/.gitignore
+++ b/cmd/restic/.gitignore
@@ -1,1 +1,2 @@
 config.mk
+restic


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
When creating backups from ZFS or btrfs snapshots, each snapshot will have a different DeviceID. This causes restic to upload the directory structure for each backup, even if nothing has changed. To solve this, this PR adds the --device-map flag which will allow users to map different device id's to the same logical device id.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->
The idea is that users can figure out what device ID their snapshot currently points to, (e.g. with `stat -c '%d'`
and then re-map that to a virtual device ID that is consistent across backups.
For example, if there's a btrfs snapshot mounted at `/home/.snapshots/123/snapshot/`, then you could do something like this:
```
device_id=$(stat -c '%d' /home/.snapshots/123/snapshot)
proot -b /home/.snapshots/123/snapshot:/home
restic backup --device-map "$device_id:42" /home
```


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
There is a decent amount of discussion on the linked issue. The larger issue here is that there are no guarantees anyways that the DeviceID is stable, and if it should be relied upon. One proposed idea was to implement an -ignore-deviceid flag, similar to the other ignore flags. However, given that the DeviceId is used to determine if symlinks span across different filesystems, this ended up not being a trivial change to implement.



<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
Closes #3041 

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [] I'm done! This pull request is ready for review.
