### PR TITLE
restore: Add support for sparse files

### DIFF
--- a/changelog/unreleased/issue-79
+++ b/changelog/unreleased/issue-79
@@ -7,6 +7,11 @@ are not actually written to disk.
 How much space is saved by writing sparse files depends on the operating
 system, file system and the distribution of zeros in the file.
 
+During backup restic still reads the whole file including sparse regions. We
+have optimized the processing speed of sparse regions.
+
 https://github.com/restic/restic/issues/79
+https://github.com/restic/restic/issues/3903
 https://github.com/restic/restic/pull/2601
+https://github.com/restic/restic/pull/3854
 https://forum.restic.net/t/sparse-file-support/1264

--- a/changelog/unreleased/issue-79
+++ b/changelog/unreleased/issue-79
@@ -1,8 +1,8 @@
 Enhancement: Restore files with many zeros as sparse files
 
-On all platforms except Windows, the restorer may now write files containing
-long runs of zeros as sparse files (also called files with holes): the zeros
-are not actually written to disk.
+When using `restore --sparse`, the restorer may now write files containing long
+runs of zeros as sparse files (also called files with holes): the zeros are not
+actually written to disk.
 
 How much space is saved by writing sparse files depends on the operating
 system, file system and the distribution of zeros in the file.

--- a/changelog/unreleased/pull-2601
+++ b/changelog/unreleased/pull-2601
@@ -1,0 +1,12 @@
+Enhancement: Restore files with many zeros as sparse files
+
+On all platforms except Windows, the restorer may now write files containing
+long runs of zeros as sparse files (also called files with holes): the zeros
+are not actually written to disk.
+
+How much space is saved by writing sparse files depends on the operating
+system, file system and the distribution of zeros in the file.
+
+https://github.com/restic/restic/issues/79
+https://github.com/restic/restic/pull/2601
+https://forum.restic.net/t/sparse-file-support/1264

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"runtime"
 	"strings"
 	"time"
 
@@ -42,6 +43,7 @@ type RestoreOptions struct {
 	InsensitiveInclude []string
 	Target             string
 	snapshotFilterOptions
+	Sparse bool
 	Verify bool
 }
 
@@ -58,6 +60,9 @@ func init() {
 	flags.StringVarP(&restoreOptions.Target, "target", "t", "", "directory to extract data to")
 
 	initSingleSnapshotFilterOptions(flags, &restoreOptions.snapshotFilterOptions)
+	if runtime.GOOS != "windows" {
+		flags.BoolVar(&restoreOptions.Sparse, "sparse", false, "restore files as sparse (not supported on windows)")
+	}
 	flags.BoolVar(&restoreOptions.Verify, "verify", false, "verify restored files content")
 }
 
@@ -147,7 +152,7 @@ func runRestore(opts RestoreOptions, gopts GlobalOptions, args []string) error {
 		return err
 	}
 
-	res, err := restorer.NewRestorer(ctx, repo, id)
+	res, err := restorer.NewRestorer(ctx, repo, id, opts.Sparse)
 	if err != nil {
 		Exitf(2, "creating restorer failed: %v\n", err)
 	}

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"runtime"
 	"strings"
 	"time"
 
@@ -60,9 +59,7 @@ func init() {
 	flags.StringVarP(&restoreOptions.Target, "target", "t", "", "directory to extract data to")
 
 	initSingleSnapshotFilterOptions(flags, &restoreOptions.snapshotFilterOptions)
-	if runtime.GOOS != "windows" {
-		flags.BoolVar(&restoreOptions.Sparse, "sparse", false, "restore files as sparse (not supported on windows)")
-	}
+	flags.BoolVar(&restoreOptions.Sparse, "sparse", false, "restore files as sparse")
 	flags.BoolVar(&restoreOptions.Verify, "verify", false, "verify restored files content")
 }
 

