### PR TITLE
repository: (Mostly) index-related cleanups

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -596,10 +596,8 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 func writeIndexFiles(gopts GlobalOptions, repo restic.Repository, removePacks restic.IDSet, extraObsolete restic.IDs) (restic.IDSet, error) {
 	Verbosef("rebuilding index\n")
 
-	idx := (repo.Index()).(*repository.MasterIndex)
-	packcount := uint64(len(idx.Packs(removePacks)))
-	bar := newProgressMax(!gopts.Quiet, packcount, "packs processed")
-	obsoleteIndexes, err := idx.Save(gopts.ctx, repo, removePacks, extraObsolete, bar)
+	bar := newProgressMax(!gopts.Quiet, 0, "packs processed")
+	obsoleteIndexes, err := repo.Index().Save(gopts.ctx, repo, removePacks, extraObsolete, bar)
 	bar.Done()
 	return obsoleteIndexes, err
 }

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -508,7 +508,6 @@ func TestCheckerBlobTypeConfusion(t *testing.T) {
 	test.OK(t, err)
 
 	test.OK(t, repo.Flush(ctx))
-	test.OK(t, repo.SaveIndex(ctx))
 
 	snapshot, err := restic.NewSnapshot([]string{"/damaged"}, []string{"test"}, "foo", time.Now())
 	test.OK(t, err)

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -131,27 +131,6 @@ var IndexFull = func(idx *Index, compress bool) bool {
 
 }
 
-// Store remembers the id and pack in the index.
-func (idx *Index) Store(pb restic.PackedBlob) {
-	idx.m.Lock()
-	defer idx.m.Unlock()
-
-	if idx.final {
-		panic("store new item in finalized index")
-	}
-
-	debug.Log("%v", pb)
-
-	// get packIndex and save if new packID
-	packIndex, ok := idx.packIDToIndex[pb.PackID]
-	if !ok {
-		packIndex = idx.addToPacks(pb.PackID)
-		idx.packIDToIndex[pb.PackID] = packIndex
-	}
-
-	idx.store(packIndex, pb.Blob)
-}
-
 // StorePack remembers the ids of all blobs of a given pack
 // in the index
 func (idx *Index) StorePack(id restic.ID, blobs []restic.Blob) {

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -46,8 +46,6 @@ type Index struct {
 	byType     [restic.NumBlobTypes]indexMap
 	packs      restic.IDs
 	mixedPacks restic.IDSet
-	// only used by Store, StorePacks does not check for already saved packIDs
-	packIDToIndex map[restic.ID]int
 
 	final      bool       // set to true for all indexes read from the backend ("finalized")
 	ids        restic.IDs // set to the IDs of the contained finalized indexes
@@ -58,9 +56,8 @@ type Index struct {
 // NewIndex returns a new index.
 func NewIndex() *Index {
 	return &Index{
-		packIDToIndex: make(map[restic.ID]int),
-		mixedPacks:    restic.NewIDSet(),
-		created:       time.Now(),
+		mixedPacks: restic.NewIDSet(),
+		created:    time.Now(),
 	}
 }
 
@@ -402,8 +399,6 @@ func (idx *Index) Finalize() {
 	defer idx.m.Unlock()
 
 	idx.final = true
-	// clear packIDToIndex as no more elements will be added
-	idx.packIDToIndex = nil
 }
 
 // IDs returns the IDs of the index, if available. If the index is not yet

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -176,24 +176,6 @@ func (idx *Index) Lookup(bh restic.BlobHandle, pbs []restic.PackedBlob) []restic
 	return pbs
 }
 
-// ListPack returns a list of blobs contained in a pack.
-func (idx *Index) ListPack(id restic.ID) (pbs []restic.PackedBlob) {
-	idx.m.Lock()
-	defer idx.m.Unlock()
-
-	for typ := range idx.byType {
-		m := &idx.byType[typ]
-		m.foreach(func(e *indexEntry) bool {
-			if idx.packs[e.packIndex] == id {
-				pbs = append(pbs, idx.toPackedBlob(e, restic.BlobType(typ)))
-			}
-			return true
-		})
-	}
-
-	return pbs
-}
-
 // Has returns true iff the id is listed in the index.
 func (idx *Index) Has(bh restic.BlobHandle) bool {
 	idx.m.Lock()

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -409,13 +409,6 @@ func (idx *Index) Encode(w io.Writer) error {
 	idx.m.Lock()
 	defer idx.m.Unlock()
 
-	return idx.encode(w)
-}
-
-// encode writes the JSON serialization of the index to the writer w.
-func (idx *Index) encode(w io.Writer) error {
-	debug.Log("encoding index")
-
 	list, err := idx.generatePackList()
 	if err != nil {
 		return err

--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -314,15 +314,6 @@ func (idx *Index) Packs() restic.IDSet {
 	return packs
 }
 
-// Count returns the number of blobs of type t in the index.
-func (idx *Index) Count(t restic.BlobType) (n uint) {
-	debug.Log("counting blobs of type %v", t)
-	idx.m.Lock()
-	defer idx.m.Unlock()
-
-	return idx.byType[t].len()
-}
-
 type packJSON struct {
 	ID    restic.ID  `json:"id"`
 	Blobs []blobJSON `json:"blobs"`

--- a/internal/repository/index_test.go
+++ b/internal/repository/index_test.go
@@ -2,6 +2,7 @@ package repository_test
 
 import (
 	"bytes"
+	"context"
 	"math/rand"
 	"sync"
 	"testing"
@@ -336,7 +337,7 @@ func TestIndexUnserialize(t *testing.T) {
 
 		rtest.Equals(t, oldIdx, idx.Supersedes())
 
-		blobs := idx.ListPack(exampleLookupTest.packID)
+		blobs := listPack(idx, exampleLookupTest.packID)
 		if len(blobs) != len(exampleLookupTest.blobs) {
 			t.Fatalf("expected %d blobs in pack, got %d", len(exampleLookupTest.blobs), len(blobs))
 		}
@@ -351,6 +352,15 @@ func TestIndexUnserialize(t *testing.T) {
 			}
 		}
 	}
+}
+
+func listPack(idx *repository.Index, id restic.ID) (pbs []restic.PackedBlob) {
+	for pb := range idx.Each(context.TODO()) {
+		if pb.PackID.Equal(id) {
+			pbs = append(pbs, pb)
+		}
+	}
+	return pbs
 }
 
 var (

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -234,14 +234,6 @@ func (mi *MasterIndex) FinalizeFullIndexes() []*Index {
 	return list
 }
 
-// All returns all indexes.
-func (mi *MasterIndex) All() []*Index {
-	mi.idxMutex.Lock()
-	defer mi.idxMutex.Unlock()
-
-	return mi.idx
-}
-
 // Each returns a channel that yields all blobs known to the index. When the
 // context is cancelled, the background goroutine terminates. This blocks any
 // modification of the index.

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -188,9 +188,9 @@ func (mi *MasterIndex) StorePack(id restic.ID, blobs []restic.Blob) {
 	mi.idx = append(mi.idx, newIdx)
 }
 
-// FinalizeNotFinalIndexes finalizes all indexes that
+// finalizeNotFinalIndexes finalizes all indexes that
 // have not yet been saved and returns that list
-func (mi *MasterIndex) FinalizeNotFinalIndexes() []*Index {
+func (mi *MasterIndex) finalizeNotFinalIndexes() []*Index {
 	mi.idxMutex.Lock()
 	defer mi.idxMutex.Unlock()
 
@@ -207,8 +207,8 @@ func (mi *MasterIndex) FinalizeNotFinalIndexes() []*Index {
 	return list
 }
 
-// FinalizeFullIndexes finalizes all indexes that are full and returns that list.
-func (mi *MasterIndex) FinalizeFullIndexes() []*Index {
+// finalizeFullIndexes finalizes all indexes that are full and returns that list.
+func (mi *MasterIndex) finalizeFullIndexes() []*Index {
 	mi.idxMutex.Lock()
 	defer mi.idxMutex.Unlock()
 
@@ -217,7 +217,6 @@ func (mi *MasterIndex) FinalizeFullIndexes() []*Index {
 	debug.Log("checking %d indexes", len(mi.idx))
 	for _, idx := range mi.idx {
 		if idx.Final() {
-			debug.Log("index %p is final", idx)
 			continue
 		}
 
@@ -425,12 +424,12 @@ func (mi *MasterIndex) saveIndex(ctx context.Context, r restic.SaverUnpacked, in
 
 // SaveIndex saves all new indexes in the backend.
 func (mi *MasterIndex) SaveIndex(ctx context.Context, r restic.SaverUnpacked) error {
-	return mi.saveIndex(ctx, r, mi.FinalizeNotFinalIndexes()...)
+	return mi.saveIndex(ctx, r, mi.finalizeNotFinalIndexes()...)
 }
 
 // SaveFullIndex saves all full indexes in the backend.
 func (mi *MasterIndex) SaveFullIndex(ctx context.Context, r restic.SaverUnpacked) error {
-	return mi.saveIndex(ctx, r, mi.FinalizeFullIndexes()...)
+	return mi.saveIndex(ctx, r, mi.finalizeFullIndexes()...)
 }
 
 // ListPacks returns the blobs of the specified pack files grouped by pack file.

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -321,7 +321,9 @@ const saveIndexParallelism = 4
 // The new index contains the IDs of all known indexes in the "supersedes"
 // field. The IDs are also returned in the IDSet obsolete.
 // After calling this function, you should remove the obsolete index files.
-func (mi *MasterIndex) Save(ctx context.Context, repo restic.Repository, packBlacklist restic.IDSet, extraObsolete restic.IDs, p *progress.Counter) (obsolete restic.IDSet, err error) {
+func (mi *MasterIndex) Save(ctx context.Context, repo restic.SaverUnpacked, packBlacklist restic.IDSet, extraObsolete restic.IDs, p *progress.Counter) (obsolete restic.IDSet, err error) {
+	p.SetMax(uint64(len(mi.Packs(packBlacklist))))
+
 	mi.idxMutex.Lock()
 	defer mi.idxMutex.Unlock()
 

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -243,13 +243,10 @@ func (mi *MasterIndex) Each(ctx context.Context) <-chan restic.PackedBlob {
 
 	go func() {
 		defer mi.idxMutex.RUnlock()
-		defer func() {
-			close(ch)
-		}()
+		defer close(ch)
 
 		for _, idx := range mi.idx {
-			idxCh := idx.Each(ctx)
-			for pb := range idxCh {
+			for pb := range idx.Each(ctx) {
 				select {
 				case <-ctx.Done():
 					return

--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -158,19 +158,6 @@ func (mi *MasterIndex) Packs(packBlacklist restic.IDSet) restic.IDSet {
 	return packs
 }
 
-// Count returns the number of blobs of type t in the index.
-func (mi *MasterIndex) Count(t restic.BlobType) (n uint) {
-	mi.idxMutex.RLock()
-	defer mi.idxMutex.RUnlock()
-
-	var sum uint
-	for _, idx := range mi.idx {
-		sum += idx.Count(t)
-	}
-
-	return sum
-}
-
 // Insert adds a new index to the MasterIndex.
 func (mi *MasterIndex) Insert(idx *Index) {
 	mi.idxMutex.Lock()

--- a/internal/repository/master_index_test.go
+++ b/internal/repository/master_index_test.go
@@ -157,16 +157,9 @@ func TestMasterMergeFinalIndexes(t *testing.T) {
 	mIdx.Insert(idx1)
 	mIdx.Insert(idx2)
 
-	finalIndexes := mIdx.FinalizeNotFinalIndexes()
+	finalIndexes, idxCount := repository.TestMergeIndex(t, mIdx)
 	rtest.Equals(t, []*repository.Index{idx1, idx2}, finalIndexes)
-
-	err := mIdx.MergeFinalIndexes()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	allIndexes := mIdx.All()
-	rtest.Equals(t, 1, len(allIndexes))
+	rtest.Equals(t, 1, idxCount)
 
 	blobCount := 0
 	for range mIdx.Each(context.TODO()) {
@@ -189,16 +182,9 @@ func TestMasterMergeFinalIndexes(t *testing.T) {
 	idx3.StorePack(blob2.PackID, []restic.Blob{blob2.Blob})
 
 	mIdx.Insert(idx3)
-	finalIndexes = mIdx.FinalizeNotFinalIndexes()
+	finalIndexes, idxCount = repository.TestMergeIndex(t, mIdx)
 	rtest.Equals(t, []*repository.Index{idx3}, finalIndexes)
-
-	err = mIdx.MergeFinalIndexes()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	allIndexes = mIdx.All()
-	rtest.Equals(t, 1, len(allIndexes))
+	rtest.Equals(t, 1, idxCount)
 
 	// Index should have same entries as before!
 	blobs = mIdx.Lookup(bhInIdx1)

--- a/internal/repository/master_index_test.go
+++ b/internal/repository/master_index_test.go
@@ -291,14 +291,12 @@ func BenchmarkMasterIndexLookupMultipleIndexUnknown(b *testing.B) {
 }
 
 func BenchmarkMasterIndexLookupParallel(b *testing.B) {
-	mIdx := repository.NewMasterIndex()
-
 	for _, numindices := range []int{25, 50, 100} {
 		var lookupBh restic.BlobHandle
 
 		b.StopTimer()
 		rng := rand.New(rand.NewSource(0))
-		mIdx, lookupBh = createRandomMasterIndex(b, rng, numindices, 10000)
+		mIdx, lookupBh := createRandomMasterIndex(b, rng, numindices, 10000)
 		b.StartTimer()
 
 		name := fmt.Sprintf("known,indices=%d", numindices)
@@ -361,7 +359,7 @@ func testIndexSave(t *testing.T, version uint) {
 		t.Fatal(err)
 	}
 
-	obsoletes, err := repo.Index().(*repository.MasterIndex).Save(context.TODO(), repo, nil, nil, nil)
+	obsoletes, err := repo.Index().Save(context.TODO(), repo, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unable to save new index: %v", err)
 	}

--- a/internal/repository/master_index_test.go
+++ b/internal/repository/master_index_test.go
@@ -122,12 +122,6 @@ func TestMasterIndex(t *testing.T) {
 	rtest.Assert(t, blobs == nil, "Expected no blobs when fetching with a random id")
 	_, found = mIdx.LookupSize(restic.NewRandomBlobHandle())
 	rtest.Assert(t, !found, "Expected no blobs when fetching with a random id")
-
-	// Test Count
-	num := mIdx.Count(restic.DataBlob)
-	rtest.Equals(t, uint(2), num)
-	num = mIdx.Count(restic.TreeBlob)
-	rtest.Equals(t, uint(2), num)
 }
 
 func TestMasterMergeFinalIndexes(t *testing.T) {

--- a/internal/repository/master_index_test.go
+++ b/internal/repository/master_index_test.go
@@ -57,12 +57,12 @@ func TestMasterIndex(t *testing.T) {
 	}
 
 	idx1 := repository.NewIndex()
-	idx1.Store(blob1)
-	idx1.Store(blob12a)
+	idx1.StorePack(blob1.PackID, []restic.Blob{blob1.Blob})
+	idx1.StorePack(blob12a.PackID, []restic.Blob{blob12a.Blob})
 
 	idx2 := repository.NewIndex()
-	idx2.Store(blob2)
-	idx2.Store(blob12b)
+	idx2.StorePack(blob2.PackID, []restic.Blob{blob2.Blob})
+	idx2.StorePack(blob12b.PackID, []restic.Blob{blob12b.Blob})
 
 	mIdx := repository.NewMasterIndex()
 	mIdx.Insert(idx1)
@@ -154,10 +154,10 @@ func TestMasterMergeFinalIndexes(t *testing.T) {
 	}
 
 	idx1 := repository.NewIndex()
-	idx1.Store(blob1)
+	idx1.StorePack(blob1.PackID, []restic.Blob{blob1.Blob})
 
 	idx2 := repository.NewIndex()
-	idx2.Store(blob2)
+	idx2.StorePack(blob2.PackID, []restic.Blob{blob2.Blob})
 
 	mIdx := repository.NewMasterIndex()
 	mIdx.Insert(idx1)
@@ -191,8 +191,8 @@ func TestMasterMergeFinalIndexes(t *testing.T) {
 
 	// merge another index containing identical blobs
 	idx3 := repository.NewIndex()
-	idx3.Store(blob1)
-	idx3.Store(blob2)
+	idx3.StorePack(blob1.PackID, []restic.Blob{blob1.Blob})
+	idx3.StorePack(blob2.PackID, []restic.Blob{blob2.Blob})
 
 	mIdx.Insert(idx3)
 	finalIndexes = mIdx.FinalizeNotFinalIndexes()

--- a/internal/repository/master_index_test.go
+++ b/internal/repository/master_index_test.go
@@ -209,11 +209,7 @@ func createRandomMasterIndex(t testing.TB, rng *rand.Rand, num, size int) (*repo
 	idx1, lookupBh := createRandomIndex(rng, size)
 	mIdx.Insert(idx1)
 
-	mIdx.FinalizeNotFinalIndexes()
-	err := mIdx.MergeFinalIndexes()
-	if err != nil {
-		t.Fatal(err)
-	}
+	repository.TestMergeIndex(t, mIdx)
 
 	return mIdx, lookupBh
 }

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -154,7 +154,7 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packe
 	if r.noAutoIndexUpdate {
 		return nil
 	}
-	return r.SaveFullIndex(ctx)
+	return r.idx.SaveFullIndex(ctx, r)
 }
 
 // countPacker returns the number of open (unfinished) packers.

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -192,9 +192,7 @@ func rebuildIndex(t *testing.T, repo restic.Repository) {
 		t.Fatal(err)
 	}
 
-	_, err = (repo.Index()).(*repository.MasterIndex).
-		Save(context.TODO(), repo, restic.NewIDSet(), nil, nil)
-
+	_, err = repo.Index().Save(context.TODO(), repo, restic.NewIDSet(), nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -155,8 +155,8 @@ func repack(t *testing.T, repo restic.Repository, packs restic.IDSet, blobs rest
 	}
 }
 
-func saveIndex(t *testing.T, repo restic.Repository) {
-	if err := repo.SaveIndex(context.TODO()); err != nil {
+func flush(t *testing.T, repo restic.Repository) {
+	if err := repo.Flush(context.TODO()); err != nil {
 		t.Fatalf("repo.SaveIndex() %v", err)
 	}
 }
@@ -237,7 +237,7 @@ func testRepack(t *testing.T, version uint) {
 			packsBefore, packsAfter)
 	}
 
-	saveIndex(t, repo)
+	flush(t, repo)
 
 	removeBlobs, keepBlobs := selectBlobs(t, repo, 0.2)
 
@@ -297,7 +297,7 @@ func testRepackCopy(t *testing.T, version uint) {
 	t.Logf("rand seed is %v", seed)
 
 	createRandomBlobs(t, repo, 100, 0.7)
-	saveIndex(t, repo)
+	flush(t, repo)
 
 	_, keepBlobs := selectBlobs(t, repo, 0.2)
 	copyPacks := findPacksForBlobs(t, repo, keepBlobs)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -519,7 +519,7 @@ func (r *Repository) SaveUnpacked(ctx context.Context, t restic.FileType, p []by
 
 // Flush saves all remaining packs and the index
 func (r *Repository) Flush(ctx context.Context) error {
-	if err := r.FlushPacks(ctx); err != nil {
+	if err := r.flushPacks(ctx); err != nil {
 		return err
 	}
 
@@ -530,8 +530,8 @@ func (r *Repository) Flush(ctx context.Context) error {
 	return r.idx.SaveIndex(ctx, r)
 }
 
-// FlushPacks saves all remaining packs.
-func (r *Repository) FlushPacks(ctx context.Context) error {
+// flushPacks saves all remaining packs.
+func (r *Repository) flushPacks(ctx context.Context) error {
 	pms := []struct {
 		t  restic.BlobType
 		pm *packerManager

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -871,11 +871,6 @@ func (r *Repository) SaveTree(ctx context.Context, t *restic.Tree) (restic.ID, e
 	return id, err
 }
 
-// Loader allows loading data from a backend.
-type Loader interface {
-	Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error
-}
-
 type BackendLoadFn func(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error
 
 // StreamPack loads the listed blobs from the specified pack file. The plaintext blob is passed to

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -643,7 +643,6 @@ func (r *Repository) CreateIndexFromPacks(ctx context.Context, packsize map[rest
 		return nil
 	})
 
-	idx := NewIndex()
 	// a worker receives an pack ID from ch, reads the pack contents, and adds them to idx
 	worker := func() error {
 		for fi := range ch {
@@ -654,7 +653,7 @@ func (r *Repository) CreateIndexFromPacks(ctx context.Context, packsize map[rest
 				invalid = append(invalid, fi.ID)
 				m.Unlock()
 			}
-			idx.StorePack(fi.ID, entries)
+			r.idx.StorePack(fi.ID, entries)
 			p.Add(1)
 		}
 
@@ -670,9 +669,6 @@ func (r *Repository) CreateIndexFromPacks(ctx context.Context, packsize map[rest
 	if err != nil {
 		return invalid, errors.Fatal(err.Error())
 	}
-
-	// Add idx to MasterIndex
-	r.idx.Insert(idx)
 
 	return invalid, nil
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -582,12 +582,6 @@ func (r *Repository) LoadIndex(ctx context.Context) error {
 		if err != nil {
 			return err
 		}
-
-		_, err = idx.IDs()
-		if err != nil {
-			return err
-		}
-
 		r.idx.Insert(idx)
 		return nil
 	})

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -414,20 +414,11 @@ func testRepositoryIncrementalIndex(t *testing.T, version uint) {
 
 	repository.IndexFull = func(*repository.Index, bool) bool { return true }
 
-	// add 15 packs
+	// add a few rounds of packs
 	for j := 0; j < 5; j++ {
-		// add 3 packs, write intermediate index
-		for i := 0; i < 3; i++ {
-			saveRandomDataBlobs(t, repo, 5, 1<<15)
-			rtest.OK(t, repo.FlushPacks(context.Background()))
-		}
+		// add some packs, write intermediate index
+		saveRandomDataBlobs(t, repo, 20, 1<<15)
 		rtest.OK(t, repo.Flush(context.TODO()))
-	}
-
-	// add another 5 packs
-	for i := 0; i < 5; i++ {
-		saveRandomDataBlobs(t, repo, 5, 1<<15)
-		rtest.OK(t, repo.FlushPacks(context.Background()))
 	}
 
 	// save final index

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -374,7 +374,7 @@ func benchmarkLoadIndex(b *testing.B, version uint) {
 	id, err := repository.SaveIndex(context.TODO(), repo, idx)
 	rtest.OK(b, err)
 
-	b.Logf("index saved as %v (%v entries)", id.Str(), idx.Count(restic.DataBlob))
+	b.Logf("index saved as %v", id.Str())
 	fi, err := repo.Backend().Stat(context.TODO(), restic.Handle{Type: restic.IndexFile, Name: id.String()})
 	rtest.OK(b, err)
 	b.Logf("filesize is %v", fi.Size)

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -362,13 +362,12 @@ func benchmarkLoadIndex(b *testing.B, version uint) {
 	idx := repository.NewIndex()
 
 	for i := 0; i < 5000; i++ {
-		idx.Store(restic.PackedBlob{
-			Blob: restic.Blob{
+		idx.StorePack(restic.NewRandomID(), []restic.Blob{
+			{
 				BlobHandle: restic.NewRandomBlobHandle(),
 				Length:     1234,
 				Offset:     1235,
 			},
-			PackID: restic.NewRandomID(),
 		})
 	}
 

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -421,8 +421,7 @@ func testRepositoryIncrementalIndex(t *testing.T, version uint) {
 			saveRandomDataBlobs(t, repo, 5, 1<<15)
 			rtest.OK(t, repo.FlushPacks(context.Background()))
 		}
-
-		rtest.OK(t, repo.SaveFullIndex(context.TODO()))
+		rtest.OK(t, repo.Flush(context.TODO()))
 	}
 
 	// add another 5 packs
@@ -432,7 +431,7 @@ func testRepositoryIncrementalIndex(t *testing.T, version uint) {
 	}
 
 	// save final index
-	rtest.OK(t, repo.SaveIndex(context.TODO()))
+	rtest.OK(t, repo.Flush(context.TODO()))
 
 	packEntries := make(map[restic.ID]map[restic.ID]struct{})
 

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -132,3 +132,13 @@ func BenchmarkAllVersions(b *testing.B, bench VersionedBenchmark) {
 		})
 	}
 }
+
+func TestMergeIndex(t testing.TB, mi *MasterIndex) ([]*Index, int) {
+	finalIndexes := mi.FinalizeNotFinalIndexes()
+	for _, idx := range finalIndexes {
+		test.OK(t, idx.SetID(restic.NewRandomID()))
+	}
+
+	test.OK(t, mi.MergeFinalIndexes())
+	return finalIndexes, len(mi.idx)
+}

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -134,7 +134,7 @@ func BenchmarkAllVersions(b *testing.B, bench VersionedBenchmark) {
 }
 
 func TestMergeIndex(t testing.TB, mi *MasterIndex) ([]*Index, int) {
-	finalIndexes := mi.FinalizeNotFinalIndexes()
+	finalIndexes := mi.finalizeNotFinalIndexes()
 	for _, idx := range finalIndexes {
 		test.OK(t, idx.SetID(restic.NewRandomID()))
 	}

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -15,16 +15,12 @@ type Repository interface {
 
 	Key() *crypto.Key
 
-	SetIndex(MasterIndex) error
-
 	Index() MasterIndex
-	SaveFullIndex(context.Context) error
-	SaveIndex(context.Context) error
 	LoadIndex(context.Context) error
+	SetIndex(MasterIndex) error
+	LookupBlobSize(ID, BlobType) (uint, bool)
 
 	Config() Config
-
-	LookupBlobSize(ID, BlobType) (uint, bool)
 
 	// List calls the function fn for each file of type t in the repository.
 	// When an error is returned by fn, processing stops and List() returns the
@@ -63,6 +59,11 @@ type Lister interface {
 // LoadJSONUnpackeder allows loading a JSON file not stored in a pack file
 type LoadJSONUnpackeder interface {
 	LoadJSONUnpacked(ctx context.Context, t FileType, id ID, dest interface{}) error
+}
+
+// SaverUnpacked allows saving a blob not stored in a pack file
+type SaverUnpacked interface {
+	SaveUnpacked(context.Context, FileType, []byte) (ID, error)
 }
 
 type PackBlobs struct {

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -76,7 +76,6 @@ type PackBlobs struct {
 type MasterIndex interface {
 	Has(BlobHandle) bool
 	Lookup(BlobHandle) []PackedBlob
-	Count(BlobType) uint
 
 	// Each returns a channel that yields all blobs known to the index. When
 	// the context is cancelled, the background goroutine terminates. This

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/restic/restic/internal/crypto"
+	"github.com/restic/restic/internal/ui/progress"
 )
 
 // Repository stores data in a backend. It provides high-level functions and
@@ -82,4 +83,6 @@ type MasterIndex interface {
 	// blocks any modification of the index.
 	Each(ctx context.Context) <-chan PackedBlob
 	ListPacks(ctx context.Context, packs IDSet) <-chan PackBlobs
+
+	Save(ctx context.Context, repo SaverUnpacked, packBlacklist IDSet, extraObsolete IDs, p *progress.Counter) (obsolete IDSet, err error)
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR simplifies some of the index code and removes several functions that are only used for testing. In addition, it slightly improves the separation between the index and repository code. These changes are nearly sufficient to allow splitting the index from the repository package.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
