### PR TITLE
restic stats: print uncompressed size in mode raw-data

### DIFF
--- a/changelog/unreleased/pull-3915
+++ b/changelog/unreleased/pull-3915
@@ -1,0 +1,9 @@
+Enhancement: add compression statistics to the restic stats command
+
+When executed in `raw-data` mode on a repository that supports compression, the `restic stats`
+command now calculates and displays, for the selected repository or snapshots, the uncompressed
+size of the data, the compression progress (percentage of data that has been compressed), the
+compression ratio of the compressed data and the total space saving, taking into account both
+the compressed and uncompressed data if the repository is only partially compressed.
+
+https://github.com/restic/restic/pull/3915

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/restic/restic/internal/backend"
+	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/walker"
 
@@ -136,11 +137,7 @@ func runStats(gopts GlobalOptions, args []string) error {
 			}
 			stats.TotalSize += uint64(pbs[0].Length)
 			if repo.Config().Version >= 2 {
-				if pbs[0].IsCompressed() {
-					stats.TotalUncompressedSize += uint64(pbs[0].UncompressedLength)
-				} else {
-					stats.TotalUncompressedSize += uint64(pbs[0].Length)
-				}
+				stats.TotalUncompressedSize += uint64(crypto.CiphertextLength(int(pbs[0].DataLength())))
 			}
 			stats.TotalBlobCount++
 		}
@@ -293,7 +290,7 @@ func verifyStatsInput(gopts GlobalOptions, args []string) error {
 // for a successful and efficient walk.
 type statsContainer struct {
 	TotalSize             uint64 `json:"total_size"`
-	TotalUncompressedSize uint64 `json:"total_uncompressed_size"`
+	TotalUncompressedSize uint64 `json:"total_uncompressed_size,omitempty"`
 	TotalFileCount        uint64 `json:"total_file_count"`
 	TotalBlobCount        uint64 `json:"total_blob_count,omitempty"`
 	// holds count of all considered snapshots


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR prints the uncompressed size of a snapshot/repository when ```restic stats``` is called in mode ```raw-data```. For example:

```
$ restic stats --mode=raw-data -r repotest/
repository ad894609 opened (repository version 2) successfully, password is correct
scanning...
Stats in raw-data mode:
    Snapshots processed:  41
       Total Blob Count:  150677
             Total Size:  71.085 GiB
Total Uncompressed Size:  77.307 GiB
```


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.