### PR TITLE
Verify cache on check

### DIFF
--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -201,6 +201,11 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 		return err
 	}
 
+	if repo.Cache != nil && opts.WithCache {
+		// verify files in already existing cache
+		repo.Cache.EnableVerification()
+	}
+
 	if !gopts.NoLock {
 		Verbosef("create exclusive lock for repository\n")
 		lock, err := lockRepoExclusive(gopts.ctx, repo)

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"strconv"
+	"sync"
 	"time"
 
 	"github.com/pkg/errors"
@@ -20,6 +21,9 @@ type Cache struct {
 	path    string
 	Base    string
 	Created bool
+
+	verifiedFiles     map[restic.Handle]struct{}
+	verifiedFilesLock sync.Mutex
 }
 
 const dirMode = 0700
@@ -156,6 +160,10 @@ func New(id string, basedir string) (c *Cache, err error) {
 func updateTimestamp(d string) error {
 	t := time.Now()
 	return fs.Chtimes(d, t, t)
+}
+
+func (c *Cache) EnableVerification() {
+	c.verifiedFiles = make(map[restic.Handle]struct{})
 }
 
 // MaxCacheAge is the default age (30 days) after which cache directories are considered old.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The PR is currently in a request for comment state.

Up to now the `check` command has to create a temporary cache to ensure that it does not miss bitrot at the repository storage. However, this has the downside that a host may have to store two copies of the repository cache: one for regular usage and one for the check command.

This PR adds support for the cache to verify its content and thereby allows the `check` command to use an already existing cache, which as a bonus will be repaired by redownloading locally damaged files if necessary.

The CLI now has an `--temporary-cache` option in addition to `--no-cache-verify` (which replaces `--with-cache`)

| temporary-cache | no-cache-verify | behavior |
|-----------------------|-----------------------|--------------|
| false | false | default: use normal cache and verify its content |
| false | true | Identical to using `--with-cache` at the moment |
| true | false | current default behavior |
| true | true | invalid |

It would probably be possible (although hacky) to let check detect that a cache already exists and then automatically use a cache if it exists and create a temporary cache otherwise. The current solution in this PR to use a normal cache be default can break some use cases where a separate host is used to run `check` for all repositories and there is not enough space to keep all caches.

Using the normal cache also has the potential downside that `check` will download all metadata of a repository and thus could increase the size of the local cache. However, if the host runs `prune` from time to time, then this won't be a problem as prune behaves in the same way.

When verifying an already existing cache blob there are a number of corner cases that can appear:
| local hash | remote hash | behavior |
| --- | --- | --- |
| correct | correct | everything is fine |
| wrong | correct | delete cache blob and retry |
| correct | wrong | fail with user visible error |
| wrong | wrong | fail with user visible error |
| wrong | == local hash | proceed normally; check will complain about that file later on. |

The last case is necessary to gracefully handle incompletely uploaded files which should allow the check command to still access and verify the file if possible.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