--- a/internal/restic/zeroprefix.go
+++ b/internal/restic/zeroprefix.go
@@ -1,0 +1,21 @@
+package restic
+
+import "bytes"
+
+// ZeroPrefixLen returns the length of the longest all-zero prefix of p.
+func ZeroPrefixLen(p []byte) (n int) {
+	// First skip 1kB-sized blocks, for speed.
+	var zeros [1024]byte
+
+	for len(p) >= len(zeros) && bytes.Equal(p[:len(zeros)], zeros[:]) {
+		p = p[len(zeros):]
+		n += len(zeros)
+	}
+
+	for len(p) > 0 && p[0] == 0 {
+		p = p[1:]
+		n++
+	}
+
+	return n
+}

--- a/internal/restic/zeroprefix_test.go
+++ b/internal/restic/zeroprefix_test.go
@@ -1,0 +1,52 @@
+package restic_test
+
+import (
+	"math/rand"
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/test"
+)
+
+func TestZeroPrefixLen(t *testing.T) {
+	var buf [2048]byte
+
+	// test zero prefixes of various lengths
+	for i := len(buf) - 1; i >= 0; i-- {
+		buf[i] = 42
+		skipped := restic.ZeroPrefixLen(buf[:])
+		test.Equals(t, i, skipped)
+	}
+	// test buffers of various sizes
+	for i := 0; i < len(buf); i++ {
+		skipped := restic.ZeroPrefixLen(buf[i:])
+		test.Equals(t, 0, skipped)
+	}
+}
+
+func BenchmarkZeroPrefixLen(b *testing.B) {
+	var (
+		buf        [4<<20 + 37]byte
+		r          = rand.New(rand.NewSource(0x618732))
+		sumSkipped int64
+	)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(buf)))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		j := r.Intn(len(buf))
+		buf[j] = 0xff
+
+		skipped := restic.ZeroPrefixLen(buf[:])
+		sumSkipped += int64(skipped)
+
+		buf[j] = 0
+	}
+
+	// The closer this is to .5, the better. If it's far off, give the
+	// benchmark more time to run with -benchtime.
+	b.Logf("average number of zeros skipped: %.3f",
+		float64(sumSkipped)/(float64(b.N*len(buf))))
+}

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -7,6 +7,7 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
+	"github.com/restic/chunker"
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
@@ -27,6 +28,7 @@ const (
 type fileInfo struct {
 	lock       sync.Mutex
 	inProgress bool
+	sparse     bool
 	size       int64
 	location   string      // file on local filesystem relative to restorer basedir
 	blobs      interface{} // blobs of the file
@@ -51,6 +53,8 @@ type fileRestorer struct {
 
 	workerCount int
 	filesWriter *filesWriter
+	zeroChunk   restic.ID
+	sparse      bool
 
 	dst   string
 	files []*fileInfo
@@ -61,7 +65,8 @@ func newFileRestorer(dst string,
 	packLoader repository.BackendLoadFn,
 	key *crypto.Key,
 	idx func(restic.BlobHandle) []restic.PackedBlob,
-	connections uint) *fileRestorer {
+	connections uint,
+	sparse bool) *fileRestorer {
 
 	// as packs are streamed the concurrency is limited by IO
 	workerCount := int(connections)
@@ -71,6 +76,8 @@ func newFileRestorer(dst string,
 		idx:         idx,
 		packLoader:  packLoader,
 		filesWriter: newFilesWriter(workerCount),
+		zeroChunk:   restic.Hash(make([]byte, chunker.MinSize)),
+		sparse:      sparse,
 		workerCount: workerCount,
 		dst:         dst,
 		Error:       restorerAbortOnAllErrors,
@@ -133,7 +140,16 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 				packOrder = append(packOrder, packID)
 			}
 			pack.files[file] = struct{}{}
+			if blob.ID.Equal(r.zeroChunk) {
+				file.sparse = r.sparse
+			}
 		})
+		if len(fileBlobs) == 1 {
+			// no need to preallocate files with a single block, thus we can always consider them to be sparse
+			// in addition, a short chunk will never match r.zeroChunk which would prevent sparseness for short files
+			file.sparse = r.sparse
+		}
+
 		if err != nil {
 			// repository index is messed up, can't do anything
 			return err
@@ -253,7 +269,7 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 						file.inProgress = true
 						createSize = file.size
 					}
-					return r.filesWriter.writeToFile(r.targetPath(file.location), blobData, offset, createSize)
+					return r.filesWriter.writeToFile(r.targetPath(file.location), blobData, offset, createSize, file.sparse)
 				}
 				err := sanitizeError(file, writeToFile())
 				if err != nil {

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -7,7 +7,6 @@ import (
 
 	"golang.org/x/sync/errgroup"
 
-	"github.com/restic/chunker"
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
@@ -76,7 +75,7 @@ func newFileRestorer(dst string,
 		idx:         idx,
 		packLoader:  packLoader,
 		filesWriter: newFilesWriter(workerCount),
-		zeroChunk:   restic.Hash(make([]byte, chunker.MinSize)),
+		zeroChunk:   repository.ZeroChunk(),
 		sparse:      sparse,
 		workerCount: workerCount,
 		dst:         dst,

--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -147,10 +147,10 @@ func newTestRepo(content []TestFile) *TestRepo {
 	return repo
 }
 
-func restoreAndVerify(t *testing.T, tempdir string, content []TestFile, files map[string]bool) {
+func restoreAndVerify(t *testing.T, tempdir string, content []TestFile, files map[string]bool, sparse bool) {
 	repo := newTestRepo(content)
 
-	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2)
+	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2, sparse)
 
 	if files == nil {
 		r.files = repo.files
@@ -188,30 +188,32 @@ func TestFileRestorerBasic(t *testing.T) {
 	tempdir, cleanup := rtest.TempDir(t)
 	defer cleanup()
 
-	restoreAndVerify(t, tempdir, []TestFile{
-		{
-			name: "file1",
-			blobs: []TestBlob{
-				{"data1-1", "pack1-1"},
-				{"data1-2", "pack1-2"},
+	for _, sparse := range []bool{false, true} {
+		restoreAndVerify(t, tempdir, []TestFile{
+			{
+				name: "file1",
+				blobs: []TestBlob{
+					{"data1-1", "pack1-1"},
+					{"data1-2", "pack1-2"},
+				},
 			},
-		},
-		{
-			name: "file2",
-			blobs: []TestBlob{
-				{"data2-1", "pack2-1"},
-				{"data2-2", "pack2-2"},
+			{
+				name: "file2",
+				blobs: []TestBlob{
+					{"data2-1", "pack2-1"},
+					{"data2-2", "pack2-2"},
+				},
 			},
-		},
-		{
-			name: "file3",
-			blobs: []TestBlob{
-				// same blob multiple times
-				{"data3-1", "pack3-1"},
-				{"data3-1", "pack3-1"},
+			{
+				name: "file3",
+				blobs: []TestBlob{
+					// same blob multiple times
+					{"data3-1", "pack3-1"},
+					{"data3-1", "pack3-1"},
+				},
 			},
-		},
-	}, nil)
+		}, nil, sparse)
+	}
 }
 
 func TestFileRestorerPackSkip(t *testing.T) {
@@ -221,28 +223,30 @@ func TestFileRestorerPackSkip(t *testing.T) {
 	files := make(map[string]bool)
 	files["file2"] = true
 
-	restoreAndVerify(t, tempdir, []TestFile{
-		{
-			name: "file1",
-			blobs: []TestBlob{
-				{"data1-1", "pack1"},
-				{"data1-2", "pack1"},
-				{"data1-3", "pack1"},
-				{"data1-4", "pack1"},
-				{"data1-5", "pack1"},
-				{"data1-6", "pack1"},
+	for _, sparse := range []bool{false, true} {
+		restoreAndVerify(t, tempdir, []TestFile{
+			{
+				name: "file1",
+				blobs: []TestBlob{
+					{"data1-1", "pack1"},
+					{"data1-2", "pack1"},
+					{"data1-3", "pack1"},
+					{"data1-4", "pack1"},
+					{"data1-5", "pack1"},
+					{"data1-6", "pack1"},
+				},
 			},
-		},
-		{
-			name: "file2",
-			blobs: []TestBlob{
-				// file is contained in pack1 but need pack parts to be skipped
-				{"data1-2", "pack1"},
-				{"data1-4", "pack1"},
-				{"data1-6", "pack1"},
+			{
+				name: "file2",
+				blobs: []TestBlob{
+					// file is contained in pack1 but need pack parts to be skipped
+					{"data1-2", "pack1"},
+					{"data1-4", "pack1"},
+					{"data1-6", "pack1"},
+				},
 			},
-		},
-	}, files)
+		}, files, sparse)
+	}
 }
 
 func TestErrorRestoreFiles(t *testing.T) {
@@ -264,7 +268,7 @@ func TestErrorRestoreFiles(t *testing.T) {
 		return loadError
 	}
 
-	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2)
+	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2, false)
 	r.files = repo.files
 
 	err := r.restoreFiles(context.TODO())
@@ -304,7 +308,7 @@ func testPartialDownloadError(t *testing.T, part int) {
 		return loader(ctx, h, length, offset, fn)
 	}
 
-	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2)
+	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2, false)
 	r.files = repo.files
 	r.Error = func(s string, e error) error {
 		// ignore errors as in the `restore` command

--- a/internal/restorer/fileswriter.go
+++ b/internal/restorer/fileswriter.go
@@ -67,7 +67,7 @@ func (w *filesWriter) writeToFile(path string, blob []byte, offset int64, create
 
 		if createSize >= 0 {
 			if sparse {
-				err = f.Truncate(createSize)
+				err = truncateSparse(f, createSize)
 				if err != nil {
 					return nil, err
 				}

--- a/internal/restorer/fileswriter_test.go
+++ b/internal/restorer/fileswriter_test.go
@@ -18,19 +18,15 @@ func TestFilesWriterBasic(t *testing.T) {
 
 	rtest.OK(t, w.writeToFile(f1, []byte{1}, 0, 2))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
-	rtest.Equals(t, 0, len(w.buckets[0].users))
 
 	rtest.OK(t, w.writeToFile(f2, []byte{2}, 0, 2))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
-	rtest.Equals(t, 0, len(w.buckets[0].users))
 
 	rtest.OK(t, w.writeToFile(f1, []byte{1}, 1, -1))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
-	rtest.Equals(t, 0, len(w.buckets[0].users))
 
 	rtest.OK(t, w.writeToFile(f2, []byte{2}, 1, -1))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
-	rtest.Equals(t, 0, len(w.buckets[0].users))
 
 	buf, err := ioutil.ReadFile(f1)
 	rtest.OK(t, err)

--- a/internal/restorer/fileswriter_test.go
+++ b/internal/restorer/fileswriter_test.go
@@ -16,16 +16,16 @@ func TestFilesWriterBasic(t *testing.T) {
 	f1 := dir + "/f1"
 	f2 := dir + "/f2"
 
-	rtest.OK(t, w.writeToFile(f1, []byte{1}, 0, 2))
+	rtest.OK(t, w.writeToFile(f1, []byte{1}, 0, 2, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 
-	rtest.OK(t, w.writeToFile(f2, []byte{2}, 0, 2))
+	rtest.OK(t, w.writeToFile(f2, []byte{2}, 0, 2, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 
-	rtest.OK(t, w.writeToFile(f1, []byte{1}, 1, -1))
+	rtest.OK(t, w.writeToFile(f1, []byte{1}, 1, -1, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 
-	rtest.OK(t, w.writeToFile(f2, []byte{2}, 1, -1))
+	rtest.OK(t, w.writeToFile(f2, []byte{2}, 1, -1, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 
 	buf, err := ioutil.ReadFile(f1)

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -324,7 +324,7 @@ func TestRestorer(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := NewRestorer(context.TODO(), repo, id)
+			res, err := NewRestorer(context.TODO(), repo, id, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -447,7 +447,7 @@ func TestRestorerRelative(t *testing.T) {
 			_, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res, err := NewRestorer(context.TODO(), repo, id)
+			res, err := NewRestorer(context.TODO(), repo, id, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -682,7 +682,7 @@ func TestRestorerTraverseTree(t *testing.T) {
 			defer cleanup()
 			sn, id := saveSnapshot(t, repo, test.Snapshot)
 
-			res, err := NewRestorer(context.TODO(), repo, id)
+			res, err := NewRestorer(context.TODO(), repo, id, false)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -764,7 +764,7 @@ func TestRestorerConsistentTimestampsAndPermissions(t *testing.T) {
 		},
 	})
 
-	res, err := NewRestorer(context.TODO(), repo, id)
+	res, err := NewRestorer(context.TODO(), repo, id, false)
 	rtest.OK(t, err)
 
 	res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
@@ -824,7 +824,7 @@ func TestVerifyCancel(t *testing.T) {
 
 	_, id := saveSnapshot(t, repo, snapshot)
 
-	res, err := NewRestorer(context.TODO(), repo, id)
+	res, err := NewRestorer(context.TODO(), repo, id, false)
 	rtest.OK(t, err)
 
 	tempdir, cleanup := rtest.TempDir(t)

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io/ioutil"
+	"math"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/restic/restic/internal/archiver"
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
@@ -848,4 +850,59 @@ func TestVerifyCancel(t *testing.T) {
 	rtest.Assert(t, err != nil, "nil error from VerifyFiles")
 	rtest.Equals(t, 1, len(errs))
 	rtest.Assert(t, strings.Contains(errs[0].Error(), "Invalid file size for"), "wrong error %q", errs[0].Error())
+}
+
+func TestRestorerSparseFiles(t *testing.T) {
+	repo, cleanup := repository.TestRepository(t)
+	defer cleanup()
+
+	var zeros [1<<20 + 13]byte
+
+	target := &fs.Reader{
+		Mode:       0600,
+		Name:       "/zeros",
+		ReadCloser: ioutil.NopCloser(bytes.NewReader(zeros[:])),
+	}
+	sc := archiver.NewScanner(target)
+	err := sc.Scan(context.TODO(), []string{"/zeros"})
+	rtest.OK(t, err)
+
+	arch := archiver.New(repo, target, archiver.Options{})
+	_, id, err := arch.Snapshot(context.Background(), []string{"/zeros"},
+		archiver.SnapshotOptions{})
+	rtest.OK(t, err)
+
+	res, err := NewRestorer(context.TODO(), repo, id, true)
+	rtest.OK(t, err)
+
+	tempdir, cleanup := rtest.TempDir(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
+
+	filename := filepath.Join(tempdir, "zeros")
+	content, err := ioutil.ReadFile(filename)
+	rtest.OK(t, err)
+
+	rtest.Equals(t, len(zeros[:]), len(content))
+	rtest.Equals(t, zeros[:], content)
+
+	blocks := getBlockCount(t, filename)
+	if blocks < 0 {
+		return
+	}
+
+	// st.Blocks is the size in 512-byte blocks.
+	denseBlocks := math.Ceil(float64(len(zeros)) / 512)
+	sparsity := 1 - float64(blocks)/denseBlocks
+
+	// This should report 100% sparse. We don't assert that,
+	// as the behavior of sparse writes depends on the underlying
+	// file system as well as the OS.
+	t.Logf("wrote %d zeros as %d blocks, %.1f%% sparse",
+		len(zeros), blocks, 100*sparsity)
 }

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"io/ioutil"
 	"math"
-	"math/rand"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -122,31 +121,4 @@ func TestRestorerSparseFiles(t *testing.T) {
 	// file system as well as the OS.
 	t.Logf("wrote %d zeros as %d blocks, %.1f%% sparse",
 		len(zeros), st.Blocks, 100*sparsity)
-}
-
-func BenchmarkZeroPrefixLen(b *testing.B) {
-	var (
-		buf        [4<<20 + 37]byte
-		r          = rand.New(rand.NewSource(0x618732))
-		sumSkipped int64
-	)
-
-	b.ReportAllocs()
-	b.SetBytes(int64(len(buf)))
-	b.ResetTimer()
-
-	for i := 0; i < b.N; i++ {
-		j := r.Intn(len(buf))
-		buf[j] = 0xff
-
-		skipped := zeroPrefixLen(buf[:])
-		sumSkipped += int64(skipped)
-
-		buf[j] = 0
-	}
-
-	// The closer this is to .5, the better. If it's far off, give the
-	// benchmark more time to run with -benchtime.
-	b.Logf("average number of zeros skipped: %.3f",
-		float64(sumSkipped)/(float64(b.N*len(buf))))
 }

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -36,7 +36,7 @@ func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
 		},
 	})
 
-	res, err := NewRestorer(context.TODO(), repo, id)
+	res, err := NewRestorer(context.TODO(), repo, id, false)
 	rtest.OK(t, err)
 
 	res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
@@ -85,8 +85,9 @@ func TestRestorerSparseFiles(t *testing.T) {
 	arch := archiver.New(repo, target, archiver.Options{})
 	_, id, err := arch.Snapshot(context.Background(), []string{"/zeros"},
 		archiver.SnapshotOptions{})
+	rtest.OK(t, err)
 
-	res, err := NewRestorer(repo, id)
+	res, err := NewRestorer(context.TODO(), repo, id, true)
 	rtest.OK(t, err)
 
 	tempdir, cleanup := rtest.TempDir(t)
@@ -102,6 +103,7 @@ func TestRestorerSparseFiles(t *testing.T) {
 	content, err := ioutil.ReadFile(filename)
 	rtest.OK(t, err)
 
+	rtest.Equals(t, len(zeros[:]), len(content))
 	rtest.Equals(t, zeros[:], content)
 
 	fi, err := os.Stat(filename)

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -4,12 +4,18 @@
 package restorer
 
 import (
+	"bytes"
 	"context"
+	"io/ioutil"
+	"math"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"syscall"
 	"testing"
 
+	"github.com/restic/restic/internal/archiver"
+	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
@@ -59,4 +65,86 @@ func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
 	if ok1 && ok2 {
 		rtest.Equals(t, s1.Ino, s2.Ino)
 	}
+}
+
+func TestRestorerSparseFiles(t *testing.T) {
+	repo, cleanup := repository.TestRepository(t)
+	defer cleanup()
+
+	var zeros [1<<20 + 13]byte
+
+	target := &fs.Reader{
+		Mode:       0600,
+		Name:       "/zeros",
+		ReadCloser: ioutil.NopCloser(bytes.NewReader(zeros[:])),
+	}
+	sc := archiver.NewScanner(target)
+	err := sc.Scan(context.TODO(), []string{"/zeros"})
+	rtest.OK(t, err)
+
+	arch := archiver.New(repo, target, archiver.Options{})
+	_, id, err := arch.Snapshot(context.Background(), []string{"/zeros"},
+		archiver.SnapshotOptions{})
+
+	res, err := NewRestorer(repo, id)
+	rtest.OK(t, err)
+
+	tempdir, cleanup := rtest.TempDir(t)
+	defer cleanup()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err = res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
+
+	filename := filepath.Join(tempdir, "zeros")
+	content, err := ioutil.ReadFile(filename)
+	rtest.OK(t, err)
+
+	rtest.Equals(t, zeros[:], content)
+
+	fi, err := os.Stat(filename)
+	rtest.OK(t, err)
+	st := fi.Sys().(*syscall.Stat_t)
+	if st == nil {
+		return
+	}
+
+	// st.Blocks is the size in 512-byte blocks.
+	denseBlocks := math.Ceil(float64(len(zeros)) / 512)
+	sparsity := 1 - float64(st.Blocks)/denseBlocks
+
+	// This should report 100% sparse. We don't assert that,
+	// as the behavior of sparse writes depends on the underlying
+	// file system as well as the OS.
+	t.Logf("wrote %d zeros as %d blocks, %.1f%% sparse",
+		len(zeros), st.Blocks, 100*sparsity)
+}
+
+func BenchmarkZeroPrefixLen(b *testing.B) {
+	var (
+		buf        [4<<20 + 37]byte
+		r          = rand.New(rand.NewSource(0x618732))
+		sumSkipped int64
+	)
+
+	b.ReportAllocs()
+	b.SetBytes(int64(len(buf)))
+	b.ResetTimer()
+
+	for i := 0; i < b.N; i++ {
+		j := r.Intn(len(buf))
+		buf[j] = 0xff
+
+		skipped := zeroPrefixLen(buf[:])
+		sumSkipped += int64(skipped)
+
+		buf[j] = 0
+	}
+
+	// The closer this is to .5, the better. If it's far off, give the
+	// benchmark more time to run with -benchtime.
+	b.Logf("average number of zeros skipped: %.3f",
+		float64(sumSkipped)/(float64(b.N*len(buf))))
 }

--- a/internal/restorer/restorer_windows_test.go
+++ b/internal/restorer/restorer_windows_test.go
@@ -1,0 +1,35 @@
+//go:build windows
+// +build windows
+
+package restorer
+
+import (
+	"math"
+	"syscall"
+	"testing"
+	"unsafe"
+
+	rtest "github.com/restic/restic/internal/test"
+	"golang.org/x/sys/windows"
+)
+
+func getBlockCount(t *testing.T, filename string) int64 {
+	libkernel32 := windows.NewLazySystemDLL("kernel32.dll")
+	err := libkernel32.Load()
+	rtest.OK(t, err)
+	proc := libkernel32.NewProc("GetCompressedFileSizeW")
+	err = proc.Find()
+	rtest.OK(t, err)
+
+	namePtr, err := syscall.UTF16PtrFromString(filename)
+	rtest.OK(t, err)
+
+	result, _, _ := proc.Call(uintptr(unsafe.Pointer(namePtr)), 0)
+
+	const invalidFileSize = uintptr(4294967295)
+	if result == invalidFileSize {
+		return -1
+	}
+
+	return int64(math.Ceil(float64(result) / 512))
+}

--- a/internal/restorer/sparsewrite.go
+++ b/internal/restorer/sparsewrite.go
@@ -1,0 +1,60 @@
+//go:build !windows
+// +build !windows
+
+package restorer
+
+import "bytes"
+
+// WriteAt writes p to f.File at offset. It tries to do a sparse write
+// and updates f.size.
+func (f *partialFile) WriteAt(p []byte, offset int64) (n int, err error) {
+	n = len(p)
+	end := offset + int64(n)
+
+	// Skip the longest all-zero prefix of p.
+	// If it's long enough, we can punch a hole in the file.
+	skipped := zeroPrefixLen(p)
+	p = p[skipped:]
+	offset += int64(skipped)
+
+	switch {
+	case len(p) == 0 && end > f.size:
+		// We need to do a Truncate, as WriteAt with length-0 input
+		// doesn't actually extend the file.
+		err = f.Truncate(end)
+		if err != nil {
+			return 0, err
+		}
+
+	case len(p) == 0:
+		// All zeros, file already big enough. A previous WriteAt or
+		// Truncate will have produced the zeros in f.File.
+
+	default:
+		n, err = f.File.WriteAt(p, offset)
+	}
+
+	end = offset + int64(n)
+	if end > f.size {
+		f.size = end
+	}
+	return n, err
+}
+
+// zeroPrefixLen returns the length of the longest all-zero prefix of p.
+func zeroPrefixLen(p []byte) (n int) {
+	// First skip 1kB-sized blocks, for speed.
+	var zeros [1024]byte
+
+	for len(p) >= len(zeros) && bytes.Equal(p[:len(zeros)], zeros[:]) {
+		p = p[len(zeros):]
+		n += len(zeros)
+	}
+
+	for len(p) > 0 && p[0] == 0 {
+		p = p[1:]
+		n++
+	}
+
+	return n
+}

--- a/internal/restorer/sparsewrite.go
+++ b/internal/restorer/sparsewrite.go
@@ -3,7 +3,9 @@
 
 package restorer
 
-import "bytes"
+import (
+	"github.com/restic/restic/internal/restic"
+)
 
 // WriteAt writes p to f.File at offset. It tries to do a sparse write
 // and updates f.size.
@@ -16,7 +18,7 @@ func (f *partialFile) WriteAt(p []byte, offset int64) (n int, err error) {
 
 	// Skip the longest all-zero prefix of p.
 	// If it's long enough, we can punch a hole in the file.
-	skipped := zeroPrefixLen(p)
+	skipped := restic.ZeroPrefixLen(p)
 	p = p[skipped:]
 	offset += int64(skipped)
 
@@ -32,22 +34,4 @@ func (f *partialFile) WriteAt(p []byte, offset int64) (n int, err error) {
 	}
 
 	return n, err
-}
-
-// zeroPrefixLen returns the length of the longest all-zero prefix of p.
-func zeroPrefixLen(p []byte) (n int) {
-	// First skip 1kB-sized blocks, for speed.
-	var zeros [1024]byte
-
-	for len(p) >= len(zeros) && bytes.Equal(p[:len(zeros)], zeros[:]) {
-		p = p[len(zeros):]
-		n += len(zeros)
-	}
-
-	for len(p) > 0 && p[0] == 0 {
-		p = p[1:]
-		n++
-	}
-
-	return n
 }

--- a/internal/restorer/sparsewrite.go
+++ b/internal/restorer/sparsewrite.go
@@ -8,6 +8,10 @@ import "bytes"
 // WriteAt writes p to f.File at offset. It tries to do a sparse write
 // and updates f.size.
 func (f *partialFile) WriteAt(p []byte, offset int64) (n int, err error) {
+	if !f.sparse {
+		return f.File.WriteAt(p, offset)
+	}
+
 	n = len(p)
 	end := offset + int64(n)
 

--- a/internal/restorer/truncate_other.go
+++ b/internal/restorer/truncate_other.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package restorer
+
+import "os"
+
+func truncateSparse(f *os.File, size int64) error {
+	return f.Truncate(size)
+}

--- a/internal/restorer/truncate_windows.go
+++ b/internal/restorer/truncate_windows.go
@@ -1,0 +1,19 @@
+package restorer
+
+import (
+	"os"
+
+	"github.com/restic/restic/internal/debug"
+	"golang.org/x/sys/windows"
+)
+
+func truncateSparse(f *os.File, size int64) error {
+	// try setting the sparse file attribute, but ignore the error if it fails
+	var t uint32
+	err := windows.DeviceIoControl(windows.Handle(f.Fd()), windows.FSCTL_SET_SPARSE, nil, 0, nil, 0, &t, nil)
+	if err != nil {
+		debug.Log("failed to set sparse attribute for %v: %v", f.Name(), err)
+	}
+
+	return f.Truncate(size)
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
It adds a `restore --sparse` option to restore files as sparse. The detection of sparseness is done at restore time, by replacing long stretches of zeros by sparse sections.

Note that this does not mean that we are no longer interested in having the archiver store precise information about which files have gaps at which places. Instead this is intended to provide basic support for sparse files which can be improved upon later.  In particular, if sparseness information was stored for a file, then it would also an option to have the restorer automatically restore such files as sparse.

The implementation is largely based on #2601, with a few modifications. The `--sparse` option was initially suggested by #2378. The restorer preallocates files by default which conflicts with restoring files as sparse. The currently taken approach is to check whether a file contains an all zeros blocks and mark is as sparse if the option was set. This then disables preallocation for that specific file. That way most files can still be preallocated. The downside is that we cannot detect even smaller sparse sections, however, these were only partially handled before.

Another change is that a sparse file is now immediately truncated to it's final size. `partialFile.WriteAt` may be called in parallel by the restorer, which could result in race conditions between the `Truncate` and `WriteAt` calls.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Supersedes #2378
Supersedes #2601
Fixes #79

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
