### PR TITLE
Mount should return exit code 0 after pressing Ctrl-C

### DIFF
--- a/changelog/unreleased/issue-2015
+++ b/changelog/unreleased/issue-2015
@@ -1,0 +1,10 @@
+Bugfix: Mount command should return exit code 0 after receiving Ctrl-C
+
+To stop the mount command, a user has to press Ctrl-C or send a SIGINT to
+restic. This caused restic to exit with a non-zero exit code.
+
+We have changed the exit code to zero as this is the expected way to stop the
+mount command.
+
+https://github.com/restic/restic/issues/2015
+https://github.com/restic/restic/pull/3894

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -197,9 +197,9 @@ func runCheck(opts CheckOptions, gopts GlobalOptions, args []string) error {
 	}
 
 	cleanup := prepareCheckCache(opts, &gopts)
-	AddCleanupHandler(func() error {
+	AddCleanupHandler(func(code int) (int, error) {
 		cleanup()
-		return nil
+		return code, nil
 	})
 
 	repo, err := OpenRepository(gopts)

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -158,13 +158,13 @@ func runMount(opts MountOptions, gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	AddCleanupHandler(func() error {
+	AddCleanupHandler(func(code int) (int, error) {
 		debug.Log("running umount cleanup handler for mount at %v", mountpoint)
 		err := umount(mountpoint)
 		if err != nil {
 			Warnf("unable to umount (maybe already umounted or still in use?): %v\n", err)
 		}
-		return nil
+		return code, nil
 	})
 
 	c, err := systemFuse.Mount(mountpoint, mountOptions...)

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -164,6 +164,10 @@ func runMount(opts MountOptions, gopts GlobalOptions, args []string) error {
 		if err != nil {
 			Warnf("unable to umount (maybe already umounted or still in use?): %v\n", err)
 		}
+		// replace error code of sigint
+		if code == 130 {
+			code = 0
+		}
 		return code, nil
 	})
 

--- a/cmd/restic/global_debug.go
+++ b/cmd/restic/global_debug.go
@@ -84,9 +84,9 @@ func runDebug() error {
 	}
 
 	if prof != nil {
-		AddCleanupHandler(func() error {
+		AddCleanupHandler(func(code int) (int, error) {
 			prof.Stop()
-			return nil
+			return code, nil
 		})
 	}
 

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -119,7 +119,7 @@ func unlockRepo(lock *restic.Lock) {
 	debug.Log("unable to find lock %v in the global list of locks, ignoring", lock)
 }
 
-func unlockAll() error {
+func unlockAll(code int) (int, error) {
 	globalLocks.Lock()
 	defer globalLocks.Unlock()
 
@@ -127,11 +127,11 @@ func unlockAll() error {
 	for _, lock := range globalLocks.locks {
 		if err := lock.Unlock(); err != nil {
 			debug.Log("error while unlocking: %v", err)
-			return err
+			return code, err
 		}
 		debug.Log("successfully removed lock")
 	}
 	globalLocks.locks = globalLocks.locks[:0]
 
-	return nil
+	return code, nil
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
To stop the mount command, a user has to press Ctrl-C or send a SIGINT to restic. This caused restic to exit with a non-zero exit code.

However, as this is the correct way to stop the mount command, an exit code of zero makes much more sense.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #2015
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
