### PR TITLE
Fix restore size calculation for multiple snapshots

### DIFF
--- a/changelog/unreleased/issue-3736
+++ b/changelog/unreleased/issue-3736
@@ -1,0 +1,8 @@
+Bugfix: `stats` fix restore size calculation for multiple snapshots
+
+Since restic 0.10.0 the restore size calculated by the `stats` command for
+multiple snapshots was too low. The hardlink detection was accidentally applied
+across multiple snapshots and thus ignored many files. This has been fixed.
+
+https://github.com/restic/restic/issues/3736
+https://github.com/restic/restic/pull/3740


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The `stats` command checks inodes to not count hardlinked files multiple times into the restore size. This check applies across all snapshots and not only within snapshots. As a result the result size was far too low when calculating it for multiple snapshots and it would vary depending on the order in which snapshots were listed.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3736
Regressed in #2540

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
