### PR TITLE
Limit number of key files tested while opening a repository

### DIFF
--- a/changelog/unreleased/pull-3776
+++ b/changelog/unreleased/pull-3776
@@ -1,0 +1,10 @@
+Bugfix: Limit number of key files tested while opening a repository
+
+Previously, restic tested the password against every key in the repository, when
+there are more and more keys in the repository, opening the repository becomes
+slower and slower.
+
+Now restic tests password up to 20 times on the key file in the repository, or
+you can use `-key-hint=<Key ID>` to specify the key file to be used.
+
+https://github.com/restic/restic/pull/3776

--- a/changelog/unreleased/pull-3776
+++ b/changelog/unreleased/pull-3776
@@ -4,7 +4,7 @@ Previously, restic tested the password against every key in the repository, when
 there are more and more keys in the repository, opening the repository becomes
 slower and slower.
 
-Now restic tests password up to 20 times on the key file in the repository, or
-you can use `-key-hint=<Key ID>` to specify the key file to be used.
+Now restic tests password against up to 20 key file in the repository. Alternatively,
+you can use `--key-hint=<Key ID>` to specify the key file to be used.
 
 https://github.com/restic/restic/pull/3776

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -1040,7 +1040,7 @@ func testRunKeyAddNewKeyUserHost(t testing.TB, gopts GlobalOptions) {
 
 	repo, err := OpenRepository(gopts)
 	rtest.OK(t, err)
-	key, err := repository.SearchKey(gopts.ctx, repo, testKeyNewPassword, 1, "")
+	key, err := repository.SearchKey(gopts.ctx, repo, testKeyNewPassword, 2, "")
 	rtest.OK(t, err)
 
 	rtest.Equals(t, "john", key.Username)

--- a/internal/repository/key.go
+++ b/internal/repository/key.go
@@ -137,6 +137,7 @@ func SearchKey(ctx context.Context, s *Repository, password string, maxKeys int,
 
 	// try at most maxKeys keys in repo
 	err = s.Backend().List(listCtx, restic.KeyFile, func(fi restic.FileInfo) error {
+		checked++
 		if maxKeys > 0 && checked > maxKeys {
 			return ErrMaxKeysReached
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

When there are many key files in the repository and wrong passwords are
entered, the process of matching passwords is very slow. Now restic can
retry up to 20 times, or you can use `-key-hint=<Key ID>` to specify
the key file to be used.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
