### PR TITLE
Skip lock file creation on forget with --no-lock and --dry-run

### DIFF
--- a/changelog/unreleased/issue-3464
+++ b/changelog/unreleased/issue-3464
@@ -1,0 +1,9 @@
+Enhancement: Skip lock creation on forget if --no-lock and --dry-run
+
+Restic used to silently ignore --no-lock option of forget. It now skips
+creation of lock file in case of both --dry-run and --no-lock are specified. If
+--no-lock option is specified without --dry-run then restic prints a warning
+message to stderr.
+
+https://github.com/restic/restic/issues/3464
+https://github.com/restic/restic/pull/3623

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"io"
 
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 	"github.com/spf13/cobra"
 )
@@ -108,10 +109,16 @@ func runForget(opts ForgetOptions, gopts GlobalOptions, args []string) error {
 		return err
 	}
 
-	lock, err := lockRepoExclusive(gopts.ctx, repo)
-	defer unlockRepo(lock)
-	if err != nil {
-		return err
+	if gopts.NoLock && !opts.DryRun {
+		return errors.Fatal("--no-lock is only applicable in combination with --dry-run for forget command")
+	}
+
+	if !opts.DryRun || !gopts.NoLock {
+		lock, err := lockRepoExclusive(gopts.ctx, repo)
+		defer unlockRepo(lock)
+		if err != nil {
+			return err
+		}
 	}
 
 	ctx, cancel := context.WithCancel(gopts.ctx)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Fixes issue #3464. --no-lock was silently ignored on forget. Now in case of --no-lock with --dry-run, forget will skip creation of lock. Warning message is shown if --no-lock is specified without --dry-run.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Issue was discussed in https://github.com/restic/restic/issues/3464

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
