### PR TITLE
archiver: Remove cleanup goroutine from BufferPool

### DIFF
--- a/internal/archiver/buffer.go
+++ b/internal/archiver/buffer.go
@@ -1,52 +1,44 @@
 package archiver
 
-import (
-	"context"
-	"sync"
-)
-
 // Buffer is a reusable buffer. After the buffer has been used, Release should
 // be called so the underlying slice is put back into the pool.
 type Buffer struct {
 	Data []byte
-	Put  func(*Buffer)
+	pool *BufferPool
 }
 
 // Release puts the buffer back into the pool it came from.
 func (b *Buffer) Release() {
-	if b.Put != nil {
-		b.Put(b)
+	pool := b.pool
+	if pool == nil || cap(b.Data) > pool.defaultSize {
+		return
+	}
+
+	select {
+	case pool.ch <- b:
+	default:
 	}
 }
 
 // BufferPool implements a limited set of reusable buffers.
 type BufferPool struct {
 	ch          chan *Buffer
-	chM         sync.Mutex
 	defaultSize int
-	clearOnce   sync.Once
 }
 
-// NewBufferPool initializes a new buffer pool. When the context is cancelled,
-// all buffers are released. The pool stores at most max items. New buffers are
-// created with defaultSize, buffers that are larger are released and not put
-// back.
-func NewBufferPool(ctx context.Context, max int, defaultSize int) *BufferPool {
+// NewBufferPool initializes a new buffer pool. The pool stores at most max
+// items. New buffers are created with defaultSize. Buffers that have grown
+// larger are not put back.
+func NewBufferPool(max int, defaultSize int) *BufferPool {
 	b := &BufferPool{
 		ch:          make(chan *Buffer, max),
 		defaultSize: defaultSize,
 	}
-	go func() {
-		<-ctx.Done()
-		b.clear()
-	}()
 	return b
 }
 
 // Get returns a new buffer, either from the pool or newly allocated.
 func (pool *BufferPool) Get() *Buffer {
-	pool.chM.Lock()
-	defer pool.chM.Unlock()
 	select {
 	case buf := <-pool.ch:
 		return buf
@@ -54,36 +46,9 @@ func (pool *BufferPool) Get() *Buffer {
 	}
 
 	b := &Buffer{
-		Put:  pool.Put,
 		Data: make([]byte, pool.defaultSize),
+		pool: pool,
 	}
 
 	return b
-}
-
-// Put returns a buffer to the pool for reuse.
-func (pool *BufferPool) Put(b *Buffer) {
-	if cap(b.Data) > pool.defaultSize {
-		return
-	}
-
-	pool.chM.Lock()
-	defer pool.chM.Unlock()
-	select {
-	case pool.ch <- b:
-	default:
-	}
-}
-
-// clear empties the buffer so that all items can be garbage collected.
-func (pool *BufferPool) clear() {
-	pool.clearOnce.Do(func() {
-		ch := pool.ch
-		pool.chM.Lock()
-		pool.ch = nil
-		pool.chM.Unlock()
-		close(ch)
-		for range ch {
-		}
-	})
 }

--- a/internal/archiver/file_saver.go
+++ b/internal/archiver/file_saver.go
@@ -76,7 +76,7 @@ func NewFileSaver(ctx context.Context, t *tomb.Tomb, save SaveBlobFn, pol chunke
 
 	s := &FileSaver{
 		saveBlob:     save,
-		saveFilePool: NewBufferPool(ctx, int(poolSize), chunker.MaxSize),
+		saveFilePool: NewBufferPool(int(poolSize), chunker.MaxSize),
 		pol:          pol,
 		ch:           ch,
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The cleanup goroutine for archiver.BufferPool isn't doing anything. Channels should and will get cleaned up by the GC when the last reference to them disappears, just like all other data structures. The goroutine is just overhead and makes crash dumps longer. Also inlined BufferPool.Put in Buffer.Release, its only caller.

Archiver benchmarks show a tiny decrease in the allocation rate:

```
name                     old time/op    new time/op    delta
ArchiverSaveFileSmall-8    3.87ms ± 2%    3.91ms ± 4%    ~     (p=0.529 n=10+10)
ArchiverSaveFileLarge-8     305ms ± 5%     302ms ± 5%    ~     (p=0.353 n=10+10)

name                     old speed      new speed      delta
ArchiverSaveFileSmall-8  1.06MB/s ± 2%  1.05MB/s ± 4%    ~     (p=0.373 n=10+10)
ArchiverSaveFileLarge-8   142MB/s ± 6%   143MB/s ± 5%    ~     (p=0.353 n=10+10)

name                     old alloc/op   new alloc/op   delta
ArchiverSaveFileSmall-8    17.9MB ± 0%    17.9MB ± 0%    ~     (p=0.497 n=10+9)
ArchiverSaveFileLarge-8     382MB ± 2%     381MB ± 2%    ~     (p=0.529 n=10+10)

name                     old allocs/op  new allocs/op  delta
ArchiverSaveFileSmall-8       528 ± 0%       526 ± 0%  -0.39%  (p=0.001 n=10+8)
ArchiverSaveFileLarge-8     1.81k ± 1%     1.78k ± 3%  -1.70%  (p=0.009 n=8+10)
```

As an aside, the comments for this type are confusing. They say

    // BufferPool implements a limited set of reusable buffers.

but BufferPool.Get returns a fresh Buffer when the pool is empty, so keeping the set of buffers limited is the caller's responsibility. I'm thinking of rewriting BufferPool as a sync.Pool or some other way as a follow-up PR. For now, I believe this is a net improvement.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
