### PR TITLE
list: Never lock the repository when listing lock files

### DIFF
--- a/changelog/unreleased/issue-1106
+++ b/changelog/unreleased/issue-1106
@@ -4,7 +4,7 @@ The `list locks` command previously locked to the repository by default. This
 has the problem that it won't work for an exclusively locked repository and
 that the command will also display its own lock file which can be confusing.
 
-Now, the `list locks` command cnever locks the repository.
+Now, the `list locks` command never locks the repository.
 
 https://github.com/restic/restic/issues/1106
 https://github.com/restic/restic/pull/3665

--- a/changelog/unreleased/issue-1106
+++ b/changelog/unreleased/issue-1106
@@ -1,0 +1,10 @@
+Bugfix: Never lock repository for `list locks`
+
+The `list locks` command previously locked to the repository by default. This
+has the problem that it won't work for an exclusively locked repository and
+that the command will also display its own lock file which can be confusing.
+
+Now, the `list locks` command cnever locks the repository.
+
+https://github.com/restic/restic/issues/1106
+https://github.com/restic/restic/pull/3665

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -39,7 +39,7 @@ func runList(cmd *cobra.Command, opts GlobalOptions, args []string) error {
 		return err
 	}
 
-	if !opts.NoLock {
+	if !opts.NoLock && args[0] != "locks" {
 		lock, err := lockRepo(opts.ctx, repo)
 		defer unlockRepo(lock)
 		if err != nil {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
There's no point in locking the repository just to list the currently existing lock files. This also won't work for an exclusively locked repository and is confusing to users.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See discussion in #1106.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
