### PR TITLE
Add powershell completion

### DIFF
--- a/changelog/unreleased/pull-3925
+++ b/changelog/unreleased/pull-3925
@@ -1,0 +1,6 @@
+Enhancement: Provide command completion for powershell
+
+Restic allows generation of completion files for bash, fish and zsh. Now powershell
+is supported, too.
+
+https://github.com/restic/restic/pull/3925/files

--- a/cmd/restic/cmd_generate.go
+++ b/cmd/restic/cmd_generate.go
@@ -10,7 +10,7 @@ import (
 
 var cmdGenerate = &cobra.Command{
 	Use:   "generate [flags]",
-	Short: "Generate manual pages and auto-completion files (bash, fish, zsh)",
+	Short: "Generate manual pages and auto-completion files (bash, fish, zsh, powershell)",
 	Long: `
 The "generate" command writes automatically generated files (like the man pages
 and the auto-completion files for bash, fish and zsh).
@@ -25,10 +25,11 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 }
 
 type generateOptions struct {
-	ManDir             string
-	BashCompletionFile string
-	FishCompletionFile string
-	ZSHCompletionFile  string
+	ManDir                   string
+	BashCompletionFile       string
+	FishCompletionFile       string
+	ZSHCompletionFile        string
+	PowerShellCompletionFile string
 }
 
 var genOpts generateOptions
@@ -40,6 +41,7 @@ func init() {
 	fs.StringVar(&genOpts.BashCompletionFile, "bash-completion", "", "write bash completion `file`")
 	fs.StringVar(&genOpts.FishCompletionFile, "fish-completion", "", "write fish completion `file`")
 	fs.StringVar(&genOpts.ZSHCompletionFile, "zsh-completion", "", "write zsh completion `file`")
+	fs.StringVar(&genOpts.PowerShellCompletionFile, "powershell-completion", "", "write powershell completion `file`")
 }
 
 func writeManpages(dir string) error {
@@ -75,6 +77,11 @@ func writeZSHCompletion(file string) error {
 	return cmdRoot.GenZshCompletionFile(file)
 }
 
+func writePowerShellCompletion(file string) error {
+	Verbosef("writing powershell completion file to %v\n", file)
+	return cmdRoot.GenPowerShellCompletionFile(file)
+}
+
 func runGenerate(cmd *cobra.Command, args []string) error {
 	if genOpts.ManDir != "" {
 		err := writeManpages(genOpts.ManDir)
@@ -99,6 +106,13 @@ func runGenerate(cmd *cobra.Command, args []string) error {
 
 	if genOpts.ZSHCompletionFile != "" {
 		err := writeZSHCompletion(genOpts.ZSHCompletionFile)
+		if err != nil {
+			return err
+		}
+	}
+
+	if genOpts.PowerShellCompletionFile != "" {
+		err := writePowerShellCompletion(genOpts.PowerShellCompletionFile)
 		if err != nil {
 			return err
 		}

--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -313,14 +313,14 @@ compiler. Building restic with gccgo may work, but is not supported.
 Autocompletion
 **************
 
-Restic can write out man pages and bash/fish/zsh compatible autocompletion scripts:
+Restic can write out man pages and bash/fish/zsh/powershell compatible autocompletion scripts:
 
 .. code-block:: console
 
     $ ./restic generate --help
 
     The "generate" command writes automatically generated files (like the man pages
-    and the auto-completion files for bash, fish and zsh).
+    and the auto-completion files for bash, fish, zsh and powershell).
 
     Usage:
       restic generate [flags] [command]
@@ -330,6 +330,7 @@ Restic can write out man pages and bash/fish/zsh compatible autocompletion scrip
           --fish-completion file   write fish completion file
       -h, --help                   help for generate
           --man directory          write man pages to directory
+          --powershell-completion  write powershell completion file
           --zsh-completion file    write zsh completion file
 
 Example for using sudo to write a bash completion script directly to the system-wide location:

--- a/helpers/prepare-release/main.go
+++ b/helpers/prepare-release/main.go
@@ -290,6 +290,7 @@ func generateFiles() {
 	run("./restic-generate.temp", "generate",
 		"--man", "doc/man",
 		"--zsh-completion", "doc/zsh-completion.zsh",
+		"--powershell-completion", "doc/powershell-completion.ps1",
 		"--fish-completion", "doc/fish-completion.fish",
 		"--bash-completion", "doc/bash-completion.sh")
 	rm("restic-generate.temp")


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Restic can generate completion files for bash, fish and zsh, but not for powershell.
Cobra can generate this, too. 

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No. I have spotted that cobra can do this and wondered why restic does not use it.

Checklist
---------

- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [X] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [X] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I have run `gofmt` on the code in all commits.
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
