### PR TITLE
Cast unix.Statfs_t.Type to int64 when checking for btrfs

### DIFF
--- a/internal/fs/setflags_linux_test.go
+++ b/internal/fs/setflags_linux_test.go
@@ -59,9 +59,13 @@ func supportsNoatime(t *testing.T, f *os.File) bool {
 	err := unix.Fstatfs(int(f.Fd()), &fsinfo)
 	rtest.OK(t, err)
 
-	return fsinfo.Type == unix.BTRFS_SUPER_MAGIC ||
-		fsinfo.Type == unix.EXT2_SUPER_MAGIC ||
-		fsinfo.Type == unix.EXT3_SUPER_MAGIC ||
-		fsinfo.Type == unix.EXT4_SUPER_MAGIC ||
-		fsinfo.Type == unix.TMPFS_MAGIC
+	// The funky cast works around a compiler error on 32-bit archs:
+	// "unix.BTRFS_SUPER_MAGIC (untyped int constant 2435016766) overflows int32".
+	// https://github.com/golang/go/issues/52061
+	typ := int64(uint(fsinfo.Type))
+	return typ == unix.BTRFS_SUPER_MAGIC ||
+		typ == unix.EXT2_SUPER_MAGIC ||
+		typ == unix.EXT3_SUPER_MAGIC ||
+		typ == unix.EXT4_SUPER_MAGIC ||
+		typ == unix.TMPFS_MAGIC
 }


### PR DESCRIPTION
Fixes #3687. Uses the cast suggested by @MichaelEischer, except that the contant isn't cast along, because it's untyped and will be converted by the compiler as necessary.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
