### PR TITLE
rclone: Return a permanent error if rclone already exited

### DIFF
--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -15,6 +15,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/limiter"
 	"github.com/restic/restic/internal/backend/rest"
@@ -174,7 +175,7 @@ func newBackend(cfg Config, lim limiter.Limiter) (*Backend, error) {
 			debug.Log("new connection requested, %v %v", network, address)
 			if dialCount > 0 {
 				// the connection to the child process is already closed
-				return nil, errors.New("rclone stdio connection already closed")
+				return nil, backoff.Permanent(errors.New("rclone stdio connection already closed"))
 			}
 			dialCount++
 			return conn, nil


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
rclone can exit early for example when the connection to rclone is relayed for example via ssh: `-o rclone.program='ssh user@example.org forced-command'`

This is one possible setup for append-only backups as described at https://ruderich.org/simon/notes/append-only-backups-with-restic-and-rclone .

If the rclone connection is interrupted, then there is no point in retrying request. Thus just return a permanent error in this case.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
