### PR TITLE
Add newline to keep prompt intact

### DIFF
--- a/cmd/restic/cmd_migrate.go
+++ b/cmd/restic/cmd_migrate.go
@@ -57,7 +57,7 @@ func checkMigrations(opts MigrateOptions, gopts GlobalOptions, repo restic.Repos
 	}
 
 	if !found {
-		Printf("no migrations found")
+		Printf("no migrations found\n")
 	}
 
 	return nil


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This adds a newline so the prompt doesn't get messed up. When no migrations are found, it looks like this:

```
$ restic -r /repository/ migrate
enter password for repository: 
repository ef0a9242 opened (repository version 2) successfully, password is correct
available migrations:
no migrations found$
```

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
