### PR TITLE
doc: recommend usage of B2's S3 API

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -450,6 +450,16 @@ The policy of the new container created by restic can be changed using environme
 Backblaze B2
 ************
 
+.. warning::
+
+   The recommended way to setup Backblaze B2 is by using its S3-compatible API.
+   Follow the documentation to `generate S3-compatible access keys`_ and then
+   setup restic as described at :ref:`Amazon S3`.
+
+    Different from the B2 backend, restic's S3 backend will only hide no longer
+    necessary files. Thus, make sure to setup lifecycle rules to eventually
+    delete hidden files.
+
 Restic can backup data to any Backblaze B2 bucket. You need to first setup the
 following environment variables with the credentials you can find in the
 dashboard on the "Buckets" page when signed into your B2 account:
@@ -487,6 +497,8 @@ Note that the bucket name must be unique across all of B2.
 The number of concurrent connections to the B2 service can be set with the ``-o
 b2.connections=10`` switch. By default, at most five parallel connections are
 established.
+
+.. _generate S3-compatible access keys: https://help.backblaze.com/hc/en-us/articles/360047425453-Getting-Started-with-the-S3-Compatible-API
 
 Microsoft Azure Blob Storage
 ****************************


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The error handling in the library we use to access B2 has been a constant source of problems. Usually it result in hard to debug cases of restic appearing to just "hang". A proper fix would require switching to a different B2 library (e.g. https://github.com/kothar/go-backblaze which is used by kopia). But I wonder whether it's really worth the effort as B2 offers a S3-compatible API by now. So the most economical solution in terms of required work is to just steer users towards the S3 API.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
I've already complained in #3859.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
