### PR TITLE
don't hang when `copy` uses a single connection

### DIFF
--- a/changelog/unreleased/issue-3897
+++ b/changelog/unreleased/issue-3897
@@ -1,0 +1,7 @@
+Bugfix: Fix stuck `copy` command when setting backend connections to 1
+
+When calling the copy command using `copy -o <backend>.connections=1` this
+caused the command to be stuck permanently. This has been fixed.
+
+https://github.com/restic/restic/issues/3897
+https://github.com/restic/restic/pull/3898

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -22,7 +22,7 @@ import (
 func Repack(ctx context.Context, repo restic.Repository, dstRepo restic.Repository, packs restic.IDSet, keepBlobs restic.BlobSet, p *progress.Counter) (obsoletePacks restic.IDSet, err error) {
 	debug.Log("repacking %d packs while keeping %d blobs", len(packs), len(keepBlobs))
 
-	if repo == dstRepo && dstRepo.Backend().Connections() < 2 {
+	if repo == dstRepo && dstRepo.Connections() < 2 {
 		return nil, errors.Fatal("repack step requires a backend connection limit of at least two")
 	}
 

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -114,6 +114,10 @@ func repack(ctx context.Context, repo restic.Repository, dstRepo restic.Reposito
 	// as packs are streamed the concurrency is limited by IO
 	// reduce by one to ensure that uploading is always possible
 	repackWorkerCount := int(repo.Connections() - 1)
+	if repo != dstRepo {
+		// no need to share the upload and download connections for different repositories
+		repackWorkerCount = int(repo.Connections())
+	}
 	for i := 0; i < repackWorkerCount; i++ {
 		wg.Go(worker)
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The copy command hangs when the source repository only uses a single backend connection. This is caused by reserving one connection for uploading, which is necessary to prevent deadlock for the `prune` command. However, `copy` uses different repositories, so there is reason to reserve a connection.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3897
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
