### PR TITLE
Wording: change repo to repository

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -111,7 +111,7 @@ func init() {
 	cmdRoot.AddCommand(cmdBackup)
 
 	f := cmdBackup.Flags()
-	f.StringVar(&backupOptions.Parent, "parent", "", "use this parent `snapshot` (default: last snapshot in the repo that has the same target files/directories, and is not newer than the snapshot time)")
+	f.StringVar(&backupOptions.Parent, "parent", "", "use this parent `snapshot` (default: last snapshot in the repository that has the same target files/directories, and is not newer than the snapshot time)")
 	f.BoolVarP(&backupOptions.Force, "force", "f", false, `force re-reading the target files/directories (overrides the "parent" flag)`)
 	f.StringArrayVarP(&backupOptions.Excludes, "exclude", "e", nil, "exclude a `pattern` (can be specified multiple times)")
 	f.StringArrayVar(&backupOptions.InsensitiveExcludes, "iexclude", nil, "same as --exclude `pattern` but ignores the casing of filenames")

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -641,7 +641,7 @@ func getUsedBlobs(gopts GlobalOptions, repo restic.Repository, ignoreSnapshots r
 	err = restic.FindUsedBlobs(ctx, repo, snapshotTrees, usedBlobs, bar)
 	if err != nil {
 		if repo.Backend().IsNotExist(err) {
-			return nil, errors.Fatal("unable to load a tree from the repo: " + err.Error())
+			return nil, errors.Fatal("unable to load a tree from the repository: " + err.Error())
 		}
 
 		return nil, err

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -140,12 +140,12 @@ func runRecover(gopts GlobalOptions) error {
 		var err error
 		treeID, err = repo.SaveTree(ctx, tree)
 		if err != nil {
-			return errors.Fatalf("unable to save new tree to the repo: %v", err)
+			return errors.Fatalf("unable to save new tree to the repository: %v", err)
 		}
 
 		err = repo.Flush(ctx)
 		if err != nil {
-			return errors.Fatalf("unable to save blobs to the repo: %v", err)
+			return errors.Fatalf("unable to save blobs to the repository: %v", err)
 		}
 		return nil
 	})

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -116,7 +116,7 @@ func init() {
 	f.BoolVar(&globalOptions.NoCache, "no-cache", false, "do not use a local cache")
 	f.StringSliceVar(&globalOptions.RootCertFilenames, "cacert", nil, "`file` to load root certificates from (default: use system certificates)")
 	f.StringVar(&globalOptions.TLSClientCertKeyFilename, "tls-client-cert", "", "path to a `file` containing PEM encoded TLS client certificate and private key")
-	f.BoolVar(&globalOptions.InsecureTLS, "insecure-tls", false, "skip TLS certificate verification when connecting to the repo (insecure)")
+	f.BoolVar(&globalOptions.InsecureTLS, "insecure-tls", false, "skip TLS certificate verification when connecting to the repository (insecure)")
 	f.BoolVar(&globalOptions.CleanupCache, "cleanup-cache", false, "auto remove old cache directories")
 	f.Var(&globalOptions.Compression, "compression", "compression mode (only available for repository format version 2), one of (auto|off|max)")
 	f.IntVar(&globalOptions.Limits.UploadKb, "limit-upload", 0, "limits uploads to a maximum rate in KiB/s. (default: unlimited)")

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -118,7 +118,7 @@ func init() {
 	f.StringVar(&globalOptions.TLSClientCertKeyFilename, "tls-client-cert", "", "path to a `file` containing PEM encoded TLS client certificate and private key")
 	f.BoolVar(&globalOptions.InsecureTLS, "insecure-tls", false, "skip TLS certificate verification when connecting to the repo (insecure)")
 	f.BoolVar(&globalOptions.CleanupCache, "cleanup-cache", false, "auto remove old cache directories")
-	f.Var(&globalOptions.Compression, "compression", "compression mode (only available for repo format version 2), one of (auto|off|max)")
+	f.Var(&globalOptions.Compression, "compression", "compression mode (only available for repository format version 2), one of (auto|off|max)")
 	f.IntVar(&globalOptions.Limits.UploadKb, "limit-upload", 0, "limits uploads to a maximum rate in KiB/s. (default: unlimited)")
 	f.IntVar(&globalOptions.Limits.DownloadKb, "limit-download", 0, "limits downloads to a maximum rate in KiB/s. (default: unlimited)")
 	f.StringSliceVarP(&globalOptions.Options, "option", "o", []string{}, "set extended option (`key=value`, can be specified multiple times)")
@@ -470,7 +470,7 @@ func OpenRepository(opts GlobalOptions) (*repository.Repository, error) {
 			id = id[:8]
 		}
 		if !opts.JSON {
-			Verbosef("repository %v opened (repo version %v) successfully, password is correct\n", id, s.Config().Version)
+			Verbosef("repository %v opened (repository version %v) successfully, password is correct\n", id, s.Config().Version)
 		}
 	}
 
@@ -712,7 +712,7 @@ func open(s string, gopts GlobalOptions, opts options.Options) (restic.Backend, 
 	}
 
 	if err != nil {
-		return nil, errors.Fatalf("unable to open repo at %v: %v", location.StripPassword(s), err)
+		return nil, errors.Fatalf("unable to open repository at %v: %v", location.StripPassword(s), err)
 	}
 
 	// wrap backend if a test specified an inner hook

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -583,7 +583,7 @@ store data there. First, you need to install and `configure`_ rclone.  The
 general backend specification format is ``rclone:<remote>:<path>``, the
 ``<remote>:<path>`` component will be directly passed to rclone. When you
 configure a remote named ``foo``, you can then call restic as follows to
-initiate a new repository in the path ``bar`` in the repo:
+initiate a new repository in the path ``bar`` in the remote ``foo``:
 
 .. code-block:: console
 

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -191,7 +191,7 @@ Dry Runs
 ********
 
 You can perform a backup in dry run mode to see what would happen without
-modifying the repo.
+modifying the repository.
 
 -  ``--dry-run``/``-n`` Report what would be done, without writing to the repository
 
@@ -202,7 +202,7 @@ Combined with ``--verbose``, you can see a list of changes:
     $ restic -r /srv/restic-repo backup ~/work --dry-run -vv | grep "added"
     modified  /plan.txt, saved in 0.000s (9.110 KiB added)
     modified  /archive.tar.gz, saved in 0.140s (25.542 MiB added)
-    Would be added to the repo: 25.551 MiB
+    Would be added to the repository: 25.551 MiB
 
 Excluding Files
 ***************

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -309,7 +309,7 @@ Upgrading must be done explicitly as a newer repository version increases the
 minimum restic version required to access the repository. For example the
 repository format version 2 is only readable using restic 0.14.0 or newer.
 
-Upgrading to repo version 2 is a two step process: first run
+Upgrading to repository version 2 is a two step process: first run
 ``migrate upgrade_repo_v2`` which will check the repository integrity and
 then upgrade the repository version. Repository problems must be corrected
 before the migration will be possible. After the migration is complete, run

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -96,7 +96,7 @@ the data directly. This can be achieved by using the `dump` command, like this:
 
 If you have saved multiple different things into the same repo, the ``latest``
 snapshot may not be the right one. For example, consider the following
-snapshots in a repo:
+snapshots in a repository:
 
 .. code-block:: console
 

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -418,8 +418,8 @@ The ``prune`` command accepts the following options:
 
     * As an absolute size (e.g. ``200M``). If you want to minimize the space
       used by your repository, pass ``0`` to this option.
-    * As a size relative to the total repo size (e.g. ``10%``). This means that
-      after prune, at most ``10%`` of the total data stored in the repo may be
+    * As a size relative to the total repository size (e.g. ``10%``). This means that
+      after prune, at most ``10%`` of the total data stored in the repository may be
       unused data. If the repository after prune has a size of 500MB, then at most
       50MB may be unused.
     * If the string ``unlimited`` is passed, there is no limit for partly

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -420,7 +420,7 @@ The ``prune`` command accepts the following options:
       used by your repository, pass ``0`` to this option.
     * As a size relative to the total repo size (e.g. ``10%``). This means that
       after prune, at most ``10%`` of the total data stored in the repo may be
-      unused data. If the repo after prune has a size of 500MB, then at most
+      unused data. If the repository after prune has a size of 500MB, then at most
       50MB may be unused.
     * If the string ``unlimited`` is passed, there is no limit for partly
       unused files. This means that as long as some data is still used within

--- a/doc/cache.rst
+++ b/doc/cache.rst
@@ -7,7 +7,7 @@ The location of the cache directory depends on the operating system and the
 environment; see :ref:`caching`.
 
 Each repository has its own cache sub-directory, consisting of the repository ID
-which is chosen at ``init``. All cache directories for different repos are
+which is chosen at ``init``. All cache directories for different repositories are
 independent of each other.
 
 Snapshots, Data and Indexes
@@ -19,8 +19,8 @@ Snapshot, Data and Index files are cached in the sub-directories ``snapshots``,
 Expiry
 ======
 
-Whenever a cache directory for a repo is used, that directory's modification
+Whenever a cache directory for a repository is used, that directory's modification
 timestamp is updated to the current time. By looking at the modification
-timestamps of the repo cache directories it is easy to decide which directories
+timestamps of the repository cache directories it is easy to decide which directories
 are old and haven't been used in a long time. Those are probably stale and can
 be removed.

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -51,7 +51,7 @@ looks like this:
     [0:00] 100.00%  16 / 16 snapshots
     no errors were found
 
-The message means that there is more data stored in the repo than
+The message means that there is more data stored in the repository than
 strictly necessary. This is uncritical. With high probability this is duplicate data
 caused by an interrupted backup run or upload operation. In
 order to clean it up, the command ``restic prune`` can be used.
@@ -168,8 +168,8 @@ scheduling algorithm to give it the least favorable niceness (19).
 The above example makes sure that the system the backup runs on
 is not slowed down, which is particularly useful for servers.
 
-Creating new repo on a Synology NAS via sftp fails
---------------------------------------------------
+Creating new repository on a Synology NAS via sftp fails
+--------------------------------------------------------
 
 For using restic with a Synology NAS via sftp, please make sure that the
 specified path is absolute, it must start with a slash (``/``).

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -50,7 +50,7 @@ Usage help is available:
           --cache-dir directory        set the cache directory. (default: use system default cache directory)
           --cleanup-cache              auto remove old cache directories
       -h, --help                       help for restic
-          --insecure-tls               skip TLS certificate verification when connecting to the repo (insecure)
+          --insecure-tls               skip TLS certificate verification when connecting to the repository (insecure)
           --json                       set output mode to JSON for commands that support it
           --key-hint key               key ID of key to try decrypting first (default: $RESTIC_KEY_HINT)
           --limit-download int         limits downloads to a maximum rate in KiB/s. (default: unlimited)
@@ -107,7 +107,7 @@ command:
           --iexclude-file file                     same as --exclude-file but ignores casing of filenames in patterns
           --ignore-inode                           ignore inode number changes when checking for modified files
       -x, --one-file-system                        exclude other file systems, don't cross filesystem boundaries and subvolumes
-          --parent snapshot                        use this parent snapshot (default: last snapshot in the repo that has the same target files/directories)
+          --parent snapshot                        use this parent snapshot (default: last snapshot in the repository that has the same target files/directories)
           --stdin                                  read backup from stdin
           --stdin-filename filename                filename to use when reading from stdin (default "stdin")
           --tag tags                               add tags for the new snapshot in the format `tag[,tag,...]` (can be specified multiple times) (default [])
@@ -119,7 +119,7 @@ command:
           --cacert file                file to load root certificates from (default: use system certificates)
           --cache-dir directory        set the cache directory. (default: use system default cache directory)
           --cleanup-cache              auto remove old cache directories
-          --insecure-tls               skip TLS certificate verification when connecting to the repo (insecure)
+          --insecure-tls               skip TLS certificate verification when connecting to the repository (insecure)
           --json                       set output mode to JSON for commands that support it
           --key-hint key               key ID of key to try decrypting first (default: $RESTIC_KEY_HINT)
           --limit-download int         limits downloads to a maximum rate in KiB/s. (default: unlimited)
@@ -431,7 +431,7 @@ The cache is ephemeral: When a file cannot be read from the cache, it is loaded
 from the repository.
 
 Within the cache directory, there's a sub directory for each repository the
-cache was used with. Restic updates the timestamps of a repo directory each
+cache was used with. Restic updates the timestamps of a repository directory each
 time it is used, so by looking at the timestamps of the sub directories of the
 cache directory it can decide which sub directories are old and probably not
 needed any more. You can either remove these directories manually, or run a

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -36,7 +36,7 @@ Usage help is available:
       mount         Mount the repository
       prune         Remove unneeded data from the repository
       rebuild-index Build a new index
-      recover       Recover data from the repository
+      recover       Recover data from the repository not referenced by snapshots
       restore       Extract the data from a snapshot
       self-update   Update the restic binary
       snapshots     List all snapshots
@@ -49,6 +49,7 @@ Usage help is available:
           --cacert file                file to load root certificates from (default: use system certificates)
           --cache-dir directory        set the cache directory. (default: use system default cache directory)
           --cleanup-cache              auto remove old cache directories
+          --compression mode           compression mode (only available for repository format version 2), one of (auto|off|max) (default auto)
       -h, --help                       help for restic
           --insecure-tls               skip TLS certificate verification when connecting to the repository (insecure)
           --json                       set output mode to JSON for commands that support it
@@ -92,6 +93,7 @@ command:
       restic backup [flags] FILE/DIR [FILE/DIR] ...
 
     Flags:
+      -n, --dry-run                                do not upload or write any data, just show what would be done
       -e, --exclude pattern                        exclude a pattern (can be specified multiple times)
           --exclude-caches                         excludes cache directories that are marked with a CACHEDIR.TAG file. See https://bford.info/cachedir/ for the Cache Directory Tagging Standard
           --exclude-file file                      read exclude patterns from a file (can be specified multiple times)
@@ -105,9 +107,10 @@ command:
       -H, --host hostname                          set the hostname for the snapshot manually. To prevent an expensive rescan use the "parent" flag
           --iexclude pattern                       same as --exclude pattern but ignores the casing of filenames
           --iexclude-file file                     same as --exclude-file but ignores casing of filenames in patterns
+          --ignore-ctime                           ignore ctime changes when checking for modified files
           --ignore-inode                           ignore inode number changes when checking for modified files
       -x, --one-file-system                        exclude other file systems, don't cross filesystem boundaries and subvolumes
-          --parent snapshot                        use this parent snapshot (default: last snapshot in the repository that has the same target files/directories)
+          --parent snapshot                        use this parent snapshot (default: last snapshot in the repository that has the same target files/directories, and is not newer than the snapshot time)
           --stdin                                  read backup from stdin
           --stdin-filename filename                filename to use when reading from stdin (default "stdin")
           --tag tags                               add tags for the new snapshot in the format `tag[,tag,...]` (can be specified multiple times) (default [])
@@ -119,6 +122,7 @@ command:
           --cacert file                file to load root certificates from (default: use system certificates)
           --cache-dir directory        set the cache directory. (default: use system default cache directory)
           --cleanup-cache              auto remove old cache directories
+          --compression mode           compression mode (only available for repository format version 2), one of (auto|off|max) (default auto)
           --insecure-tls               skip TLS certificate verification when connecting to the repository (insecure)
           --json                       set output mode to JSON for commands that support it
           --key-hint key               key ID of key to try decrypting first (default: $RESTIC_KEY_HINT)

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -425,7 +425,7 @@ message.
 The command line parameter ``--cache-dir`` or the environment variable
 ``$RESTIC_CACHE_DIR`` can be used to override the default cache location.  The
 parameter ``--no-cache`` disables the cache entirely. In this case, all data
-is loaded from the repo.
+is loaded from the repository.
 
 The cache is ephemeral: When a file cannot be read from the cache, it is loaded
 from the repository.

--- a/internal/backend/location/location.go
+++ b/internal/backend/location/location.go
@@ -101,7 +101,7 @@ func Parse(s string) (u Location, err error) {
 
 	// if s is not a path or contains ":", it's ambiguous
 	if !isPath(s) && strings.ContainsRune(s, ':') {
-		return Location{}, errors.New("invalid backend\nIf the repo is in a local directory, you need to add a `local:` prefix")
+		return Location{}, errors.New("invalid backend\nIf the repository is in a local directory, you need to add a `local:` prefix")
 	}
 
 	u.Scheme = "local"

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -725,11 +725,11 @@ func (r *Repository) SearchKey(ctx context.Context, password string, maxKeys int
 // saves the repository config.
 func (r *Repository) Init(ctx context.Context, version uint, password string, chunkerPolynomial *chunker.Pol) error {
 	if version > restic.MaxRepoVersion {
-		return fmt.Errorf("repo version %v too high", version)
+		return fmt.Errorf("repository version %v too high", version)
 	}
 
 	if version < restic.MinRepoVersion {
-		return fmt.Errorf("repo version %v too low", version)
+		return fmt.Errorf("repository version %v too low", version)
 	}
 
 	has, err := r.be.Test(ctx, restic.Handle{Type: restic.ConfigFile})

--- a/internal/ui/backup/text.go
+++ b/internal/ui/backup/text.go
@@ -178,7 +178,7 @@ func (b *TextProgress) Finish(snapshotID restic.ID, start time.Time, summary *Su
 	if dryRun {
 		verb = "Would add"
 	}
-	b.P("%s to the repo: %-5s (%-5s stored)\n", verb, formatBytes(summary.ItemStats.DataSize+summary.ItemStats.TreeSize), formatBytes(summary.ItemStats.DataSizeInRepo+summary.ItemStats.TreeSizeInRepo))
+	b.P("%s to the repository: %-5s (%-5s stored)\n", verb, formatBytes(summary.ItemStats.DataSize+summary.ItemStats.TreeSize), formatBytes(summary.ItemStats.DataSizeInRepo+summary.ItemStats.TreeSizeInRepo))
 	b.P("\n")
 	b.P("processed %v files, %v in %s",
 		summary.Files.New+summary.Files.Changed+summary.Files.Unchanged,


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR changes the word `repo` to `repository` in several places to achieve a consistent wording.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
