### PR TITLE
doc: fix missing "init" in rest-server example

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -167,7 +167,7 @@ scheme like this:
 
 .. code-block:: console
 
-    $ restic -r rest:http://host:8000/
+    $ restic -r rest:http://host:8000/ init
 
 Depending on your REST server setup, you can use HTTPS protocol,
 password protection, multiple repositories or any combination of
@@ -176,9 +176,9 @@ are some more examples:
 
 .. code-block:: console
 
-    $ restic -r rest:https://host:8000/
-    $ restic -r rest:https://user:pass@host:8000/
-    $ restic -r rest:https://user:pass@host:8000/my_backup_repo/
+    $ restic -r rest:https://host:8000/ init
+    $ restic -r rest:https://user:pass@host:8000/ init
+    $ restic -r rest:https://user:pass@host:8000/my_backup_repo/ init
 
 If you use TLS, restic will use the system's CA certificates to verify the
 server certificate. When the verification fails, restic refuses to proceed and


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

In the documentation of "Preparing a new repository" the section for rest-server misses the "init" in the command.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No

Checklist
---------

- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [X] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [X] I'm done! This pull request is ready for review.
