### PR TITLE
Improve reliability of upload retries and B2 file deletions

### DIFF
--- a/changelog/unreleased/issue-3161
+++ b/changelog/unreleased/issue-3161
@@ -1,0 +1,13 @@
+Bugfix: Reliably delete files on Backblaze B2
+
+Restic used to only delete the latest version of files stored in B2. In most
+cases this works well as there is only a single version. However, due to
+retries while uploading it is possible for multiple file versions to be stored
+at B2. This can lead to various problems if files still exist that should have
+been deleted.
+
+We have changed the implementation to delete all of them. This doubles the
+number of Class B transactions necessary to delete files.
+
+https://github.com/restic/restic/issues/3161
+https://github.com/restic/restic/pull/3885

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -274,14 +274,22 @@ func (be *b2Backend) Remove(ctx context.Context, h restic.Handle) error {
 	be.sem.GetToken()
 	defer be.sem.ReleaseToken()
 
-	obj := be.bucket.Object(be.Filename(h))
-	err := obj.Delete(ctx)
-	// consider a file as removed if b2 informs us that it does not exist
-	if b2.IsNotExist(err) {
-		return nil
+	// the retry backend will also repeat the remove method up to 10 times
+	for i := 0; i < 3; i++ {
+		obj := be.bucket.Object(be.Filename(h))
+		err := obj.Delete(ctx)
+		if err == nil {
+			// keep deleting until we are sure that no leftover file versions exist
+			continue
+		}
+		// consider a file as removed if b2 informs us that it does not exist
+		if b2.IsNotExist(err) {
+			return nil
+		}
+		return errors.Wrap(err, "Delete")
 	}
 
-	return errors.Wrap(err, "Delete")
+	return errors.New("failed to delete all file versions")
 }
 
 type semLocker struct {

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -27,7 +27,8 @@ type b2Backend struct {
 	sem sema.Semaphore
 }
 
-const defaultListMaxItems = 1000
+// Billing happens in 1000 item granlarity, but we are more interested in reducing the number of network round trips
+const defaultListMaxItems = 10 * 1000
 
 // ensure statically that *b2Backend implements restic.Backend.
 var _ restic.Backend = &b2Backend{}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
When hard deleting the latest file version on B2, this uncovers earlier versions. If an upload required retries, multiple version might exist for a file. Thus to reliably delete a file, we have to remove all versions of it. Otherwise symptoms like #3161 or even data loss can be the result.

This change allows the retry backend to skip deleting failed uploads for backends that support atomic file replacements. For these backends we just can overwrite the old copy, if it is necessary to retry an upload. This has the benefit of issuing one operation less and might be beneficial if a backend storage, due to bugs or similar, could mix up the order of the upload and delete calls.

As a random additional change the PR also increases the file listing size for B2 to the maximum in order to reduce the number of network roundtrips necessary to list the files in a large repository.

There is currently only a changelog for the B2 delete change as the other ones only affect extremely technical details.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3161

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [s] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
