### PR TITLE
cmd/restic, limiter: Move config knowledge to internal packages

### DIFF
--- a/internal/limiter/limiter_backend_test.go
+++ b/internal/limiter/limiter_backend_test.go
@@ -36,7 +36,7 @@ func TestLimitBackendSave(t *testing.T) {
 		}
 		return nil
 	}
-	limiter := NewStaticLimiter(42*1024, 42*1024)
+	limiter := NewStaticLimiter(Limits{42 * 1024, 42 * 1024})
 	limbe := LimitBackend(be, limiter)
 
 	rd := restic.NewByteReader(data, nil)
@@ -82,7 +82,7 @@ func TestLimitBackendLoad(t *testing.T) {
 			}
 			return newTracedReadCloser(src), nil
 		}
-		limiter := NewStaticLimiter(42*1024, 42*1024)
+		limiter := NewStaticLimiter(Limits{42 * 1024, 42 * 1024})
 		limbe := LimitBackend(be, limiter)
 
 		err := limbe.Load(context.TODO(), testHandle, 0, 0, func(rd io.Reader) error {

--- a/internal/limiter/static_limiter.go
+++ b/internal/limiter/static_limiter.go
@@ -12,20 +12,27 @@ type staticLimiter struct {
 	downstream *ratelimit.Bucket
 }
 
+// Limits represents static upload and download limits.
+// For both, zero means unlimited.
+type Limits struct {
+	UploadKb   int
+	DownloadKb int
+}
+
 // NewStaticLimiter constructs a Limiter with a fixed (static) upload and
 // download rate cap
-func NewStaticLimiter(uploadKb, downloadKb int) Limiter {
+func NewStaticLimiter(l Limits) Limiter {
 	var (
 		upstreamBucket   *ratelimit.Bucket
 		downstreamBucket *ratelimit.Bucket
 	)
 
-	if uploadKb > 0 {
-		upstreamBucket = ratelimit.NewBucketWithRate(toByteRate(uploadKb), int64(toByteRate(uploadKb)))
+	if l.UploadKb > 0 {
+		upstreamBucket = ratelimit.NewBucketWithRate(toByteRate(l.UploadKb), int64(toByteRate(l.UploadKb)))
 	}
 
-	if downloadKb > 0 {
-		downstreamBucket = ratelimit.NewBucketWithRate(toByteRate(downloadKb), int64(toByteRate(downloadKb)))
+	if l.DownloadKb > 0 {
+		downstreamBucket = ratelimit.NewBucketWithRate(toByteRate(l.DownloadKb), int64(toByteRate(l.DownloadKb)))
 	}
 
 	return staticLimiter{


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This is some cleanup for cmd/restic/global.go.

The GlobalOptions struct now embeds a backend.TransportOptions, so it doesn't need to construct one in open and create. The upload and download limits are similarly now a struct in internal/limiter that is embedded in GlobalOptions.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

This is a follow-up to #3795. I'm still trying to move the code that opens/creates backends from cmd/restic/global.go to internal/backend or a subpackage of it, in order to create a REST API (#60) that can open repositories (#832). This patch decouples that code from GlobalOptions.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
