### PR TITLE
ignore filenames which are not IDs when expanding a prefix

### DIFF
--- a/changelog/unreleased/pull-3943
+++ b/changelog/unreleased/pull-3943
@@ -1,0 +1,9 @@
+Enhancement: Ignore additional files in repository
+
+Some commands like `find` and `restore` could become confused by additional
+files in the repository. This could cause restic to fail with an `multiple IDs
+with prefix "12345678" found` error. These commands now ignore additional
+files.
+
+https://github.com/restic/restic/pull/3943
+https://forum.restic.net/t/which-protocol-should-i-choose-for-remote-linux-backups/5446/17

--- a/internal/restic/backend_find.go
+++ b/internal/restic/backend_find.go
@@ -3,6 +3,8 @@ package restic
 import (
 	"context"
 	"fmt"
+
+	"github.com/restic/restic/internal/debug"
 )
 
 // A MultipleIDMatchesError is returned by Find() when multiple IDs with a
@@ -31,6 +33,13 @@ func Find(ctx context.Context, be Lister, t FileType, prefix string) (string, er
 	defer cancel()
 
 	err := be.List(ctx, t, func(fi FileInfo) error {
+		// ignore filename which are not an id
+		_, err := ParseID(fi.Name)
+		if err != nil {
+			debug.Log("unable to parse %v as an ID", fi.Name)
+			return nil
+		}
+
 		if len(fi.Name) >= len(prefix) && prefix == fi.Name[:len(prefix)] {
 			if match == "" {
 				match = fi.Name


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Some backends (see https://forum.restic.net/t/which-protocol-should-i-choose-for-remote-linux-backups/5446/17 ) generate additional files for each existing file, e.g.
```
1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef
1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef.sha256
```

For some commands when trying to reference a snapshot, this then leads to an "multiple IDs with prefix" error.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://forum.restic.net/t/which-protocol-should-i-choose-for-remote-linux-backups/5446/17

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
