### PR TITLE
Implement compression support

### DIFF
--- a/changelog/unreleased/issue-21
+++ b/changelog/unreleased/issue-21
@@ -4,6 +4,11 @@ We have added compression support to the restic repository format. To create a
 repository using the new format run `init --repository-version 2`. Please note
 that the repository cannot be read by restic versions prior to 0.14.0.
 
+You can configure if data is compressed with the option `--compression`. It can
+be set to `auto` (the default, which will compress very fast), `max` (which
+will trade backup speed and CPU usage for better compression), or `off` (which
+disables compression). Each setting is only applied for the single run of restic.
+
 The new format version has not received much testing yet. Do not rely on it as
 your only backup copy! Please run `check` in regular intervals to detect any
 problems.

--- a/changelog/unreleased/issue-21
+++ b/changelog/unreleased/issue-21
@@ -1,0 +1,16 @@
+Enhancement: Add comppression support
+
+We have added compression support to the restic repository format. To create a
+repository using the new format run `init --repository-version 2`. Please note
+that the repository cannot be read by restic versions prior to 0.14.0.
+
+The new format version has not received much testing yet. Do not rely on it as
+your only backup copy! Please run `check` in regular intervals to detect any
+problems.
+
+Upgrading in place is not yet supported. As a workaround, first create a new
+repository using `init --repository-version 2 --copy-chunker-params --repo2 path/to/old/repo`.
+Then use the `copy` command to copy all snapshots to the new repository.
+
+https://github.com/restic/restic/issues/21
+https://github.com/restic/restic/pull/3666

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -333,44 +333,37 @@ func loadBlobs(ctx context.Context, repo restic.Repository, pack restic.ID, list
 
 		nonce, plaintext := buf[:key.NonceSize()], buf[key.NonceSize():]
 		plaintext, err = key.Open(plaintext[:0], nonce, plaintext, nil)
+		outputPrefix := ""
+		filePrefix := ""
 		if err != nil {
 			Warnf("error decrypting blob: %v\n", err)
-			var plain []byte
 			if tryRepair || repairByte {
-				plain = tryRepairWithBitflip(ctx, key, buf, repairByte)
+				plaintext = tryRepairWithBitflip(ctx, key, buf, repairByte)
 			}
-			var prefix string
-			if plain != nil {
-				id := restic.Hash(plain)
-				if !id.Equal(blob.ID) {
-					Printf("         repaired blob (length %v), hash is %v, ID does not match, wanted %v\n", len(plain), id, blob.ID)
-					prefix = "repaired-wrong-hash-"
-				} else {
-					Printf("         successfully repaired blob (length %v), hash is %v, ID matches\n", len(plain), id)
-					prefix = "repaired-"
-				}
+			if plaintext != nil {
+				outputPrefix = "repaired "
+				filePrefix = "repaired-"
 			} else {
-				plain = decryptUnsigned(ctx, key, buf)
-				prefix = "damaged-"
+				plaintext = decryptUnsigned(ctx, key, buf)
+				err = storePlainBlob(blob.ID, "damaged-", plaintext)
+				if err != nil {
+					return err
+				}
+				continue
 			}
-			err = storePlainBlob(blob.ID, prefix, plain)
-			if err != nil {
-				return err
-			}
-			continue
 		}
 
 		id := restic.Hash(plaintext)
 		var prefix string
 		if !id.Equal(blob.ID) {
-			Printf("         successfully decrypted blob (length %v), hash is %v, ID does not match, wanted %v\n", len(plaintext), id, blob.ID)
+			Printf("         successfully %vdecrypted blob (length %v), hash is %v, ID does not match, wanted %v\n", outputPrefix, len(plaintext), id, blob.ID)
 			prefix = "wrong-hash-"
 		} else {
-			Printf("         successfully decrypted blob (length %v), hash is %v, ID matches\n", len(plaintext), id)
+			Printf("         successfully %vdecrypted blob (length %v), hash is %v, ID matches\n", outputPrefix, len(plaintext), id)
 			prefix = "correct-"
 		}
 		if extractPack {
-			err = storePlainBlob(id, prefix, plaintext)
+			err = storePlainBlob(id, filePrefix+prefix, plaintext)
 			if err != nil {
 				return err
 			}
@@ -476,27 +469,15 @@ func examinePack(ctx context.Context, repo restic.Repository, id restic.ID) erro
 
 	blobsLoaded := false
 	// examine all data the indexes have for the pack file
-	for _, idx := range repo.Index().(*repository.MasterIndex).All() {
-		idxIDs, err := idx.IDs()
-		if err != nil {
-			idxIDs = restic.IDs{}
-		}
-
-		blobs := idx.ListPack(id)
+	for b := range repo.Index().ListPacks(ctx, restic.NewIDSet(id)) {
+		blobs := b.Blobs
 		if len(blobs) == 0 {
 			continue
 		}
 
-		Printf("    index %v:\n", idxIDs)
+		checkPackSize(blobs, fi.Size)
 
-		// convert list of blobs to []restic.Blob
-		var list []restic.Blob
-		for _, b := range blobs {
-			list = append(list, b.Blob)
-		}
-		checkPackSize(list, fi.Size)
-
-		err = loadBlobs(ctx, repo, id, list)
+		err = loadBlobs(ctx, repo, id, blobs)
 		if err != nil {
 			Warnf("error: %v\n", err)
 		} else {
@@ -532,14 +513,10 @@ func checkPackSize(blobs []restic.Blob, fileSize int64) {
 		if offset != uint64(pb.Offset) {
 			Printf("      hole in file, want offset %v, got %v\n", offset, pb.Offset)
 		}
-		offset += uint64(pb.Length)
+		offset = uint64(pb.Offset + pb.Length)
 		size += uint64(pb.Length)
 	}
-
-	// compute header size, per blob: 1 byte type, 4 byte length, 32 byte id
-	size += uint64(restic.CiphertextLength(len(blobs) * (1 + 4 + 32)))
-	// length in uint32 little endian
-	size += 4
+	size += uint64(pack.CalculateHeaderSize(blobs))
 
 	if uint64(fileSize) != size {
 		Printf("      file sizes do not match: computed %v from index, file size is %v\n", size, fileSize)

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -86,7 +86,7 @@ func runInit(opts InitOptions, gopts GlobalOptions, args []string) error {
 		return errors.Fatalf("create repository at %s failed: %v\n", location.StripPassword(gopts.Repo), err)
 	}
 
-	s := repository.New(be)
+	s := repository.New(be, repository.Options{Compression: gopts.Compression})
 
 	err = s.Init(gopts.ctx, version, gopts.password, chunkerPolynomial)
 	if err != nil {

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -1,10 +1,13 @@
 package main
 
 import (
+	"strconv"
+
 	"github.com/restic/chunker"
 	"github.com/restic/restic/internal/backend/location"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
 
 	"github.com/spf13/cobra"
 )
@@ -30,6 +33,7 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 type InitOptions struct {
 	secondaryRepoOptions
 	CopyChunkerParameters bool
+	RepositoryVersion     string
 }
 
 var initOptions InitOptions
@@ -40,9 +44,26 @@ func init() {
 	f := cmdInit.Flags()
 	initSecondaryRepoOptions(f, &initOptions.secondaryRepoOptions, "secondary", "to copy chunker parameters from")
 	f.BoolVar(&initOptions.CopyChunkerParameters, "copy-chunker-params", false, "copy chunker parameters from the secondary repository (useful with the copy command)")
+	f.StringVar(&initOptions.RepositoryVersion, "repository-version", "stable", "repository format version to use, allowed values are a format version, 'latest' and 'stable'")
 }
 
 func runInit(opts InitOptions, gopts GlobalOptions, args []string) error {
+	var version uint
+	if opts.RepositoryVersion == "latest" || opts.RepositoryVersion == "" {
+		version = restic.MaxRepoVersion
+	} else if opts.RepositoryVersion == "stable" {
+		version = restic.StableRepoVersion
+	} else {
+		v, err := strconv.ParseUint(opts.RepositoryVersion, 10, 32)
+		if err != nil {
+			return errors.Fatal("invalid repository version")
+		}
+		version = uint(v)
+	}
+	if version < restic.MinRepoVersion || version > restic.MaxRepoVersion {
+		return errors.Fatalf("only repository versions between %v and %v are allowed", restic.MinRepoVersion, restic.MaxRepoVersion)
+	}
+
 	chunkerPolynomial, err := maybeReadChunkerPolynomial(opts, gopts)
 	if err != nil {
 		return err
@@ -67,7 +88,7 @@ func runInit(opts InitOptions, gopts GlobalOptions, args []string) error {
 
 	s := repository.New(be)
 
-	err = s.Init(gopts.ctx, gopts.password, chunkerPolynomial)
+	err = s.Init(gopts.ctx, version, gopts.password, chunkerPolynomial)
 	if err != nil {
 		return errors.Fatalf("create key in repository at %s failed: %v\n", location.StripPassword(gopts.Repo), err)
 	}

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -471,7 +471,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 			id = id[:8]
 		}
 		if !opts.JSON {
-			Verbosef("repository %v opened successfully, password is correct\n", id)
+			Verbosef("repository %v opened (repo version %v) successfully, password is correct\n", id, s.Config().Version)
 		}
 	}
 

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -64,6 +64,7 @@ type GlobalOptions struct {
 	InsecureTLS     bool
 	TLSClientCert   string
 	CleanupCache    bool
+	Compression     repository.CompressionMode
 
 	LimitUploadKb   int
 	LimitDownloadKb int
@@ -120,6 +121,7 @@ func init() {
 	f.StringVar(&globalOptions.TLSClientCert, "tls-client-cert", "", "path to a `file` containing PEM encoded TLS client certificate and private key")
 	f.BoolVar(&globalOptions.InsecureTLS, "insecure-tls", false, "skip TLS certificate verification when connecting to the repo (insecure)")
 	f.BoolVar(&globalOptions.CleanupCache, "cleanup-cache", false, "auto remove old cache directories")
+	f.Var(&globalOptions.Compression, "compression", "compression mode (only available for repo format version 2), one of (auto|off|max)")
 	f.IntVar(&globalOptions.LimitUploadKb, "limit-upload", 0, "limits uploads to a maximum rate in KiB/s. (default: unlimited)")
 	f.IntVar(&globalOptions.LimitDownloadKb, "limit-download", 0, "limits downloads to a maximum rate in KiB/s. (default: unlimited)")
 	f.StringSliceVarP(&globalOptions.Options, "option", "o", []string{}, "set extended option (`key=value`, can be specified multiple times)")
@@ -435,7 +437,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		}
 	}
 
-	s := repository.New(be)
+	s := repository.New(be, repository.Options{Compression: opts.Compression})
 
 	passwordTriesLeft := 1
 	if stdinIsTerminal() && opts.password == "" {

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -1470,7 +1470,7 @@ func TestRebuildIndexAlwaysFull(t *testing.T) {
 	defer func() {
 		repository.IndexFull = indexFull
 	}()
-	repository.IndexFull = func(*repository.Index) bool { return true }
+	repository.IndexFull = func(*repository.Index, bool) bool { return true }
 	testRebuildIndex(t, nil)
 }
 

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -35,6 +35,13 @@ options exist:
  * Configuring a program to be called when the password is needed via the
    option ``--password-command`` or the environment variable
    ``RESTIC_PASSWORD_COMMAND``
+   
+ * The ``init`` command has an option called ``--repository-version`` which can
+   be used to explicitely set the version for the new repository. By default,
+   the current stable version is used. Have a look at the `design documentation
+   <https://github.com/restic/restic/blob/master/doc/design.rst>`__ for
+   details.
+
 
 Local
 *****
@@ -692,4 +699,3 @@ On MSYS2, you can install ``winpty`` as follows:
 
     $ pacman -S winpty
     $ winpty restic -r /srv/restic-repo init
-

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -74,19 +74,18 @@ format is contained in the section "Changes" below.
 
 The field ``id`` holds a unique ID which consists of 32 random bytes, encoded
 in hexadecimal. This uniquely identifies the repository, regardless if it is
-accessed via SFTP or locally. The field ``chunker_polynomial`` contains a
-parameter that is used for splitting large files into smaller chunks (see
-below).
+accessed via a remote storage backend or locally. The field
+``chunker_polynomial`` contains a parameter that is used for splitting large
+files into smaller chunks (see below).
 
 Repository Layout
 -----------------
 
 The ``local`` and ``sftp`` backends are implemented using files and
 directories stored in a file system. The directory layout is the same
-for both backend types.
+for both backend types and is also used for all other remote backends.
 
-The basic layout of a repository stored in a ``local`` or ``sftp``
-backend is shown here:
+The basic layout of a repository is shown here:
 
 ::
 
@@ -112,8 +111,7 @@ backend is shown here:
     │   └── 22a5af1bdc6e616f8a29579458c49627e01b32210d09adb288d1ecda7c5711ec
     └── tmp
 
-A local repository can be initialized with the ``restic init`` command,
-e.g.:
+A local repository can be initialized with the ``restic init`` command, e.g.:
 
 .. code-block:: console
 
@@ -459,7 +457,7 @@ Blobs of data. The SHA-256 hashes of all Blobs are saved in an ordered
 list which then represents the content of the file.
 
 In order to relate these plaintext hashes to the actual location within
-a Pack file , an index is used. If the index is not available, the
+a Pack file, an index is used. If the index is not available, the
 header of all data Blobs can be read.
 
 Trees and Data

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -62,18 +62,21 @@ like the following:
 .. code:: json
 
     {
-      "version": 1,
+      "version": 2,
       "id": "5956a3f67a6230d4a92cefb29529f10196c7d92582ec305fd71ff6d331d6271b",
       "chunker_polynomial": "25b468838dcb75"
     }
 
 After decryption, restic first checks that the version field contains a
-version number that it understands, otherwise it aborts. At the moment,
-the version is expected to be 1. The field ``id`` holds a unique ID
-which consists of 32 random bytes, encoded in hexadecimal. This uniquely
-identifies the repository, regardless if it is accessed via SFTP or
-locally. The field ``chunker_polynomial`` contains a parameter that is
-used for splitting large files into smaller chunks (see below).
+version number that it understands, otherwise it aborts. At the moment, the
+version is expected to be 1 or 2. The list of changes in the repository
+format is contained in the section "Changes" below.
+
+The field ``id`` holds a unique ID which consists of 32 random bytes, encoded
+in hexadecimal. This uniquely identifies the repository, regardless if it is
+accessed via SFTP or locally. The field ``chunker_polynomial`` contains a
+parameter that is used for splitting large files into smaller chunks (see
+below).
 
 Repository Layout
 -----------------
@@ -186,29 +189,65 @@ After decryption, a Pack's header consists of the following elements:
 
 ::
 
-    Type_Blob1 || Length(EncryptedBlob1) || Hash(Plaintext_Blob1) ||
+    Type_Blob1 || Data_Blob1 ||
     [...]
-    Type_BlobN || Length(EncryptedBlobN) || Hash(Plaintext_Blobn) ||
+    Type_BlobN || Data_BlobN ||
+
+The Blob type field is a single byte. What follows it depends on the type. The
+following Blob types are defined:
+
++-----------+----------------------+-------------------------------------------------------------------------------+
+| Type      | Meaning              |  Data                                                                         |
++===========+======================+===============================================================================+
+| 0b00      | data blob            |  ``Length(encrypted_blob) || Hash(plaintext_blob)``                           |
++-----------+----------------------+-------------------------------------------------------------------------------+
+| 0b01      | tree blob            |  ``Length(encrypted_blob) || Hash(plaintext_blob)``                           |
++-----------+----------------------+-------------------------------------------------------------------------------+
+| 0b10      | compressed data blob |  ``Length(encrypted_blob) || Length(plaintext_blob) || Hash(plaintext_blob)`` |
++-----------+----------------------+-------------------------------------------------------------------------------+
+| 0b11      | compressed tree blob |  ``Length(encrypted_blob) || Length(plaintext_blob) || Hash(plaintext_blob)`` |
++-----------+----------------------+-------------------------------------------------------------------------------+
 
 This is enough to calculate the offsets for all the Blobs in the Pack.
-Length is the length of a Blob as a four byte integer in little-endian
-format. The type field is a one byte field and labels the content of a
-blob according to the following table:
+The length fields are encoded as four byte integers in little-endian
+format. In the Data column, ``Length(plaintext_blob)`` means the length
+of the decrypted and uncompressed data a blob consists of.
 
-+--------+-----------+
-| Type   | Meaning   |
-+========+===========+
-| 0      | data      |
-+--------+-----------+
-| 1      | tree      |
-+--------+-----------+
+All other types are invalid, more types may be added in the future. The
+compressed types are only valid for repository format version 2. Data and
+tree blobs may be compressed with the zstandard compression algorithm.
 
-All other types are invalid, more types may be added in the future.
+In repository format version 1, data and tree blobs should be stored in
+separate pack files. In version 2, they must be stored in separate files.
+Compressed and non-compress blobs of the same type may be mixed in a pack
+file.
 
 For reconstructing the index or parsing a pack without an index, first
 the last four bytes must be read in order to find the length of the
 header. Afterwards, the header can be read and parsed, which yields all
 plaintext hashes, types, offsets and lengths of all included blobs.
+
+Unpacked Data Format
+====================
+
+Individual files for the index, locks or snapshots are encrypted
+and authenticated like Data and Tree Blobs, so the outer structure is
+``IV || Ciphertext || MAC`` again. In repository format version 1 the
+plaintext always consists of a JSON document which must either be an
+object or an array.
+
+Repository format version 2 adds support for compression. The plaintext
+now starts with a header to indicate the encoding version to distinguish
+it from plain JSON and to allow for further evolution of the storage format:
+``encoding_version || data``
+The ``encoding_version`` field is encoded as one byte.
+For backwards compatibility the encoding versions '[' (0x5b) and '{' (0x7b)
+are used to mark that the whole plaintext (including the encoding version
+byte) should treated as JSON document.
+
+For new data the encoding version is currently always ``2``. For that
+version ``data`` contains a JSON document compressed using the zstandard
+compression algorithm.
 
 Indexing
 ========
@@ -216,10 +255,9 @@ Indexing
 Index files contain information about Data and Tree Blobs and the Packs
 they are contained in and store this information in the repository. When
 the local cached index is not accessible any more, the index files can
-be downloaded and used to reconstruct the index. The files are encrypted
-and authenticated like Data and Tree Blobs, so the outer structure is
-``IV || Ciphertext || MAC`` again. The plaintext consists of a JSON
-document like the following:
+be downloaded and used to reconstruct the index. The file encoding is
+described in the "Unpacked Data Format" section. The plaintext consists
+of a JSON document like the following:
 
 .. code:: json
 
@@ -235,18 +273,22 @@ document like the following:
               "id": "3ec79977ef0cf5de7b08cd12b874cd0f62bbaf7f07f3497a5b1bbcc8cb39b1ce",
               "type": "data",
               "offset": 0,
-              "length": 25
-            },{
+              "length": 38,
+              // no 'uncompressed_length' as blob is not compressed
+            },
+            {
               "id": "9ccb846e60d90d4eb915848add7aa7ea1e4bbabfc60e573db9f7bfb2789afbae",
               "type": "tree",
               "offset": 38,
-              "length": 100
+              "length": 112,
+              "uncompressed_length": 511,
             },
             {
               "id": "d3dc577b4ffd38cc4b32122cabf8655a0223ed22edfd93b353dc0c3f2b0fdf66",
               "type": "data",
               "offset": 150,
-              "length": 123
+              "length": 123,
+              "uncompressed_length": 234,
             }
           ]
         }, [...]
@@ -255,7 +297,11 @@ document like the following:
 
 This JSON document lists Packs and the blobs contained therein. In this
 example, the Pack ``73d04e61`` contains two data Blobs and one Tree
-blob, the plaintext hashes are listed afterwards.
+blob, the plaintext hashes are listed afterwards. The ``length`` field
+corresponds to ``Length(encrypted_blob)`` in the pack file header.
+Field ``uncompressed_length`` is only present for compressed blobs and
+therefore is never present in version 1. It is set to the value of
+``Length(blob)``.
 
 The field ``supersedes`` lists the storage IDs of index files that have
 been replaced with the current index file. This happens when index files
@@ -350,8 +396,9 @@ Snapshots
 
 A snapshot represents a directory with all files and sub-directories at
 a given point in time. For each backup that is made, a new snapshot is
-created. A snapshot is a JSON document that is stored in an encrypted
-file below the directory ``snapshots`` in the repository. The filename
+created. A snapshot is a JSON document that is stored in a file below
+the directory ``snapshots`` in the repository. It uses the file encoding
+described in the "Unpacked Data Format" section. The filename
 is the storage ID. This string is unique and used within restic to
 uniquely identify a snapshot.
 
@@ -517,8 +564,8 @@ time there must not be any other locks (exclusive and non-exclusive).
 There may be multiple non-exclusive locks in parallel.
 
 A lock is a file in the subdir ``locks`` whose filename is the storage
-ID of the contents. It is encrypted and authenticated the same way as
-other files in the repository and contains the following JSON structure:
+ID of the contents. It is stored in the file encoding described in the
+"Unpacked Data Format" section and contains the following JSON structure:
 
 .. code:: json
 
@@ -721,3 +768,11 @@ An adversary who has a leaked (decrypted) key for a repository could:
    only be done using the ``copy`` command, which moves the data into a new
    repository with a new master key, or by making a completely new repository
    and new backup.
+
+Changes
+=======
+
+Repository Version 2
+--------------------
+
+ * Support compression for blobs (data/tree) and index / lock / snapshot files

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/hashicorp/golang-lru v0.5.4
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/juju/ratelimit v1.0.1
-	github.com/klauspost/compress v1.15.1 // indirect
+	github.com/klauspost/compress v1.15.1
 	github.com/klauspost/cpuid/v2 v2.0.12 // indirect
 	github.com/kurin/blazer v0.5.4-0.20211030221322-ba894c124ac6
 	github.com/minio/md5-simd v1.1.2 // indirect

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1894,7 +1894,7 @@ func TestArchiverContextCanceled(t *testing.T) {
 	defer removeTempdir()
 
 	// Ensure that the archiver itself reports the canceled context and not just the backend
-	repo, _ := repository.TestRepositoryWithBackend(t, &noCancelBackend{mem.New()})
+	repo, _ := repository.TestRepositoryWithBackend(t, &noCancelBackend{mem.New()}, 0)
 
 	back := restictest.Chdir(t, tempdir)
 	defer back()

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -350,7 +350,7 @@ func TestCheckerModifiedData(t *testing.T) {
 	t.Logf("archived as %v", sn.ID().Str())
 
 	beError := &errorBackend{Backend: repo.Backend()}
-	checkRepo := repository.New(beError)
+	checkRepo := repository.New(beError, repository.Options{})
 	test.OK(t, checkRepo.SearchKey(context.TODO(), test.TestPassword, 5, ""))
 
 	chkr := checker.New(checkRepo, false)

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -54,10 +54,18 @@ var plainEntrySize = uint(binary.Size(restic.BlobType(0)) + headerLengthSize + l
 // headerEntry describes the format of header entries. It serves only as
 // documentation.
 type headerEntry struct {
-	Type             uint8
-	Length           uint32
-	ID               restic.ID
-	CompressedLength uint32
+	Type   uint8
+	Length uint32
+	ID     restic.ID
+}
+
+// compressedHeaderEntry describes the format of header entries for compressed blobs.
+// It serves only as documentation.
+type compressedHeaderEntry struct {
+	Type               uint8
+	Length             uint32
+	UncompressedLength uint32
+	ID                 restic.ID
 }
 
 // Finalize writes the header for all added blobs and finalizes the pack.

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -38,7 +38,7 @@ func newPack(t testing.TB, k *crypto.Key, lengths []int) ([]Buf, []byte, uint) {
 	var buf bytes.Buffer
 	p := pack.NewPacker(k, &buf)
 	for _, b := range bufs {
-		_, err := p.Add(restic.TreeBlob, b.id, b.data)
+		_, err := p.Add(restic.TreeBlob, b.id, b.data, 2*len(b.data))
 		rtest.OK(t, err)
 	}
 

--- a/internal/repository/indexmap.go
+++ b/internal/repository/indexmap.go
@@ -131,12 +131,12 @@ func (m *indexMap) len() uint { return m.numentries }
 
 func (m *indexMap) newEntry() *indexEntry {
 	// Allocating in batches means that we get closer to optimal space usage,
-	// as Go's malloc will overallocate for structures of size 56 (indexEntry
+	// as Go's malloc will overallocate for structures of size 60 (indexEntry
 	// on amd64).
 	//
-	// 256*56 and 256*48 both have minimal malloc overhead among reasonable sizes.
+	// 128*60 and 128*60 both have low malloc overhead among reasonable sizes.
 	// See src/runtime/sizeclasses.go in the standard library.
-	const entryAllocBatch = 256
+	const entryAllocBatch = 128
 
 	if m.free == nil {
 		free := new([entryAllocBatch]indexEntry)

--- a/internal/repository/indexmap.go
+++ b/internal/repository/indexmap.go
@@ -32,7 +32,7 @@ const (
 
 // add inserts an indexEntry for the given arguments into the map,
 // using id as the key.
-func (m *indexMap) add(id restic.ID, packIdx int, offset, length uint32) {
+func (m *indexMap) add(id restic.ID, packIdx int, offset, length uint32, uncompressedLength uint32) {
 	switch {
 	case m.numentries == 0: // Lazy initialization.
 		m.init()
@@ -47,6 +47,7 @@ func (m *indexMap) add(id restic.ID, packIdx int, offset, length uint32) {
 	e.packIndex = packIdx
 	e.offset = offset
 	e.length = length
+	e.uncompressedLength = uncompressedLength
 
 	m.buckets[h] = e
 	m.numentries++
@@ -152,9 +153,10 @@ func (m *indexMap) newEntry() *indexEntry {
 }
 
 type indexEntry struct {
-	id        restic.ID
-	next      *indexEntry
-	packIndex int // Position in containing Index's packs field.
-	offset    uint32
-	length    uint32
+	id                 restic.ID
+	next               *indexEntry
+	packIndex          int // Position in containing Index's packs field.
+	offset             uint32
+	length             uint32
+	uncompressedLength uint32
 }

--- a/internal/repository/indexmap_test.go
+++ b/internal/repository/indexmap_test.go
@@ -22,7 +22,7 @@ func TestIndexMapBasic(t *testing.T) {
 		r.Read(id[:])
 		rtest.Assert(t, m.get(id) == nil, "%v retrieved but not added", id)
 
-		m.add(id, 0, 0, 0)
+		m.add(id, 0, 0, 0, 0)
 		rtest.Assert(t, m.get(id) != nil, "%v added but not retrieved", id)
 		rtest.Equals(t, uint(i), m.len())
 	}
@@ -41,7 +41,7 @@ func TestIndexMapForeach(t *testing.T) {
 	for i := 0; i < N; i++ {
 		var id restic.ID
 		id[0] = byte(i)
-		m.add(id, i, uint32(i), uint32(i))
+		m.add(id, i, uint32(i), uint32(i), uint32(i/2))
 	}
 
 	seen := make(map[int]struct{})
@@ -51,6 +51,7 @@ func TestIndexMapForeach(t *testing.T) {
 		rtest.Equals(t, i, e.packIndex)
 		rtest.Equals(t, i, int(e.length))
 		rtest.Equals(t, i, int(e.offset))
+		rtest.Equals(t, i/2, int(e.uncompressedLength))
 
 		seen[i] = struct{}{}
 		return true
@@ -85,13 +86,13 @@ func TestIndexMapForeachWithID(t *testing.T) {
 
 	// Test insertion and retrieval of duplicates.
 	for i := 0; i < ndups; i++ {
-		m.add(id, i, 0, 0)
+		m.add(id, i, 0, 0, 0)
 	}
 
 	for i := 0; i < 100; i++ {
 		var otherid restic.ID
 		r.Read(otherid[:])
-		m.add(otherid, -1, 0, 0)
+		m.add(otherid, -1, 0, 0, 0)
 	}
 
 	n = 0
@@ -109,7 +110,7 @@ func TestIndexMapForeachWithID(t *testing.T) {
 
 func BenchmarkIndexMapHash(b *testing.B) {
 	var m indexMap
-	m.add(restic.ID{}, 0, 0, 0) // Trigger lazy initialization.
+	m.add(restic.ID{}, 0, 0, 0, 0) // Trigger lazy initialization.
 
 	ids := make([]restic.ID, 128) // 4 KiB.
 	r := rand.New(rand.NewSource(time.Now().UnixNano()))

--- a/internal/repository/master_index_test.go
+++ b/internal/repository/master_index_test.go
@@ -30,9 +30,10 @@ func TestMasterIndex(t *testing.T) {
 	blob2 := restic.PackedBlob{
 		PackID: restic.NewRandomID(),
 		Blob: restic.Blob{
-			BlobHandle: bhInIdx2,
-			Length:     uint(restic.CiphertextLength(100)),
-			Offset:     10,
+			BlobHandle:         bhInIdx2,
+			Length:             uint(restic.CiphertextLength(100)),
+			Offset:             10,
+			UncompressedLength: 200,
 		},
 	}
 
@@ -48,9 +49,10 @@ func TestMasterIndex(t *testing.T) {
 	blob12b := restic.PackedBlob{
 		PackID: restic.NewRandomID(),
 		Blob: restic.Blob{
-			BlobHandle: bhInIdx12,
-			Length:     uint(restic.CiphertextLength(123)),
-			Offset:     50,
+			BlobHandle:         bhInIdx12,
+			Length:             uint(restic.CiphertextLength(123)),
+			Offset:             50,
+			UncompressedLength: 80,
 		},
 	}
 
@@ -86,7 +88,7 @@ func TestMasterIndex(t *testing.T) {
 
 	size, found = mIdx.LookupSize(bhInIdx2)
 	rtest.Equals(t, true, found)
-	rtest.Equals(t, uint(100), size)
+	rtest.Equals(t, uint(200), size)
 
 	// test idInIdx12
 	found = mIdx.Has(bhInIdx12)
@@ -144,9 +146,10 @@ func TestMasterMergeFinalIndexes(t *testing.T) {
 	blob2 := restic.PackedBlob{
 		PackID: restic.NewRandomID(),
 		Blob: restic.Blob{
-			BlobHandle: bhInIdx2,
-			Length:     100,
-			Offset:     10,
+			BlobHandle:         bhInIdx2,
+			Length:             100,
+			Offset:             10,
+			UncompressedLength: 200,
 		},
 	}
 

--- a/internal/repository/master_index_test.go
+++ b/internal/repository/master_index_test.go
@@ -335,8 +335,8 @@ var (
 	depth        = 3
 )
 
-func createFilledRepo(t testing.TB, snapshots int, dup float32) (restic.Repository, func()) {
-	repo, cleanup := repository.TestRepository(t)
+func createFilledRepo(t testing.TB, snapshots int, dup float32, version uint) (restic.Repository, func()) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
 
 	for i := 0; i < 3; i++ {
 		restic.TestCreateSnapshot(t, repo, snapshotTime.Add(time.Duration(i)*time.Second), depth, dup)
@@ -346,7 +346,11 @@ func createFilledRepo(t testing.TB, snapshots int, dup float32) (restic.Reposito
 }
 
 func TestIndexSave(t *testing.T) {
-	repo, cleanup := createFilledRepo(t, 3, 0)
+	repository.TestAllVersions(t, testIndexSave)
+}
+
+func testIndexSave(t *testing.T, version uint) {
+	repo, cleanup := createFilledRepo(t, 3, 0, version)
 	defer cleanup()
 
 	err := repo.LoadIndex(context.TODO())

--- a/internal/repository/packer_manager_test.go
+++ b/internal/repository/packer_manager_test.go
@@ -70,7 +70,7 @@ func fillPacks(t testing.TB, rnd *rand.Rand, be Saver, pm *packerManager, buf []
 		// Only change a few bytes so we know we're not benchmarking the RNG.
 		rnd.Read(buf[:min(l, 4)])
 
-		n, err := packer.Add(restic.DataBlob, id, buf)
+		n, err := packer.Add(restic.DataBlob, id, buf, 0)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -212,7 +212,11 @@ func reloadIndex(t *testing.T, repo restic.Repository) {
 }
 
 func TestRepack(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
+	repository.TestAllVersions(t, testRepack)
+}
+
+func testRepack(t *testing.T, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
 	defer cleanup()
 
 	seed := time.Now().UnixNano()
@@ -279,9 +283,13 @@ func TestRepack(t *testing.T) {
 }
 
 func TestRepackCopy(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
+	repository.TestAllVersions(t, testRepackCopy)
+}
+
+func testRepackCopy(t *testing.T, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
 	defer cleanup()
-	dstRepo, dstCleanup := repository.TestRepository(t)
+	dstRepo, dstCleanup := repository.TestRepositoryWithVersion(t, version)
 	defer dstCleanup()
 
 	seed := time.Now().UnixNano()
@@ -318,7 +326,11 @@ func TestRepackCopy(t *testing.T) {
 }
 
 func TestRepackWrongBlob(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
+	repository.TestAllVersions(t, testRepackWrongBlob)
+}
+
+func testRepackWrongBlob(t *testing.T, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
 	defer cleanup()
 
 	seed := time.Now().UnixNano()

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -439,7 +439,7 @@ func (r *Repository) decompressUnpacked(p []byte) ([]byte, error) {
 		return p, nil
 	}
 
-	if len(p) < 1 {
+	if len(p) == 0 {
 		// too short for version header
 		return p, nil
 	}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -1021,9 +1021,8 @@ func StreamPack(ctx context.Context, beLoad BackendLoadFn, key *crypto.Key, pack
 			nonce, ciphertext := buf[:key.NonceSize()], buf[key.NonceSize():]
 			plaintext, err := key.Open(ciphertext[:0], nonce, ciphertext, nil)
 			if err == nil && entry.IsCompressed() {
-				if cap(decode) < int(entry.DataLength()) {
-					decode = make([]byte, 0, entry.DataLength())
-				}
+				// DecodeAll will allocate a slice if it is not large enough since it
+				// knows the decompressed size (because we're using EncodeAll)
 				decode, err = dec.DecodeAll(plaintext, decode[:0])
 				plaintext = decode
 				if err != nil {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -661,7 +661,15 @@ func (r *Repository) SearchKey(ctx context.Context, password string, maxKeys int
 
 // Init creates a new master key with the supplied password, initializes and
 // saves the repository config.
-func (r *Repository) Init(ctx context.Context, password string, chunkerPolynomial *chunker.Pol) error {
+func (r *Repository) Init(ctx context.Context, version uint, password string, chunkerPolynomial *chunker.Pol) error {
+	if version > restic.MaxRepoVersion {
+		return fmt.Errorf("repo version %v too high", version)
+	}
+
+	if version < restic.MinRepoVersion {
+		return fmt.Errorf("repo version %v too low", version)
+	}
+
 	has, err := r.be.Test(ctx, restic.Handle{Type: restic.ConfigFile})
 	if err != nil {
 		return err
@@ -670,7 +678,7 @@ func (r *Repository) Init(ctx context.Context, password string, chunkerPolynomia
 		return errors.New("repository master key and config already initialized")
 	}
 
-	cfg, err := restic.CreateConfig()
+	cfg, err := restic.CreateConfig(version)
 	if err != nil {
 		return err
 	}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -698,6 +698,9 @@ func (r *Repository) SearchKey(ctx context.Context, password string, maxKeys int
 	} else if err != nil {
 		return errors.Fatalf("config cannot be loaded: %v", err)
 	}
+	if r.Config().Version >= 2 {
+		r.idx.markCompressed()
+	}
 	return nil
 }
 

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -28,7 +28,11 @@ var testSizes = []int{5, 23, 2<<18 + 23, 1 << 20}
 var rnd = rand.New(rand.NewSource(time.Now().UnixNano()))
 
 func TestSave(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
+	repository.TestAllVersions(t, testSave)
+}
+
+func testSave(t *testing.T, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
 	defer cleanup()
 
 	for _, size := range testSizes {
@@ -63,7 +67,11 @@ func TestSave(t *testing.T) {
 }
 
 func TestSaveFrom(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
+	repository.TestAllVersions(t, testSaveFrom)
+}
+
+func testSaveFrom(t *testing.T, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
 	defer cleanup()
 
 	for _, size := range testSizes {
@@ -96,7 +104,11 @@ func TestSaveFrom(t *testing.T) {
 }
 
 func BenchmarkSaveAndEncrypt(t *testing.B) {
-	repo, cleanup := repository.TestRepository(t)
+	repository.BenchmarkAllVersions(t, benchmarkSaveAndEncrypt)
+}
+
+func benchmarkSaveAndEncrypt(t *testing.B, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
 	defer cleanup()
 
 	size := 4 << 20 // 4MiB
@@ -118,7 +130,11 @@ func BenchmarkSaveAndEncrypt(t *testing.B) {
 }
 
 func TestLoadTree(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
+	repository.TestAllVersions(t, testLoadTree)
+}
+
+func testLoadTree(t *testing.T, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
 	defer cleanup()
 
 	if rtest.BenchArchiveDirectory == "" {
@@ -134,7 +150,11 @@ func TestLoadTree(t *testing.T) {
 }
 
 func BenchmarkLoadTree(t *testing.B) {
-	repo, cleanup := repository.TestRepository(t)
+	repository.BenchmarkAllVersions(t, benchmarkLoadTree)
+}
+
+func benchmarkLoadTree(t *testing.B, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
 	defer cleanup()
 
 	if rtest.BenchArchiveDirectory == "" {
@@ -154,7 +174,11 @@ func BenchmarkLoadTree(t *testing.B) {
 }
 
 func TestLoadBlob(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
+	repository.TestAllVersions(t, testLoadBlob)
+}
+
+func testLoadBlob(t *testing.T, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
 	defer cleanup()
 
 	length := 1000000
@@ -183,7 +207,11 @@ func TestLoadBlob(t *testing.T) {
 }
 
 func BenchmarkLoadBlob(b *testing.B) {
-	repo, cleanup := repository.TestRepository(b)
+	repository.BenchmarkAllVersions(b, benchmarkLoadBlob)
+}
+
+func benchmarkLoadBlob(b *testing.B, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(b, version)
 	defer cleanup()
 
 	length := 1000000
@@ -219,7 +247,11 @@ func BenchmarkLoadBlob(b *testing.B) {
 }
 
 func BenchmarkLoadUnpacked(b *testing.B) {
-	repo, cleanup := repository.TestRepository(b)
+	repository.BenchmarkAllVersions(b, benchmarkLoadUnpacked)
+}
+
+func benchmarkLoadUnpacked(b *testing.B, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(b, version)
 	defer cleanup()
 
 	length := 1000000
@@ -255,7 +287,11 @@ func BenchmarkLoadUnpacked(b *testing.B) {
 }
 
 func TestLoadJSONUnpacked(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
+	repository.TestAllVersions(t, testLoadJSONUnpacked)
+}
+
+func testLoadJSONUnpacked(t *testing.T, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
 	defer cleanup()
 
 	if rtest.BenchArchiveDirectory == "" {
@@ -313,9 +349,13 @@ func loadIndex(ctx context.Context, repo restic.Repository, id restic.ID) (*repo
 }
 
 func BenchmarkLoadIndex(b *testing.B) {
+	repository.BenchmarkAllVersions(b, benchmarkLoadIndex)
+}
+
+func benchmarkLoadIndex(b *testing.B, version uint) {
 	repository.TestUseLowSecurityKDFParameters(b)
 
-	repo, cleanup := repository.TestRepository(b)
+	repo, cleanup := repository.TestRepositoryWithVersion(b, version)
 	defer cleanup()
 
 	idx := repository.NewIndex()
@@ -362,7 +402,11 @@ func saveRandomDataBlobs(t testing.TB, repo restic.Repository, num int, sizeMax 
 }
 
 func TestRepositoryIncrementalIndex(t *testing.T) {
-	r, cleanup := repository.TestRepository(t)
+	repository.TestAllVersions(t, testRepositoryIncrementalIndex)
+}
+
+func testRepositoryIncrementalIndex(t *testing.T, version uint) {
+	r, cleanup := repository.TestRepositoryWithVersion(t, version)
 	defer cleanup()
 
 	repo := r.(*repository.Repository)

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -367,7 +367,7 @@ func TestRepositoryIncrementalIndex(t *testing.T) {
 
 	repo := r.(*repository.Repository)
 
-	repository.IndexFull = func(*repository.Index) bool { return true }
+	repository.IndexFull = func(*repository.Index, bool) bool { return true }
 
 	// add 15 packs
 	for j := 0; j < 5; j++ {

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -51,7 +51,7 @@ func TestRepositoryWithBackend(t testing.TB, be restic.Backend) (r restic.Reposi
 		be, beCleanup = TestBackend(t)
 	}
 
-	repo := New(be)
+	repo := New(be, Options{})
 
 	cfg := restic.TestCreateConfig(t, TestChunkerPol)
 	err := repo.init(context.TODO(), test.TestPassword, cfg)
@@ -98,7 +98,7 @@ func TestOpenLocal(t testing.TB, dir string) (r restic.Repository) {
 		t.Fatal(err)
 	}
 
-	repo := New(be)
+	repo := New(be, Options{})
 	err = repo.SearchKey(context.TODO(), test.TestPassword, 10, "")
 	if err != nil {
 		t.Fatal(err)

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -2,6 +2,7 @@ package repository
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -41,7 +42,7 @@ const TestChunkerPol = chunker.Pol(0x3DA3358B4DC173)
 // TestRepositoryWithBackend returns a repository initialized with a test
 // password. If be is nil, an in-memory backend is used. A constant polynomial
 // is used for the chunker and low-security test parameters.
-func TestRepositoryWithBackend(t testing.TB, be restic.Backend) (r restic.Repository, cleanup func()) {
+func TestRepositoryWithBackend(t testing.TB, be restic.Backend, version uint) (r restic.Repository, cleanup func()) {
 	t.Helper()
 	TestUseLowSecurityKDFParameters(t)
 	restic.TestDisableCheckPolynomial(t)
@@ -53,7 +54,7 @@ func TestRepositoryWithBackend(t testing.TB, be restic.Backend) (r restic.Reposi
 
 	repo := New(be, Options{})
 
-	cfg := restic.TestCreateConfig(t, TestChunkerPol)
+	cfg := restic.TestCreateConfig(t, TestChunkerPol, version)
 	err := repo.init(context.TODO(), test.TestPassword, cfg)
 	if err != nil {
 		t.Fatalf("TestRepository(): initialize repo failed: %v", err)
@@ -72,6 +73,11 @@ func TestRepositoryWithBackend(t testing.TB, be restic.Backend) (r restic.Reposi
 // instead. The directory is not removed, but left there for inspection.
 func TestRepository(t testing.TB) (r restic.Repository, cleanup func()) {
 	t.Helper()
+	return TestRepositoryWithVersion(t, 0)
+}
+
+func TestRepositoryWithVersion(t testing.TB, version uint) (r restic.Repository, cleanup func()) {
+	t.Helper()
 	dir := os.Getenv("RESTIC_TEST_REPO")
 	if dir != "" {
 		_, err := os.Stat(dir)
@@ -80,7 +86,7 @@ func TestRepository(t testing.TB) (r restic.Repository, cleanup func()) {
 			if err != nil {
 				t.Fatalf("error creating local backend at %v: %v", dir, err)
 			}
-			return TestRepositoryWithBackend(t, be)
+			return TestRepositoryWithBackend(t, be, version)
 		}
 
 		if err == nil {
@@ -88,7 +94,7 @@ func TestRepository(t testing.TB) (r restic.Repository, cleanup func()) {
 		}
 	}
 
-	return TestRepositoryWithBackend(t, nil)
+	return TestRepositoryWithBackend(t, nil, version)
 }
 
 // TestOpenLocal opens a local repository.
@@ -105,4 +111,24 @@ func TestOpenLocal(t testing.TB, dir string) (r restic.Repository) {
 	}
 
 	return repo
+}
+
+type VersionedTest func(t *testing.T, version uint)
+
+func TestAllVersions(t *testing.T, test VersionedTest) {
+	for version := restic.MinRepoVersion; version <= restic.MaxRepoVersion; version++ {
+		t.Run(fmt.Sprintf("v%d", version), func(t *testing.T) {
+			test(t, uint(version))
+		})
+	}
+}
+
+type VersionedBenchmark func(b *testing.B, version uint)
+
+func BenchmarkAllVersions(b *testing.B, bench VersionedBenchmark) {
+	for version := restic.MinRepoVersion; version <= restic.MaxRepoVersion; version++ {
+		b.Run(fmt.Sprintf("v%d", version), func(b *testing.B) {
+			bench(b, uint(version))
+		})
+	}
 }

--- a/internal/restic/blob.go
+++ b/internal/restic/blob.go
@@ -9,13 +9,25 @@ import (
 // Blob is one part of a file or a tree.
 type Blob struct {
 	BlobHandle
-	Length uint
-	Offset uint
+	Length             uint
+	Offset             uint
+	UncompressedLength uint
 }
 
 func (b Blob) String() string {
-	return fmt.Sprintf("<Blob (%v) %v, offset %v, length %v>",
-		b.Type, b.ID.Str(), b.Offset, b.Length)
+	return fmt.Sprintf("<Blob (%v) %v, offset %v, length %v, uncompressed length %v>",
+		b.Type, b.ID.Str(), b.Offset, b.Length, b.UncompressedLength)
+}
+
+func (b Blob) DataLength() uint {
+	if b.UncompressedLength != 0 {
+		return b.UncompressedLength
+	}
+	return uint(PlaintextLength(int(b.Length)))
+}
+
+func (b Blob) IsCompressed() bool {
+	return b.UncompressedLength != 0
 }
 
 // PackedBlob is a blob stored within a file.

--- a/internal/restic/config.go
+++ b/internal/restic/config.go
@@ -18,9 +18,12 @@ type Config struct {
 	ChunkerPolynomial chunker.Pol `json:"chunker_polynomial"`
 }
 
-// RepoVersion is the version that is written to the config when a repository
+const MinRepoVersion = 1
+const MaxRepoVersion = 2
+
+// StableRepoVersion is the version that is written to the config when a repository
 // is newly created with Init().
-const RepoVersion = 1
+const StableRepoVersion = 1
 
 // JSONUnpackedLoader loads unpacked JSON.
 type JSONUnpackedLoader interface {
@@ -29,7 +32,7 @@ type JSONUnpackedLoader interface {
 
 // CreateConfig creates a config file with a randomly selected polynomial and
 // ID.
-func CreateConfig() (Config, error) {
+func CreateConfig(version uint) (Config, error) {
 	var (
 		err error
 		cfg Config
@@ -41,7 +44,7 @@ func CreateConfig() (Config, error) {
 	}
 
 	cfg.ID = NewRandomID().String()
-	cfg.Version = RepoVersion
+	cfg.Version = version
 
 	debug.Log("New config: %#v", cfg)
 	return cfg, nil
@@ -52,7 +55,7 @@ func TestCreateConfig(t testing.TB, pol chunker.Pol) (cfg Config) {
 	cfg.ChunkerPolynomial = pol
 
 	cfg.ID = NewRandomID().String()
-	cfg.Version = RepoVersion
+	cfg.Version = StableRepoVersion
 
 	return cfg
 }
@@ -77,7 +80,7 @@ func LoadConfig(ctx context.Context, r JSONUnpackedLoader) (Config, error) {
 		return Config{}, err
 	}
 
-	if cfg.Version != RepoVersion {
+	if cfg.Version < MinRepoVersion || cfg.Version > MaxRepoVersion {
 		return Config{}, errors.Errorf("unsupported repository version %v", cfg.Version)
 	}
 

--- a/internal/restic/config.go
+++ b/internal/restic/config.go
@@ -51,11 +51,17 @@ func CreateConfig(version uint) (Config, error) {
 }
 
 // TestCreateConfig creates a config for use within tests.
-func TestCreateConfig(t testing.TB, pol chunker.Pol) (cfg Config) {
+func TestCreateConfig(t testing.TB, pol chunker.Pol, version uint) (cfg Config) {
 	cfg.ChunkerPolynomial = pol
 
 	cfg.ID = NewRandomID().String()
-	cfg.Version = StableRepoVersion
+	if version == 0 {
+		version = StableRepoVersion
+	}
+	if version < MinRepoVersion || version > MaxRepoVersion {
+		t.Fatalf("version %d is out of range", version)
+	}
+	cfg.Version = version
 
 	return cfg
 }

--- a/internal/restic/config_test.go
+++ b/internal/restic/config_test.go
@@ -32,7 +32,7 @@ func TestConfig(t *testing.T) {
 		return restic.ID{}, nil
 	}
 
-	cfg1, err := restic.CreateConfig()
+	cfg1, err := restic.CreateConfig(restic.MaxRepoVersion)
 	rtest.OK(t, err)
 
 	_, err = saver(save).SaveJSONUnpacked(restic.ConfigFile, cfg1)

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -117,7 +117,7 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 		err := r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob) {
 			if largeFile {
 				packsMap[packID] = append(packsMap[packID], fileBlobInfo{id: blob.ID, offset: fileOffset})
-				fileOffset += int64(restic.PlaintextLength(int(blob.Length)))
+				fileOffset += int64(blob.DataLength())
 			}
 			pack, ok := packs[packID]
 			if !ok {
@@ -195,7 +195,7 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 				if packID.Equal(pack.id) {
 					addBlob(blob, fileOffset)
 				}
-				fileOffset += int64(restic.PlaintextLength(int(blob.Length)))
+				fileOffset += int64(blob.DataLength())
 			})
 			if err != nil {
 				// restoreFiles should have caught this error before


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR implements support for compression in restic. The repository format description was updated to reflect the changes necessary to support compressed data in a repository.

In a nutshell, pack files now support compressed variants of tree and data blobs which have been added as a straightforward extension of the current pack header format. Internally, compressed and uncompressed blobs are treated equivalently, the only difference is how they are stored in a pack file. This removes the need for far reaching modifications to support compression in every part of restic.

Unpacked files likes lock, index and snapshot files are also compressed before encryption. The compressed plaintext starts with a null byte and version byte to allow restic to determine whether an unpacked file is compressed or not. The null byte was chosen as marker for the new format as valid JSON cannot start with a null byte.

The `init` command now includes a flag `--repository-version` which allows users to select the repository format version. Besides numerical values (`1` == old format, and `2` == compression support) two special values `latest` and `stable` are supported. The purpose of them it to allow users to easily opt-in to all new features while allowing us to update the default repository format used to create new repositories more conservatively. The default repository format is `stable` which for testing purposes is currently set to version `2`. A design alternative here would be to provide a restic version as alias for a repository version. That would allow users to e.g. set the minimum required restic version to `0.13.0` to get the compression support.

~~The code diff is rather large as it is based on #3513 and #3484 which provide a unified implementation for streaming pack files 
In addition, several commits can be split off into a separate code refactoring PR that can be reviewed separately (although the cleanups are a prerequisite for this PR).~~

The PR is currently in a request for comment state, with at least the following list of TODOs remaining:
- [x] Tests which explicitly test both old and new repository format
- [x] Use old repository version by default for a certain time
- [x] Split basic refactoring into a separate PR
- [x] Decide on whether we want to expose the raw repository version to restic users or just use a minimum required version as proxy
- [x] Document `--repository-version` option
- [x] Future work: Mechanism to upgrade repositories to version 2

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Replaces #2441
Implements a part of #21

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
