### PR TITLE
Fix rclone (scoop shim) and sftp issue due to detached console on Windows

### DIFF
--- a/changelog/unreleased/issue-3692
+++ b/changelog/unreleased/issue-3692
@@ -1,0 +1,12 @@
+Bugfix: Fix rclone (shimmed by Scoop) and sftp stopped working on Windows
+
+In #3602 a fix was introduced to fix the problem that rclone prematurely exits
+when Ctrl+C is pressed on Windows. The solution was to create the subprocess
+with its console detached from the restic console. However, such solution
+fails when using rclone install by scoop or using sftp with a passphrase-
+protected private key. We've fixed that by using a different approach to prevent
+Ctrl-C from passing down too early.
+
+https://github.com/restic/restic/issues/3681
+https://github.com/restic/restic/issues/3692
+https://github.com/restic/restic/pull/3696

--- a/internal/backend/foreground_windows.go
+++ b/internal/backend/foreground_windows.go
@@ -11,7 +11,7 @@ import (
 func startForeground(cmd *exec.Cmd) (bg func() error, err error) {
 	// just start the process and hope for the best
 	cmd.SysProcAttr = &syscall.SysProcAttr{}
-	cmd.SysProcAttr.CreationFlags = windows.DETACHED_PROCESS
+	cmd.SysProcAttr.CreationFlags = windows.CREATE_NEW_PROCESS_GROUP
 	err = cmd.Start()
 	if err != nil {
 		return nil, errors.Wrap(err, "cmd.Start")


### PR DESCRIPTION
# What does this PR change? What problem does it solve?

In #3602 a fix was introduced to fix the problem that rclone prematurely exits
when Ctrl+C is pressed on Windows. The solution was to create the subprocess
with its console detached from the restic console. However, such solution
proved to be problematic because:

1. If the user is using Scoop to install rclone, the `rclone.exe` actually points to a "shim" executable created by scoop to relocate the exe. However, current it isn't forwarding the redirected stdio streams correctly, therefore the communication between restic and rclone is broken.
2. When using OpenSSH to upload files with SFTP, the private key may need passphrase. Before #3602 was introduced, the passphrase interactive input was based on stderr + `_getwch`. stderr is redirected to restic (therefore to the console), while`_getwch` is not redirected (therefore direct read from the console). However, after #3602 `_getwch` was no longer usable due to the detached console, and there's no easy solution for users.

However, @DRON-666 suggests that we should use `CREATE_NEW_PROCESS_GROUP` instead of `DETACHED_PROCESS` as the creation flag, so the process won't be detached, but the Ctrl+C is still not prematurely passed down, enabling graceful cleanup.

# Was the change previously discussed in an issue or on the forum?

Closes #3681 , closes #3692 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] ~~I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
