### PR TITLE
doc: sftp with password actually works

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -67,9 +67,9 @@ SFTP
 ****
 
 In order to backup data via SFTP, you must first set up a server with
-SSH and let it know your public key. Passwordless login is really
-important since restic fails to connect to the repository if the server
-prompts for credentials.
+SSH and let it know your public key. Passwordless login is important
+since automatic backups are not possible if the server prompts for
+credentials.
 
 Once the server is configured, the setup of the SFTP repository can
 simply be achieved by changing the URL scheme in the ``init`` command:
@@ -148,7 +148,7 @@ SFTP connection, you can specify the command to be run with the option
 .. note:: Please be aware that sftp servers close connections when no data is
           received by the client. This can happen when restic is processing huge
           amounts of unchanged data. To avoid this issue add the following lines 
-          to the client’s .ssh/config file:
+          to the client's .ssh/config file:
 
 ::
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The documentation claims that SFTP does not work if the server asks for a password. However, that is just wrong, a user can type in the password if running restic interactively. A ssh-key based login is only required for automated backups.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- ~~[ ] I have run `gofmt` on the code in all commits.~~
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
