### PR TITLE
Support non utf symlink targets

### DIFF
--- a/changelog/unreleased/issue-3311
+++ b/changelog/unreleased/issue-3311
@@ -1,0 +1,12 @@
+Bugfix: Support non-UTF8 paths as symlink target
+
+Restic versions before 0.16.0 did not correctly backup and restore symlinks
+that contain a non-UTF8 target. Note that this only affects system that still
+use a non-Unicode encoding for filesystem paths.
+
+We have extended the repository format to add support for such symlinks. Please
+note that at least restic version 0.16.0 must be used for both backup and
+restore to correctly handle non-UTF8 symlink targets.
+
+https://github.com/restic/restic/issues/3311
+https://github.com/restic/restic/pull/3802


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Currently symlinks whose target name is invalid utf8 are not backed up correctly. The invalid characters are replaced with `\ufffd`. This PR introduces an optional quoted field which is used for symlink targets which might not encode correctly. The old `linktarget` field in a Node still exists and continues to be set to stay backwards compatible to older clients. Thus, for old clients the symlink will behave just as before, whereas later restic versions which support the new field will use that one automatically instead.

This allows for a backwards compatible addition of a correct symlink encoding. I've decided against binding the symlink encoding to a specific repository version as that would create all sorts of headaches when copying snapshots between repositories with different versions.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3311

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
