### PR TITLE
doc: Add note about using rclone for Google Drive

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -518,6 +518,10 @@ established.
 Google Cloud Storage
 ********************
 
+.. note:: Google Cloud Storage is not the same service as Google Drive - to use
+          the latter, please see :ref:`other-services` for instructions on using
+          the rclone backend.
+
 Restic supports Google Cloud Storage as a backend and connects via a `service account`_.
 
 For normal restic operation, the service account must have the
@@ -574,6 +578,8 @@ established.
 .. _service account: https://cloud.google.com/storage/docs/authentication#service_accounts
 .. _create a service account key: https://cloud.google.com/storage/docs/authentication#generating-a-private-key
 .. _default authentication material: https://developers.google.com/identity/protocols/application-default-credentials
+
+.. _other-services:
 
 Other Services via rclone
 *************************


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It wasn't clear that Google Cloud Storage and Google Drive are two different services and that one should use the rclone backend for the latter. This commit adds a note with this information.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

https://forum.restic.net/t/total-bafflement-with-first-steps-for-restic-with-a-gdrive-account/5213

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
