### PR TITLE
Reduce quadratic time complexity of `Snapshot.HasPaths`

### DIFF
--- a/changelog/unreleased/pull-3905
+++ b/changelog/unreleased/pull-3905
@@ -1,0 +1,6 @@
+Enhancement: Improve speed of parent snapshot searching for `backup` command
+
+Backing up a large number of files using `--files-from-verbatim` or `--files-from-raw`
+options could require a long time to find the parent snapshot. This has been improved.
+
+https://github.com/restic/restic/pull/3905

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -237,19 +237,14 @@ func (sn *Snapshot) HasTagList(l []TagList) bool {
 	return false
 }
 
-func (sn *Snapshot) hasPath(path string) bool {
-	for _, snPath := range sn.Paths {
-		if path == snPath {
-			return true
-		}
-	}
-	return false
-}
-
 // HasPaths returns true if the snapshot has all of the paths.
 func (sn *Snapshot) HasPaths(paths []string) bool {
+	m := make(map[string]struct{}, len(sn.Paths))
+	for _, snPath := range sn.Paths {
+		m[snPath] = struct{}{}
+	}
 	for _, path := range paths {
-		if !sn.hasPath(path) {
+		if _, ok := m[path]; !ok {
 			return false
 		}
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Before this PR:
```
>restic backup --parent 1c65efbf --files-from-verbatim files.txt
repository 5f625b2c opened (repository version 2) successfully, password is correct
using parent snapshot 1c65efbf

Files:           0 new,     0 changed, 59871 unmodified
Dirs:            0 new,     0 changed,  4395 unmodified
Added to the repository: 0 B   (0 B   stored)

processed 59871 files, 2.511 GiB in 0:06
snapshot cf26e25d saved

>restic backup --files-from-verbatim files.txt
repository 5f625b2c opened (repository version 2) successfully, password is correct
using parent snapshot cf26e25d

Files:           0 new,     0 changed, 59871 unmodified
Dirs:            0 new,     0 changed,  4395 unmodified
Added to the repository: 0 B   (0 B   stored)

processed 59871 files, 2.511 GiB in 0:16
snapshot 2665923b saved
```
10s difference between running with and without `--parent` option.

After this PR:
```
>restic backup --parent 1c65efbf --files-from-verbatim files.txt
repository 5f625b2c opened (repository version 2) successfully, password is correct
using parent snapshot 1c65efbf

Files:           0 new,     0 changed, 59871 unmodified
Dirs:            0 new,     0 changed,  4395 unmodified
Added to the repository: 0 B   (0 B   stored)

processed 59871 files, 2.511 GiB in 0:06
snapshot 148578b4 saved

>restic backup --files-from-verbatim files.txt
repository 5f625b2c opened (repository version 2) successfully, password is correct
using parent snapshot 148578b4

Files:           0 new,     0 changed, 59871 unmodified
Dirs:            0 new,     0 changed,  4395 unmodified
Added to the repository: 0 B   (0 B   stored)

processed 59871 files, 2.511 GiB in 0:08
snapshot 27dd17d3 saved
```
Less then 2s now.

Was the change discussed in an issue or in the forum before?
------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [Contribution Guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches)
- [x] I have enabled [maintainer edits for this PR](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork)
~- [ ] I have added tests for all changes in this PR~
~- [ ] I have added documentation for the changes (in the manual)~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (template [here](https://github.com/restic/restic/blob/master/changelog/TEMPLATE))
- [x] I have run `gofmt` on the code in all commits
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits)
- [x] I'm done, this Pull Request is ready for review