### PR TITLE
backup: Ignore xattr.list permission error for parent directories

### DIFF
--- a/internal/restic/node_xattr.go
+++ b/internal/restic/node_xattr.go
@@ -4,6 +4,8 @@
 package restic
 
 import (
+	"fmt"
+	"os"
 	"syscall"
 
 	"github.com/restic/restic/internal/errors"
@@ -20,7 +22,15 @@ func Getxattr(path, name string) ([]byte, error) {
 // Listxattr retrieves a list of names of extended attributes associated with the
 // given path in the file system.
 func Listxattr(path string) ([]string, error) {
-	l, err := xattr.List(path)
+	l, err := xattr.List(path + "df")
+	if err != nil {
+		var xerr *xattr.Error
+		fmt.Fprintln(os.Stderr, "\nis xattr.Error", errors.As(err, &xerr))
+		if xerr != nil {
+			fmt.Fprintf(os.Stderr, "%v; %#v; %T\n\n", xerr.Err, xerr.Err, xerr.Err)
+			fmt.Fprintln(os.Stderr, xerr.Op == "xattr.list", errors.Is(xerr.Err, syscall.EPERM), errors.Is(xerr.Err, os.ErrPermission))
+		}
+	}
 	return l, handleXattrErr(err)
 }
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
On FreeBSD, limited users may not be able to even list xattrs for the parent directories above the snapshot source paths. As this can cause the backup to fail, just ignore those errors. The "fix" is somewhat messy, but changing NodeFromFileInfo everywhere is probably not better either.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3600 
Fixes https://forum.restic.net/t/cant-use-an-absolute-path-maybe-only-as-an-user/5268

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
