### PR TITLE
Add environment variable RESTIC_COMPRESSION

### DIFF
--- a/changelog/unreleased/issue-21
+++ b/changelog/unreleased/issue-21
@@ -8,6 +8,7 @@ You can configure if data is compressed with the option `--compression`. It can
 be set to `auto` (the default, which will compress very fast), `max` (which
 will trade backup speed and CPU usage for better compression), or `off` (which
 disables compression). Each setting is only applied for the single run of restic.
+The option can also be set via the environment variable `RESTIC_COMPRESSION`.
 
 The new format version has not received much testing yet. Do not rely on it as
 your only backup copy! Please run `check` in regular intervals to detect any

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -125,6 +125,12 @@ func init() {
 	// Use our "generate" command instead of the cobra provided "completion" command
 	cmdRoot.CompletionOptions.DisableDefaultCmd = true
 
+	comp := os.Getenv("RESTIC_COMPRESSION")
+	if comp != "" {
+		// ignore error as there's no good way to handle it
+		_ = globalOptions.Compression.Set(comp)
+	}
+
 	restoreTerminal()
 }
 

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -552,6 +552,7 @@ environment variables. The following lists these environment variables:
     RESTIC_PASSWORD_COMMAND             Command printing the password for the repository to stdout
     RESTIC_KEY_HINT                     ID of key to try decrypting first, before other keys
     RESTIC_CACHE_DIR                    Location of the cache directory
+    RESTIC_COMPRESSION                  Compression mode (only available for repository format version 2)
     RESTIC_PROGRESS_FPS                 Frames per second by which the progress bar is updated
 
     TMPDIR                              Location for temporary files

--- a/doc/047_tuning_backup_parameters.rst
+++ b/doc/047_tuning_backup_parameters.rst
@@ -46,4 +46,5 @@ For a repository using at least repository format version 2, you can configure h
 is compressed with the option ``--compression``. It can be set to ```auto``` (the default,
 which will compress very fast), ``max`` (which will trade backup speed and CPU usage for
 slightly better compression), or ``off`` (which disables compression). Each setting is
-only applied for the single run of restic.
+only applied for the single run of restic. The option can also be set via the environment
+variable ``RESTIC_COMPRESSION``.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
It allows specifying the `--compression` option via the environment variable `RESTIC_COMPRESSION`.

The ugliest part of the code right now is, that the environment variable is silently ignored if it is set to an invalid value. But I don't see a good way to cleanly return an error in that case. (Except for moving the code to main.go)

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See https://forum.restic.net/t/compression-support-has-landed-in-master/4997/47 .

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
