### PR TITLE
Added security note for passing pw via env variable

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -526,7 +526,7 @@ environment variables. The following lists these environment variables:
     RESTIC_REPOSITORY_FILE              Name of file containing the repository location (replaces --repository-file)
     RESTIC_REPOSITORY                   Location of repository (replaces -r)
     RESTIC_PASSWORD_FILE                Location of password file (replaces --password-file)
-    RESTIC_PASSWORD                     The actual password for the repository
+    RESTIC_PASSWORD                     The actual password for the repository (note security notice below)
     RESTIC_PASSWORD_COMMAND             Command printing the password for the repository to stdout
     RESTIC_KEY_HINT                     ID of key to try decrypting first, before other keys
     RESTIC_CACHE_DIR                    Location of the cache directory
@@ -581,6 +581,10 @@ See :ref:`caching` for the rules concerning cache locations when
 The external programs that restic may execute include ``rclone`` (for rclone
 backends) and ``ssh`` (for the SFTP backend). These may respond to further
 environment variables and configuration files; see their respective manuals.
+
+Security note for linux when passing password via ``RESTIC_PASSWORD`` environment variable: 
+Password is still visible to other processes running as the same user 
+as restic. Environment variables can be seen by executing  ``cat /proc/`pidof restic`/environ``.
 
 
 Exit status codes


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
It adds a security note that environment variables can be seen by other processes running as the same user as restic does.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

It is only a small documentation update. Feel free to change the wording. 
I was aware that passwords via commandline are unsafe because they can be read by other processes easily and thats why I used environment variables. But these aren't so secure as thought. So I've created this pull request.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
