### PR TITLE
local: Ignore additional errors for directory syncing

### DIFF
--- a/changelog/unreleased/issue-3720
+++ b/changelog/unreleased/issue-3720
@@ -1,0 +1,13 @@
+Bugfix: Fix directory sync errors related repositories accessed via SMB
+
+On Linux and macOS accessing a repository via a SMB/CIFS mount resulted in
+restic failing to save the lock file:
+
+Save(<lock/071fe833f0>) returned error, retrying after 552.330144ms: sync /repo/locks: no such file or directory
+Save(<lock/bf789d7343>) returned error, retrying after 552.330144ms: sync /repo/locks: invalid argument
+
+This has been fixed by ignoring these error codes.
+
+https://github.com/restic/restic/issues/3720
+https://github.com/restic/restic/issues/3751
+https://github.com/restic/restic/pull/3752

--- a/internal/backend/local/local_unix.go
+++ b/internal/backend/local/local_unix.go
@@ -19,7 +19,7 @@ func fsyncDir(dir string) error {
 	}
 
 	err = d.Sync()
-	if errors.Is(err, syscall.ENOTSUP) {
+	if errors.Is(err, syscall.ENOTSUP) || errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.EINVAL) {
 		err = nil
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Apparently SMB/CIFS on Linux/macOS returns somewhat random errnos when trying to sync a windows share which does not support calling fsync for a directory.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3720
Fixes #3751

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
