### PR TITLE
Revert "restic prune: Merge three loops over the index"

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -242,26 +242,11 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 
 	Verbosef("searching used packs...\n")
 
-	indexPack := make(map[restic.ID]packInfo)
 	keepBlobs := restic.NewBlobSet()
+	duplicateBlobs := restic.NewBlobSet()
 
-	// iterate over all blobs in index to generate packInfo and find duplicates
+	// iterate over all blobs in index to find out which blobs are duplicates
 	for blob := range repo.Index().Each(ctx) {
-		ip, seen := indexPack[blob.PackID]
-
-		if seen {
-			// mark mixed packs with "Invalid blob type"
-			if ip.tpe != blob.Type {
-				ip.tpe = restic.InvalidBlob
-			}
-		} else {
-			ip = packInfo{
-				tpe:      blob.Type,
-				usedSize: pack.HeaderSize,
-			}
-		}
-		ip.usedSize += uint64(pack.CalculateEntrySize(blob.Blob))
-
 		bh := blob.BlobHandle
 		size := uint64(blob.Length)
 		switch {
@@ -270,27 +255,14 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 			keepBlobs.Insert(bh)
 			stats.size.used += size
 			stats.blobs.used++
-			ip.usedSize += size
-			ip.usedBlobs++
-
-		case keepBlobs.Has(bh): // duplicate of a blob that we want to keep
+		case keepBlobs.Has(bh): // duplicate blob
+			duplicateBlobs.Insert(bh)
 			stats.size.duplicate += size
 			stats.blobs.duplicate++
-			ip.usedSize += size
-			ip.duplicateBlobs++
-
-		default: // unused, don't care if it's a duplicate
+		default:
 			stats.size.unused += size
 			stats.blobs.unused++
-			ip.unusedSize += size
-			ip.unusedBlobs++
 		}
-
-		if !blob.IsCompressed() {
-			ip.uncompressed = true
-		}
-		// update indexPack
-		indexPack[blob.PackID] = ip
 	}
 
 	// Check if all used blobs have been found in index
@@ -301,6 +273,48 @@ func prune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, usedB
 			"Please report this error (along with the output of the 'prune' run) at\n"+
 			"https://github.com/restic/restic/issues/new/choose\n", usedBlobs)
 		return errorIndexIncomplete
+	}
+
+	indexPack := make(map[restic.ID]packInfo)
+
+	// save computed pack header size
+	for pid, hdrSize := range pack.Size(ctx, repo.Index(), true) {
+		// initialize tpe with NumBlobTypes to indicate it's not set
+		indexPack[pid] = packInfo{tpe: restic.NumBlobTypes, usedSize: uint64(hdrSize)}
+	}
+
+	// iterate over all blobs in index to generate packInfo
+	for blob := range repo.Index().Each(ctx) {
+		ip := indexPack[blob.PackID]
+
+		// Set blob type if not yet set
+		if ip.tpe == restic.NumBlobTypes {
+			ip.tpe = blob.Type
+		}
+
+		// mark mixed packs with "Invalid blob type"
+		if ip.tpe != blob.Type {
+			ip.tpe = restic.InvalidBlob
+		}
+
+		bh := blob.BlobHandle
+		size := uint64(blob.Length)
+		switch {
+		case duplicateBlobs.Has(bh): // duplicate blob
+			ip.usedSize += size
+			ip.duplicateBlobs++
+		case keepBlobs.Has(bh): // used blob, not duplicate
+			ip.usedSize += size
+			ip.usedBlobs++
+		default: // unused blob
+			ip.unusedSize += size
+			ip.unusedBlobs++
+		}
+		if !blob.IsCompressed() {
+			ip.uncompressed = true
+		}
+		// update indexPack
+		indexPack[blob.PackID] = ip
 	}
 
 	Verbosef("collecting packs for deletion and repacking\n")

--- a/cmd/restic/cmd_rebuild_index.go
+++ b/cmd/restic/cmd_rebuild_index.go
@@ -98,7 +98,7 @@ func rebuildIndex(opts RebuildIndexOptions, gopts GlobalOptions, repo *repositor
 		if err != nil {
 			return err
 		}
-		packSizeFromIndex = pack.Size(ctx, repo.Index())
+		packSizeFromIndex = pack.Size(ctx, repo.Index(), false)
 	}
 
 	Verbosef("getting pack files to read...\n")

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -131,7 +131,7 @@ func (c *Checker) LoadIndex(ctx context.Context) (hints []error, errs []error) {
 	}
 
 	// compute pack size using index entries
-	c.packs = pack.Size(ctx, c.masterIndex)
+	c.packs = pack.Size(ctx, c.masterIndex, false)
 
 	debug.Log("checking for duplicate packs")
 	for packID := range c.packs {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This reverts commit 8bdfcf779fb4e7260fc05649beb7c524d7518bbe.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Should fix #3809. Also needed to make #3290 apply cleanly.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
