### PR TITLE
Improve handling of temporary files on windows

### DIFF
--- a/changelog/unreleased/issue-3465
+++ b/changelog/unreleased/issue-3465
@@ -1,0 +1,10 @@
+Enhancement: Improve handling of temporary files on Windows
+
+In some cases restic failed to delete temporary files causing the current
+command to fail. This has been fixed by ensuring that Windows automatically
+deletes the file. In addition, temporary files are only written to disk if
+necessary to reduce disk writes.
+
+https://github.com/restic/restic/issues/3465
+https://github.com/restic/restic/issues/1551
+https://github.com/restic/restic/pull/3610

--- a/internal/fs/file_windows.go
+++ b/internal/fs/file_windows.go
@@ -1,41 +1,14 @@
 package fs
 
 import (
+	"math/rand"
 	"os"
 	"path/filepath"
-	"strings"
-	"syscall"
 	"strconv"
-	"sync"
+	"strings"
 	"time"
-)
 
-// Random number state.
-// We generate random temporary file names so that there's a good
-// chance the file doesn't exist yet - keeps the number of tries in
-// TempFile to a minimum.
-var rand uint32
-var randmu sync.Mutex
-
-func reseed() uint32 {
-	return uint32(time.Now().UnixNano() + int64(os.Getpid()))
-}
-
-func nextRandom() string {
-	randmu.Lock()
-	r := rand
-	if r == 0 {
-		r = reseed()
-	}
-	r = r*1664525 + 1013904223 // constants from Numerical Recipes
-	rand = r
-	randmu.Unlock()
-	return strconv.Itoa(int(1e9 + r%1e9))[1:]
-}
-
-const (
-	FILE_ATTRIBUTE_TEMPORARY  = 0x00000100
-	FILE_FLAG_DELETE_ON_CLOSE = 0x04000000
+	"golang.org/x/sys/windows"
 )
 
 // fixpath returns an absolute path on windows, so restic can open long file
@@ -61,25 +34,41 @@ func fixpath(name string) string {
 	return name
 }
 
