### PR TITLE
fix: rclone receiving SIGINT prematurely on Windows causing restic hang forever (#3601)

### DIFF
--- a/changelog/unreleased/issue-3601
+++ b/changelog/unreleased/issue-3601
@@ -1,0 +1,11 @@
+Bugfix: Fix rclone backend prematurely exiting when receiving SIGINT on Windows
+
+On Windows, Restic now start the rclone process detached from the
+restic console (similar to starting processes on a new process
+group on Linux). Therefore, when Ctrl+C is pressed on the console
+where restic runs, restic could gracefully clean up using clone,
+and rclone won't exit prematurely leading to restic hanging up with
+"stdio pipes closed" errors.
+
+https://github.com/restic/restic/issue/3601
+https://github.com/restic/restic/pull/3602

--- a/internal/backend/foreground_windows.go
+++ b/internal/backend/foreground_windows.go
@@ -2,12 +2,16 @@ package backend
 
 import (
 	"os/exec"
+	"syscall"
 
 	"github.com/restic/restic/internal/errors"
+	"golang.org/x/sys/windows"
 )
 
 func startForeground(cmd *exec.Cmd) (bg func() error, err error) {
 	// just start the process and hope for the best
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	cmd.SysProcAttr.CreationFlags = windows.DETACHED_PROCESS
 	err = cmd.Start()
 	if err != nil {
 		return nil, errors.Wrap(err, "cmd.Start")


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR changed subprocess creation behavior when spawning rclone on Windows, specifying `DETACHED_PROCESS` as the creation flag. This effectively prevents premature SIGINT sending to the rclone process when hitting Ctrl+C in the console window. More detail is described in the associated issue #3601.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #3601.

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes (this is pretty tough to write a test I guess?).
- [ ] I have added documentation for relevant changes (in the manual) (is this needed for such a bug fix?).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)) (same, needed?).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
