### PR TITLE
migrate: Report why an migration cannot be applied

### DIFF
--- a/cmd/restic/cmd_migrate.go
+++ b/cmd/restic/cmd_migrate.go
@@ -45,7 +45,7 @@ func checkMigrations(opts MigrateOptions, gopts GlobalOptions, repo restic.Repos
 	found := false
 
 	for _, m := range migrations.All {
-		ok, err := m.Check(ctx, repo)
+		ok, _, err := m.Check(ctx, repo)
 		if err != nil {
 			return err
 		}
@@ -70,14 +70,17 @@ func applyMigrations(opts MigrateOptions, gopts GlobalOptions, repo restic.Repos
 	for _, name := range args {
 		for _, m := range migrations.All {
 			if m.Name() == name {
-				ok, err := m.Check(ctx, repo)
+				ok, reason, err := m.Check(ctx, repo)
 				if err != nil {
 					return err
 				}
 
 				if !ok {
 					if !opts.Force {
-						Warnf("migration %v cannot be applied: check failed\nIf you want to apply this migration anyway, re-run with option --force\n", m.Name())
+						if reason == "" {
+							reason = "check failed"
+						}
+						Warnf("migration %v cannot be applied: %v\nIf you want to apply this migration anyway, re-run with option --force\n", m.Name(), reason)
 						continue
 					}
 

--- a/internal/migrations/interface.go
+++ b/internal/migrations/interface.go
@@ -8,8 +8,8 @@ import (
 
 // Migration implements a data migration.
 type Migration interface {
-	// Check returns true if the migration can be applied to a repo.
-	Check(context.Context, restic.Repository) (bool, error)
+	// Check returns true if the migration can be applied to a repo. If the option is not applicable it can return a specific reason.
+	Check(context.Context, restic.Repository) (bool, string, error)
 
 	RepoCheck() bool
 

--- a/internal/migrations/s3_layout.go
+++ b/internal/migrations/s3_layout.go
@@ -38,19 +38,19 @@ func toS3Backend(repo restic.Repository) *s3.Backend {
 }
 
 // Check tests whether the migration can be applied.
-func (m *S3Layout) Check(ctx context.Context, repo restic.Repository) (bool, error) {
+func (m *S3Layout) Check(ctx context.Context, repo restic.Repository) (bool, string, error) {
 	be := toS3Backend(repo)
 	if be == nil {
 		debug.Log("backend is not s3")
-		return false, nil
+		return false, "backend is not s3", nil
 	}
 
 	if be.Layout.Name() != "s3legacy" {
 		debug.Log("layout is not s3legacy")
-		return false, nil
+		return false, "not using the legacy s3 layout", nil
 	}
 
-	return true, nil
+	return true, "", nil
 }
 
 func (m *S3Layout) RepoCheck() bool {

--- a/internal/migrations/upgrade_repo_v2.go
+++ b/internal/migrations/upgrade_repo_v2.go
@@ -45,9 +45,13 @@ func (*UpgradeRepoV2) Desc() string {
 	return "upgrade a repository to version 2"
 }
 
-func (*UpgradeRepoV2) Check(ctx context.Context, repo restic.Repository) (bool, error) {
+func (*UpgradeRepoV2) Check(ctx context.Context, repo restic.Repository) (bool, string, error) {
 	isV1 := repo.Config().Version == 1
-	return isV1, nil
+	reason := ""
+	if !isV1 {
+		reason = fmt.Sprintf("repository is already upgraded to version %v", repo.Config().Version)
+	}
+	return isV1, reason, nil
 }
 
 func (*UpgradeRepoV2) RepoCheck() bool {

--- a/internal/migrations/upgrade_repo_v2_test.go
+++ b/internal/migrations/upgrade_repo_v2_test.go
@@ -23,7 +23,7 @@ func TestUpgradeRepoV2(t *testing.T) {
 
 	m := &UpgradeRepoV2{}
 
-	ok, err := m.Check(context.Background(), repo)
+	ok, _, err := m.Check(context.Background(), repo)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -81,7 +81,7 @@ func TestUpgradeRepoV2Failure(t *testing.T) {
 
 	m := &UpgradeRepoV2{}
 
-	ok, err := m.Check(context.Background(), repo)
+	ok, _, err := m.Check(context.Background(), repo)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Just returning that `Migration upgrade cannot be applied: check failed`
is not too useful when running `migrate upgrade_repo_v2`.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://forum.restic.net/t/migration-upgrade-repo-v2-cannot-be-applied-check-failed/5407
Fixes https://forum.restic.net/t/restic-0-14-0-released/5359/19
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
