### PR TITLE
Add Resticprofile to the documentation

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -533,8 +533,11 @@ Restic does not have a built-in way of scheduling backups, as it's a tool
 that runs when executed rather than a daemon. There are plenty of different
 ways to schedule backup runs on various different platforms, e.g. systemd
 and cron on Linux/BSD and Task Scheduler in Windows, depending on one's
-needs and requirements. When scheduling restic to run recurringly, please
-make sure to detect already running instances before starting the backup.
+needs and requirements. If you don't want to implement your own scheduling,
+you can use `resticprofile <https://github.com/creativeprojects/resticprofile/#resticprofile>`__.
+
+When scheduling restic to run recurringly, please make sure to detect already
+running instances before starting the backup.
 
 Space requirements
 ******************


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It adds [resticprofile](https://github.com/creativeprojects/resticprofile) to the documentation (at [doc/040_backup.rst#scheduling-backups](https://github.com/restic/restic/blob/master/doc/040_backup.rst#scheduling-backups)) to inform users of a scheduler via config files.
This could accelerate and increase the adoption of restic, as it did for me.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Yes, it was posted on the forum: [add-resticprofile-to-the-restic-documentation/5188](https://forum.restic.net/t/add-resticprofile-to-the-restic-documentation/5188).

It solves issue #2882 asking for config file support.

@creativeprojects may be interested in the discussion. 

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes. (no code change)
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)). (not relevant)
- [ ] I have run `gofmt` on the code in all commits. (no code added)
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
