### PR TITLE
all: Move away from pkg/errors, easy cases

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -144,7 +144,7 @@ func init() {
 func filterExisting(items []string) (result []string, err error) {
 	for _, item := range items {
 		_, err := fs.Lstat(item)
-		if err != nil && os.IsNotExist(errors.Cause(err)) {
+		if errors.Is(err, os.ErrNotExist) {
 			Warnf("%v does not exist, skipping\n", item)
 			continue
 		}

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -116,7 +116,7 @@ func runMount(opts MountOptions, gopts GlobalOptions, args []string) error {
 
 	mountpoint := args[0]
 
-	if _, err := resticfs.Stat(mountpoint); os.IsNotExist(errors.Cause(err)) {
+	if _, err := resticfs.Stat(mountpoint); errors.Is(err, os.ErrNotExist) {
 		Verbosef("Mountpoint %s doesn't exist\n", mountpoint)
 		return err
 	}

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -297,7 +297,7 @@ func resolvePassword(opts GlobalOptions, envStr string) (string, error) {
 	}
 	if opts.PasswordFile != "" {
 		s, err := textfile.Read(opts.PasswordFile)
-		if os.IsNotExist(errors.Cause(err)) {
+		if errors.Is(err, os.ErrNotExist) {
 			return "", errors.Fatalf("%s does not exist", opts.PasswordFile)
 		}
 		return strings.TrimSpace(string(s)), errors.Wrap(err, "Readfile")
@@ -398,7 +398,7 @@ func ReadRepo(opts GlobalOptions) (string, error) {
 		}
 
 		s, err := textfile.Read(opts.RepositoryFile)
-		if os.IsNotExist(errors.Cause(err)) {
+		if errors.Is(err, os.ErrNotExist) {
 			return "", errors.Fatalf("%s does not exist", opts.RepositoryFile)
 		}
 		if err != nil {

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -98,7 +98,7 @@ func main() {
 	err := cmdRoot.Execute()
 
 	switch {
-	case restic.IsAlreadyLocked(errors.Cause(err)):
+	case restic.IsAlreadyLocked(err):
 		fmt.Fprintf(os.Stderr, "%v\nthe `unlock` command can be used to remove stale locks\n", err)
 	case err == ErrInvalidSourceData:
 		fmt.Fprintf(os.Stderr, "Warning: %v\n", err)

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -2040,8 +2040,8 @@ func TestArchiverAbortEarlyOnError(t *testing.T) {
 			})
 
 			_, _, err := arch.Snapshot(ctx, []string{"."}, SnapshotOptions{Time: time.Now()})
-			if errors.Cause(err) != test.err {
-				t.Errorf("expected error (%v) not found, got %v", test.err, errors.Cause(err))
+			if !errors.Is(err, test.err) {
+				t.Errorf("expected error (%v) not found, got %v", test.err, err)
 			}
 
 			t.Logf("Snapshot return error: %v", err)

--- a/internal/archiver/file_saver.go
+++ b/internal/archiver/file_saver.go
@@ -165,7 +165,7 @@ func (s *FileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 	for {
 		buf := s.saveFilePool.Get()
 		chunk, err := chnker.Next(buf.Data)
-		if errors.Cause(err) == io.EOF {
+		if err == io.EOF {
 			buf.Release()
 			break
 		}

--- a/internal/backend/layout.go
+++ b/internal/backend/layout.go
@@ -152,7 +152,7 @@ func ParseLayout(ctx context.Context, repo Filesystem, layout, defaultLayout, pa
 		l, err = DetectLayout(ctx, repo, path)
 
 		// use the default layout if auto detection failed
-		if errors.Cause(err) == ErrLayoutDetectionFailed && defaultLayout != "" {
+		if errors.Is(err, ErrLayoutDetectionFailed) && defaultLayout != "" {
 			debug.Log("error: %v, use default layout %v", err, defaultLayout)
 			return ParseLayout(ctx, repo, defaultLayout, "", path)
 		}

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -71,7 +71,7 @@ func (be *MemoryBackend) Test(ctx context.Context, h restic.Handle) (bool, error
 
 // IsNotExist returns true if the file does not exist.
 func (be *MemoryBackend) IsNotExist(err error) bool {
-	return errors.Cause(err) == errNotFound
+	return errors.Is(err, errNotFound)
 }
 
 // Save adds new Data to the backend.

--- a/internal/backend/rclone/backend_test.go
+++ b/internal/backend/rclone/backend_test.go
@@ -29,7 +29,8 @@ func newTestSuite(t testing.TB) *test.Suite {
 			t.Logf("Create()")
 			cfg := config.(rclone.Config)
 			be, err := rclone.Create(context.TODO(), cfg)
-			if e, ok := errors.Cause(err).(*exec.Error); ok && e.Err == exec.ErrNotFound {
+			var e *exec.Error
+			if errors.As(err, &e) && e.Err == exec.ErrNotFound {
 				t.Skipf("program %q not found", e.Name)
 				return nil, nil
 			}

--- a/internal/backend/rclone/internal_test.go
+++ b/internal/backend/rclone/internal_test.go
@@ -18,7 +18,8 @@ func TestRcloneExit(t *testing.T) {
 	cfg := NewConfig()
 	cfg.Remote = dir
 	be, err := Open(cfg, nil)
-	if e, ok := errors.Cause(err).(*exec.Error); ok && e.Err == exec.ErrNotFound {
+	var e *exec.Error
+	if errors.As(err, &e) && e.Err == exec.ErrNotFound {
 		t.Skipf("program %q not found", e.Name)
 		return
 	}

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -183,7 +183,6 @@ func (r *SFTP) ReadDir(ctx context.Context, dir string) ([]os.FileInfo, error) {
 
 // IsNotExist returns true if the error is caused by a not existing file.
 func (r *SFTP) IsNotExist(err error) bool {
-	err = errors.Cause(err)
 	return errors.Is(err, os.ErrNotExist)
 }
 
@@ -496,7 +495,7 @@ func (r *SFTP) Test(ctx context.Context, h restic.Handle) (bool, error) {
 	defer r.sem.ReleaseToken()
 
 	_, err := r.c.Lstat(r.Filename(h))
-	if os.IsNotExist(errors.Cause(err)) {
+	if errors.Is(err, os.ErrNotExist) {
 		return false, nil
 	}
 

--- a/internal/backend/sftp/sftp_test.go
+++ b/internal/backend/sftp/sftp_test.go
@@ -20,7 +20,7 @@ func findSFTPServerBinary() string {
 	for _, dir := range strings.Split(rtest.TestSFTPPath, ":") {
 		testpath := filepath.Join(dir, "sftp-server")
 		_, err := os.Stat(testpath)
-		if !os.IsNotExist(errors.Cause(err)) {
+		if !errors.Is(err, os.ErrNotExist) {
 			return testpath
 		}
 	}

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -311,11 +311,8 @@ func (be *beSwift) removeKeys(ctx context.Context, t restic.FileType) error {
 
 // IsNotExist returns true if the error is caused by a not existing file.
 func (be *beSwift) IsNotExist(err error) bool {
-	if e, ok := errors.Cause(err).(*swift.Error); ok {
-		return e.StatusCode == http.StatusNotFound
-	}
-
-	return false
+	var e *swift.Error
+	return errors.As(err, &e) && e.StatusCode == http.StatusNotFound
 }
 
 // Delete removes all restic objects in the container.

--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -361,8 +361,8 @@ func (s *Suite) TestListCancel(t *testing.T) {
 			return nil
 		})
 
-		if errors.Cause(err) != context.Canceled {
-			t.Fatalf("expected error not found, want %v, got %v", context.Canceled, errors.Cause(err))
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("expected error not found, want %v, got %v", context.Canceled, err)
 		}
 	})
 
@@ -380,7 +380,7 @@ func (s *Suite) TestListCancel(t *testing.T) {
 			return nil
 		})
 
-		if errors.Cause(err) != context.Canceled {
+		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected error not found, want %v, got %v", context.Canceled, err)
 		}
 
@@ -403,7 +403,7 @@ func (s *Suite) TestListCancel(t *testing.T) {
 			return nil
 		})
 
-		if errors.Cause(err) != context.Canceled {
+		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected error not found, want %v, got %v", context.Canceled, err)
 		}
 
@@ -429,7 +429,7 @@ func (s *Suite) TestListCancel(t *testing.T) {
 			return nil
 		})
 
-		if errors.Cause(err) != context.DeadlineExceeded {
+		if !errors.Is(err, context.DeadlineExceeded) {
 			t.Fatalf("expected error not found, want %#v, got %#v", context.DeadlineExceeded, err)
 		}
 

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -109,7 +109,7 @@ func TestMissingPack(t *testing.T) {
 	test.Assert(t, len(errs) == 1,
 		"expected exactly one error, got %v", len(errs))
 
-	if err, ok := errs[0].(checker.PackError); ok {
+	if err, ok := errs[0].(*checker.PackError); ok {
 		test.Equals(t, packHandle.Name, err.ID.String())
 	} else {
 		t.Errorf("expected error returned by checker.Packs() to be PackError, got %v", err)
@@ -145,7 +145,7 @@ func TestUnreferencedPack(t *testing.T) {
 	test.Assert(t, len(errs) == 1,
 		"expected exactly one error, got %v", len(errs))
 
-	if err, ok := errs[0].(checker.PackError); ok {
+	if err, ok := errs[0].(*checker.PackError); ok {
 		test.Equals(t, packID, err.ID.String())
 	} else {
 		t.Errorf("expected error returned by checker.Packs() to be PackError, got %v", err)

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -52,4 +52,6 @@ func Cause(err error) error {
 
 // Go 1.13-style error handling.
 
+func As(err error, tgt interface{}) bool { return errors.As(err, tgt) }
+
 func Is(x, y error) bool { return errors.Is(x, y) }

--- a/internal/repository/key.go
+++ b/internal/repository/key.go
@@ -153,7 +153,7 @@ func SearchKey(ctx context.Context, s *Repository, password string, maxKeys int,
 			debug.Log("key %v returned error %v", fi.Name, err)
 
 			// ErrUnauthenticated means the password is wrong, try the next key
-			if errors.Cause(err) == crypto.ErrUnauthenticated {
+			if errors.Is(err, crypto.ErrUnauthenticated) {
 				return nil
 			}
 

--- a/internal/restic/testing.go
+++ b/internal/restic/testing.go
@@ -9,8 +9,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/restic/restic/internal/errors"
-
 	"github.com/restic/chunker"
 )
 
@@ -44,7 +42,7 @@ func (fs *fakeFileSystem) saveFile(ctx context.Context, rd io.Reader) (blobs IDs
 	blobs = IDs{}
 	for {
 		chunk, err := fs.chunker.Next(fs.buf)
-		if errors.Cause(err) == io.EOF {
+		if err == io.EOF {
 			break
 		}
 

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -175,7 +175,7 @@ func ResetReadOnly(t testing.TB, dir string) {
 
 		return nil
 	})
-	if os.IsNotExist(errors.Cause(err)) {
+	if errors.Is(err, os.ErrNotExist) {
 		err = nil
 	}
 	OK(t, err)
@@ -186,7 +186,7 @@ func ResetReadOnly(t testing.TB, dir string) {
 func RemoveAll(t testing.TB, path string) {
 	ResetReadOnly(t, path)
 	err := os.RemoveAll(path)
-	if os.IsNotExist(errors.Cause(err)) {
+	if errors.Is(err, os.ErrNotExist) {
 		err = nil
 	}
 	OK(t, err)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

[github.com/pkg/errors](https://github.com/pkg/errors) is no longer getting updates, because Go 1.13 went with the more flexible errors.{As,Is} function. Use those instead: errors from pkg/errors already support the Unwrap interface used by 1.13 error handling.

Also:

* check for io.EOF with a straight ==. That value should not be wrapped, and the chunker (whose error is checked in the cases changed) does not wrap it.
* Give custom Error methods pointer receivers, so there's no ambiguity when type-switching since the value type will no longer implement error.
* Make restic.ErrAlreadyLocked private, and rename it to alreadyLockedError to match the stdlib convention that error type
  names end in Error.
* Make s3.Backend.IsAccessDenied a private function.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

#3420 already contained some errors.Is usage.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
