### PR TITLE
doc: Fix typo in compression section

### DIFF
--- a/doc/047_tuning_backup_parameters.rst
+++ b/doc/047_tuning_backup_parameters.rst
@@ -44,7 +44,7 @@ Compression
 ===========
 
 For a repository using at least repository format version 2, you can configure how data
-is compressed with the option ``--compression``. It can be set to ```auto``` (the default,
+is compressed with the option ``--compression``. It can be set to ``auto`` (the default,
 which will compress very fast), ``max`` (which will trade backup speed and CPU usage for
 slightly better compression), or ``off`` (which disables compression). Each setting is
 only applied for the single run of restic. The option can also be set via the environment


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Fixes a typo in the documentation for compression.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] ~~I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- [ ] ~~There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [ ] ~~I have run `gofmt` on the code in all commits.~~
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
