### PR TITLE
Print used key name if config fails to load

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -593,7 +593,9 @@ func (r *Repository) SearchKey(ctx context.Context, password string, maxKeys int
 	r.treePM.key = key.master
 	r.keyName = key.Name()
 	r.cfg, err = restic.LoadConfig(ctx, r)
-	if err != nil {
+	if err == crypto.ErrUnauthenticated {
+		return errors.Fatalf("config or key %v is damaged: %v", key.Name(), err)
+	} else if err != nil {
 		return errors.Fatalf("config cannot be loaded: %v", err)
 	}
 	return nil


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Extend the error message printed when restic fails to decrypt the repository config. It now also includes the ID of the used key:
`Fatal: config or key b34cae616d49e7caaa60918abd4906139e5e2502a6dfb6d08076547ab6bd7bda is damaged: ciphertext verification failed`

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3430

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
