### PR TITLE
add a note about installation via epel for RHEL / CentOS Stream 8 & 9

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -131,7 +131,7 @@ On openSUSE (leap 15.0 and greater, and tumbleweed), you can install restic usin
 RHEL & CentOS
 =============
 
-For RHEL / CentOS Stream 8 & 9 restic can be installed via epel repository, you can try the following:
+For RHEL / CentOS Stream 8 & 9 restic can be installed from the EPEL repository:
 
 .. code-block:: console
 

--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -131,7 +131,14 @@ On openSUSE (leap 15.0 and greater, and tumbleweed), you can install restic usin
 RHEL & CentOS
 =============
 
-restic can be installed via copr repository, for RHEL7/CentOS you can try the following:
+For RHEL / CentOS Stream 8 & 9 restic can be installed via epel repository, you can try the following:
+
+.. code-block:: console
+
+    $ dnf install epel-release
+    $ dnf install restic
+
+For RHEL7/CentOS there is a copr repository available, you can try the following:
 
 .. code-block:: console
 


### PR DESCRIPTION
As soon as

* https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2022-aa2bdf10d1 
* https://bodhi.fedoraproject.org/updates/FEDORA-EPEL-2022-2912720425

got pushed to the stable repositories, restic can be installed through EPEL on RHEL / CentOS Stream 8 & 9, which is much more convenient than an additional copr repository.

The EPEL packages are maintained by the same person that maintained the copr repo.

