### PR TITLE
doc: Update link to GCS documentation

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -583,7 +583,7 @@ The number of concurrent connections to the GCS service can be set with the
 established.
 
 .. _service account: https://cloud.google.com/storage/docs/authentication#service_accounts
-.. _create a service account key: https://cloud.google.com/storage/docs/authentication#generating-a-private-key
+.. _create a service account key: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#iam-service-account-keys-create-console
 .. _default authentication material: https://developers.google.com/identity/protocols/application-default-credentials
 
 .. _other-services:

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -582,9 +582,9 @@ The number of concurrent connections to the GCS service can be set with the
 ``-o gs.connections=10`` switch. By default, at most five parallel connections are
 established.
 
-.. _service account: https://cloud.google.com/storage/docs/authentication#service_accounts
+.. _service account: https://cloud.google.com/iam/docs/service-accounts
 .. _create a service account key: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#iam-service-account-keys-create-console
-.. _default authentication material: https://developers.google.com/identity/protocols/application-default-credentials
+.. _default authentication material: https://cloud.google.com/docs/authentication/production
 
 .. _other-services:
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Updates the link to Google Cloud Storage documentation about creating a service account key.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #3856.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.