### PR TITLE
DOCS: Incorrectly used SI units when IEC units were meant (fix #3669)

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -346,12 +346,12 @@ option:
 
     $ restic -r /srv/restic-repo backup ~/work --exclude-larger-than 1M
 
-This excludes files in ``~/work`` which are larger than 1 MB from the backup.
+This excludes files in ``~/work`` which are larger than 1 MiB from the backup.
 
 The default unit for the size value is bytes, so e.g. ``--exclude-larger-than 2048``
-would exclude files larger than 2048 bytes (2 kilobytes). To specify other units,
-suffix the size value with one of ``k``/``K`` for kilobytes, ``m``/``M`` for megabytes,
-``g``/``G`` for gigabytes and ``t``/``T`` for terabytes (e.g. ``1k``, ``10K``, ``20m``,
+would exclude files larger than 2048 bytes (2 KiB). To specify other units,
+suffix the size value with one of ``k``/``K`` for KiB (1024 bytes), ``m``/``M`` for MiB (1024^2 bytes),
+``g``/``G`` for GiB (1024^3 bytes) and ``t``/``T`` for TiB (1024^4 bytes), e.g. ``1k``, ``10K``, ``20m``,
 ``20M``,  ``30g``, ``30G``, ``2t`` or ``2T``).
 
 Including Files


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Issue #3669 

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Issue #3669 

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
