### PR TITLE
[issue 2449] fix problems with trailing slash...

### DIFF
--- a/changelog/unreleased/issue-2449
+++ b/changelog/unreleased/issue-2449
@@ -1,0 +1,7 @@
+Bugfix: Trailing slashes in directory names on windows
+
+If you were autocompleting a path with spaces in it, e.g. `c:\test thing\`
+then restic couldn't read it because the backslash escaped the trailing quote.
+
+https://github.com/restic/restic/issues/2449
+https://github.com/restic/restic/pull/3637

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -455,6 +455,19 @@ func collectTargets(opts BackupOptions, args []string) (targets []string, err er
 		targets = append(targets, fromfile...)
 	}
 
+	// fix dangling trailing quotes on windows
+	if runtime.GOOS == "windows" {
+		argsFixed := []string{}
+		for _, a := range args {
+			if strings.HasSuffix(a, "\"") && !strings.HasPrefix(a, "\"") {
+				argsFixed = append(argsFixed, strings.TrimRight(a, "\""))
+			} else {
+				argsFixed = append(argsFixed, a)
+			}
+		}
+		args = argsFixed
+	}
+
 	// Merge args into files-from so we can reuse the normal args checks
 	// and have the ability to use both files-from and args at the same time.
 	targets = append(targets, args...)


### PR DESCRIPTION
... in path names on windows, which in turn will escape the quotes

What does this PR change? What problem does it solve?
-----------------------------------------------------

See #2449 - if you're autocompleting a path with spaces in it, e.g. `c:\test thing\` then it can't be read because the backslash escapes the trailing quote.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #2449

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
