### PR TITLE
cache: fix flaky TestFileSaveConcurrent on windows

### DIFF
--- a/internal/cache/file_test.go
+++ b/internal/cache/file_test.go
@@ -207,10 +207,13 @@ func TestFileLoad(t *testing.T) {
 // Simulate multiple processes writing to a cache, using goroutines.
 //
 // The possibility of sharing a cache between multiple concurrent restic
-// processes isn't guaranteed in the docs and doesn't always work on Windows
-// due to the Go runtime opening files without FILE_SHARE_DELETE, hence the
-// check on GOOS. This is considered a "nice to have" on POSIX, for now.
+// processes isn't guaranteed in the docs and doesn't always work on Windows, hence the
+// check on GOOS. Cache sharing is considered a "nice to have" on POSIX, for now.
 //
+// The cache first creates a temporary file and then renames it to its final name.
+// On Windows renaming internally creates a file handle with a shareMode which
+// includes FILE_SHARE_DELETE. The Go runtime opens files without FILE_SHARE_DELETE,
+// thus Open(fn) will fail until the file handle used for renaming was closed.
 // See https://devblogs.microsoft.com/oldnewthing/20211022-00/?p=105822
 // for hints on how to fix this properly.
 func TestFileSaveConcurrent(t *testing.T) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The test would from time to time fail with ERROR_SHARING_VIOLATION, see for example https://github.com/restic/restic/runs/8286388017?check_suite_focus=true#step:7:34 . The underlying reason is that when caching a file, the cache creates a temporary file, downloads the data and renames the temp file to its final name. This rename step on windows implicitly opens a file handle with a shareMode that includes FILE_SHARE_DELETE (https://devblogs.microsoft.com/oldnewthing/20211022-00/?p=105822). However, when opening a file, go only requests READ/WRITE sharing which results in the above error (https://github.com/golang/go/blob/54182ff54a687272dd7632c3a963e036ce03cb7c/src/syscall/syscall_windows.go#L332).

Strictly speaking the proper fix would be to open the cache file with a shareMode which includes FILE_SHARE_DELETE. But I'm not particularly eager to implement our own `os.Open` function.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
