### PR TITLE
Print password error message on stderr

### DIFF
--- a/changelog/unreleased/pull-3716
+++ b/changelog/unreleased/pull-3716
@@ -1,0 +1,7 @@
+Bugfix: Print "wrong password" error on stderr
+
+If a wrong password was entered, the error message was printed on stdout and
+not on stderr as intended. This has been fixed.
+
+https://github.com/restic/restic/pull/3716
+https://forum.restic.net/t/should-error-messages-end-up-in-output-file-when-redirecting-dump-to-stdout/4965

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -455,7 +455,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 		err = s.SearchKey(opts.ctx, opts.password, maxKeys, opts.KeyHint)
 		if err != nil && passwordTriesLeft > 1 {
 			opts.password = ""
-			fmt.Printf("%s. Try again\n", err)
+			fmt.Fprintf(os.Stderr, "%s. Try again\n", err)
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
As reported in https://forum.restic.net/t/should-error-messages-end-up-in-output-file-when-redirecting-dump-to-stdout/4965 , restic prints the "wrong password or no key found" error on stdout. This is a problem when redirecting stdout e.g. for the `dump` command.

Thus print the error on stderr, this is also more consistent with the passord prompt itself which is already printed on stderr.

Although the change is minimal, I've added a changelog entry as this could affect some wrapper scripts.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://forum.restic.net/t/should-error-messages-end-up-in-output-file-when-redirecting-dump-to-stdout/4965

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
