### PR TITLE
sftp: Only connect once to server during `init`

### DIFF
--- a/changelog/unreleased/issue-2152
+++ b/changelog/unreleased/issue-2152
@@ -1,0 +1,11 @@
+Enhancement: only open connection once for `init` command using sftp backend
+
+The `init` command using the sftp backend used to connect twice to the
+repository. This can be inconvenient if the user must enter a password or cause
+`init` to fail if the server does not correctly close the first sftp
+connection.
+
+This has been fixed by reusing the initial sftp connection.
+
+https://github.com/restic/restic/issues/2152
+https://github.com/restic/restic/pull/3882


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This is especially useful if ssh asks for a password or if closing the initial connection could return an error due to a problematic server implementation.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #2152

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
