### PR TITLE
cache: Don't Lstat before creating CACHEDIR.TAG

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -59,11 +59,6 @@ func writeCachedirTag(dir string) error {
 	}
 
 	tagfile := filepath.Join(dir, "CACHEDIR.TAG")
-	_, err := fs.Lstat(tagfile)
-	if err != nil && !errors.Is(err, os.ErrNotExist) {
-		return errors.WithStack(err)
-	}
-
 	f, err := fs.OpenFile(tagfile, os.O_CREATE|os.O_EXCL|os.O_WRONLY, fileMode)
 	if err != nil {
 		if errors.Is(err, os.ErrExist) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The tag file is opened with O_CREATE|O_EXCL and ErrExist is handled, so we don't need to check for existence first.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
