### PR TITLE
forget: Error when invalid unit is given in duration policy

### DIFF
--- a/changelog/unreleased/issue-3861
+++ b/changelog/unreleased/issue-3861
@@ -1,0 +1,8 @@
+Bugfix: Yield error on invalid policy to `forget`
+
+The `forget` command previously silently ignored invalid/unsupported
+units in the duration options, such as e.g. `--keep-within-daily 2w`.
+
+Specifying an invalid/unsupported duration unit now results in an error.
+
+https://github.com/restic/restic/issues/3861

--- a/changelog/unreleased/issue-3861
+++ b/changelog/unreleased/issue-3861
@@ -6,3 +6,4 @@ units in the duration options, such as e.g. `--keep-within-daily 2w`.
 Specifying an invalid/unsupported duration unit now results in an error.
 
 https://github.com/restic/restic/issues/3861
+https://github.com/restic/restic/pull/3862

--- a/internal/restic/duration.go
+++ b/internal/restic/duration.go
@@ -76,8 +76,7 @@ func nextNumber(input string) (num int, rest string, err error) {
 	return num, rest, nil
 }
 
-// ParseDuration parses a duration from a string. The format is:
-//    6y5m234d37h
+// ParseDuration parses a duration from a string. The format is `6y5m234d37h`
 func ParseDuration(s string) (Duration, error) {
 	var (
 		d   Duration

--- a/internal/restic/duration.go
+++ b/internal/restic/duration.go
@@ -106,6 +106,8 @@ func ParseDuration(s string) (Duration, error) {
 			d.Days = num
 		case 'h':
 			d.Hours = num
+		default:
+			return Duration{}, errors.Errorf("invalid unit %q found after number %d", s[0], num)
 		}
 
 		s = s[1:]

--- a/internal/restic/duration_test.go
+++ b/internal/restic/duration_test.go
@@ -83,8 +83,14 @@ func TestParseDuration(t *testing.T) {
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
 			d, err := ParseDuration(test.input)
-			if err != nil && !test.err {
-				t.Fatal(err)
+			if test.err {
+				if err == nil {
+					t.Fatalf("Missing error for %v", test.input)
+				}
+			} else {
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 
 			if !cmp.Equal(d, test.d) {

--- a/internal/restic/duration_test.go
+++ b/internal/restic/duration_test.go
@@ -63,23 +63,27 @@ func TestParseDuration(t *testing.T) {
 		input  string
 		d      Duration
 		output string
+		err    bool
 	}{
-		{"9h", Duration{Hours: 9}, "9h"},
-		{"3d", Duration{Days: 3}, "3d"},
-		{"4d2h", Duration{Days: 4, Hours: 2}, "4d2h"},
-		{"7m5d", Duration{Months: 7, Days: 5}, "7m5d"},
-		{"6m4d8h", Duration{Months: 6, Days: 4, Hours: 8}, "6m4d8h"},
-		{"5d7m", Duration{Months: 7, Days: 5}, "7m5d"},
-		{"4h3d9m", Duration{Months: 9, Days: 3, Hours: 4}, "9m3d4h"},
-		{"-7m5d", Duration{Months: -7, Days: 5}, "-7m5d"},
-		{"1y4m-5d-3h", Duration{Years: 1, Months: 4, Days: -5, Hours: -3}, "1y4m-5d-3h"},
-		{"2y7m-5d", Duration{Years: 2, Months: 7, Days: -5}, "2y7m-5d"},
+		{input: "9h", d: Duration{Hours: 9}, output: "9h"},
+		{input: "3d", d: Duration{Days: 3}, output: "3d"},
+		{input: "4d2h", d: Duration{Days: 4, Hours: 2}, output: "4d2h"},
+		{input: "7m5d", d: Duration{Months: 7, Days: 5}, output: "7m5d"},
+		{input: "6m4d8h", d: Duration{Months: 6, Days: 4, Hours: 8}, output: "6m4d8h"},
+		{input: "5d7m", d: Duration{Months: 7, Days: 5}, output: "7m5d"},
+		{input: "4h3d9m", d: Duration{Months: 9, Days: 3, Hours: 4}, output: "9m3d4h"},
+		{input: "-7m5d", d: Duration{Months: -7, Days: 5}, output: "-7m5d"},
+		{input: "1y4m-5d-3h", d: Duration{Years: 1, Months: 4, Days: -5, Hours: -3}, output: "1y4m-5d-3h"},
+		{input: "2y7m-5d", d: Duration{Years: 2, Months: 7, Days: -5}, output: "2y7m-5d"},
+		{input: "2w", err: true},
+		{input: "1y4m3w1d", err: true},
+		{input: "s", err: true},
 	}
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
 			d, err := ParseDuration(test.input)
-			if err != nil {
+			if err != nil && !test.err {
 				t.Fatal(err)
 			}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Yields an error when the user tries to specify an invalid/unsupported unit in a duration to the policy options to `forget`, e.g. `--keep-within-daily 2w` where `w` is unsupported by the `Duration` type. Previously an unsupported unit was silently ignored.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #3861.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] ~~I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
