### PR TITLE
repository: Do not report ignored packs in EachByPack

### DIFF
--- a/internal/repository/index.go
+++ b/internal/repository/index.go
@@ -276,10 +276,10 @@ func (idx *Index) EachByPack(ctx context.Context, packBlacklist restic.IDSet) <-
 			m := &idx.byType[typ]
 			m.foreach(func(e *indexEntry) bool {
 				packID := idx.packs[e.packIndex]
-				if _, ok := byPack[packID]; !ok {
-					byPack[packID] = make([][]*indexEntry, restic.NumBlobTypes)
-				}
 				if !idx.final || !packBlacklist.Has(packID) {
+					if _, ok := byPack[packID]; !ok {
+						byPack[packID] = make([][]*indexEntry, restic.NumBlobTypes)
+					}
 					byPack[packID][typ] = append(byPack[packID][typ], e)
 				}
 				return true


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Ignored packs were reported as an empty pack by EachByPack. The most immediate effect of this is that the progress bar for rebuilding the index reports processing more packs than actually exist.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes a regression introduced in #3772.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
