### PR TITLE
Split prune into slightly small functions

### DIFF
--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -521,9 +521,6 @@ func decidePackAction(ctx context.Context, opts PruneOptions, gopts GlobalOption
 		}
 	}
 
-	// calculate limit for number of unused bytes in the repo after repacking
-	maxUnusedSizeAfter := opts.maxUnusedBytes(stats.size.used)
-
 	// Sort repackCandidates such that packs with highest ratio unused/used space are picked first.
 	// This is equivalent to sorting by unused / total space.
 	// Instead of unused[i] / used[i] > unused[j] / used[j] we use
@@ -548,6 +545,9 @@ func decidePackAction(ctx context.Context, opts PruneOptions, gopts GlobalOption
 		stats.blobs.repackrm += p.unusedBlobs
 		stats.size.repackrm += p.unusedSize
 	}
+
+	// calculate limit for number of unused bytes in the repo after repacking
+	maxUnusedSizeAfter := opts.maxUnusedBytes(stats.size.used)
 
 	for _, p := range repackCandidates {
 		reachedUnusedSizeAfter := (stats.size.unused-stats.size.remove-stats.size.repackrm < maxUnusedSizeAfter)

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -658,6 +658,14 @@ func doPrune(opts PruneOptions, gopts GlobalOptions, repo restic.Repository, pla
 
 		// Also remove repacked packs
 		plan.removePacks.Merge(plan.repackPacks)
+
+		if len(plan.keepBlobs) != 0 {
+			Warnf("%v was not repacked\n\n"+
+				"Integrity check failed.\n"+
+				"Please report this error (along with the output of the 'prune' run) at\n"+
+				"https://github.com/restic/restic/issues/new/choose\n", plan.keepBlobs)
+			return errors.Fatal("internal error: blobs were not repacked")
+		}
 	}
 
 	if len(plan.ignorePacks) == 0 {

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -354,4 +355,53 @@ func testRepackWrongBlob(t *testing.T, version uint) {
 		t.Fatal("expected repack to fail but got no error")
 	}
 	t.Logf("found expected error: %v", err)
+}
+
+func TestRepackBlobFallback(t *testing.T) {
+	repository.TestAllVersions(t, testRepackBlobFallback)
+}
+
+func testRepackBlobFallback(t *testing.T, version uint) {
+	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
+	defer cleanup()
+
+	seed := time.Now().UnixNano()
+	rand.Seed(seed)
+	t.Logf("rand seed is %v", seed)
+
+	length := randomSize(10*1024, 1024*1024) // 10KiB to 1MiB of data
+	buf := make([]byte, length)
+	rand.Read(buf)
+	id := restic.Hash(buf)
+
+	// corrupted copy
+	modbuf := make([]byte, len(buf))
+	copy(modbuf, buf)
+	// invert first data byte
+	modbuf[0] ^= 0xff
+
+	// create pack with broken copy
+	var wg errgroup.Group
+	repo.StartPackUploader(context.TODO(), &wg)
+	_, _, _, err := repo.SaveBlob(context.TODO(), restic.DataBlob, modbuf, id, false)
+	rtest.OK(t, err)
+	rtest.OK(t, repo.Flush(context.Background()))
+
+	// find pack with damaged blob
+	keepBlobs := restic.NewBlobSet(restic.BlobHandle{Type: restic.DataBlob, ID: id})
+	rewritePacks := findPacksForBlobs(t, repo, keepBlobs)
+
+	// create pack with valid copy
+	repo.StartPackUploader(context.TODO(), &wg)
+	_, _, _, err = repo.SaveBlob(context.TODO(), restic.DataBlob, buf, id, true)
+	rtest.OK(t, err)
+	rtest.OK(t, repo.Flush(context.Background()))
+
+	// repack must fallback to valid copy
+	_, err = repository.Repack(context.TODO(), repo, repo, rewritePacks, keepBlobs, nil)
+	rtest.OK(t, err)
+
+	keepBlobs = restic.NewBlobSet(restic.BlobHandle{Type: restic.DataBlob, ID: id})
+	packs := findPacksForBlobs(t, repo, keepBlobs)
+	rtest.Assert(t, len(packs) == 3, "unexpected number of copies: %v", len(packs))
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
`prune` is currently a function with over 400 lines of code. This PR splits it into three pieces with only a bit more than 100 lines of code. There is definitely room for further refactoring, but I wanted to keep this PR simple.

In addition, the PR contains two small commits which add a sanity check that all expected blob were repacked and a fallback in case a blob cannot be read while reading a pack. The latter might help with situations where multiple copies of a blob exist.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
