### PR TITLE
Validate exclude patterns

### DIFF
--- a/changelog/unreleased/issue-3709
+++ b/changelog/unreleased/issue-3709
@@ -1,0 +1,9 @@
+Enhancement: Validate exclude patterns before backing up
+
+Exclude patterns provided via `--exclude`, `--iexclude`, `--exclude-file` or `--iexclude-file`
+previously weren't validated. As a consequence, invalid patterns resulted in all files being backed up.
+restic now validates all patterns before running the backup and aborts with a fatal error
+if an invalid pattern is detected.
+
+https://github.com/restic/restic/issues/3709
+https://github.com/restic/restic/pull/3734

--- a/cmd/restic/integration_filter_pattern_test.go
+++ b/cmd/restic/integration_filter_pattern_test.go
@@ -1,0 +1,69 @@
+//go:build go1.16
+// +build go1.16
+
+// Before Go 1.16 filepath.Match returned early on a failed match,
+// and thus did not report any later syntax error in the pattern.
+// https://go.dev/doc/go1.16#path/filepath
+
+package main
+
+import (
+	"io/ioutil"
+	"path/filepath"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestBackupFailsWhenUsingInvalidPatterns(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+
+	var err error
+
+	// Test --exclude
+	err = testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"testdata"}, BackupOptions{Excludes: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}, env.gopts)
+
+	rtest.Equals(t, `Fatal: --exclude: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+
+	// Test --iexclude
+	err = testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"testdata"}, BackupOptions{InsensitiveExcludes: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}, env.gopts)
+
+	rtest.Equals(t, `Fatal: --iexclude: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+}
+
+func TestBackupFailsWhenUsingInvalidPatternsFromFile(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+
+	// Create an exclude file with some invalid patterns
+	excludeFile := env.base + "/excludefile"
+	fileErr := ioutil.WriteFile(excludeFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
+	if fileErr != nil {
+		t.Fatalf("Could not write exclude file: %v", fileErr)
+	}
+
+	var err error
+
+	// Test --exclude-file:
+	err = testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"testdata"}, BackupOptions{ExcludeFiles: []string{excludeFile}}, env.gopts)
+
+	rtest.Equals(t, `Fatal: --exclude-file: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+
+	// Test --iexclude-file
+	err = testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"testdata"}, BackupOptions{InsensitiveExcludeFiles: []string{excludeFile}}, env.gopts)
+
+	rtest.Equals(t, `Fatal: --iexclude-file: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+}

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -220,6 +220,27 @@ func match(pattern Pattern, strs []string) (matched bool, err error) {
 	return false, nil
 }
 
