### PR TITLE
add --no-scan to backup command

### DIFF
--- a/changelog/unreleased/pull-3931
+++ b/changelog/unreleased/pull-3931
@@ -1,0 +1,8 @@
+Enhancement: Allow backup file tree scanner to be disabled
+
+Restic walks the file tree in a separate scanner process to find the total size
+and file/directory count, and uses that to provide an ETA.  This can slow down
+backups, especially of network filesystems.  The new flag `--no-scan`
+can be used to speed up such backups.
+
+https://github.com/restic/restic/pull/3931

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -204,8 +204,17 @@ Combined with ``--verbose``, you can see a list of changes:
     modified  /archive.tar.gz, saved in 0.140s (25.542 MiB added)
     Would be added to the repository: 25.551 MiB
 
-.. _backup-excluding-files:
+Disabling Backup Progress Estimation
+************************************
 
+When you start a backup, restic will concurrently count the number of
+files and their total size, which is used to estimate how long it will
+take.  This will cause some extra I/O, which can slow down backup of
+network file systems or fuse mounts.
+
+-  ``--no-scan``  Do not run scanner to estimate size of backup
+
+.. _backup-excluding-files:
 Excluding Files
 ***************
 


### PR DESCRIPTION
The scanner process has only cosmetic effect for the progress printer, and can be disabled without impacting functionality when the user does not need an estimate of completion.

In many cases the scanner process can provide beneficial priming of the file system cache, so as general advice it should not be disabled. However, tests have shown that backup of NFS and fuse based filesystems, where stat(2) is relatively expensive, can be significantly faster without the scanner.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This patch allows users to avoid some unnecessary I/O during backup caused by the job size scanner when appropriate.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Michael Eischer previously suggest to disable the scanner implicitly for quiet jobs in PR #2336

His testing showed that although user and system time was reduced, real time could in fact increase.  Also, the difference was relatively small when run locally on SSD.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
