### PR TITLE
mount: Only remember successful snapshot refreshes

### DIFF
--- a/internal/fuse/snapshots_dirstruct.go
+++ b/internal/fuse/snapshots_dirstruct.go
@@ -280,9 +280,8 @@ func (d *SnapshotsDirStructure) updateSnapshots(ctx context.Context) error {
 	// sort snapshots ascending by time (default order is descending)
 	sort.Sort(sort.Reverse(snapshots))
 
-	d.lastCheck = time.Now()
-
 	if d.snCount == len(snapshots) {
+		d.lastCheck = time.Now()
 		return nil
 	}
 
@@ -291,8 +290,8 @@ func (d *SnapshotsDirStructure) updateSnapshots(ctx context.Context) error {
 		return err
 	}
 
+	d.lastCheck = time.Now()
 	d.snCount = len(snapshots)
-
 	d.makeDirs(snapshots)
 	return nil
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
If the context provided by the fuse library is canceled before the index
was loaded this could lead to missing snapshots.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
