### PR TITLE
migrate: Cleanup option to request repository check

### DIFF
--- a/cmd/restic/cmd_migrate.go
+++ b/cmd/restic/cmd_migrate.go
@@ -84,8 +84,7 @@ func applyMigrations(opts MigrateOptions, gopts GlobalOptions, repo restic.Repos
 					Warnf("check for migration %v failed, continuing anyway\n", m.Name())
 				}
 
-				repoCheckOpts := m.RepoCheckOptions()
-				if repoCheckOpts != nil {
+				if m.RepoCheck() {
 					Printf("checking repository integrity...\n")
 
 					checkOptions := CheckOptions{}

--- a/internal/migrations/interface.go
+++ b/internal/migrations/interface.go
@@ -6,15 +6,12 @@ import (
 	"github.com/restic/restic/internal/restic"
 )
 
-type RepositoryCheckOptions struct {
-}
-
 // Migration implements a data migration.
 type Migration interface {
 	// Check returns true if the migration can be applied to a repo.
 	Check(context.Context, restic.Repository) (bool, error)
 
-	RepoCheckOptions() *RepositoryCheckOptions
+	RepoCheck() bool
 
 	// Apply runs the migration.
 	Apply(context.Context, restic.Repository) error

--- a/internal/migrations/s3_layout.go
+++ b/internal/migrations/s3_layout.go
@@ -37,8 +37,8 @@ func (m *S3Layout) Check(ctx context.Context, repo restic.Repository) (bool, err
 	return true, nil
 }
 
-func (m *S3Layout) RepoCheckOptions() *RepositoryCheckOptions {
-	return nil
+func (m *S3Layout) RepoCheck() bool {
+	return false
 }
 
 func retry(max int, fail func(err error), f func() error) error {

--- a/internal/migrations/upgrade_repo_v2.go
+++ b/internal/migrations/upgrade_repo_v2.go
@@ -50,8 +50,8 @@ func (*UpgradeRepoV2) Check(ctx context.Context, repo restic.Repository) (bool, 
 	return isV1, nil
 }
 
-func (*UpgradeRepoV2) RepoCheckOptions() *RepositoryCheckOptions {
-	return &RepositoryCheckOptions{}
+func (*UpgradeRepoV2) RepoCheck() bool {
+	return true
 }
 func (*UpgradeRepoV2) upgrade(ctx context.Context, repo restic.Repository) error {
 	h := restic.Handle{Type: restic.ConfigFile}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Remove the RepositoryCheckOptions struct which is essentially useless so far.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Followup to #3704.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
