### PR TITLE
Let `check` warn about legacy variants of the repo format version 1

### DIFF
--- a/changelog/unreleased/issue-3295
+++ b/changelog/unreleased/issue-3295
@@ -1,0 +1,12 @@
+Change: Deprecate `check --check-unused` and add further checks
+
+Since restic 0.12.0, it is expected to still have unused blobs after running
+`prune`. This made the `check --check-unused` rather useless and tended to
+confuse users. The options has been deprecated and is now ignored.
+
+`check` now also warns if a repository is using either the legacy S3 layout or
+mixed pack files with both tree and data blobs. The latter is known to cause
+performance problems.
+
+https://github.com/restic/restic/issues/3295
+https://github.com/restic/restic/pull/3730

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -221,11 +221,15 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 
 	errorsFound := false
 	suggestIndexRebuild := false
+	mixedFound := false
 	for _, hint := range hints {
 		switch hint.(type) {
 		case *checker.ErrDuplicatePacks, *checker.ErrOldIndexFormat:
 			Printf("%v\n", hint)
 			suggestIndexRebuild = true
+		case *checker.ErrMixedPack:
+			Printf("%v\n", hint)
+			mixedFound = true
 		default:
 			Warnf("error: %v\n", hint)
 			errorsFound = true
@@ -234,6 +238,9 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 
 	if suggestIndexRebuild {
 		Printf("This is non-critical, you can run `restic rebuild-index' to correct this\n")
+	}
+	if mixedFound {
+		Printf("Mixed packs with tree and data blobs are non-critical, you can run `restic prune` to correct this.\n")
 	}
 
 	if len(errs) > 0 {

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -260,10 +260,12 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 		if checker.IsOrphanedPack(err) {
 			orphanedPacks++
 			Verbosef("%v\n", err)
-			continue
+		} else if _, ok := err.(*checker.ErrLegacyLayout); ok {
+			Verbosef("repository still uses the S3 legacy layout\nPlease run `restic migrate s3legacy` to correct this.\n")
+		} else {
+			errorsFound = true
+			Warnf("%v\n", err)
 		}
-		errorsFound = true
-		Warnf("error: %v\n", err)
 	}
 
 	if orphanedPacks > 0 {

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -57,7 +57,13 @@ func init() {
 	f := cmdCheck.Flags()
 	f.BoolVar(&checkOptions.ReadData, "read-data", false, "read all data blobs")
 	f.StringVar(&checkOptions.ReadDataSubset, "read-data-subset", "", "read a `subset` of data packs, specified as 'n/t' for specific part, or either 'x%' or 'x.y%' or a size in bytes with suffixes k/K, m/M, g/G, t/T for a random subset")
-	f.BoolVar(&checkOptions.CheckUnused, "check-unused", false, "find unused blobs")
+	var ignored bool
+	f.BoolVar(&ignored, "check-unused", false, "find unused blobs")
+	err := f.MarkDeprecated("check-unused", "`--check-unused` is deprecated and will be ignored")
+	if err != nil {
+		// MarkDeprecated only returns an error when the flag is not found
+		panic(err)
+	}
 	f.BoolVar(&checkOptions.WithCache, "with-cache", false, "use the cache")
 }
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -14,6 +14,7 @@ import (
 	"github.com/minio/sha256-simd"
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/s3"
+	"github.com/restic/restic/internal/cache"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/hashing"
@@ -193,6 +194,11 @@ func IsOrphanedPack(err error) bool {
 }
 
 func isS3Legacy(b restic.Backend) bool {
+	// unwrap cache
+	if be, ok := b.(*cache.Backend); ok {
+		b = be.Backend
+	}
+
 	be, ok := b.(*s3.Backend)
 	if !ok {
 		return false

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -66,6 +66,15 @@ func (e *ErrDuplicatePacks) Error() string {
 	return fmt.Sprintf("pack %v contained in several indexes: %v", e.PackID, e.Indexes)
 }
 
+// ErrMixedPack is returned when a pack is found that contains both tree and data blobs.
+type ErrMixedPack struct {
+	PackID restic.ID
+}
+
+func (e *ErrMixedPack) Error() string {
+	return fmt.Sprintf("pack %v contains a mix of tree and data blobs", e.PackID.Str())
+}
+
 // ErrOldIndexFormat is returned when an index with the old format is
 // found.
 type ErrOldIndexFormat struct {
@@ -139,6 +148,11 @@ func (c *Checker) LoadIndex(ctx context.Context) (hints []error, errs []error) {
 			hints = append(hints, &ErrDuplicatePacks{
 				PackID:  packID,
 				Indexes: packToIndex[packID],
+			})
+		}
+		if c.masterIndex.IsMixedPack(packID) {
+			hints = append(hints, &ErrMixedPack{
+				PackID: packID,
 			})
 		}
 	}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/minio/sha256-simd"
 	"github.com/restic/restic/internal/backend"
+	"github.com/restic/restic/internal/backend/s3"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/hashing"
@@ -54,6 +55,13 @@ func New(repo restic.Repository, trackUnused bool) *Checker {
 	c.blobRefs.M = restic.NewBlobSet()
 
 	return c
+}
+
+// ErrLegacyLayout is returned when the repository uses the S3 legacy layout.
+type ErrLegacyLayout struct{}
+
+func (e *ErrLegacyLayout) Error() string {
+	return "repository uses S3 legacy layout"
 }
 
 // ErrDuplicatePacks is returned when a pack is found in more than one index.
@@ -184,11 +192,24 @@ func IsOrphanedPack(err error) bool {
 	return errors.As(err, &e) && e.Orphaned
 }
 
+func isS3Legacy(b restic.Backend) bool {
+	be, ok := b.(*s3.Backend)
+	if !ok {
+		return false
+	}
+
+	return be.Layout.Name() == "s3legacy"
+}
+
 // Packs checks that all packs referenced in the index are still available and
 // there are no packs that aren't in an index. errChan is closed after all
 // packs have been checked.
 func (c *Checker) Packs(ctx context.Context, errChan chan<- error) {
 	defer close(errChan)
+
+	if isS3Legacy(c.repo.Backend()) {
+		errChan <- &ErrLegacyLayout{}
+	}
 
 	debug.Log("checking for %d packs", len(c.packs))
 

--- a/internal/migrations/s3_layout.go
+++ b/internal/migrations/s3_layout.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/s3"
+	"github.com/restic/restic/internal/cache"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
@@ -21,10 +22,25 @@ func init() {
 // "default" layout.
 type S3Layout struct{}
 
+func toS3Backend(repo restic.Repository) *s3.Backend {
+	b := repo.Backend()
+	// unwrap cache
+	if be, ok := b.(*cache.Backend); ok {
+		b = be.Backend
+	}
+
+	be, ok := b.(*s3.Backend)
+	if !ok {
+		debug.Log("backend is not s3")
+		return nil
+	}
+	return be
+}
+
 // Check tests whether the migration can be applied.
 func (m *S3Layout) Check(ctx context.Context, repo restic.Repository) (bool, error) {
-	be, ok := repo.Backend().(*s3.Backend)
-	if !ok {
+	be := toS3Backend(repo)
+	if be == nil {
 		debug.Log("backend is not s3")
 		return false, nil
 	}
@@ -75,8 +91,8 @@ func (m *S3Layout) moveFiles(ctx context.Context, be *s3.Backend, l backend.Layo
 
 // Apply runs the migration.
 func (m *S3Layout) Apply(ctx context.Context, repo restic.Repository) error {
-	be, ok := repo.Backend().(*s3.Backend)
-	if !ok {
+	be := toS3Backend(repo)
+	if be == nil {
 		debug.Log("backend is not s3")
 		return errors.New("backend is not s3")
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The legacy S3 repository layout and mixed packs are not used for new repositories since quite some time. Especially the mixed packs are a problem as they will drastically increase the cache size and slow down everything. This PR let's  check complain about these legacy variants of the repository format version 1.

The mixed packs warning leads to the somewhat ugly situation that the test data used for the check is also affected by that warning. I've decided to simply filter these warnings, as that way the test implicitly tests that we are still able to read old repositories.

The `--check-unused` option is also deprecated as it is now rather useless since `prune` no longer removes all unused blob by default. This removes the option from the CLI, but keeps it for internal test case usage.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No. I've only complained about `--check-unused` being confusing somewhere in the forum ;-) .
Fixes #3295

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
