### PR TITLE
Add note that larger packs increase disk wear

### DIFF
--- a/doc/047_tuning_backup_parameters.rst
+++ b/doc/047_tuning_backup_parameters.rst
@@ -72,3 +72,9 @@ of backend connections plus one. For example, if the backend uses 5 connections 
 for most backends), with a target pack size of 64 MiB, you'll need a *minimum* of 384 MiB
 of space in the temp directory. A bit of tuning may be required to strike a balance between
 resource usage at the backup client and the number of pack files in the repository.
+
+Note that larger pack files increase the chance that the temporary pack files are written
+to disk. An operating system usually caches file write operations in memory and writes
+them to disk after a short delay. As larger pack files take longer to upload, this
+increases the chance of these files being written to disk. This can increase disk wear
+for SSDs.

--- a/doc/047_tuning_backup_parameters.rst
+++ b/doc/047_tuning_backup_parameters.rst
@@ -28,7 +28,7 @@ the REST backend the parameter would be ``-o rest.connections=5``. By default re
 ``5`` connections for each backend, except for the local backend which uses a limit of ``2``.
 The defaults should work well in most cases. For high-latency backends it can be beneficial
 to increase the number of connections. Please be aware that this increases the resource
-consumption of restic and that a too high connection count *will degrade performace*.
+consumption of restic and that a too high connection count *will degrade performance*.
 
 
 CPU Usage


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Add a remark that larger pack files likely lead to more disk writes.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Suggested by https://github.com/restic/restic/pull/3731#issuecomment-1207489817

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