-// TempFile creates a temporary file.
+// TempFile creates a temporary file which is marked as delete-on-close
 func TempFile(dir, prefix string) (f *os.File, err error) {
+	// slightly modified implementation of ioutil.TempFile(dir, prefix) to allow us to add
+	// the FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE flags.
+	// These provide two large benefits:
+	// FILE_ATTRIBUTE_TEMPORARY tells Windows to keep the file in memory only if possible
+	// which reduces the amount of unnecessary disk writes.
+	// FILE_FLAG_DELETE_ON_CLOSE instructs Windows to automatically delete the file once
+	// all file descriptors are closed.
+
 	if dir == "" {
 		dir = os.TempDir()
 	}
 
-	access := uint32(syscall.GENERIC_READ | syscall.GENERIC_WRITE)
-	creation := uint32(syscall.CREATE_NEW)
-	flags := uint32(FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE)
-	
-	for i := 0; i < 10000; i++ {
-		path := filepath.Join(dir, prefix+nextRandom())
+	access := uint32(windows.GENERIC_READ | windows.GENERIC_WRITE)
+	creation := uint32(windows.CREATE_NEW)
+	share := uint32(0) // prevent other processes from accessing the file
+	flags := uint32(windows.FILE_ATTRIBUTE_TEMPORARY | windows.FILE_FLAG_DELETE_ON_CLOSE)
 
-		h, err := syscall.CreateFile(syscall.StringToUTF16Ptr(path), access, 0, nil, creation, flags, 0)
-		if err == nil {
-			return os.NewFile(uintptr(h), path), nil
+	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
+	for i := 0; i < 10000; i++ {
+		randSuffix := strconv.Itoa(int(1e9 + rnd.Intn(1e9)%1e9))[1:]
+		path := filepath.Join(dir, prefix+randSuffix)
+
+		ptr, err := windows.UTF16PtrFromString(path)
+		if err != nil {
+			return nil, err
 		}
+		h, err := windows.CreateFile(ptr, access, share, nil, creation, flags, 0)
+		if os.IsExist(err) {
+			continue
+		}
+		return os.NewFile(uintptr(h), path), err
 	}
-	
+
 	// Proper error handling is still to do
 	return nil, os.ErrExist
 }

--- a/internal/fs/file_windows.go
+++ b/internal/fs/file_windows.go
@@ -1,10 +1,41 @@
 package fs
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
+	"syscall"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// Random number state.
+// We generate random temporary file names so that there's a good
+// chance the file doesn't exist yet - keeps the number of tries in
+// TempFile to a minimum.
+var rand uint32
+var randmu sync.Mutex
+
+func reseed() uint32 {
+	return uint32(time.Now().UnixNano() + int64(os.Getpid()))
+}
+
+func nextRandom() string {
+	randmu.Lock()
+	r := rand
+	if r == 0 {
+		r = reseed()
+	}
+	r = r*1664525 + 1013904223 // constants from Numerical Recipes
+	rand = r
+	randmu.Unlock()
+	return strconv.Itoa(int(1e9 + r%1e9))[1:]
+}
+
+const (
+	FILE_ATTRIBUTE_TEMPORARY  = 0x00000100
+	FILE_FLAG_DELETE_ON_CLOSE = 0x04000000
 )
 
 // fixpath returns an absolute path on windows, so restic can open long file
@@ -32,7 +63,25 @@ func fixpath(name string) string {
 
 // TempFile creates a temporary file.
 func TempFile(dir, prefix string) (f *os.File, err error) {
-	return ioutil.TempFile(dir, prefix)
+	if dir == "" {
+		dir = os.TempDir()
+	}
+
+	access := uint32(syscall.GENERIC_READ | syscall.GENERIC_WRITE)
+	creation := uint32(syscall.CREATE_NEW)
+	flags := uint32(FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE)
+	
+	for i := 0; i < 10000; i++ {
+		path := filepath.Join(dir, prefix+nextRandom())
+
+		h, err := syscall.CreateFile(syscall.StringToUTF16Ptr(path), access, 0, nil, creation, flags, 0)
+		if err == nil {
+			return os.NewFile(uintptr(h), path), nil
+		}
+	}
+	
+	// Proper error handling is still to do
+	return nil, os.ErrExist
 }
 
 // Chmod changes the mode of the named file to mode.

--- a/internal/fs/file_windows_test.go
+++ b/internal/fs/file_windows_test.go
@@ -1,0 +1,35 @@
+package fs_test
+
+import (
+	"errors"
+	"os"
+	"testing"
+
+	"github.com/restic/restic/internal/fs"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestTempFile(t *testing.T) {
+	// create two temp files at the same time to check that the
+	// collision avoidance works
+	f, err := fs.TempFile("", "test")
+	fn := f.Name()
+	rtest.OK(t, err)
+	f2, err := fs.TempFile("", "test")
+	fn2 := f2.Name()
+	rtest.OK(t, err)
+	rtest.Assert(t, fn != fn2, "filenames don't differ %s", fn)
+
+	_, err = os.Stat(fn)
+	rtest.OK(t, err)
+	_, err = os.Stat(fn2)
+	rtest.OK(t, err)
+
+	rtest.OK(t, f.Close())
+	rtest.OK(t, f2.Close())
+
+	_, err = os.Stat(fn)
+	rtest.Assert(t, errors.Is(err, os.ErrNotExist), "err %s", err)
+	_, err = os.Stat(fn2)
+	rtest.Assert(t, errors.Is(err, os.ErrNotExist), "err %s", err)
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
restic currently uses `ioutil.TempFile(...)` to create its temporary files on Windows. As files cannot be deleted on Windows while these are still opened, restic sometimes leaves temporary files behind. This PR sets the FILE_FLAG_DELETE_ON_CLOSE flag to let windows delete the file automatically once all references were deleted. In addition, the flag FILE_ATTRIBUTE_TEMPORARY is added to avoid unnecessary writes of the temporary files to disk.

As `os.Open` and therefore `ioutil.TempFile` do not support these flags, this PR introduces a custom `TempFile` implementation, that directly calls `syscall.CreateFile`.

This PR is based on the code from @ducalex in #3465.

The temporary file is also created using shareMode 0, which prevents other processes from accessing the file in parallel. Thus restic is the only process which can open the file. As it will be deleted on close, this ensures that a tempfile can be removed, which fixes #1551.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #3465.
Closes #1551.
Supersedes #3306.

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
