### PR TITLE
Only display the message if there were locks to be removed

### DIFF
--- a/changelog/unreleased/issue-3929
+++ b/changelog/unreleased/issue-3929
@@ -1,0 +1,7 @@
+Enhancement: Only display the message if there were locks to be removed
+
+`restic unlock` now only shows `successfully removed locks` if there were locks to be removed.
+In addition, it also reports the number of the removed lock files.
+
+https://github.com/restic/restic/issues/3929
+https://github.com/restic/restic/pull/3935

--- a/cmd/restic/cmd_unlock.go
+++ b/cmd/restic/cmd_unlock.go
@@ -46,11 +46,13 @@ func runUnlock(opts UnlockOptions, gopts GlobalOptions) error {
 		fn = restic.RemoveAllLocks
 	}
 
-	err = fn(gopts.ctx, repo)
+	processed, err := fn(gopts.ctx, repo)
 	if err != nil {
 		return err
 	}
 
-	Verbosef("successfully removed locks\n")
+	if processed > 0 {
+		Verbosef("successfully removed %d locks\n", processed)
+	}
 	return nil
 }

--- a/internal/restic/lock_test.go
+++ b/internal/restic/lock_test.go
@@ -184,7 +184,8 @@ func TestLockWithStaleLock(t *testing.T) {
 	id3, err := createFakeLock(repo, time.Now().Add(-time.Minute), os.Getpid()+500000)
 	rtest.OK(t, err)
 
-	rtest.OK(t, restic.RemoveStaleLocks(context.TODO(), repo))
+	processed, err := restic.RemoveStaleLocks(context.TODO(), repo)
+	rtest.OK(t, err)
 
 	rtest.Assert(t, lockExists(repo, t, id1) == false,
 		"stale lock still exists after RemoveStaleLocks was called")
@@ -192,6 +193,9 @@ func TestLockWithStaleLock(t *testing.T) {
 		"non-stale lock was removed by RemoveStaleLocks")
 	rtest.Assert(t, lockExists(repo, t, id3) == false,
 		"stale lock still exists after RemoveStaleLocks was called")
+	rtest.Assert(t, processed == 2,
+		"number of locks removed does not match: expected %d, got %d",
+		2, processed)
 
 	rtest.OK(t, removeLock(repo, id2))
 }
@@ -209,7 +213,8 @@ func TestRemoveAllLocks(t *testing.T) {
 	id3, err := createFakeLock(repo, time.Now().Add(-time.Minute), os.Getpid()+500000)
 	rtest.OK(t, err)
 
-	rtest.OK(t, restic.RemoveAllLocks(context.TODO(), repo))
+	processed, err := restic.RemoveAllLocks(context.TODO(), repo)
+	rtest.OK(t, err)
 
 	rtest.Assert(t, lockExists(repo, t, id1) == false,
 		"lock still exists after RemoveAllLocks was called")
@@ -217,6 +222,9 @@ func TestRemoveAllLocks(t *testing.T) {
 		"lock still exists after RemoveAllLocks was called")
 	rtest.Assert(t, lockExists(repo, t, id3) == false,
 		"lock still exists after RemoveAllLocks was called")
+	rtest.Assert(t, processed == 3,
+		"number of locks removed does not match: expected %d, got %d",
+		3, processed)
 }
 
 func TestLockRefresh(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

`restic unlock` should only show `successfully removed locks` if there were locks to be removed.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #3929
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
