### PR TITLE
add SAS authentication option for Azure repos

### DIFF
--- a/changelog/unreleased/issue-2295
+++ b/changelog/unreleased/issue-2295
@@ -1,0 +1,14 @@
+Enhancement: Allow use of SAS token to authenticate to Azure
+
+Previously restic only supported AccountKeys to authenticate to Azure
+storage accounts, which necessitates giving a significant amount of
+access.
+
+We added support for Azure SAS tokens which are a more fine-grained
+and time-limited manner of granting access. Set the `AZURE_ACCOUNT_NAME`
+and `AZURE_ACCOUNT_SAS` environment variables to use a SAS token for
+authentication. Note that if `AZURE_ACCOUNT_KEY` is set, it will take
+preference.
+
+https://github.com/restic/restic/issues/2295
+https://github.com/restic/restic/pull/3661

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -596,6 +596,10 @@ func parseConfig(loc location.Location, opts options.Options) (interface{}, erro
 			cfg.AccountKey = options.NewSecretString(os.Getenv("AZURE_ACCOUNT_KEY"))
 		}
 
+		if cfg.AccountSAS.String() == "" {
+			cfg.AccountSAS = options.NewSecretString(os.Getenv("AZURE_ACCOUNT_SAS"))
+		}
+
 		if err := opts.Apply(loc.Scheme, &cfg); err != nil {
 			return nil, err
 		}

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -506,10 +506,6 @@ or
     $ export AZURE_ACCOUNT_NAME=<ACCOUNT_NAME>
     $ export AZURE_ACCOUNT_SAS=<SAS_TOKEN>
 
-With the later form, ensure your ``SAS_TOKEN`` does not start with a leading
-``?``. If the generated token starts with a leading ``?`` it is safe to just
-delete the first character (the ``?``) before use.
-
 Afterwards you can initialize a repository in a container called ``foo`` in the
 root path like this:
 

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -499,6 +499,17 @@ account name and key as follows:
     $ export AZURE_ACCOUNT_NAME=<ACCOUNT_NAME>
     $ export AZURE_ACCOUNT_KEY=<SECRET_KEY>
 
+or
+
+.. code-block:: console
+
+    $ export AZURE_ACCOUNT_NAME=<ACCOUNT_NAME>
+    $ export AZURE_ACCOUNT_SAS=<SAS_TOKEN>
+
+With the later form, ensure your ``SAS_TOKEN`` does not start with a leading
+``?``. If the generated token starts with a leading ``?`` it is safe to just
+delete the first character (the ``?``) before use.
+
 Afterwards you can initialize a repository in a container called ``foo`` in the
 root path like this:
 

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -593,6 +593,7 @@ environment variables. The following lists these environment variables:
 
     AZURE_ACCOUNT_NAME                  Account name for Azure
     AZURE_ACCOUNT_KEY                   Account key for Azure
+    AZURE_ACCOUNT_SAS                   Shared access signatures (SAS) for Azure
 
     GOOGLE_PROJECT_ID                   Project ID for Google Cloud Storage
     GOOGLE_APPLICATION_CREDENTIALS      Application Credentials for Google Cloud Storage (e.g. $HOME/.config/gs-secret-restic-key.json)

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -57,7 +57,12 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 		// we (as per the SDK ) assume the default Azure portal.
 		url := fmt.Sprintf("https://%s.blob.core.windows.net/", cfg.AccountName)
 		debug.Log(" - using sas token")
-		client, err = storage.NewAccountSASClientFromEndpointToken(url, cfg.AccountSAS.Unwrap())
+		sas := cfg.AccountSAS.Unwrap()
+		// strip query sign prefix
+		if sas[0] == '?' {
+			sas = sas[1:]
+		}
+		client, err = storage.NewAccountSASClientFromEndpointToken(url, sas)
 		if err != nil {
 			return nil, errors.Wrap(err, "NewAccountSASClientFromEndpointToken")
 		}

--- a/internal/backend/azure/config.go
+++ b/internal/backend/azure/config.go
@@ -12,6 +12,7 @@ import (
 // server.
 type Config struct {
 	AccountName string
+	AccountSAS  options.SecretString
 	AccountKey  options.SecretString
 	Container   string
 	Prefix      string


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds the ability to use Azure SAS tokens for authentication. This feature is requested in #2295 

<!--
Describe the changes and their purpose here, as detailed as needed.
-->
This change adds an additional string value to the azure configuration struct to store the SAS, and a separate path to create the service client.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes:  #2295

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.

I haven't coded any tests as they will require an update to the testing infrastructure to create SAS TOKEN, (although that should be a relatively straightforward change in the workflow). Functionally they should do the same as the existing tests but with a SAS token provided instead of ACCOUNT_KEY.

NB: I'm a relative newbie in Go so there may be some style issues.