### PR TITLE
Sanitize tags when used as filenames by restic mount

### DIFF
--- a/changelog/unreleased/issue-2907
+++ b/changelog/unreleased/issue-2907
@@ -6,5 +6,10 @@ formatting of the time for a snapshot is now controlled using `--time-template`
 and supports subdirectories to for example group snapshots by year. Please
 refer to the help output of the `mount` command for further details.
 
+Characters in tag names which are not allowed in a filename are replaced by
+underscores `_`. For example a tag `foo/bar` will result in a directory name
+of `foo_bar`.
+
 https://github.com/restic/restic/issues/2907
 https://github.com/restic/restic/pull/2913
+https://github.com/restic/restic/pull/3691

--- a/internal/fuse/snapshots_dirstruct.go
+++ b/internal/fuse/snapshots_dirstruct.go
@@ -97,6 +97,7 @@ func pathsFromSn(pathTemplate string, timeTemplate string, sn *restic.Snapshot) 
 				// needs special treatment: Rebuild the string builders
 				newout := make([]strings.Builder, len(out)*len(sn.Tags))
 				for i, tag := range sn.Tags {
+					tag = filenameFromTag(tag)
 					for j := range out {
 						newout[i*len(out)+j].WriteString(out[j].String() + tag)
 					}
@@ -137,6 +138,24 @@ func pathsFromSn(pathTemplate string, timeTemplate string, sn *restic.Snapshot) 
 	}
 
 	return paths, timeSuffix
+}
+
+// Some tags are problematic when used as filenames:
+//
+//	""
+//	".", ".."
+//	anything containing '/'
+//
+// Replace all special character by underscores "_", an empty tag is also represented as a underscore.
+func filenameFromTag(tag string) string {
+	switch tag {
+	case "", ".":
+		return "_"
+	case "..":
+		return "__"
+	}
+
+	return strings.ReplaceAll(tag, "/", "_")
 }
 
 // determine static path prefix

--- a/internal/fuse/snapshots_dirstruct_test.go
+++ b/internal/fuse/snapshots_dirstruct_test.go
@@ -273,3 +273,19 @@ func TestMakeEmptyDirs(t *testing.T) {
 
 	verifyEntries(t, expNames, expLatest, sds.entries)
 }
+
+func TestFilenameFromTag(t *testing.T) {
+	for _, c := range []struct {
+		tag, filename string
+	}{
+		{"", "_"},
+		{".", "_"},
+		{"..", "__"},
+		{"%.", "%."},
+		{"foo", "foo"},
+		{"foo ", "foo "},
+		{"foo/bar_baz", "foo_bar_baz"},
+	} {
+		test.Equals(t, c.filename, filenameFromTag(c.tag))
+	}
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Draft PR, untested.

Tags that are not valid filenames (and some that are) are now sanitized by restic mount for display in the tags/ directory.

The rule is explained in the comment:

```
// Some tags are problematic when used as filenames:
//
//     ""
//     ".", ".."
//     anything containing '/'
//
// We prepend a '%' to mark these as special, then replace '/' by "%_"
// and '%' by "%%". Because this produces ambiguity when the actual tag
// starts with '%', we do the same to any tag name already starting with '%'.
```

E.g., "foo/bar" becomes "%foo%_bar".

I chose '%' because it should be rare in actual tags and it's not a special character to common shells. The rule is ad hoc, but designed to pass through as many tags unchanged as possible. The resulting filenames are always valid on Linux; to my knowledge, FreeBSD allows the same filenames as Linux; but I didn't really consider MacOS much, which may or may not require valid (normalized?) Unicode filenames.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Should fix #3690, but I haven't tested it yet.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
