### PR TITLE
Fix error on temp file deletion on windows

### DIFF
--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -5,6 +5,7 @@ import (
 	"hash"
 	"io"
 	"os"
+	"runtime"
 	"sync"
 
 	"github.com/restic/restic/internal/errors"
@@ -137,9 +138,12 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packe
 		return errors.Wrap(err, "close tempfile")
 	}
 
-	err = fs.RemoveIfExists(p.tmpfile.Name())
-	if err != nil {
-		return errors.Wrap(err, "Remove")
+	// on windows the tempfile is automatically deleted on close
+	if runtime.GOOS != "windows" {
+		err = fs.RemoveIfExists(p.tmpfile.Name())
+		if err != nil {
+			return errors.Wrap(err, "Remove")
+		}
 	}
 
 	// update blobs in the index


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Apparently it can take a moment between closing a tempfile marked as DELETE_ON_CLOSE and it actually being deleted. During that time the file is inaccessible. Thus just skip deleting the temp file on windows.

This fixes the sporadic test failures on Windows, e.g.: https://github.com/restic/restic/actions/runs/2296657687

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
This is a follow-up for #3610.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~ 
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
