### PR TITLE
Reduce memory usage for large directories/files

### DIFF
--- a/changelog/unreleased/pull-3773
+++ b/changelog/unreleased/pull-3773
@@ -1,0 +1,7 @@
+Enhancement: Optimize memory usage for directories with many files
+
+Backing up a directory with hundred thousands or more files causes restic to
+require large amounts of memory. We have optimized `backup` command such that
+it requires up to 30% less memory.
+
+https://github.com/restic/restic/pull/3773

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -647,7 +647,7 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 		}
 
 		errorHandler := func(item string, err error) error {
-			return progressReporter.Error(item, nil, err)
+			return progressReporter.Error(item, err)
 		}
 
 		messageHandler := func(msg string, args ...interface{}) {
@@ -690,9 +690,9 @@ func runBackup(opts BackupOptions, gopts GlobalOptions, term *termstatus.Termina
 	arch.Select = selectFilter
 	arch.WithAtime = opts.WithAtime
 	success := true
-	arch.Error = func(item string, fi os.FileInfo, err error) error {
+	arch.Error = func(item string, err error) error {
 		success = false
-		return progressReporter.Error(item, fi, err)
+		return progressReporter.Error(item, err)
 	}
 	arch.CompleteItem = progressReporter.CompleteItem
 	arch.StartFile = progressReporter.StartFile

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -184,17 +184,17 @@ func (arch *Archiver) saveTree(ctx context.Context, t *restic.TreeJSONBuilder) (
 	b := &Buffer{Data: buf}
 	res := arch.blobSaver.Save(ctx, restic.TreeBlob, b)
 
-	res.Wait(ctx)
-	if !res.Known() {
+	sbr := res.Take(ctx)
+	if !sbr.known {
 		s.TreeBlobs++
-		s.TreeSize += uint64(res.Length())
-		s.TreeSizeInRepo += uint64(res.SizeInRepo())
+		s.TreeSize += uint64(sbr.length)
+		s.TreeSizeInRepo += uint64(sbr.sizeInRepo)
 	}
-	// The context was canceled in the meantime, res.ID() might be invalid
+	// The context was canceled in the meantime, id might be invalid
 	if ctx.Err() != nil {
 		return restic.ID{}, s, ctx.Err()
 	}
-	return res.ID(), s, nil
+	return sbr.id, s, nil
 }
 
 // nodeFromFileInfo returns the restic node from an os.FileInfo.

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -2,7 +2,6 @@ package archiver
 
 import (
 	"context"
-	"encoding/json"
 	"os"
 	"path"
 	"runtime"
@@ -175,16 +174,12 @@ func (arch *Archiver) error(item string, err error) error {
 
 // saveTree stores a tree in the repo. It checks the index and the known blobs
 // before saving anything.
-func (arch *Archiver) saveTree(ctx context.Context, t *restic.Tree) (restic.ID, ItemStats, error) {
+func (arch *Archiver) saveTree(ctx context.Context, t *restic.TreeJSONBuilder) (restic.ID, ItemStats, error) {
 	var s ItemStats
-	buf, err := json.Marshal(t)
+	buf, err := t.Finalize()
 	if err != nil {
-		return restic.ID{}, s, errors.Wrap(err, "MarshalJSON")
+		return restic.ID{}, s, err
 	}
-
-	// append a newline so that the data is always consistent (json.Encoder
-	// adds a newline after each object)
-	buf = append(buf, '\n')
 
 	b := &Buffer{Data: buf}
 	res := arch.blobSaver.Save(ctx, restic.TreeBlob, b)
@@ -620,7 +615,11 @@ func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, 
 			return nil, err
 		}
 
-		id, nodeStats, err := arch.saveTree(ctx, subtree)
+		tb, err := restic.TreeToBuilder(subtree)
+		if err != nil {
+			return nil, err
+		}
+		id, nodeStats, err := arch.saveTree(ctx, tb)
 		if err != nil {
 			return nil, err
 		}
@@ -834,7 +833,11 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 				return errors.New("snapshot is empty")
 			}
 
-			rootTreeID, stats, err = arch.saveTree(wgCtx, tree)
+			tb, err := restic.TreeToBuilder(tree)
+			if err != nil {
+				return err
+			}
+			rootTreeID, stats, err = arch.saveTree(wgCtx, tb)
 			arch.stopWorkers()
 			return err
 		})

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -295,8 +295,7 @@ type FutureNode struct {
 	snPath, target string
 
 	// kept to call the error callback function
-	absTarget string
-	fi        os.FileInfo
+	fi os.FileInfo
 
 	node  *restic.Node
 	stats ItemStats
@@ -365,8 +364,6 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 	if err != nil {
 		return FutureNode{}, false, err
 	}
-
-	fn.absTarget = abstarget
 
 	// exclude files by path before running Lstat to reduce number of lstat calls
 	if !arch.SelectByName(abstarget) {

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -47,7 +47,7 @@ func saveFile(t testing.TB, repo restic.Repository, filename string, filesystem 
 	arch := New(repo, filesystem, Options{})
 	arch.runWorkers(ctx, wg)
 
-	arch.Error = func(item string, fi os.FileInfo, err error) error {
+	arch.Error = func(item string, err error) error {
 		t.Errorf("archiver error for %v: %v", item, err)
 		return err
 	}
@@ -217,7 +217,7 @@ func TestArchiverSave(t *testing.T) {
 			repo.StartPackUploader(ctx, wg)
 
 			arch := New(repo, fs.Track{FS: fs.Local{}}, Options{})
-			arch.Error = func(item string, fi os.FileInfo, err error) error {
+			arch.Error = func(item string, err error) error {
 				t.Errorf("archiver error for %v: %v", item, err)
 				return err
 			}
@@ -295,7 +295,7 @@ func TestArchiverSaveReaderFS(t *testing.T) {
 			}
 
 			arch := New(repo, readerFs, Options{})
-			arch.Error = func(item string, fi os.FileInfo, err error) error {
+			arch.Error = func(item string, err error) error {
 				t.Errorf("archiver error for %v: %v", item, err)
 				return err
 			}
@@ -1723,7 +1723,7 @@ func TestArchiverParent(t *testing.T) {
 
 func TestArchiverErrorReporting(t *testing.T) {
 	ignoreErrorForBasename := func(basename string) ErrorFunc {
-		return func(item string, fi os.FileInfo, err error) error {
+		return func(item string, err error) error {
 			if filepath.Base(item) == "targetfile" {
 				t.Logf("ignoring error for targetfile: %v", err)
 				return nil
@@ -2248,7 +2248,7 @@ func TestRacyFileSwap(t *testing.T) {
 	repo.StartPackUploader(ctx, wg)
 
 	arch := New(repo, fs.Track{FS: statfs}, Options{})
-	arch.Error = func(item string, fi os.FileInfo, err error) error {
+	arch.Error = func(item string, err error) error {
 		t.Logf("archiver error as expected for %v: %v", item, err)
 		return err
 	}

--- a/internal/archiver/blob_saver.go
+++ b/internal/archiver/blob_saver.go
@@ -11,7 +11,6 @@ import (
 // Saver allows saving a blob.
 type Saver interface {
 	SaveBlob(ctx context.Context, t restic.BlobType, data []byte, id restic.ID, storeDuplicate bool) (restic.ID, bool, int, error)
-	Index() restic.MasterIndex
 }
 
 // BlobSaver concurrently saves incoming blobs to the repo.

--- a/internal/archiver/blob_saver.go
+++ b/internal/archiver/blob_saver.go
@@ -44,9 +44,7 @@ func (s *BlobSaver) TriggerShutdown() {
 // Save stores a blob in the repo. It checks the index and the known blobs
 // before saving anything. It takes ownership of the buffer passed in.
 func (s *BlobSaver) Save(ctx context.Context, t restic.BlobType, buf *Buffer) FutureBlob {
-	// buf might be freed once the job was submitted, thus calculate the length now
-	length := len(buf.Data)
-	ch := make(chan saveBlobResponse, 1)
+	ch := make(chan SaveBlobResponse, 1)
 	select {
 	case s.ch <- saveBlobJob{BlobType: t, buf: buf, ch: ch}:
 	case <-ctx.Done():
@@ -55,72 +53,62 @@ func (s *BlobSaver) Save(ctx context.Context, t restic.BlobType, buf *Buffer) Fu
 		return FutureBlob{ch: ch}
 	}
 
-	return FutureBlob{ch: ch, length: length}
+	return FutureBlob{ch: ch}
 }
 
 // FutureBlob is returned by SaveBlob and will return the data once it has been processed.
 type FutureBlob struct {
-	ch     <-chan saveBlobResponse
-	length int
-	res    saveBlobResponse
+	ch <-chan SaveBlobResponse
 }
 
-// Wait blocks until the result is available or the context is cancelled.
-func (s *FutureBlob) Wait(ctx context.Context) {
+func (s *FutureBlob) Poll() *SaveBlobResponse {
 	select {
-	case <-ctx.Done():
-		return
 	case res, ok := <-s.ch:
 		if ok {
-			s.res = res
+			return &res
 		}
+	default:
 	}
+	return nil
 }
 
-// ID returns the ID of the blob after it has been saved.
-func (s *FutureBlob) ID() restic.ID {
-	return s.res.id
-}
-
-// Known returns whether or not the blob was already known.
-func (s *FutureBlob) Known() bool {
-	return s.res.known
-}
-
-// Length returns the raw length of the blob.
-func (s *FutureBlob) Length() int {
-	return s.length
-}
-
-// SizeInRepo returns the number of bytes added to the repo (including
-// compression and crypto overhead).
-func (s *FutureBlob) SizeInRepo() int {
-	return s.res.size
+// Take blocks until the result is available or the context is cancelled.
+func (s *FutureBlob) Take(ctx context.Context) SaveBlobResponse {
+	select {
+	case res, ok := <-s.ch:
+		if ok {
+			return res
+		}
+	case <-ctx.Done():
+	}
+	return SaveBlobResponse{}
 }
 
 type saveBlobJob struct {
 	restic.BlobType
 	buf *Buffer
-	ch  chan<- saveBlobResponse
+	ch  chan<- SaveBlobResponse
 }
 
-type saveBlobResponse struct {
-	id    restic.ID
-	known bool
-	size  int
+type SaveBlobResponse struct {
+	id         restic.ID
+	length     int
+	sizeInRepo int
+	known      bool
 }
 
-func (s *BlobSaver) saveBlob(ctx context.Context, t restic.BlobType, buf []byte) (saveBlobResponse, error) {
-	id, known, size, err := s.repo.SaveBlob(ctx, t, buf, restic.ID{}, false)
+func (s *BlobSaver) saveBlob(ctx context.Context, t restic.BlobType, buf []byte) (SaveBlobResponse, error) {
+	id, known, sizeInRepo, err := s.repo.SaveBlob(ctx, t, buf, restic.ID{}, false)
 
 	if err != nil {
-		return saveBlobResponse{}, err
+		return SaveBlobResponse{}, err
 	}
 
-	return saveBlobResponse{
-		id:    id,
-		known: known,
-		size:  size,
+	return SaveBlobResponse{
+		id:         id,
+		length:     len(buf),
+		sizeInRepo: sizeInRepo,
+		known:      known,
 	}, nil
 }
 

--- a/internal/archiver/blob_saver_test.go
+++ b/internal/archiver/blob_saver_test.go
@@ -54,8 +54,8 @@ func TestBlobSaver(t *testing.T) {
 	}
 
 	for i, blob := range results {
-		blob.Wait(ctx)
-		if blob.Known() {
+		sbr := blob.Take(ctx)
+		if sbr.known {
 			t.Errorf("blob %v is known, that should not be the case", i)
 		}
 	}

--- a/internal/archiver/file_saver.go
+++ b/internal/archiver/file_saver.go
@@ -13,41 +13,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// FutureFile is returned by Save and will return the data once it
-// has been processed.
-type FutureFile struct {
-	ch  <-chan saveFileResponse
-	res saveFileResponse
-}
-
-// Wait blocks until the result of the save operation is received or ctx is
-// cancelled.
-func (s *FutureFile) Wait(ctx context.Context) {
-	select {
-	case res, ok := <-s.ch:
-		if ok {
-			s.res = res
-		}
-	case <-ctx.Done():
-		return
-	}
-}
-
-// Node returns the node once it is available.
-func (s *FutureFile) Node() *restic.Node {
-	return s.res.node
-}
-
-// Stats returns the stats for the file once they are available.
-func (s *FutureFile) Stats() ItemStats {
-	return s.res.stats
-}
-
-// Err returns the error in case an error occurred.
-func (s *FutureFile) Err() error {
-	return s.res.err
-}
-
 // SaveBlobFn saves a blob to a repo.
 type SaveBlobFn func(context.Context, restic.BlobType, *Buffer) FutureBlob
 
@@ -102,10 +67,11 @@ type CompleteFunc func(*restic.Node, ItemStats)
 
 // Save stores the file f and returns the data once it has been completed. The
 // file is closed by Save.
-func (s *FileSaver) Save(ctx context.Context, snPath string, file fs.File, fi os.FileInfo, start func(), complete CompleteFunc) FutureFile {
-	ch := make(chan saveFileResponse, 1)
+func (s *FileSaver) Save(ctx context.Context, snPath string, target string, file fs.File, fi os.FileInfo, start func(), complete CompleteFunc) FutureNode {
+	fn, ch := newFutureNode()
 	job := saveFileJob{
 		snPath:   snPath,
+		target:   target,
 		file:     file,
 		fi:       fi,
 		start:    start,
@@ -121,41 +87,42 @@ func (s *FileSaver) Save(ctx context.Context, snPath string, file fs.File, fi os
 		close(ch)
 	}
 
-	return FutureFile{ch: ch}
+	return fn
 }
 
 type saveFileJob struct {
 	snPath   string
+	target   string
 	file     fs.File
 	fi       os.FileInfo
-	ch       chan<- saveFileResponse
+	ch       chan<- futureNodeResult
 	complete CompleteFunc
 	start    func()
 }
 
-type saveFileResponse struct {
-	node  *restic.Node
-	stats ItemStats
-	err   error
-}
-
 // saveFile stores the file f in the repo, then closes it.
-func (s *FileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPath string, f fs.File, fi os.FileInfo, start func()) saveFileResponse {
+func (s *FileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPath string, target string, f fs.File, fi os.FileInfo, start func()) futureNodeResult {
 	start()
 
 	stats := ItemStats{}
+	fnr := futureNodeResult{
+		snPath: snPath,
+		target: target,
+	}
 
 	debug.Log("%v", snPath)
 
 	node, err := s.NodeFromFileInfo(f.Name(), fi)
 	if err != nil {
 		_ = f.Close()
-		return saveFileResponse{err: err}
+		fnr.err = err
+		return fnr
 	}
 
 	if node.Type != "file" {
 		_ = f.Close()
-		return saveFileResponse{err: errors.Errorf("node type %q is wrong", node.Type)}
+		fnr.err = errors.Errorf("node type %q is wrong", node.Type)
+		return fnr
 	}
 
 	// reuse the chunker
@@ -179,13 +146,15 @@ func (s *FileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 
 		if err != nil {
 			_ = f.Close()
-			return saveFileResponse{err: err}
+			fnr.err = err
+			return fnr
 		}
 
 		// test if the context has been cancelled, return the error
 		if ctx.Err() != nil {
 			_ = f.Close()
-			return saveFileResponse{err: ctx.Err()}
+			fnr.err = ctx.Err()
+			return fnr
 		}
 
 		res := s.saveBlob(ctx, restic.DataBlob, buf)
@@ -194,7 +163,8 @@ func (s *FileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 		// test if the context has been cancelled, return the error
 		if ctx.Err() != nil {
 			_ = f.Close()
-			return saveFileResponse{err: ctx.Err()}
+			fnr.err = ctx.Err()
+			return fnr
 		}
 
 		s.CompleteBlob(f.Name(), uint64(len(chunk.Data)))
@@ -202,7 +172,8 @@ func (s *FileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 
 	err = f.Close()
 	if err != nil {
-		return saveFileResponse{err: err}
+		fnr.err = err
+		return fnr
 	}
 
 	for _, res := range results {
@@ -217,11 +188,9 @@ func (s *FileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 	}
 
 	node.Size = size
-
-	return saveFileResponse{
-		node:  node,
-		stats: stats,
-	}
+	fnr.node = node
+	fnr.stats = stats
+	return fnr
 }
 
 func (s *FileSaver) worker(ctx context.Context, jobs <-chan saveFileJob) {
@@ -239,7 +208,8 @@ func (s *FileSaver) worker(ctx context.Context, jobs <-chan saveFileJob) {
 				return
 			}
 		}
-		res := s.saveFile(ctx, chnker, job.snPath, job.file, job.fi, job.start)
+
+		res := s.saveFile(ctx, chnker, job.snPath, job.target, job.file, job.fi, job.start)
 		if job.complete != nil {
 			job.complete(res.node, res.stats)
 		}

--- a/internal/archiver/file_saver_test.go
+++ b/internal/archiver/file_saver_test.go
@@ -34,7 +34,7 @@ func startFileSaver(ctx context.Context, t testing.TB) (*FileSaver, context.Cont
 	wg, ctx := errgroup.WithContext(ctx)
 
 	saveBlob := func(ctx context.Context, tpe restic.BlobType, buf *Buffer) FutureBlob {
-		ch := make(chan saveBlobResponse)
+		ch := make(chan SaveBlobResponse)
 		close(ch)
 		return FutureBlob{ch: ch}
 	}

--- a/internal/archiver/file_saver_test.go
+++ b/internal/archiver/file_saver_test.go
@@ -64,7 +64,7 @@ func TestFileSaver(t *testing.T) {
 	testFs := fs.Local{}
 	s, ctx, wg := startFileSaver(ctx, t)
 
-	var results []FutureFile
+	var results []FutureNode
 
 	for _, filename := range files {
 		f, err := testFs.Open(filename)
@@ -77,14 +77,14 @@ func TestFileSaver(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		ff := s.Save(ctx, filename, f, fi, startFn, completeFn)
+		ff := s.Save(ctx, filename, filename, f, fi, startFn, completeFn)
 		results = append(results, ff)
 	}
 
 	for _, file := range results {
-		file.Wait(ctx)
-		if file.Err() != nil {
-			t.Errorf("unable to save file: %v", file.Err())
+		fnr := file.take(ctx)
+		if fnr.err != nil {
+			t.Errorf("unable to save file: %v", fnr.err)
 		}
 	}
 

--- a/internal/archiver/scanner.go
+++ b/internal/archiver/scanner.go
@@ -27,7 +27,7 @@ func NewScanner(fs fs.FS) *Scanner {
 		FS:           fs,
 		SelectByName: func(item string) bool { return true },
 		Select:       func(item string, fi os.FileInfo) bool { return true },
-		Error:        func(item string, fi os.FileInfo, err error) error { return err },
+		Error:        func(item string, err error) error { return err },
 		Result:       func(item string, s ScanStats) {},
 	}
 }
@@ -111,7 +111,7 @@ func (s *Scanner) scan(ctx context.Context, stats ScanStats, target string) (Sca
 	// get file information
 	fi, err := s.FS.Lstat(target)
 	if err != nil {
-		return stats, s.Error(target, fi, err)
+		return stats, s.Error(target, err)
 	}
 
 	// run remaining select functions that require file information
@@ -126,7 +126,7 @@ func (s *Scanner) scan(ctx context.Context, stats ScanStats, target string) (Sca
 	case fi.Mode().IsDir():
 		names, err := readdirnames(s.FS, target, fs.O_NOFOLLOW)
 		if err != nil {
-			return stats, s.Error(target, fi, err)
+			return stats, s.Error(target, err)
 		}
 		sort.Strings(names)
 

--- a/internal/archiver/scanner_test.go
+++ b/internal/archiver/scanner_test.go
@@ -133,7 +133,7 @@ func TestScannerError(t *testing.T) {
 		src     TestDir
 		result  ScanStats
 		selFn   SelectFunc
-		errFn   func(t testing.TB, item string, fi os.FileInfo, err error) error
+		errFn   func(t testing.TB, item string, err error) error
 		resFn   func(t testing.TB, item string, s ScanStats)
 		prepare func(t testing.TB)
 	}{
@@ -173,7 +173,7 @@ func TestScannerError(t *testing.T) {
 					t.Fatal(err)
 				}
 			},
-			errFn: func(t testing.TB, item string, fi os.FileInfo, err error) error {
+			errFn: func(t testing.TB, item string, err error) error {
 				if item == filepath.FromSlash("work/subdir") {
 					return nil
 				}
@@ -198,7 +198,7 @@ func TestScannerError(t *testing.T) {
 					}
 				}
 			},
-			errFn: func(t testing.TB, item string, fi os.FileInfo, err error) error {
+			errFn: func(t testing.TB, item string, err error) error {
 				if item == "foo" {
 					t.Logf("ignoring error for %v: %v", item, err)
 					return nil
@@ -257,13 +257,13 @@ func TestScannerError(t *testing.T) {
 				}
 			}
 			if test.errFn != nil {
-				sc.Error = func(item string, fi os.FileInfo, err error) error {
+				sc.Error = func(item string, err error) error {
 					p, relErr := filepath.Rel(cur, item)
 					if relErr != nil {
 						panic(relErr)
 					}
 
-					return test.errFn(t, p, fi, err)
+					return test.errFn(t, p, err)
 				}
 			}
 

--- a/internal/archiver/tree_saver.go
+++ b/internal/archiver/tree_saver.go
@@ -114,7 +114,7 @@ func (s *TreeSaver) save(ctx context.Context, snPath string, node *restic.Node, 
 		// return the error if it wasn't ignored
 		if fn.err != nil {
 			debug.Log("err for %v: %v", fn.snPath, fn.err)
-			fn.err = s.errFn(fn.target, fn.fi, fn.err)
+			fn.err = s.errFn(fn.target, fn.err)
 			if fn.err == nil {
 				// ignore error
 				continue

--- a/internal/archiver/tree_saver.go
+++ b/internal/archiver/tree_saver.go
@@ -8,35 +8,6 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// FutureTree is returned by Save and will return the data once it
-// has been processed.
-type FutureTree struct {
-	ch  <-chan saveTreeResponse
-	res saveTreeResponse
-}
-
-// Wait blocks until the data has been received or ctx is cancelled.
-func (s *FutureTree) Wait(ctx context.Context) {
-	select {
-	case <-ctx.Done():
-		return
-	case res, ok := <-s.ch:
-		if ok {
-			s.res = res
-		}
-	}
-}
-
-// Node returns the node.
-func (s *FutureTree) Node() *restic.Node {
-	return s.res.node
-}
-
-// Stats returns the stats for the file.
-func (s *FutureTree) Stats() ItemStats {
-	return s.res.stats
-}
-
 // TreeSaver concurrently saves incoming trees to the repo.
 type TreeSaver struct {
 	saveTree func(context.Context, *restic.Tree) (restic.ID, ItemStats, error)
@@ -70,10 +41,11 @@ func (s *TreeSaver) TriggerShutdown() {
 }
 
 // Save stores the dir d and returns the data once it has been completed.
-func (s *TreeSaver) Save(ctx context.Context, snPath string, node *restic.Node, nodes []FutureNode, complete CompleteFunc) FutureTree {
-	ch := make(chan saveTreeResponse, 1)
+func (s *TreeSaver) Save(ctx context.Context, snPath string, target string, node *restic.Node, nodes []FutureNode, complete CompleteFunc) FutureNode {
+	fn, ch := newFutureNode()
 	job := saveTreeJob{
 		snPath:   snPath,
+		target:   target,
 		node:     node,
 		nodes:    nodes,
 		ch:       ch,
@@ -86,51 +58,53 @@ func (s *TreeSaver) Save(ctx context.Context, snPath string, node *restic.Node, 
 		close(ch)
 	}
 
-	return FutureTree{ch: ch}
+	return fn
 }
 
 type saveTreeJob struct {
 	snPath   string
-	nodes    []FutureNode
+	target   string
 	node     *restic.Node
-	ch       chan<- saveTreeResponse
+	nodes    []FutureNode
+	ch       chan<- futureNodeResult
 	complete CompleteFunc
 }
 
-type saveTreeResponse struct {
-	node  *restic.Node
-	stats ItemStats
-}
-
 // save stores the nodes as a tree in the repo.
-func (s *TreeSaver) save(ctx context.Context, snPath string, node *restic.Node, nodes []FutureNode) (*restic.Node, ItemStats, error) {
+func (s *TreeSaver) save(ctx context.Context, job *saveTreeJob) (*restic.Node, ItemStats, error) {
 	var stats ItemStats
+	node := job.node
+	nodes := job.nodes
+	// allow GC of nodes array once the loop is finished
+	job.nodes = nil
 
 	tree := restic.NewTree(len(nodes))
 
-	for _, fn := range nodes {
-		fn.wait(ctx)
+	for i, fn := range nodes {
+		// fn is a copy, so clear the original value explicitly
+		nodes[i] = FutureNode{}
+		fnr := fn.take(ctx)
 
 		// return the error if it wasn't ignored
-		if fn.err != nil {
-			debug.Log("err for %v: %v", fn.snPath, fn.err)
-			fn.err = s.errFn(fn.target, fn.err)
-			if fn.err == nil {
+		if fnr.err != nil {
+			debug.Log("err for %v: %v", fnr.snPath, fnr.err)
+			fnr.err = s.errFn(fnr.target, fnr.err)
+			if fnr.err == nil {
 				// ignore error
 				continue
 			}
 
-			return nil, stats, fn.err
+			return nil, stats, fnr.err
 		}
 
 		// when the error is ignored, the node could not be saved, so ignore it
-		if fn.node == nil {
-			debug.Log("%v excluded: %v", fn.snPath, fn.target)
+		if fnr.node == nil {
+			debug.Log("%v excluded: %v", fnr.snPath, fnr.target)
 			continue
 		}
 
-		debug.Log("insert %v", fn.node.Name)
-		err := tree.Insert(fn.node)
+		debug.Log("insert %v", fnr.node.Name)
+		err := tree.Insert(fnr.node)
 		if err != nil {
 			return nil, stats, err
 		}
@@ -158,7 +132,8 @@ func (s *TreeSaver) worker(ctx context.Context, jobs <-chan saveTreeJob) error {
 				return nil
 			}
 		}
-		node, stats, err := s.save(ctx, job.snPath, job.node, job.nodes)
+
+		node, stats, err := s.save(ctx, &job)
 		if err != nil {
 			debug.Log("error saving tree blob: %v", err)
 			close(job.ch)
@@ -168,9 +143,11 @@ func (s *TreeSaver) worker(ctx context.Context, jobs <-chan saveTreeJob) error {
 		if job.complete != nil {
 			job.complete(node, stats)
 		}
-		job.ch <- saveTreeResponse{
-			node:  node,
-			stats: stats,
+		job.ch <- futureNodeResult{
+			snPath: job.snPath,
+			target: job.target,
+			node:   node,
+			stats:  stats,
 		}
 		close(job.ch)
 	}

--- a/internal/archiver/tree_saver_test.go
+++ b/internal/archiver/tree_saver_test.go
@@ -3,7 +3,6 @@ package archiver
 import (
 	"context"
 	"fmt"
-	"os"
 	"runtime"
 	"sync/atomic"
 	"testing"
@@ -23,7 +22,7 @@ func TestTreeSaver(t *testing.T) {
 		return restic.NewRandomID(), ItemStats{TreeBlobs: 1, TreeSize: 123}, nil
 	}
 
-	errFn := func(snPath string, fi os.FileInfo, err error) error {
+	errFn := func(snPath string, err error) error {
 		return nil
 	}
 
@@ -83,7 +82,7 @@ func TestTreeSaverError(t *testing.T) {
 				return restic.NewRandomID(), ItemStats{TreeBlobs: 1, TreeSize: 123}, nil
 			}
 
-			errFn := func(snPath string, fi os.FileInfo, err error) error {
+			errFn := func(snPath string, err error) error {
 				t.Logf("ignoring error %v\n", err)
 				return nil
 			}

--- a/internal/archiver/tree_saver_test.go
+++ b/internal/archiver/tree_saver_test.go
@@ -28,19 +28,19 @@ func TestTreeSaver(t *testing.T) {
 
 	b := NewTreeSaver(ctx, wg, uint(runtime.NumCPU()), saveFn, errFn)
 
-	var results []FutureTree
+	var results []FutureNode
 
 	for i := 0; i < 20; i++ {
 		node := &restic.Node{
 			Name: fmt.Sprintf("file-%d", i),
 		}
 
-		fb := b.Save(ctx, "/", node, nil, nil)
+		fb := b.Save(ctx, "/", node.Name, node, nil, nil)
 		results = append(results, fb)
 	}
 
 	for _, tree := range results {
-		tree.Wait(ctx)
+		tree.take(ctx)
 	}
 
 	b.TriggerShutdown()
@@ -89,19 +89,19 @@ func TestTreeSaverError(t *testing.T) {
 
 			b := NewTreeSaver(ctx, wg, uint(runtime.NumCPU()), saveFn, errFn)
 
-			var results []FutureTree
+			var results []FutureNode
 
 			for i := 0; i < test.trees; i++ {
 				node := &restic.Node{
 					Name: fmt.Sprintf("file-%d", i),
 				}
 
-				fb := b.Save(ctx, "/", node, nil, nil)
+				fb := b.Save(ctx, "/", node.Name, node, nil, nil)
 				results = append(results, fb)
 			}
 
 			for _, tree := range results {
-				tree.Wait(ctx)
+				tree.take(ctx)
 			}
 
 			b.TriggerShutdown()

--- a/internal/archiver/tree_saver_test.go
+++ b/internal/archiver/tree_saver_test.go
@@ -18,7 +18,7 @@ func TestTreeSaver(t *testing.T) {
 
 	wg, ctx := errgroup.WithContext(ctx)
 
-	saveFn := func(context.Context, *restic.Tree) (restic.ID, ItemStats, error) {
+	saveFn := func(context.Context, *restic.TreeJSONBuilder) (restic.ID, ItemStats, error) {
 		return restic.NewRandomID(), ItemStats{TreeBlobs: 1, TreeSize: 123}, nil
 	}
 
@@ -73,7 +73,7 @@ func TestTreeSaverError(t *testing.T) {
 			wg, ctx := errgroup.WithContext(ctx)
 
 			var num int32
-			saveFn := func(context.Context, *restic.Tree) (restic.ID, ItemStats, error) {
+			saveFn := func(context.Context, *restic.TreeJSONBuilder) (restic.ID, ItemStats, error) {
 				val := atomic.AddInt32(&num, 1)
 				if val == test.failAt {
 					t.Logf("sending error for request %v\n", test.failAt)

--- a/internal/ui/backup/json.go
+++ b/internal/ui/backup/json.go
@@ -3,7 +3,6 @@ package backup
 import (
 	"bytes"
 	"encoding/json"
-	"os"
 	"sort"
 	"time"
 
@@ -79,7 +78,7 @@ func (b *JSONProgress) Update(total, processed Counter, errors uint, currentFile
 
 // ScannerError is the error callback function for the scanner, it prints the
 // error in verbose mode and returns nil.
-func (b *JSONProgress) ScannerError(item string, fi os.FileInfo, err error) error {
+func (b *JSONProgress) ScannerError(item string, err error) error {
 	b.error(errorUpdate{
 		MessageType: "error",
 		Error:       err,
@@ -90,7 +89,7 @@ func (b *JSONProgress) ScannerError(item string, fi os.FileInfo, err error) erro
 }
 
 // Error is the error callback function for the archiver, it prints the error and returns nil.
-func (b *JSONProgress) Error(item string, fi os.FileInfo, err error) error {
+func (b *JSONProgress) Error(item string, err error) error {
 	b.error(errorUpdate{
 		MessageType: "error",
 		Error:       err,

--- a/internal/ui/backup/progress.go
+++ b/internal/ui/backup/progress.go
@@ -3,7 +3,6 @@ package backup
 import (
 	"context"
 	"io"
-	"os"
 	"sync"
 	"time"
 
@@ -14,8 +13,8 @@ import (
 
 type ProgressPrinter interface {
 	Update(total, processed Counter, errors uint, currentFiles map[string]struct{}, start time.Time, secs uint64)
-	Error(item string, fi os.FileInfo, err error) error
-	ScannerError(item string, fi os.FileInfo, err error) error
+	Error(item string, err error) error
+	ScannerError(item string, err error) error
 	CompleteItem(messageType string, item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration)
 	ReportTotal(item string, start time.Time, s archiver.ScanStats)
 	Finish(snapshotID restic.ID, start time.Time, summary *Summary, dryRun bool)
@@ -44,11 +43,11 @@ type ProgressReporter interface {
 	CompleteItem(item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration)
 	StartFile(filename string)
 	CompleteBlob(filename string, bytes uint64)
-	ScannerError(item string, fi os.FileInfo, err error) error
+	ScannerError(item string, err error) error
 	ReportTotal(item string, s archiver.ScanStats)
 	SetMinUpdatePause(d time.Duration)
 	Run(ctx context.Context) error
-	Error(item string, fi os.FileInfo, err error) error
+	Error(item string, err error) error
 	Finish(snapshotID restic.ID)
 }
 
@@ -173,13 +172,13 @@ func (p *Progress) Run(ctx context.Context) error {
 
 // ScannerError is the error callback function for the scanner, it prints the
 // error in verbose mode and returns nil.
-func (p *Progress) ScannerError(item string, fi os.FileInfo, err error) error {
-	return p.printer.ScannerError(item, fi, err)
+func (p *Progress) ScannerError(item string, err error) error {
+	return p.printer.ScannerError(item, err)
 }
 
 // Error is the error callback function for the archiver, it prints the error and returns nil.
-func (p *Progress) Error(item string, fi os.FileInfo, err error) error {
-	cbErr := p.printer.Error(item, fi, err)
+func (p *Progress) Error(item string, err error) error {
+	cbErr := p.printer.Error(item, err)
 
 	select {
 	case p.errCh <- struct{}{}:

--- a/internal/ui/backup/text.go
+++ b/internal/ui/backup/text.go
@@ -2,7 +2,6 @@ package backup
 
 import (
 	"fmt"
-	"os"
 	"sort"
 	"time"
 
@@ -75,13 +74,13 @@ func (b *TextProgress) Update(total, processed Counter, errors uint, currentFile
 
 // ScannerError is the error callback function for the scanner, it prints the
 // error in verbose mode and returns nil.
-func (b *TextProgress) ScannerError(item string, fi os.FileInfo, err error) error {
+func (b *TextProgress) ScannerError(item string, err error) error {
 	b.V("scan: %v\n", err)
 	return nil
 }
 
 // Error is the error callback function for the archiver, it prints the error and returns nil.
-func (b *TextProgress) Error(item string, fi os.FileInfo, err error) error {
+func (b *TextProgress) Error(item string, err error) error {
 	b.E("error: %v\n", err)
 	return nil
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
restic requires a lot of memory to backup large files and directories. This PR reduces the peak memory usage by about 30-50% (depending on the GC settings). It is not intended as a complete solution to the memory usage problems, as that would require a repository format change as discussed in #2532.

Instead this PR takes the route of reducing the size of structs used during backup. Most notably the FutureNode/File/Tree structs. As the archiver preallocates the FutureNode array for each directory, the optimum would be to reduce the size of each FutureNode to a single reference. As we need a way to wait for the result, this would require a reference to a go channel. However, a channel seems to require about 96 bytes on 64-bit platforms which would regress the memory usage for files that are identical to the parent snapshot. Thus the FutureNode contains an additional reference to the result if it was already available.

The next problem is that to store a Tree in the repository, there are currently up to four items kept in-memory for each directory entry. First there is the FutureNode array, then the Nodes themselves, the serialized JSON of the tree and its encrypted variant while storing these in the repository.

As the FutureNode array is now rather small, it is sufficient to just clear all reference within the FutureNode to allow freeing most memory. The PR introduces a TreeBuilder which incrementally serialized the Tree and thereby ensures that each Node is only kept once in memory: either as Node or its serialized representation.

That way each node is represented in at most two items at a time in memory.

And finally the FutureBlob struct is slimmed down to a single reference to a channel. To reduce the memory usage further, FutureBlobs are collected as soon as possible.

Memory usage measurements:
using go 1.18.2, test data set 500k empty files in a single folder `for i in {1..500000} ; do touch abcefghijklt$i ; done`
test command: `/usr/bin/time -v $restic backup -n ../test/huge`

| commit | resident set size (KB) | elapsed | GOGC=1 rss (KB) | GOGC=1 elapsed |
|----|----|----|----|----|
| master | 1371208 | 0:18.72 | 830552 | 0:27.79 |
| remove fileinfo  | 1305528 | 0:17.88 | 770456 | 0:29.20 |
| unify node | 1056048 | 0:17.62 | 589192 | 0:34.06 |
| incremental tree |  887124 | 0:17.75 | 403124 | 0:34.45 |
| optimize large |  921864 | 0:17.72 | 402248 | 0:34.85 |

The table reports the results of the first test run, I've repeated the tests another two times, which result in the same overall trends.
The memory usage decreases by roughly 35% and a bit over 50% using GOGC=1. The measurements without `GOGC=1` are somewhat unstable as the GC can run at different points in time, but the general trend is stable across repetitions. The memory usage increase for `optimize large` appears to be an outlier as the test case uses no FutureBlobs. The elapsed time increases a bit for `GOGC=1` which seems to be caused by the different dataset that has to be scanned during GC. Without `GOGC` the elapsed time seems to be largely unchanged, although it is also too noisy for any further conclusions.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Related to #2446, but the specific changes were not discussed.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
