### PR TITLE
Update tests to Go 1.19

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  latest_go: "1.18.x"
+  latest_go: "1.19.x"
   GO111MODULE: on
 
 jobs:
@@ -19,22 +19,28 @@ jobs:
         # list of jobs to run:
         include:
           - job_name: Windows
-            go: 1.18.x
+            go: 1.19.x
             os: windows-latest
             install_verb: install
 
           - job_name: macOS
-            go: 1.18.x
+            go: 1.19.x
             os: macOS-latest
             test_fuse: false
             install_verb: install
 
           - job_name: Linux
-            go: 1.18.x
+            go: 1.19.x
             os: ubuntu-latest
             test_cloud_backends: true
             test_fuse: true
             check_changelog: true
+            install_verb: install
+
+          - job_name: Linux
+            go: 1.18.x
+            os: ubuntu-latest
+            test_fuse: true
             install_verb: install
 
           - job_name: Linux

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -266,7 +266,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.45
+          version: v1.48
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true
           args: --verbose --timeout 5m

--- a/internal/restic/snapshot_policy.go
+++ b/internal/restic/snapshot_policy.go
@@ -190,7 +190,7 @@ type KeepReason struct {
 // according to the policy p. list is sorted in the process. reasons contains
 // the reasons to keep each snapshot, it is in the same order as keep.
 func ApplyPolicy(list Snapshots, p ExpirePolicy) (keep, remove Snapshots, reasons []KeepReason) {
-	sort.Sort(list)
+	sort.Stable(list)
 
 	if p.Empty() {
 		for _, sn := range list {

--- a/internal/restic/testdata/policy_keep_snapshots_0
+++ b/internal/restic/testdata/policy_keep_snapshots_0
@@ -153,33 +153,33 @@
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
-      "paths": [
-        "path1",
-        "path2"
-      ],
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
-      "paths": null,
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
       "paths": null
     },
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
       "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": [
+        "path1",
+        "path2"
+      ],
       "tags": [
         "foo",
         "bar"
@@ -915,39 +915,6 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
-        "paths": [
-          "path1",
-          "path2"
-        ],
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "policy is empty"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
-        "paths": null,
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "policy is empty"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
         "paths": null
       },
       "matches": [
@@ -960,6 +927,39 @@
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
         "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "policy is empty"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
+        "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "policy is empty"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
+        "paths": [
+          "path1",
+          "path2"
+        ],
         "tags": [
           "foo",
           "bar"

--- a/internal/restic/testdata/policy_keep_snapshots_18
+++ b/internal/restic/testdata/policy_keep_snapshots_18
@@ -3,28 +3,28 @@
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
+      "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
       "paths": [
         "path1",
         "path2"
       ],
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
-      "paths": null,
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
-      "paths": null,
       "tags": [
         "foo",
         "bar"
@@ -157,40 +157,40 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
+        "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "has tags [foo]"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
+        "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "has tags [foo]"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
         "paths": [
           "path1",
           "path2"
         ],
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "has tags [foo]"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
-        "paths": null,
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "has tags [foo]"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
-        "paths": null,
         "tags": [
           "foo",
           "bar"

--- a/internal/restic/testdata/policy_keep_snapshots_19
+++ b/internal/restic/testdata/policy_keep_snapshots_19
@@ -3,28 +3,28 @@
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
+      "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
       "paths": [
         "path1",
         "path2"
       ],
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
-      "paths": null,
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
-      "paths": null,
       "tags": [
         "foo",
         "bar"
@@ -45,40 +45,40 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
+        "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "has tags [foo, bar]"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
+        "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "has tags [foo, bar]"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
         "paths": [
           "path1",
           "path2"
         ],
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "has tags [foo, bar]"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
-        "paths": null,
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "has tags [foo, bar]"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
-        "paths": null,
         "tags": [
           "foo",
           "bar"

--- a/internal/restic/testdata/policy_keep_snapshots_20
+++ b/internal/restic/testdata/policy_keep_snapshots_20
@@ -3,28 +3,28 @@
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
+      "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
       "paths": [
         "path1",
         "path2"
       ],
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
-      "paths": null,
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
-      "paths": null,
       "tags": [
         "foo",
         "bar"
@@ -165,42 +165,42 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
+        "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "has tags [foo]",
+        "has tags [bar]"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
+        "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "has tags [foo]",
+        "has tags [bar]"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
         "paths": [
           "path1",
           "path2"
         ],
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "has tags [foo]",
-        "has tags [bar]"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
-        "paths": null,
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "has tags [foo]",
-        "has tags [bar]"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
-        "paths": null,
         "tags": [
           "foo",
           "bar"

--- a/internal/restic/testdata/policy_keep_snapshots_26
+++ b/internal/restic/testdata/policy_keep_snapshots_26
@@ -153,33 +153,33 @@
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
-      "paths": [
-        "path1",
-        "path2"
-      ],
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
-      "paths": null,
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
       "paths": null
     },
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
       "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": [
+        "path1",
+        "path2"
+      ],
       "tags": [
         "foo",
         "bar"
@@ -666,39 +666,6 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
-        "paths": [
-          "path1",
-          "path2"
-        ],
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "within 1y1m1d"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
-        "paths": null,
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "within 1y1m1d"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
         "paths": null
       },
       "matches": [
@@ -711,6 +678,39 @@
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
         "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "within 1y1m1d"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
+        "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "within 1y1m1d"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
+        "paths": [
+          "path1",
+          "path2"
+        ],
         "tags": [
           "foo",
           "bar"

--- a/internal/restic/testdata/policy_keep_snapshots_29
+++ b/internal/restic/testdata/policy_keep_snapshots_29
@@ -153,33 +153,33 @@
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
-      "paths": [
-        "path1",
-        "path2"
-      ],
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
-      "paths": null,
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
       "paths": null
     },
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
       "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": [
+        "path1",
+        "path2"
+      ],
       "tags": [
         "foo",
         "bar"
@@ -695,39 +695,6 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
-        "paths": [
-          "path1",
-          "path2"
-        ],
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "within 1y2m3d3h"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
-        "paths": null,
-        "tags": [
-          "foo",
-          "bar"
-        ]
-      },
-      "matches": [
-        "within 1y2m3d3h"
-      ],
-      "counters": {}
-    },
-    {
-      "snapshot": {
-        "time": "2015-10-22T10:20:30Z",
-        "tree": null,
         "paths": null
       },
       "matches": [
@@ -740,6 +707,39 @@
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
         "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "within 1y2m3d3h"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
+        "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
+      },
+      "matches": [
+        "within 1y2m3d3h"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2015-10-22T10:20:30Z",
+        "tree": null,
+        "paths": [
+          "path1",
+          "path2"
+        ],
         "tags": [
           "foo",
           "bar"

--- a/internal/restic/testdata/policy_keep_snapshots_3
+++ b/internal/restic/testdata/policy_keep_snapshots_3
@@ -153,33 +153,33 @@
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
-      "paths": [
-        "path1",
-        "path2"
-      ],
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
-      "paths": null,
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
       "paths": null
     },
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
       "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": [
+        "path1",
+        "path2"
+      ],
       "tags": [
         "foo",
         "bar"
@@ -955,14 +955,7 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
-        "paths": [
-          "path1",
-          "path2"
-        ],
-        "tags": [
-          "foo",
-          "bar"
-        ]
+        "paths": null
       },
       "matches": [
         "last snapshot"
@@ -992,7 +985,11 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
-        "paths": null
+        "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
       },
       "matches": [
         "last snapshot"
@@ -1005,7 +1002,10 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
-        "paths": null,
+        "paths": [
+          "path1",
+          "path2"
+        ],
         "tags": [
           "foo",
           "bar"

--- a/internal/restic/testdata/policy_keep_snapshots_4
+++ b/internal/restic/testdata/policy_keep_snapshots_4
@@ -153,33 +153,33 @@
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
-      "paths": [
-        "path1",
-        "path2"
-      ],
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
-      "paths": null,
-      "tags": [
-        "foo",
-        "bar"
-      ]
-    },
-    {
-      "time": "2015-10-22T10:20:30Z",
-      "tree": null,
       "paths": null
     },
     {
       "time": "2015-10-22T10:20:30Z",
       "tree": null,
       "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": null,
+      "tags": [
+        "foo",
+        "bar"
+      ]
+    },
+    {
+      "time": "2015-10-22T10:20:30Z",
+      "tree": null,
+      "paths": [
+        "path1",
+        "path2"
+      ],
       "tags": [
         "foo",
         "bar"
@@ -975,14 +975,7 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
-        "paths": [
-          "path1",
-          "path2"
-        ],
-        "tags": [
-          "foo",
-          "bar"
-        ]
+        "paths": null
       },
       "matches": [
         "last snapshot"
@@ -1012,7 +1005,11 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
-        "paths": null
+        "paths": null,
+        "tags": [
+          "foo",
+          "bar"
+        ]
       },
       "matches": [
         "last snapshot"
@@ -1025,7 +1022,10 @@
       "snapshot": {
         "time": "2015-10-22T10:20:30Z",
         "tree": null,
-        "paths": null,
+        "paths": [
+          "path1",
+          "path2"
+        ],
         "tags": [
           "foo",
           "bar"


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

With Go 1.19 being released, I gave it a shot and updated GitHub Actions to test against Go 1.19

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Not that I'm aware of.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
