### PR TITLE
Cleanup release helper

### DIFF
--- a/helpers/build-release-binaries/main.go
+++ b/helpers/build-release-binaries/main.go
@@ -103,7 +103,6 @@ func build(sourceDir, outputDir, goos, goarch string) (filename string) {
 	)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
-	c.Dir = sourceDir
 
 	verbose("run %v %v in %v", "go", c.Args, c.Dir)
 
@@ -151,11 +150,9 @@ func compress(goos, inputDir, filename string) (outputFile string) {
 	case "windows":
 		outputFile = strings.TrimSuffix(filename, ".exe") + ".zip"
 		c = exec.Command("zip", "-q", "-X", outputFile, filename)
-		c.Dir = inputDir
 	default:
 		outputFile = filename + ".bz2"
 		c = exec.Command("bzip2", filename)
-		c.Dir = inputDir
 	}
 
 	rm(filepath.Join(inputDir, outputFile))

--- a/helpers/build-release-binaries/main.go
+++ b/helpers/build-release-binaries/main.go
@@ -232,6 +232,18 @@ var defaultBuildTargets = map[string][]string{
 	"solaris": {"amd64"},
 }
 
+func downloadModules(sourceDir string) {
+	c := exec.Command("go", "mod", "download")
+	c.Stdout = os.Stdout
+	c.Stderr = os.Stderr
+	c.Dir = sourceDir
+
+	err := c.Run()
+	if err != nil {
+		die("error downloading modules: %v", err)
+	}
+}
+
 func main() {
 	if len(pflag.Args()) != 0 {
 		die("USAGE: build-release-binaries [OPTIONS]")
@@ -241,5 +253,6 @@ func main() {
 	outputDir := abs(opts.OutputDir)
 	mkdir(outputDir)
 
+	downloadModules(sourceDir)
 	buildTargets(sourceDir, outputDir, defaultBuildTargets)
 }

--- a/helpers/build-release-binaries/main.go
+++ b/helpers/build-release-binaries/main.go
@@ -103,15 +103,13 @@ func build(sourceDir, outputDir, goos, goarch string) (filename string) {
 	)
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
-
-	verbose("run %v %v in %v", "go", c.Args, c.Dir)
-
 	c.Dir = sourceDir
 	c.Env = append(os.Environ(),
 		"CGO_ENABLED=0",
 		"GOOS="+goos,
 		"GOARCH="+goarch,
 	)
+	verbose("run %v %v in %v", "go", c.Args, c.Dir)
 
 	err := c.Run()
 	if err != nil {
@@ -160,7 +158,6 @@ func compress(goos, inputDir, filename string) (outputFile string) {
 	c.Stdout = os.Stdout
 	c.Stderr = os.Stderr
 	c.Dir = inputDir
-
 	verbose("run %v %v in %v", "go", c.Args, c.Dir)
 
 	err := c.Run()


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
While reviewing https://github.com/restic/builder/pull/14 I tried to reproduce the release binaries and ran into a few problems. This PR limits the build concurrency to avoid running out of resources and no longer runs the initial dependency download in parallel.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
