### PR TITLE
Remove existing path before restoring a symlink

### DIFF
--- a/changelog/unreleased/pull-3780
+++ b/changelog/unreleased/pull-3780
@@ -1,0 +1,7 @@
+Bugfix: Make sure that symlinks can be created during recovery
+
+When restoring a symlink, restic reported an error if the target path already existed.
+With this change, the potentially existing target path is first removed before the symlink is recreated.
+
+https://github.com/restic/restic/issues/2578
+https://github.com/restic/restic/pull/3780

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -300,7 +300,7 @@ func (node Node) createSymlinkAt(path string) error {
 		return nil
 	}
 
-	if err := os.RemoveAll(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return errors.Wrap(err, "Symlink")
 	}
 

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -299,8 +299,12 @@ func (node Node) createSymlinkAt(path string) error {
 	if runtime.GOOS == "windows" {
 		return nil
 	}
-	err := fs.Symlink(node.LinkTarget, path)
-	if err != nil {
+
+	if err := os.RemoveAll(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return errors.Wrap(err, "Symlink")
+	}
+
+	if err := fs.Symlink(node.LinkTarget, path); err != nil {
 		return errors.Wrap(err, "Symlink")
 	}
 


### PR DESCRIPTION
Bugfix: Make sure that symlinks can be created during recovery

When restoring a symlink, restic reported an error if the target path already existed.
With this change, the potentially existing target path is first removed before the symlink is recreated.

https://github.com/restic/restic/issues/2578

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

At the moment restic overwrites existing data in the restore target, unless it is a symlink, in which case an error is thrown.

From my point of view, restic should behave with symlinks in the same way as with all other file types and "overwrite" already existing paths.

This change causes restic to "overwrite" existing data (by delete and create) even if a symlink is to be restored.

See #2578 for more details.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Closes #2578

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [ x ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ x ] I'm done! This pull request is ready for review.
