### PR TITLE
Added hint for --compression max in migration process

### DIFF
--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -320,4 +320,9 @@ parameter, see :ref:`customize-pruning` for more details.
 File contents stored in the repository will not be rewritten, data from new
 backups will be compressed. Over time more and more of the repository will
 be compressed. To speed up this process and compress all not yet compressed
-data, you can run ``prune --repack-uncompressed``.
+data, you can run ``prune --repack-uncompressed``. When you plan creating 
+your backups with maximum compression you should also use this flag 
+when doing this step since you can't switch to maximum compression later.
+Complete command for repacking with maximum compression: 
+``restic prune --repack-uncompressed --compression max``.
+

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -320,9 +320,7 @@ parameter, see :ref:`customize-pruning` for more details.
 File contents stored in the repository will not be rewritten, data from new
 backups will be compressed. Over time more and more of the repository will
 be compressed. To speed up this process and compress all not yet compressed
-data, you can run ``prune --repack-uncompressed``. When you plan creating 
-your backups with maximum compression you should also use this flag 
-when doing this step since you can't switch to maximum compression later.
-Complete command for repacking with maximum compression: 
-``restic prune --repack-uncompressed --compression max``.
-
+data, you can run ``prune --repack-uncompressed``. When you plan to create
+your backups with maximum compression, you should also add the
+``--compression max`` flag to the prune command. For already backed up data,
+the compression level cannot be changed later on.


### PR DESCRIPTION
Added hint for --compression max in migration process. Since this is a onetime process users should be aware of this and consider this step.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Users might not be aware that the should specify maxmium compression on migration process since they can't later go from default compression to maxmium compression.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No, since this is only a documentation update and users a free to ignore it.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