+// ValidatePatterns validates a slice of patterns.
+// Returns true if all patterns are valid - false otherwise, along with the invalid patterns.
+func ValidatePatterns(patterns []string) (allValid bool, invalidPatterns []string) {
+	invalidPatterns = make([]string, 0)
+
+	for _, Pattern := range ParsePatterns(patterns) {
+		// Validate all pattern parts
+		for _, part := range Pattern.parts {
+			// Validate the pattern part by trying to match it against itself
+			if _, validErr := filepath.Match(part.pattern, part.pattern); validErr != nil {
+				invalidPatterns = append(invalidPatterns, Pattern.original)
+
+				// If a single part is invalid, stop processing this pattern
+				continue
+			}
+		}
+	}
+
+	return len(invalidPatterns) == 0, invalidPatterns
+}
+
 // ParsePatterns prepares a list of patterns for use with List.
 func ParsePatterns(pattern []string) []Pattern {
 	patpat := make([]Pattern, 0)

--- a/internal/filter/filter.go
+++ b/internal/filter/filter.go
@@ -18,6 +18,7 @@ type patternPart struct {
 
 // Pattern represents a preparsed filter pattern
 type Pattern struct {
+	original  string
 	parts     []patternPart
 	isNegated bool
 }
@@ -31,6 +32,9 @@ func prepareStr(str string) ([]string, error) {
 
 func preparePattern(patternStr string) Pattern {
 	var negate bool
+
+	originalPattern := patternStr
+
 	if patternStr[0] == '!' {
 		negate = true
 		patternStr = patternStr[1:]
@@ -48,7 +52,7 @@ func preparePattern(patternStr string) Pattern {
 		parts[i] = patternPart{part, isSimple}
 	}
 
-	return Pattern{parts, negate}
+	return Pattern{originalPattern, parts, negate}
 }
 
 // Split p into path components. Assuming p has been Cleaned, no component
@@ -130,7 +134,7 @@ func childMatch(pattern Pattern, strs []string) (matched bool, err error) {
 	} else {
 		l = len(strs)
 	}
-	return match(Pattern{pattern.parts[0:l], pattern.isNegated}, strs)
+	return match(Pattern{pattern.original, pattern.parts[0:l], pattern.isNegated}, strs)
 }
 
 func hasDoubleWildcard(list Pattern) (ok bool, pos int) {
@@ -158,7 +162,7 @@ func match(pattern Pattern, strs []string) (matched bool, err error) {
 			}
 			newPat = append(newPat, pattern.parts[pos+1:]...)
 
-			matched, err := match(Pattern{newPat, pattern.isNegated}, strs)
+			matched, err := match(Pattern{pattern.original, newPat, pattern.isNegated}, strs)
 			if err != nil {
 				return false, err
 			}

--- a/internal/filter/filter_patterns_test.go
+++ b/internal/filter/filter_patterns_test.go
@@ -1,0 +1,57 @@
+//go:build go1.16
+// +build go1.16
+
+// Before Go 1.16 filepath.Match returned early on a failed match,
+// and thus did not report any later syntax error in the pattern.
+// https://go.dev/doc/go1.16#path/filepath
+
+package filter_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/restic/restic/internal/filter"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestValidPatterns(t *testing.T) {
+	// Test invalid patterns are detected and returned
+	t.Run("detect-invalid-patterns", func(t *testing.T) {
+		allValid, invalidPatterns := filter.ValidatePatterns([]string{"*.foo", "*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"})
+
+		rtest.Assert(t, allValid == false, "Expected invalid patterns to be detected")
+
+		rtest.Equals(t, invalidPatterns, []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"})
+	})
+
+	// Test all patterns defined in matchTests are valid
+	patterns := make([]string, 0)
+
+	for _, data := range matchTests {
+		patterns = append(patterns, data.pattern)
+	}
+
+	t.Run("validate-patterns", func(t *testing.T) {
+		allValid, invalidPatterns := filter.ValidatePatterns(patterns)
+
+		if !allValid {
+			t.Errorf("Found invalid pattern(s):\n%s", strings.Join(invalidPatterns, "\n"))
+		}
+	})
+
+	// Test all patterns defined in childMatchTests are valid
+	childPatterns := make([]string, 0)
+
+	for _, data := range childMatchTests {
+		childPatterns = append(childPatterns, data.pattern)
+	}
+
+	t.Run("validate-child-patterns", func(t *testing.T) {
+		allValid, invalidPatterns := filter.ValidatePatterns(childPatterns)
+
+		if !allValid {
+			t.Errorf("Found invalid child pattern(s):\n%s", strings.Join(invalidPatterns, "\n"))
+		}
+	})
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Exclude patterns provided via `--exclude`, `--iexclude`, `--exclude-file` or `--iexclude-file` are validated. Invalid patterns cause `restic backup` to abort with a fatal error displaying the invalid patterns.
To achieve this, the `Pattern` struct is extended to include the original pattern. After parsing each pattern with `ParsePatterns`, every pattern part is validated using `filepath.Match`, by matching the pattern against itself.

Before Go 1.16 `filepath.Match` does not correctly report syntax errors, see https://go.dev/doc/go1.16#path/filepath
The corresponding tests are therefore only executed for Go 1.16+.

`restic restore` also accepts patterns - a follow-up MR could validate them as well.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #3709

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
