### PR TITLE
Add GCS option for encryption keys

### DIFF
--- a/changelog/unreleased/pull-3612
+++ b/changelog/unreleased/pull-3612
@@ -1,0 +1,8 @@
+Enhancement: Add GCS option for encryption keys
+
+We have added support Google Cloud Customer-supplied 
+encryption keys. Users can provide 256-bit AES crypto 
+keys to add an extra layer of protection to stored files in the cloud.
+
+https://github.com/restic/restic/pull/3612
+https://github.com/restic/restic/issues/3530

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -554,13 +554,30 @@ repository in the bucket ``foo`` at the root path:
     enter password for new repository:
     enter password again:
 
-    created restic repository bde47d6254 at gs:foo2/
+    created restic repository bde47d6254 at gs:foo:/
     [...]
 
 The number of concurrent connections to the GCS service can be set with the
 ``-o gs.connections=10`` switch. By default, at most five parallel connections are
 established.
 
+User can define encryption keys to enable `customer-supplied encryption`_ for the repository.
+Keys must be a base64-encoded string of the AES-256 encryption key wanted.
+
+.. code-block:: console
+
+    $ export GOOGLE_ENCRYPTION_KEY=000000000...
+
+To enable key rotation, users can also define up to 100 decryption keys which will allow
+for access to the repo after a change of encryption key from first init.
+Decryption keys are formatting identically to encryption keys.
+
+.. code-block:: console
+
+    $ export GOOGLE_DECRYPTION_KEY1=001000000...
+    $ export GOOGLE_DECRYPTION_KEY100=1000000000...
+
+.. _customer-supplied encryption: https://cloud.google.com/storage/docs/encryption/customer-supplied-keys?hl=en
 .. _service account: https://cloud.google.com/storage/docs/authentication#service_accounts
 .. _create a service account key: https://cloud.google.com/storage/docs/authentication#generating-a-private-key
 .. _default authentication material: https://developers.google.com/identity/protocols/application-default-credentials

--- a/internal/backend/gs/config.go
+++ b/internal/backend/gs/config.go
@@ -8,6 +8,11 @@ import (
 	"github.com/restic/restic/internal/options"
 )
 
+type gsKeyTuple struct {
+	Key    []byte
+	KeySha string
+}
+
 // Config contains all configuration necessary to connect to a Google Cloud Storage
 // bucket. We use Google's default application credentials to acquire an access token, so
 // we don't require that calling code supply any authentication material here.
@@ -17,6 +22,10 @@ type Config struct {
 	Prefix    string
 
 	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+
+	//https://cloud.google.com/storage/docs/encryption/customer-supplied-keys#gsutil
+	EncryptionKey  gsKeyTuple        `option:"encryption_key" help:"Use custom-supplied encryption key."`
+	DecryptionKeys map[string][]byte `option:"decryption_keys" help:"Use custom-supplied decryption keys."`
 }
 
 // NewConfig returns a new Config with the default values filled in.

--- a/internal/backend/gs/config_test.go
+++ b/internal/backend/gs/config_test.go
@@ -31,7 +31,7 @@ func TestParseConfig(t *testing.T) {
 			continue
 		}
 
-		if cfg != test.cfg {
+		if (cfg.(Config).Bucket != test.cfg.Bucket) || (cfg.(Config).Prefix != test.cfg.Prefix) || (cfg.(Config).Connections != test.cfg.Connections) {
 			t.Errorf("test %d:\ninput:\n  %s\n wrong config, want:\n  %v\ngot:\n  %v",
 				i, test.s, test.cfg, cfg)
 			continue


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
These changes allow users to provide 256-bit AES crypto keys to Google Cloud Storage to enable [Customer-supplied encryption](https://cloud.google.com/storage/docs/encryption/customer-supplied-keys?hl=en). By providing one's own keys which are beyond Google's management, users enable an extra layer of protection for their data in the cloud. Once data is encrypted with provided keys, data can not be downloaded or decrypted without providing the same key that was used to encrypt.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #3530

Checklist
---------

- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [X] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [X] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I have run `gofmt` on the code in all commits.
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
