### PR TITLE
Report symlink sizes from FUSE mount

### DIFF
--- a/changelog/unreleased/issue-3667
+++ b/changelog/unreleased/issue-3667
@@ -1,0 +1,8 @@
+Bugfix: restic mount now reports symlinks sizes
+
+Symlinks used to have size zero in restic mountpoints, confusing some
+third-party tools. They now have a size equal to the byte length of their
+target path, as required by POSIX.
+
+https://github.com/restic/restic/issues/3667
+https://github.com/restic/restic/pull/3668

--- a/internal/fuse/link.go
+++ b/internal/fuse/link.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || linux
 // +build darwin freebsd linux
 
 package fuse
@@ -40,6 +41,8 @@ func (l *link) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Mtime = l.node.ModTime
 
 	a.Nlink = uint32(l.node.Links)
+	a.Size = uint64(len(l.node.LinkTarget))
+	a.Blocks = 1 + a.Size/blockSize
 
 	return nil
 }

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -440,6 +440,8 @@ func (l *snapshotLink) Readlink(ctx context.Context, req *fuse.ReadlinkRequest) 
 func (l *snapshotLink) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Inode = l.inode
 	a.Mode = os.ModeSymlink | 0777
+	a.Size = uint64(len(l.target))
+	a.Blocks = 1 + a.Size/blockSize
 	a.Uid = l.root.uid
 	a.Gid = l.root.gid
 	a.Atime = l.snapshot.Time


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Restic mount now correctly reports the sizes of symlinks. It also reports a non-zero block count for symlinks, just in case.

I tested it by using an actual mount of one of my backup repos., but I wasn't sure how to unit test this without just repeating the code.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes #3667.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
