### PR TITLE
Don't crash if SecretString is uninitialized

### DIFF
--- a/internal/options/secret_string.go
+++ b/internal/options/secret_string.go
@@ -13,12 +13,15 @@ func (s SecretString) GoString() string {
 }
 
 func (s SecretString) String() string {
-	if len(*s.s) == 0 {
+	if s.s == nil || len(*s.s) == 0 {
 		return ``
 	}
 	return `**redacted**`
 }
 
 func (s *SecretString) Unwrap() string {
+	if s.s == nil {
+		return ""
+	}
 	return *s.s
 }

--- a/internal/options/secret_string_test.go
+++ b/internal/options/secret_string_test.go
@@ -53,3 +53,11 @@ func TestSecretStringEmpty(t *testing.T) {
 	test.Equals(t, `""`, fmt.Sprintf("%#v", secret))
 	test.Equals(t, keyStr, secret.Unwrap())
 }
+
+func TestSecretStringDefault(t *testing.T) {
+	secretStruct := &secretTest{}
+
+	test.Equals(t, "", secretStruct.str.String())
+	test.Equals(t, `""`, secretStruct.str.GoString())
+	test.Equals(t, "", secretStruct.str.Unwrap())
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Fixes a crash introduced by #3470 .

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3470.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
