### PR TITLE
Fix test failures on Solaris

### DIFF
--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -67,7 +67,7 @@ func isSymlink(fi os.FileInfo) bool {
 
 func sameModTime(fi1, fi2 os.FileInfo) bool {
 	switch runtime.GOOS {
-	case "darwin", "freebsd", "openbsd", "netbsd":
+	case "darwin", "freebsd", "openbsd", "netbsd", "solaris":
 		if isSymlink(fi1) && isSymlink(fi2) {
 			return true
 		}

--- a/internal/restic/node_test.go
+++ b/internal/restic/node_test.go
@@ -210,7 +210,7 @@ func TestNodeRestoreAt(t *testing.T) {
 				"%v: GID doesn't match (%v != %v)", test.Type, test.GID, n2.GID)
 			if test.Type != "symlink" {
 				// On OpenBSD only root can set sticky bit (see sticky(8)).
-				if runtime.GOOS != "openbsd" && runtime.GOOS != "netbsd" && test.Name == "testSticky" {
+				if runtime.GOOS != "openbsd" && runtime.GOOS != "netbsd" && runtime.GOOS != "solaris" && test.Name == "testSticky" {
 					rtest.Assert(t, test.Mode == n2.Mode,
 						"%v: mode doesn't match (0%o != 0%o)", test.Type, test.Mode, n2.Mode)
 				}
@@ -228,7 +228,7 @@ func AssertFsTimeEqual(t *testing.T, label string, nodeType string, t1 time.Time
 	// Go currently doesn't support setting timestamps of symbolic links on darwin and bsd
 	if nodeType == "symlink" {
 		switch runtime.GOOS {
-		case "darwin", "freebsd", "openbsd", "netbsd":
+		case "darwin", "freebsd", "openbsd", "netbsd", "solaris":
 			return
 		}
 	}

--- a/internal/restic/node_unix_test.go
+++ b/internal/restic/node_unix_test.go
@@ -93,7 +93,9 @@ func TestNodeFromFileInfo(t *testing.T) {
 
 	// on darwin, users are not permitted to list the extended attributes of
 	// /dev/null, therefore skip it.
-	if runtime.GOOS != "darwin" {
+	// on solaris, /dev/null is a symlink to a device node in /devices
+	// which does not support extended attributes, therefore skip it.
+	if runtime.GOOS != "darwin" && runtime.GOOS != "solaris" {
 		tests = append(tests, Test{"/dev/null", true})
 	}
 


### PR DESCRIPTION
Add exceptions for symlinks, sticky bits, and device nodes in the same places where the BSDSs and/or Darwin have them.

What does this PR change? What problem does it solve?
-----------------------------------------------------

These changes allow for the tests to pass on Solaris.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Mentioned in #3628

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
