### PR TITLE
repository: remove IsMixedPack and add replacement for checker

### DIFF
--- a/internal/repository/master_index.go
+++ b/internal/repository/master_index.go
@@ -106,18 +106,6 @@ func (mi *MasterIndex) Has(bh restic.BlobHandle) bool {
 	return false
 }
 
-func (mi *MasterIndex) IsMixedPack(packID restic.ID) bool {
-	mi.idxMutex.RLock()
-	defer mi.idxMutex.RUnlock()
-
-	for _, idx := range mi.idx {
-		if idx.MixedPacks().Has(packID) {
-			return true
-		}
-	}
-	return false
-}
-
 // IDs returns the IDs of all indexes contained in the index.
 func (mi *MasterIndex) IDs() restic.IDSet {
 	mi.idxMutex.RLock()

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -157,8 +157,7 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packe
 	}
 
 	id := restic.IDFromHash(hr.Sum(nil))
-	h := restic.Handle{Type: restic.PackFile, Name: id.String(),
-		ContainedBlobType: t}
+	h := restic.Handle{Type: restic.PackFile, Name: id.String(), ContainedBlobType: t}
 	var beHash []byte
 	if beHr != nil {
 		beHash = beHr.Sum(nil)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -277,12 +277,7 @@ func (r *Repository) LoadBlob(ctx context.Context, t restic.BlobType, id restic.
 		}
 
 		// load blob from pack
-		bt := t
-		if r.idx.IsMixedPack(blob.PackID) {
-			bt = restic.InvalidBlob
-		}
-		h := restic.Handle{Type: restic.PackFile,
-			Name: blob.PackID.String(), ContainedBlobType: bt}
+		h := restic.Handle{Type: restic.PackFile, Name: blob.PackID.String(), ContainedBlobType: t}
 
 		switch {
 		case cap(buf) < int(blob.Length):


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Remove Index.IsMixedPack to remove code which is no longer used for repositories created using somewhat recent restic versions.

Repositories with mixed packs are probably quite rare by now. When loading data blobs from a mixed pack file, this will no longer trigger caching that file. However, usually tree blobs are accessed first such that this shouldn't make much of a difference.

The checker still checks for mixed packs, thus add a simple, local replacement.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
