### PR TITLE
Refactor file handing for self-update.

### DIFF
--- a/changelog/unreleased/issue-2248
+++ b/changelog/unreleased/issue-2248
@@ -1,0 +1,8 @@
+Bugfix: Support self-update on Windows
+
+Restic self-update would fail in situations where the operating system
+locks running binaries, including Windows. The new behavior works around
+this by renaming the running file and swapping the updated file in place.
+
+https://github.com/restic/restic/issues/2248
+https://github.com/restic/restic/pull/3675

--- a/internal/selfupdate/download_unix.go
+++ b/internal/selfupdate/download_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package selfupdate
+
+// Remove the target binary.
+func removeResticBinary(dir, target string) error {
+	// removed on rename on this platform
+	return nil
+}

--- a/internal/selfupdate/download_windows.go
+++ b/internal/selfupdate/download_windows.go
@@ -1,0 +1,23 @@
+//go:build windows
+// +build windows
+
+package selfupdate
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Rename (rather than remove) the running version. The running binary will be locked
+// on Windows and cannot be removed while still executing.
+func removeResticBinary(dir, target string) error {
+	backup := filepath.Join(dir, filepath.Base(target)+".bak")
+	if _, err := os.Stat(backup); err == nil {
+		_ = os.Remove(backup)
+	}
+	if err := os.Rename(target, backup); err != nil {
+		return fmt.Errorf("unable to rename target file: %v", err)
+	}
+	return nil
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR refactors file handling in self-update to better support existing failure modes.

* New file payloads are written to a temp file before touching the original binary. Minimizes the possibility of failing mid-write and corrupting the binary.
* The original binary is moved out to a temp directory rather than removing it, to avoid the binary being locked on some operating systems. 

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #2248

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [X ] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [X ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [X ] I have added documentation for relevant changes (in the manual).
- [X ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X ] I have run `gofmt` on the code in all commits.
- [X ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [X ] I'm done! This pull request is ready for review.
