### PR TITLE
Fix golangci lint warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,7 +24,7 @@ linters:
     - govet
 
     # make sure names and comments are used according to the conventions
-    - golint
+    - revive
 
     # detect when assignments to existing variables are not used
     - ineffassign
@@ -51,7 +51,7 @@ issues:
 
   # list of things to not warn about
   exclude:
-    # golint: do not warn about missing comments for exported stuff
-    - exported (function|method|var|type|const) `.*` should have comment or be unexported
-    # golint: ignore constants in all caps
+    # revive: do not warn about missing comments for exported stuff
+    - exported (function|method|var|type|const) .* should have comment or be unexported
+    # revive: ignore constants in all caps
     - don't use ALL_CAPS in Go names; use CamelCase

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -1,3 +1,4 @@
+//go:build debug
 // +build debug
 
 package main

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || linux
 // +build darwin freebsd linux
 
 package main

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -37,7 +37,7 @@ import (
 
 	"os/exec"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 var version = "0.13.0-dev (compiled manually)"
@@ -145,13 +145,13 @@ func checkErrno(err error) error {
 }
 
 func stdinIsTerminal() bool {
-	return terminal.IsTerminal(int(os.Stdin.Fd()))
+	return term.IsTerminal(int(os.Stdin.Fd()))
 }
 
 func stdoutIsTerminal() bool {
 	// mintty on windows can use pipes which behave like a posix terminal,
 	// but which are not a terminal handle
-	return terminal.IsTerminal(int(os.Stdout.Fd())) || stdoutCanUpdateStatus()
+	return term.IsTerminal(int(os.Stdout.Fd())) || stdoutCanUpdateStatus()
 }
 
 func stdoutCanUpdateStatus() bool {
@@ -159,7 +159,7 @@ func stdoutCanUpdateStatus() bool {
 }
 
 func stdoutTerminalWidth() int {
-	w, _, err := terminal.GetSize(int(os.Stdout.Fd()))
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
 		return 0
 	}
@@ -172,12 +172,12 @@ func stdoutTerminalWidth() int {
 // program execution must revert changes to the terminal configuration itself.
 // The terminal configuration is only restored while reading a password.
 func restoreTerminal() {
-	if !terminal.IsTerminal(int(os.Stdout.Fd())) {
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
 		return
 	}
 
 	fd := int(os.Stdout.Fd())
-	state, err := terminal.GetState(fd)
+	state, err := term.GetState(fd)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "unable to get terminal state: %v\n", err)
 		return
@@ -192,7 +192,7 @@ func restoreTerminal() {
 		if !isReadingPassword {
 			return nil
 		}
-		err := checkErrno(terminal.Restore(fd, state))
+		err := checkErrno(term.Restore(fd, state))
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "unable to restore terminal state: %v\n", err)
 		}
@@ -322,7 +322,7 @@ func readPassword(in io.Reader) (password string, err error) {
 func readPasswordTerminal(in *os.File, out io.Writer, prompt string) (password string, err error) {
 	fmt.Fprint(out, prompt)
 	isReadingPassword = true
-	buf, err := terminal.ReadPassword(int(in.Fd()))
+	buf, err := term.ReadPassword(int(in.Fd()))
 	isReadingPassword = false
 	fmt.Fprintln(out)
 	if err != nil {

--- a/cmd/restic/global_debug.go
+++ b/cmd/restic/global_debug.go
@@ -1,3 +1,4 @@
+//go:build debug || profile
 // +build debug profile
 
 package main

--- a/cmd/restic/global_release.go
+++ b/cmd/restic/global_release.go
@@ -1,3 +1,4 @@
+//go:build !debug && !profile
 // +build !debug,!profile
 
 package main

--- a/cmd/restic/integration_fuse_test.go
+++ b/cmd/restic/integration_fuse_test.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || linux
 // +build darwin freebsd linux
 
 package main

--- a/cmd/restic/integration_helpers_unix_test.go
+++ b/cmd/restic/integration_helpers_unix_test.go
@@ -1,4 +1,5 @@
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package main
 

--- a/cmd/restic/integration_helpers_windows_test.go
+++ b/cmd/restic/integration_helpers_windows_test.go
@@ -1,4 +1,5 @@
-//+build windows
+//go:build windows
+// +build windows
 
 package main
 

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	golang.org/x/oauth2 v0.0.0-20210628180205-a41e5a781914
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
 	golang.org/x/sys v0.0.0-20210630005230-0f9fa26af87c
+	golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1
 	golang.org/x/text v0.3.6
 	google.golang.org/api v0.50.0
 	gopkg.in/tomb.v2 v2.0.0-20161208151619-d5d1b5820637

--- a/internal/archiver/archiver_unix_test.go
+++ b/internal/archiver/archiver_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package archiver

--- a/internal/archiver/archiver_windows_test.go
+++ b/internal/archiver/archiver_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package archiver

--- a/internal/backend/foreground_sysv.go
+++ b/internal/backend/foreground_sysv.go
@@ -1,3 +1,4 @@
+//go:build aix || solaris
 // +build aix solaris
 
 package backend

--- a/internal/backend/foreground_test.go
+++ b/internal/backend/foreground_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package backend_test

--- a/internal/backend/foreground_unix.go
+++ b/internal/backend/foreground_unix.go
@@ -1,3 +1,4 @@
+//go:build !aix && !solaris && !windows
 // +build !aix,!solaris,!windows
 
 package backend

--- a/internal/backend/local/local_unix.go
+++ b/internal/backend/local/local_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package local

--- a/internal/bloblru/cache.go
+++ b/internal/bloblru/cache.go
@@ -22,7 +22,7 @@ type Cache struct {
 	free, size int // Current and max capacity, in bytes.
 }
 
-// Construct a blob cache that stores at most size bytes worth of blobs.
+// New constructs a blob cache that stores at most size bytes worth of blobs.
 func New(size int) *Cache {
 	c := &Cache{
 		free: size,

--- a/internal/debug/debug.go
+++ b/internal/debug/debug.go
@@ -1,3 +1,4 @@
+//go:build debug
 // +build debug
 
 package debug

--- a/internal/debug/debug_release.go
+++ b/internal/debug/debug_release.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 package debug

--- a/internal/debug/hooks.go
+++ b/internal/debug/hooks.go
@@ -1,3 +1,4 @@
+//go:build debug
 // +build debug
 
 package debug

--- a/internal/debug/hooks_release.go
+++ b/internal/debug/hooks_release.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 package debug

--- a/internal/debug/round_tripper_debug.go
+++ b/internal/debug/round_tripper_debug.go
@@ -1,3 +1,4 @@
+//go:build debug
 // +build debug
 
 package debug

--- a/internal/debug/round_tripper_release.go
+++ b/internal/debug/round_tripper_release.go
@@ -1,3 +1,4 @@
+//go:build !debug
 // +build !debug
 
 package debug

--- a/internal/fs/const_unix.go
+++ b/internal/fs/const_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package fs

--- a/internal/fs/const_windows.go
+++ b/internal/fs/const_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package fs

--- a/internal/fs/deviceid_unix.go
+++ b/internal/fs/deviceid_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package fs

--- a/internal/fs/deviceid_windows.go
+++ b/internal/fs/deviceid_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package fs

--- a/internal/fs/file_unix.go
+++ b/internal/fs/file_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package fs

--- a/internal/fs/fs_local_vss.go
+++ b/internal/fs/fs_local_vss.go
@@ -117,7 +117,7 @@ func (fs *LocalVss) snapshotPath(path string) string {
 			fs.msgMessage("creating VSS snapshot for [%s]\n", vssVolume)
 
 			if snapshot, err := NewVssSnapshot(vssVolume, 120, fs.msgError); err != nil {
-				_ = fs.msgError(vssVolume, errors.Errorf("failed to create snapshot for [%s]: %s\n",
+				_ = fs.msgError(vssVolume, errors.Errorf("failed to create snapshot for [%s]: %s",
 					vssVolume, err))
 				fs.failedSnapshots[volumeNameLower] = struct{}{}
 			} else {

--- a/internal/fs/stat_bsd.go
+++ b/internal/fs/stat_bsd.go
@@ -1,3 +1,4 @@
+//go:build freebsd || darwin || netbsd
 // +build freebsd darwin netbsd
 
 package fs

--- a/internal/fs/stat_unix.go
+++ b/internal/fs/stat_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !darwin && !freebsd && !netbsd
 // +build !windows,!darwin,!freebsd,!netbsd
 
 package fs

--- a/internal/fs/stat_windows.go
+++ b/internal/fs/stat_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package fs

--- a/internal/fs/vss.go
+++ b/internal/fs/vss.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package fs

--- a/internal/fs/vss_windows.go
+++ b/internal/fs/vss_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package fs

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || linux
 // +build darwin freebsd linux
 
 package fuse

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || linux
 // +build darwin freebsd linux
 
 package fuse

--- a/internal/fuse/meta_dir.go
+++ b/internal/fuse/meta_dir.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || linux
 // +build darwin freebsd linux
 
 package fuse

--- a/internal/fuse/other.go
+++ b/internal/fuse/other.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || linux
 // +build darwin freebsd linux
 
 package fuse

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -1,3 +1,4 @@
+//go:build darwin || freebsd || linux
 // +build darwin freebsd linux
 
 package fuse

--- a/internal/limiter/static_limiter_test.go
+++ b/internal/limiter/static_limiter_test.go
@@ -56,7 +56,7 @@ func TestRoundTripperReader(t *testing.T) {
 	_, err := io.ReadFull(rand.Reader, data)
 	test.OK(t, err)
 
-	var send *tracedReadCloser = newTracedReadCloser(bytes.NewReader(data))
+	send := newTracedReadCloser(bytes.NewReader(data))
 	var recv *tracedReadCloser
 
 	rt := limiter.Transport(roundTripper(func(req *http.Request) (*http.Response, error) {

--- a/internal/restic/lock_unix.go
+++ b/internal/restic/lock_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package restic

--- a/internal/restic/mknod_unix.go
+++ b/internal/restic/mknod_unix.go
@@ -1,3 +1,4 @@
+//go:build !freebsd && !windows
 // +build !freebsd,!windows
 
 package restic

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -166,7 +166,7 @@ func (node *Node) CreateAt(ctx context.Context, path string, repo Repository) er
 	case "socket":
 		return nil
 	default:
-		return errors.Errorf("filetype %q not implemented!\n", node.Type)
+		return errors.Errorf("filetype %q not implemented", node.Type)
 	}
 
 	return nil

--- a/internal/restic/node_aix.go
+++ b/internal/restic/node_aix.go
@@ -1,3 +1,4 @@
+//go:build aix
 // +build aix
 
 package restic

--- a/internal/restic/node_freebsd.go
+++ b/internal/restic/node_freebsd.go
@@ -1,3 +1,4 @@
+//go:build freebsd
 // +build freebsd
 
 package restic

--- a/internal/restic/node_unix.go
+++ b/internal/restic/node_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package restic

--- a/internal/restic/node_unix_test.go
+++ b/internal/restic/node_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package restic

--- a/internal/restorer/preallocate_other.go
+++ b/internal/restorer/preallocate_other.go
@@ -1,3 +1,4 @@
+//go:build !linux && !darwin
 // +build !linux,!darwin
 
 package restorer

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -1,4 +1,5 @@
-//+build !windows
+//go:build !windows
+// +build !windows
 
 package restorer
 

--- a/internal/ui/progress/counter_test.go
+++ b/internal/ui/progress/counter_test.go
@@ -61,7 +61,7 @@ func TestCounter(t *testing.T) {
 
 func TestCounterNil(t *testing.T) {
 	// Shouldn't panic.
-	var c *progress.Counter = nil
+	var c *progress.Counter
 	c.Add(1)
 	c.Done()
 }

--- a/internal/ui/signals/signals_bsd.go
+++ b/internal/ui/signals/signals_bsd.go
@@ -1,3 +1,4 @@
+//go:build darwin || dragonfly || freebsd || netbsd || openbsd
 // +build darwin dragonfly freebsd netbsd openbsd
 
 package signals

--- a/internal/ui/signals/signals_sysv.go
+++ b/internal/ui/signals/signals_sysv.go
@@ -1,3 +1,4 @@
+//go:build aix || linux || solaris
 // +build aix linux solaris
 
 package signals

--- a/internal/ui/termstatus/background.go
+++ b/internal/ui/termstatus/background.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package termstatus

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 	"unicode"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	"golang.org/x/text/width"
 )
 
@@ -321,7 +321,7 @@ func (t *Terminal) SetStatus(lines []string) {
 	var width int
 	if t.canUpdateStatus {
 		var err error
-		width, _, err = terminal.GetSize(int(t.fd))
+		width, _, err = term.GetSize(int(t.fd))
 		if err != nil || width <= 0 {
 			// use 80 columns by default
 			width = 80

--- a/internal/ui/termstatus/terminal_unix.go
+++ b/internal/ui/termstatus/terminal_unix.go
@@ -7,7 +7,7 @@ import (
 	"io"
 	"os"
 
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 )
 
 // clearCurrentLine removes all characters from the current line and resets the
@@ -24,7 +24,7 @@ func moveCursorUp(wr io.Writer, fd uintptr) func(io.Writer, uintptr, int) {
 // CanUpdateStatus returns true if status lines can be printed, the process
 // output is not redirected to a file or pipe.
 func CanUpdateStatus(fd uintptr) bool {
-	if !terminal.IsTerminal(int(fd)) {
+	if !term.IsTerminal(int(fd)) {
 		return false
 	}
 	term := os.Getenv("TERM")

--- a/internal/ui/termstatus/terminal_unix.go
+++ b/internal/ui/termstatus/terminal_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package termstatus

--- a/internal/ui/termstatus/terminal_windows.go
+++ b/internal/ui/termstatus/terminal_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package termstatus


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR fixes all warnings currently reported across the code base by golangci-lint.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
