### PR TITLE
[issue 3558]: Add a FAQ section for invalid Windows filenames

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -219,3 +219,9 @@ be a very strong password, if not for being in this documentation.
 
 There are plenty of tools out there, such as OpenSSL, pwgen or KeePass that can
 generate a sufficiently complex, random and long password.
+
+Restic backup command fails to find a valid file in Windows
+-----------------------------------------------------------
+
+If the name of a file in Windows contains an invalid character, Restic will not be
+able to read the file. To solve this issue, consider renaming the particular file. 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
fixes #3558 

As discussed in the issue, I have added the relevant FAQ section for invalid filenames in Windows

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #3558 

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
