### PR TITLE
restore: validate include/exclude patterns

### DIFF
--- a/changelog/unreleased/pull-3819
+++ b/changelog/unreleased/pull-3819
@@ -1,0 +1,10 @@
+Enhancement: Validate include/exclude patterns before restoring
+
+Patterns provided to `restic restore` via `--exclude`, `--iexclude`,
+`--include` and `--iinclude` weren't validated before running the restore.
+Invalid patterns would result in error messages being printed repeatedly
+and possibly unwanted files being restored.
+restic now validates all patterns before running the restore and aborts with
+a fatal error if an invalid pattern is detected.
+
+https://github.com/restic/restic/pull/3819

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -70,6 +70,28 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 	hasExcludes := len(opts.Exclude) > 0 || len(opts.InsensitiveExclude) > 0
 	hasIncludes := len(opts.Include) > 0 || len(opts.InsensitiveInclude) > 0
 
+	// Validate provided patterns
+	if len(opts.Exclude) > 0 {
+		if valid, invalidPatterns := filter.ValidatePatterns(opts.Exclude); !valid {
+			return errors.Fatalf("--exclude: invalid pattern(s) provided:\n%s", strings.Join(invalidPatterns, "\n"))
+		}
+	}
+	if len(opts.InsensitiveExclude) > 0 {
+		if valid, invalidPatterns := filter.ValidatePatterns(opts.InsensitiveExclude); !valid {
+			return errors.Fatalf("--iexclude: invalid pattern(s) provided:\n%s", strings.Join(invalidPatterns, "\n"))
+		}
+	}
+	if len(opts.Include) > 0 {
+		if valid, invalidPatterns := filter.ValidatePatterns(opts.Include); !valid {
+			return errors.Fatalf("--include: invalid pattern(s) provided:\n%s", strings.Join(invalidPatterns, "\n"))
+		}
+	}
+	if len(opts.InsensitiveInclude) > 0 {
+		if valid, invalidPatterns := filter.ValidatePatterns(opts.InsensitiveInclude); !valid {
+			return errors.Fatalf("--iinclude: invalid pattern(s) provided:\n%s", strings.Join(invalidPatterns, "\n"))
+		}
+	}
+
 	for i, str := range opts.InsensitiveExclude {
 		opts.InsensitiveExclude[i] = strings.ToLower(str)
 	}

--- a/cmd/restic/integration_filter_pattern_test.go
+++ b/cmd/restic/integration_filter_pattern_test.go
@@ -67,3 +67,40 @@ func TestBackupFailsWhenUsingInvalidPatternsFromFile(t *testing.T) {
 *[._]log[.-][0-9]
 !*[._]log[.-][0-9]`, err.Error())
 }
+
+func TestRestoreFailsWhenUsingInvalidPatterns(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+
+	var err error
+
+	// Test --exclude
+	err = testRunRestoreAssumeFailure(t, "latest", RestoreOptions{Exclude: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}, env.gopts)
+
+	rtest.Equals(t, `Fatal: --exclude: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+
+	// Test --iexclude
+	err = testRunRestoreAssumeFailure(t, "latest", RestoreOptions{InsensitiveExclude: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}, env.gopts)
+
+	rtest.Equals(t, `Fatal: --iexclude: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+
+	// Test --include
+	err = testRunRestoreAssumeFailure(t, "latest", RestoreOptions{Include: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}, env.gopts)
+
+	rtest.Equals(t, `Fatal: --include: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+
+	// Test --iinclude
+	err = testRunRestoreAssumeFailure(t, "latest", RestoreOptions{InsensitiveInclude: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}, env.gopts)
+
+	rtest.Equals(t, `Fatal: --iinclude: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+}

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -131,6 +131,12 @@ func testRunRestoreIncludes(t testing.TB, gopts GlobalOptions, dir string, snaps
 	rtest.OK(t, runRestore(opts, gopts, []string{snapshotID.String()}))
 }
 
+func testRunRestoreAssumeFailure(t testing.TB, snapshotID string, opts RestoreOptions, gopts GlobalOptions) error {
+	err := runRestore(opts, gopts, []string{snapshotID})
+
+	return err
+}
+
 func testRunCheck(t testing.TB, gopts GlobalOptions) {
 	opts := CheckOptions{
 		ReadData:    true,


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This is a follow-up to #3734 - patterns provided to `restic restore` via `--exclude`, `--iexclude`, `--include` and `--iinclude` are validated before the restore.
Providing an invalid pattern e.g. via `--exclude` would result in `error for exclude pattern: Match: syntax error in pattern` being printed repeatedly. Futhermore, the user would possibly restore unwanted files. 

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
