### PR TITLE
prune: Fix crash on snapshot loading error

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -596,10 +596,11 @@ func getUsedBlobs(gopts GlobalOptions, repo restic.Repository, ignoreSnapshots r
 	Verbosef("loading all snapshots...\n")
 	err = restic.ForAllSnapshots(gopts.ctx, repo.Backend(), repo, ignoreSnapshots,
 		func(id restic.ID, sn *restic.Snapshot, err error) error {
-			debug.Log("add snapshot %v (tree %v, error %v)", id, *sn.Tree, err)
 			if err != nil {
+				debug.Log("failed to load snapshot %v (error %v)", id, err)
 				return err
 			}
+			debug.Log("add snapshot %v (tree %v)", id, *sn.Tree)
 			snapshotTrees = append(snapshotTrees, *sn.Tree)
 			return nil
 		})

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -605,7 +605,7 @@ func getUsedBlobs(gopts GlobalOptions, repo restic.Repository, ignoreSnapshots r
 			return nil
 		})
 	if err != nil {
-		return nil, err
+		return nil, errors.Fatalf("failed loading snapshot: %v", err)
 	}
 
 	Verbosef("finding data that is still in use for %d snapshots\n", len(snapshotTrees))


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Don't crash in prune when failing to load a snapshot.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3763.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
