### PR TITLE
cmd/restic: Remove trailing "..." from progress messages

### DIFF
--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -58,7 +58,10 @@ func printProgress(status string, canUpdateStatus bool) {
 		if w < 3 {
 			status = termstatus.Truncate(status, w)
 		} else {
-			status = termstatus.Truncate(status, w-3) + "..."
+			trunc := termstatus.Truncate(status, w-3)
+			if len(trunc) < len(status) {
+				status = trunc + "..."
+			}
 		}
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

These were added after message since the last refactor of the progress printing code. Also skips an allocation in the common case.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Not that I'm aware.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
