### PR TITLE
Don't set a parent for --stdin backups

### DIFF
--- a/changelog/unreleased/issue-3641
+++ b/changelog/unreleased/issue-3641
@@ -1,0 +1,13 @@
+Change: Backups from stdin no longer have a parent
+
+Snapshots made with `restic backup --stdin` no longer have a parent snapshot.
+Since parent snapshots are only used to skip files in the scanning phase
+based on filename and timestamps, the parent snapshot of a `--stdin` snapshot
+was meaningless to begin with. Not setting a parent allows `restic backup`
+to skip some startup operations.
+
+The `--parent` option is still available for `restic backup --stdin`,
+but is now ignored.
+
+https://github.com/restic/restic/issues/3641
+https://github.com/restic/restic/pull/3645

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -579,16 +579,19 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		return err
 	}
 
-	parentSnapshotID, err := findParentSnapshot(gopts.ctx, repo, opts, targets, timeStamp)
-	if err != nil {
-		return err
-	}
+	var parentSnapshotID *restic.ID
+	if !opts.Stdin {
+		parentSnapshotID, err = findParentSnapshot(gopts.ctx, repo, opts, targets, timeStamp)
+		if err != nil {
+			return err
+		}
 
-	if !gopts.JSON {
-		if parentSnapshotID != nil {
-			progressPrinter.P("using parent snapshot %v\n", parentSnapshotID.Str())
-		} else {
-			progressPrinter.P("no parent snapshot found, will read all files\n")
+		if !gopts.JSON {
+			if parentSnapshotID != nil {
+				progressPrinter.P("using parent snapshot %v\n", parentSnapshotID.Str())
+			} else {
+				progressPrinter.P("no parent snapshot found, will read all files\n")
+			}
 		}
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Backups from --stdin now get a null parent. Loading any parent tree for these only wastes time and memory. --parent is now implicitly ignored when --stdin is given.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes #3641, where it was shown that the most recent tree will get picked.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
