### PR TITLE
hashing: Remove io.WriterTo implementation

### DIFF
--- a/internal/hashing/reader.go
+++ b/internal/hashing/reader.go
@@ -5,47 +5,25 @@ import (
 	"io"
 )
 
-// ReadSumer hashes all data read from the underlying reader.
-type ReadSumer interface {
-	io.Reader
-	// Sum returns the hash of the data read so far.
-	Sum(d []byte) []byte
-}
-
-type reader struct {
-	io.Reader
+// Reader hashes all data read from the underlying reader.
+type Reader struct {
+	r io.Reader
 	h hash.Hash
 }
 
-type readWriterTo struct {
-	reader
-	writerTo io.WriterTo
+// NewReader returns a new Reader that uses the hash h. If the underlying
+// reader supports WriteTo then the returned reader will do so too.
+func NewReader(r io.Reader, h hash.Hash) *Reader {
+	return &Reader{r: r, h: h}
 }
 
-// NewReader returns a new ReadSummer that uses the hash h. If the underlying
-// reader supports WriteTo then the returned reader will do so too.
-func NewReader(r io.Reader, h hash.Hash) ReadSumer {
-	rs := reader{
-		Reader: io.TeeReader(r, h),
-		h:      h,
-	}
-
-	if _, ok := r.(io.WriterTo); ok {
-		return &readWriterTo{
-			reader:   rs,
-			writerTo: r.(io.WriterTo),
-		}
-	}
-
-	return &rs
+func (h *Reader) Read(p []byte) (int, error) {
+	n, err := h.r.Read(p)
+	_, _ = h.h.Write(p[:n]) // Never returns an error.
+	return n, err
 }
 
 // Sum returns the hash of the data read so far.
-func (h *reader) Sum(d []byte) []byte {
+func (h *Reader) Sum(d []byte) []byte {
 	return h.h.Sum(d)
-}
-
-// WriteTo reads all data into the passed writer
-func (h *readWriterTo) WriteTo(w io.Writer) (int64, error) {
-	return h.writerTo.WriteTo(NewWriter(w, h.h))
 }

--- a/internal/hashing/reader_test.go
+++ b/internal/hashing/reader_test.go
@@ -7,25 +7,7 @@ import (
 	"io"
 	"io/ioutil"
 	"testing"
-
-	rtest "github.com/restic/restic/internal/test"
 )
-
-// only expose Read method
-type onlyReader struct {
-	io.Reader
-}
-
-type traceWriterTo struct {
-	io.Reader
-	writerTo io.WriterTo
-	Traced   bool
-}
-
-func (r *traceWriterTo) WriteTo(w io.Writer) (n int64, err error) {
-	r.Traced = true
-	return r.writerTo.WriteTo(w)
-}
 
 func TestReader(t *testing.T) {
 	tests := []int{5, 23, 2<<18 + 23, 1 << 20}
@@ -39,44 +21,22 @@ func TestReader(t *testing.T) {
 
 		expectedHash := sha256.Sum256(data)
 
-		for _, test := range []struct {
-			innerWriteTo, outerWriteTo bool
-		}{{false, false}, {false, true}, {true, false}, {true, true}} {
-			// test both code paths in WriteTo
-			src := bytes.NewReader(data)
-			rawSrc := &traceWriterTo{Reader: src, writerTo: src}
-			innerSrc := io.Reader(rawSrc)
-			if !test.innerWriteTo {
-				innerSrc = &onlyReader{Reader: rawSrc}
-			}
+		rd := NewReader(bytes.NewReader(data), sha256.New())
+		n, err := io.Copy(ioutil.Discard, rd)
+		if err != nil {
+			t.Fatal(err)
+		}
 
-			rd := NewReader(innerSrc, sha256.New())
-			// test both Read and WriteTo
-			outerSrc := io.Reader(rd)
-			if !test.outerWriteTo {
-				outerSrc = &onlyReader{Reader: outerSrc}
-			}
+		if n != int64(size) {
+			t.Errorf("Reader: invalid number of bytes written: got %d, expected %d",
+				n, size)
+		}
 
-			n, err := io.Copy(ioutil.Discard, outerSrc)
-			if err != nil {
-				t.Fatal(err)
-			}
+		resultingHash := rd.Sum(nil)
 
-			if n != int64(size) {
-				t.Errorf("Reader: invalid number of bytes written: got %d, expected %d",
-					n, size)
-			}
-
-			resultingHash := rd.Sum(nil)
-
-			if !bytes.Equal(expectedHash[:], resultingHash) {
-				t.Errorf("Reader: hashes do not match: expected %02x, got %02x",
-					expectedHash, resultingHash)
-			}
-
-			rtest.Assert(t, rawSrc.Traced == (test.innerWriteTo && test.outerWriteTo),
-				"unexpected/missing writeTo call innerWriteTo %v outerWriteTo %v",
-				test.innerWriteTo, test.outerWriteTo)
+		if !bytes.Equal(expectedHash[:], resultingHash) {
+			t.Errorf("Reader: hashes do not match: expected %02x, got %02x",
+				expectedHash, resultingHash)
 		}
 	}
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This functionality has gone unused since
4b3dc415ef41593fdd5e3cc0db3b78b3bbef5411 changed hashing.Reader's only
client to use ioutil.ReadAll on a bufio.Reader wrapping the hashing
Reader.

Reverts bcb852a8d0a674c5131668baae0826578f2e588a.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
