### PR TITLE
mount: Fix input/output errors for canceled syscalls

### DIFF
--- a/changelog/unreleased/issue-3567
+++ b/changelog/unreleased/issue-3567
@@ -1,0 +1,11 @@
+Bugfix: Improve handling of interrupted syscalls in `mount` command
+
+Accessing restic's fuse mount could result in "input / output" errors when
+using programs in which syscalls can be interrupted. This is for example the
+case for go programs.
+
+We have corrected the error handling for interrupted syscalls.
+
+https://github.com/restic/restic/issues/3567
+https://github.com/restic/restic/issues/3694
+https://github.com/restic/restic/pull/3875

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -34,7 +34,7 @@ func cleanupNodeName(name string) string {
 	return filepath.Base(name)
 }
 
-func newDir(ctx context.Context, root *Root, inode, parentInode uint64, node *restic.Node) (*dir, error) {
+func newDir(root *Root, inode, parentInode uint64, node *restic.Node) (*dir, error) {
 	debug.Log("new dir for %v (%v)", node.Name, node.Subtree)
 
 	return &dir{
@@ -74,7 +74,7 @@ func replaceSpecialNodes(ctx context.Context, repo restic.Repository, node *rest
 	return tree.Nodes, nil
 }
 
-func newDirFromSnapshot(ctx context.Context, root *Root, inode uint64, snapshot *restic.Snapshot) (*dir, error) {
+func newDirFromSnapshot(root *Root, inode uint64, snapshot *restic.Snapshot) (*dir, error) {
 	debug.Log("new dir for snapshot %v (%v)", snapshot.ID(), snapshot.Tree)
 	return &dir{
 		root: root,
@@ -206,13 +206,13 @@ func (d *dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	}
 	switch node.Type {
 	case "dir":
-		return newDir(ctx, d.root, fs.GenerateDynamicInode(d.inode, name), d.inode, node)
+		return newDir(d.root, fs.GenerateDynamicInode(d.inode, name), d.inode, node)
 	case "file":
-		return newFile(ctx, d.root, fs.GenerateDynamicInode(d.inode, name), node)
+		return newFile(d.root, fs.GenerateDynamicInode(d.inode, name), node)
 	case "symlink":
-		return newLink(ctx, d.root, fs.GenerateDynamicInode(d.inode, name), node)
+		return newLink(d.root, fs.GenerateDynamicInode(d.inode, name), node)
 	case "dev", "chardev", "fifo", "socket":
-		return newOther(ctx, d.root, fs.GenerateDynamicInode(d.inode, name), node)
+		return newOther(d.root, fs.GenerateDynamicInode(d.inode, name), node)
 	default:
 		debug.Log("  node %v has unknown type %v", name, node.Type)
 		return nil, fuse.ENOENT

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -105,7 +105,7 @@ func (f *openFile) getBlobAt(ctx context.Context, i int) (blob []byte, err error
 	blob, err = f.root.repo.LoadBlob(ctx, restic.DataBlob, f.node.Content[i], nil)
 	if err != nil {
 		debug.Log("LoadBlob(%v, %v) failed: %v", f.node.Name, f.node.Content[i], err)
-		return nil, err
+		return nil, unwrapCtxCanceled(err)
 	}
 
 	f.root.blobCache.Add(f.node.Content[i], blob)

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -36,7 +36,7 @@ type openFile struct {
 	cumsize []uint64
 }
 
-func newFile(ctx context.Context, root *Root, inode uint64, node *restic.Node) (fusefile *file, err error) {
+func newFile(root *Root, inode uint64, node *restic.Node) (fusefile *file, err error) {
 	debug.Log("create new file for %v with %d blobs", node.Name, len(node.Content))
 	return &file{
 		inode: inode,

--- a/internal/fuse/fuse_test.go
+++ b/internal/fuse/fuse_test.go
@@ -119,7 +119,7 @@ func TestFuseFile(t *testing.T) {
 	root := &Root{repo: repo, blobCache: bloblru.New(blobCacheSize)}
 
 	inode := fs.GenerateDynamicInode(1, "foo")
-	f, err := newFile(context.TODO(), root, inode, node)
+	f, err := newFile(root, inode, node)
 	rtest.OK(t, err)
 	of, err := f.Open(context.TODO(), nil, nil)
 	rtest.OK(t, err)
@@ -163,7 +163,7 @@ func TestFuseDir(t *testing.T) {
 	}
 	parentInode := fs.GenerateDynamicInode(0, "parent")
 	inode := fs.GenerateDynamicInode(1, "foo")
-	d, err := newDir(context.TODO(), root, inode, parentInode, node)
+	d, err := newDir(root, inode, parentInode, node)
 	rtest.OK(t, err)
 
 	// don't open the directory as that would require setting up a proper tree blob

--- a/internal/fuse/link.go
+++ b/internal/fuse/link.go
@@ -20,7 +20,7 @@ type link struct {
 	inode uint64
 }
 
-func newLink(ctx context.Context, root *Root, inode uint64, node *restic.Node) (*link, error) {
+func newLink(root *Root, inode uint64, node *restic.Node) (*link, error) {
 	return &link{root: root, inode: inode, node: node}, nil
 }
 

--- a/internal/fuse/other.go
+++ b/internal/fuse/other.go
@@ -16,7 +16,7 @@ type other struct {
 	inode uint64
 }
 
-func newOther(ctx context.Context, root *Root, inode uint64, node *restic.Node) (*other, error) {
+func newOther(root *Root, inode uint64, node *restic.Node) (*other, error) {
 	return &other{root: root, inode: inode, node: node}, nil
 }
 

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -58,7 +58,7 @@ func (d *SnapshotsDir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 	// update snapshots
 	meta, err := d.dirStruct.UpdatePrefix(ctx, d.prefix)
 	if err != nil {
-		return nil, err
+		return nil, unwrapCtxCanceled(err)
 	} else if meta == nil {
 		return nil, fuse.ENOENT
 	}
@@ -97,7 +97,7 @@ func (d *SnapshotsDir) Lookup(ctx context.Context, name string) (fs.Node, error)
 
 	meta, err := d.dirStruct.UpdatePrefix(ctx, d.prefix)
 	if err != nil {
-		return nil, err
+		return nil, unwrapCtxCanceled(err)
 	} else if meta == nil {
 		return nil, fuse.ENOENT
 	}

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -105,9 +105,9 @@ func (d *SnapshotsDir) Lookup(ctx context.Context, name string) (fs.Node, error)
 	entry := meta.names[name]
 	if entry != nil {
 		if entry.linkTarget != "" {
-			return newSnapshotLink(ctx, d.root, fs.GenerateDynamicInode(d.inode, name), entry.linkTarget, entry.snapshot)
+			return newSnapshotLink(d.root, fs.GenerateDynamicInode(d.inode, name), entry.linkTarget, entry.snapshot)
 		} else if entry.snapshot != nil {
-			return newDirFromSnapshot(ctx, d.root, fs.GenerateDynamicInode(d.inode, name), entry.snapshot)
+			return newDirFromSnapshot(d.root, fs.GenerateDynamicInode(d.inode, name), entry.snapshot)
 		} else {
 			return NewSnapshotsDir(d.root, fs.GenerateDynamicInode(d.inode, name), d.inode, d.dirStruct, d.prefix+"/"+name), nil
 		}
@@ -127,7 +127,7 @@ type snapshotLink struct {
 var _ = fs.NodeReadlinker(&snapshotLink{})
 
 // newSnapshotLink
-func newSnapshotLink(ctx context.Context, root *Root, inode uint64, target string, snapshot *restic.Snapshot) (*snapshotLink, error) {
+func newSnapshotLink(root *Root, inode uint64, target string, snapshot *restic.Snapshot) (*snapshotLink, error) {
 	return &snapshotLink{root: root, inode: inode, target: target, snapshot: snapshot}, nil
 }
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Accessing restic's fuse mount could result in "input / output" errors for programs in which syscall can be interrupted. This is for example the case for go programs.

bazil/fuse expects us to return context.Canceled to signal that a syscall was successfully interrupted. Returning a wrapped version of that error however causes the fuse library to signal an EIO (input/output error). Thus unwrap context.Canceled errors before returning them.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3694

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
