### PR TITLE
Rework snapshot filtering

### DIFF
--- a/changelog/unreleased/pull-3951
+++ b/changelog/unreleased/pull-3951
@@ -1,0 +1,6 @@
+Bugfix: `ls` returns exit code 1 if snapshot cannot be loaded
+
+If the `ls` command failed to load a snapshot, it only printed a warning and
+returned exit code 0. This has been changed to return exit code 1 instead.
+
+https://github.com/restic/restic/pull/3951

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -505,27 +505,20 @@ func collectTargets(opts BackupOptions, args []string) (targets []string, err er
 // parent returns the ID of the parent snapshot. If there is none, nil is
 // returned.
 func findParentSnapshot(ctx context.Context, repo restic.Repository, opts BackupOptions, targets []string, timeStampLimit time.Time) (parentID *restic.ID, err error) {
-	// Force using a parent
-	if !opts.Force && opts.Parent != "" {
-		id, err := restic.FindSnapshot(ctx, repo.Backend(), opts.Parent)
-		if err != nil {
-			return nil, errors.Fatalf("invalid id %q: %v", opts.Parent, err)
-		}
-
-		parentID = &id
+	if opts.Force {
+		return nil, nil
 	}
 
-	// Find last snapshot to set it as parent, if not already set
-	if !opts.Force && parentID == nil {
-		id, err := restic.FindLatestSnapshot(ctx, repo.Backend(), repo, targets, []restic.TagList{}, []string{opts.Host}, &timeStampLimit)
-		if err == nil {
-			parentID = &id
-		} else if err != restic.ErrNoSnapshotFound {
-			return nil, err
-		}
+	snName := opts.Parent
+	if snName == "" {
+		snName = "latest"
 	}
-
-	return parentID, nil
+	id, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, []string{opts.Host}, []restic.TagList{}, targets, &timeStampLimit, snName)
+	// Snapshot not found is ok if no explicit parent was set
+	if opts.Parent == "" && errors.Is(err, restic.ErrNoSnapshotFound) {
+		err = nil
+	}
+	return &id, err
 }
 
 func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, term *termstatus.Terminal, args []string) error {

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -55,18 +55,10 @@ func runCat(ctx context.Context, gopts GlobalOptions, args []string) error {
 	tpe := args[0]
 
 	var id restic.ID
-	if tpe != "masterkey" && tpe != "config" {
+	if tpe != "masterkey" && tpe != "config" && tpe != "snapshot" {
 		id, err = restic.ParseID(args[1])
 		if err != nil {
-			if tpe != "snapshot" {
-				return errors.Fatalf("unable to parse ID: %v\n", err)
-			}
-
-			// find snapshot id with prefix
-			id, err = restic.FindSnapshot(ctx, repo.Backend(), args[1])
-			if err != nil {
-				return errors.Fatalf("could not find snapshot: %v\n", err)
-			}
+			return errors.Fatalf("unable to parse ID: %v\n", err)
 		}
 	}
 
@@ -88,9 +80,9 @@ func runCat(ctx context.Context, gopts GlobalOptions, args []string) error {
 		Println(string(buf))
 		return nil
 	case "snapshot":
-		sn, err := restic.LoadSnapshot(ctx, repo, id)
+		sn, err := restic.FindSnapshot(ctx, repo.Backend(), repo, args[1])
 		if err != nil {
-			return err
+			return errors.Fatalf("could not find snapshot: %v\n", err)
 		}
 
 		buf, err := json.MarshalIndent(sn, "", "  ")

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -54,11 +54,11 @@ func init() {
 }
 
 func loadSnapshot(ctx context.Context, be restic.Lister, repo restic.Repository, desc string) (*restic.Snapshot, error) {
-	id, err := restic.FindSnapshot(ctx, be, desc)
+	sn, err := restic.FindSnapshot(ctx, be, repo, desc)
 	if err != nil {
 		return nil, errors.Fatal(err.Error())
 	}
-	return restic.LoadSnapshot(ctx, repo, id)
+	return sn, err
 }
 
 // Comparer collects all things needed to compare two snapshots.

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -139,7 +139,7 @@ func runDump(ctx context.Context, opts DumpOptions, gopts GlobalOptions, args []
 		}
 	}
 
-	id, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Paths, opts.Tags, opts.Hosts, snapshotIDString)
+	id, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Paths, opts.Tags, opts.Hosts, nil, snapshotIDString)
 	if err != nil {
 		Exitf(1, "failed to find snapshot: %v", err)
 	}

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -139,14 +139,9 @@ func runDump(ctx context.Context, opts DumpOptions, gopts GlobalOptions, args []
 		}
 	}
 
-	id, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Paths, opts.Tags, opts.Hosts, nil, snapshotIDString)
+	sn, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Paths, opts.Tags, opts.Hosts, nil, snapshotIDString)
 	if err != nil {
 		Exitf(1, "failed to find snapshot: %v", err)
-	}
-
-	sn, err := restic.LoadSnapshot(ctx, repo, id)
-	if err != nil {
-		Exitf(2, "loading snapshot %q failed: %v", snapshotIDString, err)
 	}
 
 	err = repo.LoadIndex(ctx)

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -139,18 +139,9 @@ func runDump(ctx context.Context, opts DumpOptions, gopts GlobalOptions, args []
 		}
 	}
 
-	var id restic.ID
-
-	if snapshotIDString == "latest" {
-		id, err = restic.FindLatestSnapshot(ctx, repo.Backend(), repo, opts.Paths, opts.Tags, opts.Hosts, nil)
-		if err != nil {
-			Exitf(1, "latest snapshot for criteria not found: %v Paths:%v Hosts:%v", err, opts.Paths, opts.Hosts)
-		}
-	} else {
-		id, err = restic.FindSnapshot(ctx, repo.Backend(), snapshotIDString)
-		if err != nil {
-			Exitf(1, "invalid id %q: %v", snapshotIDString, err)
-		}
+	id, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Paths, opts.Tags, opts.Hosts, snapshotIDString)
+	if err != nil {
+		Exitf(1, "failed to find snapshot: %v", err)
 	}
 
 	sn, err := restic.LoadSnapshot(ctx, repo, id)

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -50,7 +50,7 @@ func init() {
 	cmdRoot.AddCommand(cmdDump)
 
 	flags := cmdDump.Flags()
-	initMultiSnapshotFilterOptions(flags, &dumpOptions.snapshotFilterOptions, true)
+	initSingleSnapshotFilterOptions(flags, &dumpOptions.snapshotFilterOptions)
 	flags.StringVarP(&dumpOptions.Archive, "archive", "a", "tar", "set archive `format` as \"tar\" or \"zip\"")
 }
 

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -210,11 +210,7 @@ func runLs(ctx context.Context, opts LsOptions, gopts GlobalOptions, args []stri
 		}
 	}
 
-	id, err := restic.FindFilteredSnapshot(ctx, snapshotLister, repo, opts.Hosts, opts.Tags, opts.Paths, nil, args[0])
-	if err != nil {
-		return err
-	}
-	sn, err := restic.LoadSnapshot(ctx, repo, id)
+	sn, err := restic.FindFilteredSnapshot(ctx, snapshotLister, repo, opts.Hosts, opts.Tags, opts.Paths, nil, args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -210,7 +210,7 @@ func runLs(ctx context.Context, opts LsOptions, gopts GlobalOptions, args []stri
 		}
 	}
 
-	id, err := restic.FindFilteredSnapshot(ctx, snapshotLister, repo, opts.Hosts, opts.Tags, opts.Paths, args[0])
+	id, err := restic.FindFilteredSnapshot(ctx, snapshotLister, repo, opts.Hosts, opts.Tags, opts.Paths, nil, args[0])
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -131,18 +131,9 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions, a
 		}
 	}
 
-	var id restic.ID
-
-	if snapshotIDString == "latest" {
-		id, err = restic.FindLatestSnapshot(ctx, repo.Backend(), repo, opts.Paths, opts.Tags, opts.Hosts, nil)
-		if err != nil {
-			Exitf(1, "latest snapshot for criteria not found: %v Paths:%v Hosts:%v", err, opts.Paths, opts.Hosts)
-		}
-	} else {
-		id, err = restic.FindSnapshot(ctx, repo.Backend(), snapshotIDString)
-		if err != nil {
-			Exitf(1, "invalid id %q: %v", snapshotIDString, err)
-		}
+	id, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Hosts, opts.Tags, opts.Paths, snapshotIDString)
+	if err != nil {
+		Exitf(1, "failed to find snapshot %q: %v", snapshotIDString, err)
 	}
 
 	err = repo.LoadIndex(ctx)

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -131,9 +131,9 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions, a
 		}
 	}
 
-	id, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Hosts, opts.Tags, opts.Paths, nil, snapshotIDString)
+	sn, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Hosts, opts.Tags, opts.Paths, nil, snapshotIDString)
 	if err != nil {
-		Exitf(1, "failed to find snapshot %q: %v", snapshotIDString, err)
+		Exitf(1, "failed to find snapshot: %v", err)
 	}
 
 	err = repo.LoadIndex(ctx)
@@ -141,10 +141,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions, a
 		return err
 	}
 
-	res, err := restorer.NewRestorer(ctx, repo, id, opts.Sparse)
-	if err != nil {
-		Exitf(2, "creating restorer failed: %v\n", err)
-	}
+	res := restorer.NewRestorer(ctx, repo, sn, opts.Sparse)
 
 	totalErrors := 0
 	res.Error = func(location string, err error) error {

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -131,7 +131,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions, a
 		}
 	}
 
-	id, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Hosts, opts.Tags, opts.Paths, snapshotIDString)
+	id, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Hosts, opts.Tags, opts.Paths, nil, snapshotIDString)
 	if err != nil {
 		Exitf(1, "failed to find snapshot %q: %v", snapshotIDString, err)
 	}

--- a/cmd/restic/find.go
+++ b/cmd/restic/find.go
@@ -37,70 +37,26 @@ func FindFilteredSnapshots(ctx context.Context, be restic.Lister, loader restic.
 	out := make(chan *restic.Snapshot)
 	go func() {
 		defer close(out)
-		if len(snapshotIDs) != 0 {
-			// memorize snapshots list to prevent repeated backend listings
-			be, err := backend.MemorizeList(ctx, be, restic.SnapshotFile)
-			if err != nil {
-				Warnf("could not load snapshots: %v\n", err)
-				return
-			}
-
-			var (
-				id         restic.ID
-				usedFilter bool
-			)
-			ids := make(restic.IDs, 0, len(snapshotIDs))
-			// Process all snapshot IDs given as arguments.
-			for _, s := range snapshotIDs {
-				if s == "latest" {
-					usedFilter = true
-					id, err = restic.FindLatestSnapshot(ctx, be, loader, paths, tags, hosts, nil)
-					if err != nil {
-						Warnf("Ignoring %q, no snapshot matched given filter (Paths:%v Tags:%v Hosts:%v)\n", s, paths, tags, hosts)
-						continue
-					}
-				} else {
-					id, err = restic.FindSnapshot(ctx, be, s)
-					if err != nil {
-						Warnf("Ignoring %q: %v\n", s, err)
-						continue
-					}
-				}
-				ids = append(ids, id)
-			}
-
-			// Give the user some indication their filters are not used.
-			if !usedFilter && (len(hosts) != 0 || len(tags) != 0 || len(paths) != 0) {
-				Warnf("Ignoring filters as there are explicit snapshot ids given\n")
-			}
-
-			for _, id := range ids.Uniq() {
-				sn, err := restic.LoadSnapshot(ctx, loader, id)
-				if err != nil {
-					Warnf("Ignoring %q, could not load snapshot: %v\n", id, err)
-					continue
-				}
-				select {
-				case <-ctx.Done():
-					return
-				case out <- sn:
-				}
-			}
-			return
-		}
-
-		snapshots, err := restic.FindFilteredSnapshots(ctx, be, loader, hosts, tags, paths)
+		be, err := backend.MemorizeList(ctx, be, restic.SnapshotFile)
 		if err != nil {
 			Warnf("could not load snapshots: %v\n", err)
 			return
 		}
 
-		for _, sn := range snapshots {
-			select {
-			case <-ctx.Done():
-				return
-			case out <- sn:
+		err = restic.FindFilteredSnapshots(ctx, be, loader, hosts, tags, paths, snapshotIDs, func(id string, sn *restic.Snapshot, err error) error {
+			if err != nil {
+				Warnf("Ignoring %q: %v\n", id, err)
+			} else {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case out <- sn:
+				}
 			}
+			return nil
+		})
+		if err != nil {
+			Warnf("could not load snapshots: %v\n", err)
 		}
 	}()
 	return out

--- a/cmd/restic/find.go
+++ b/cmd/restic/find.go
@@ -15,6 +15,7 @@ type snapshotFilterOptions struct {
 }
 
 // initMultiSnapshotFilterOptions is used for commands that work on multiple snapshots
+// MUST be combined with restic.FindFilteredSnapshots or FindFilteredSnapshots
 func initMultiSnapshotFilterOptions(flags *pflag.FlagSet, options *snapshotFilterOptions, addHostShorthand bool) {
 	hostShorthand := "H"
 	if !addHostShorthand {
@@ -26,6 +27,7 @@ func initMultiSnapshotFilterOptions(flags *pflag.FlagSet, options *snapshotFilte
 }
 
 // initSingleSnapshotFilterOptions is used for commands that work on a single snapshot
+// MUST be combined with restic.FindFilteredSnapshot
 func initSingleSnapshotFilterOptions(flags *pflag.FlagSet, options *snapshotFilterOptions) {
 	flags.StringArrayVarP(&options.Hosts, "host", "H", nil, "only consider snapshots for this `host`, when snapshot ID \"latest\" is given (can be specified multiple times)")
 	flags.Var(&options.Tags, "tag", "only consider snapshots including `tag[,tag,...]`, when snapshot ID \"latest\" is given (can be specified multiple times)")

--- a/internal/archiver/testing.go
+++ b/internal/archiver/testing.go
@@ -26,7 +26,11 @@ func TestSnapshot(t testing.TB, repo restic.Repository, path string, parent *res
 		Tags:     []string{"test"},
 	}
 	if parent != nil {
-		opts.ParentSnapshot = *parent
+		sn, err := restic.LoadSnapshot(context.TODO(), arch.Repo, *parent)
+		if err != nil {
+			t.Fatal(err)
+		}
+		opts.ParentSnapshot = sn
 	}
 	sn, _, err := arch.Snapshot(context.TODO(), []string{path}, opts)
 	if err != nil {

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -592,11 +592,7 @@ func benchmarkSnapshotScaling(t *testing.B, newSnapshots int) {
 	chkr, repo, cleanup := loadBenchRepository(t)
 	defer cleanup()
 
-	snID, err := restic.FindSnapshot(context.TODO(), repo.Backend(), "51d249d2")
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	snID := restic.TestParseID("51d249d28815200d59e4be7b3f21a157b864dc343353df9d8e498220c2499b02")
 	sn2, err := restic.LoadSnapshot(context.TODO(), repo, snID)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/fuse/snapshots_dirstruct.go
+++ b/internal/fuse/snapshots_dirstruct.go
@@ -292,7 +292,13 @@ func (d *SnapshotsDirStructure) updateSnapshots(ctx context.Context) error {
 		return nil
 	}
 
-	snapshots, err := restic.FindFilteredSnapshots(ctx, d.root.repo.Backend(), d.root.repo, d.root.cfg.Hosts, d.root.cfg.Tags, d.root.cfg.Paths)
+	var snapshots restic.Snapshots
+	err := restic.FindFilteredSnapshots(ctx, d.root.repo.Backend(), d.root.repo, d.root.cfg.Hosts, d.root.cfg.Tags, d.root.cfg.Paths, nil, func(id string, sn *restic.Snapshot, err error) error {
+		if sn != nil {
+			snapshots = append(snapshots, sn)
+		}
+		return nil
+	})
 	if err != nil {
 		return err
 	}

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -73,15 +73,19 @@ func findLatestSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked, h
 // FindSnapshot takes a string and tries to find a snapshot whose ID matches
 // the string as closely as possible.
 func FindSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked, s string) (*Snapshot, error) {
-	// find snapshot id with prefix
-	name, err := Find(ctx, be, SnapshotFile, s)
+	// no need to list snapshots if `s` is already a full id
+	id, err := ParseID(s)
 	if err != nil {
-		return nil, err
-	}
+		// find snapshot id with prefix
+		name, err := Find(ctx, be, SnapshotFile, s)
+		if err != nil {
+			return nil, err
+		}
 
-	id, err := ParseID(name)
-	if err != nil {
-		return nil, err
+		id, err = ParseID(name)
+		if err != nil {
+			return nil, err
+		}
 	}
 	return LoadSnapshot(ctx, loader, id)
 }

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -12,8 +12,8 @@ import (
 // ErrNoSnapshotFound is returned when no snapshot for the given criteria could be found.
 var ErrNoSnapshotFound = errors.New("no snapshot found")
 
-// FindLatestSnapshot finds latest snapshot with optional target/directory, tags, hostname, and timestamp filters.
-func FindLatestSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked, targets []string,
+// findLatestSnapshot finds latest snapshot with optional target/directory, tags, hostname, and timestamp filters.
+func findLatestSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked, targets []string,
 	tagLists []TagList, hostnames []string, timeStampLimit *time.Time) (ID, error) {
 
 	var err error
@@ -91,7 +91,7 @@ func FindSnapshot(ctx context.Context, be Lister, s string) (ID, error) {
 
 func FindFilteredSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked, hosts []string, tags []TagList, paths []string, timeStampLimit *time.Time, snapshotID string) (ID, error) {
 	if snapshotID == "latest" {
-		id, err := FindLatestSnapshot(ctx, be, loader, paths, tags, hosts, timeStampLimit)
+		id, err := findLatestSnapshot(ctx, be, loader, paths, tags, hosts, timeStampLimit)
 		if err == ErrNoSnapshotFound {
 			err = fmt.Errorf("snapshot filter (Paths:%v Tags:%v Hosts:%v): %w", paths, tags, hosts, err)
 		}
@@ -124,7 +124,7 @@ func FindFilteredSnapshots(ctx context.Context, be Lister, loader LoaderUnpacked
 
 				usedFilter = true
 
-				id, err = FindLatestSnapshot(ctx, be, loader, paths, tags, hosts, nil)
+				id, err = findLatestSnapshot(ctx, be, loader, paths, tags, hosts, nil)
 				if err == ErrNoSnapshotFound {
 					err = errors.Errorf("no snapshot matched given filter (Paths:%v Tags:%v Hosts:%v)", paths, tags, hosts)
 				}

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -88,6 +88,22 @@ func FindSnapshot(ctx context.Context, be Lister, s string) (ID, error) {
 	return ParseID(name)
 }
 
+func FindFilteredSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked, hosts []string, tags []TagList, paths []string, snapshotID string) (ID, error) {
+	if snapshotID == "latest" {
+		id, err := FindLatestSnapshot(ctx, be, loader, paths, tags, hosts, nil)
+		if err == ErrNoSnapshotFound {
+			err = errors.Errorf("no snapshot matched given filter (Paths:%v Tags:%v Hosts:%v)", paths, tags, hosts)
+		}
+		return id, err
+	} else {
+		id, err := FindSnapshot(ctx, be, snapshotID)
+		if err != nil {
+			return ID{}, err
+		}
+		return id, err
+	}
+}
+
 type SnapshotFindCb func(string, *Snapshot, error) error
 
 // FindFilteredSnapshots yields Snapshots, either given explicitly by `snapshotIDs` or filtered from the list of all snapshots.

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -13,12 +13,12 @@ import (
 var ErrNoSnapshotFound = errors.New("no snapshot found")
 
 // findLatestSnapshot finds latest snapshot with optional target/directory, tags, hostname, and timestamp filters.
-func findLatestSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked, targets []string,
-	tagLists []TagList, hostnames []string, timeStampLimit *time.Time) (ID, error) {
+func findLatestSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked,
+	hosts []string, tags []TagList, paths []string, timeStampLimit *time.Time) (ID, error) {
 
 	var err error
-	absTargets := make([]string, 0, len(targets))
-	for _, target := range targets {
+	absTargets := make([]string, 0, len(paths))
+	for _, target := range paths {
 		if !filepath.IsAbs(target) {
 			target, err = filepath.Abs(target)
 			if err != nil {
@@ -47,11 +47,11 @@ func findLatestSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked, t
 			return nil
 		}
 
-		if !snapshot.HasHostname(hostnames) {
+		if !snapshot.HasHostname(hosts) {
 			return nil
 		}
 
-		if !snapshot.HasTagList(tagLists) {
+		if !snapshot.HasTagList(tags) {
 			return nil
 		}
 
@@ -91,7 +91,7 @@ func FindSnapshot(ctx context.Context, be Lister, s string) (ID, error) {
 
 func FindFilteredSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked, hosts []string, tags []TagList, paths []string, timeStampLimit *time.Time, snapshotID string) (ID, error) {
 	if snapshotID == "latest" {
-		id, err := findLatestSnapshot(ctx, be, loader, paths, tags, hosts, timeStampLimit)
+		id, err := findLatestSnapshot(ctx, be, loader, hosts, tags, paths, timeStampLimit)
 		if err == ErrNoSnapshotFound {
 			err = fmt.Errorf("snapshot filter (Paths:%v Tags:%v Hosts:%v): %w", paths, tags, hosts, err)
 		}
@@ -124,7 +124,7 @@ func FindFilteredSnapshots(ctx context.Context, be Lister, loader LoaderUnpacked
 
 				usedFilter = true
 
-				id, err = findLatestSnapshot(ctx, be, loader, paths, tags, hosts, nil)
+				id, err = findLatestSnapshot(ctx, be, loader, hosts, tags, paths, nil)
 				if err == ErrNoSnapshotFound {
 					err = errors.Errorf("no snapshot matched given filter (Paths:%v Tags:%v Hosts:%v)", paths, tags, hosts)
 				}

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -2,6 +2,7 @@ package restic
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"time"
 
@@ -88,11 +89,11 @@ func FindSnapshot(ctx context.Context, be Lister, s string) (ID, error) {
 	return ParseID(name)
 }
 
-func FindFilteredSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked, hosts []string, tags []TagList, paths []string, snapshotID string) (ID, error) {
+func FindFilteredSnapshot(ctx context.Context, be Lister, loader LoaderUnpacked, hosts []string, tags []TagList, paths []string, timeStampLimit *time.Time, snapshotID string) (ID, error) {
 	if snapshotID == "latest" {
-		id, err := FindLatestSnapshot(ctx, be, loader, paths, tags, hosts, nil)
+		id, err := FindLatestSnapshot(ctx, be, loader, paths, tags, hosts, timeStampLimit)
 		if err == ErrNoSnapshotFound {
-			err = errors.Errorf("no snapshot matched given filter (Paths:%v Tags:%v Hosts:%v)", paths, tags, hosts)
+			err = fmt.Errorf("snapshot filter (Paths:%v Tags:%v Hosts:%v): %w", paths, tags, hosts, err)
 		}
 		return id, err
 	} else {

--- a/internal/restic/snapshot_find_test.go
+++ b/internal/restic/snapshot_find_test.go
@@ -16,7 +16,7 @@ func TestFindLatestSnapshot(t *testing.T) {
 	restic.TestCreateSnapshot(t, repo, parseTimeUTC("2017-07-07 07:07:07"), 1, 0)
 	latestSnapshot := restic.TestCreateSnapshot(t, repo, parseTimeUTC("2019-09-09 09:09:09"), 1, 0)
 
-	id, err := restic.FindLatestSnapshot(context.TODO(), repo.Backend(), repo, []string{}, []restic.TagList{}, []string{"foo"}, nil)
+	id, err := restic.FindFilteredSnapshot(context.TODO(), repo.Backend(), repo, []string{"foo"}, []restic.TagList{}, []string{}, nil, "latest")
 	if err != nil {
 		t.Fatalf("FindLatestSnapshot returned error: %v", err)
 	}
@@ -36,7 +36,7 @@ func TestFindLatestSnapshotWithMaxTimestamp(t *testing.T) {
 
 	maxTimestamp := parseTimeUTC("2018-08-08 08:08:08")
 
-	id, err := restic.FindLatestSnapshot(context.TODO(), repo.Backend(), repo, []string{}, []restic.TagList{}, []string{"foo"}, &maxTimestamp)
+	id, err := restic.FindFilteredSnapshot(context.TODO(), repo.Backend(), repo, []string{"foo"}, []restic.TagList{}, []string{}, &maxTimestamp, "latest")
 	if err != nil {
 		t.Fatalf("FindLatestSnapshot returned error: %v", err)
 	}

--- a/internal/restic/snapshot_find_test.go
+++ b/internal/restic/snapshot_find_test.go
@@ -16,13 +16,13 @@ func TestFindLatestSnapshot(t *testing.T) {
 	restic.TestCreateSnapshot(t, repo, parseTimeUTC("2017-07-07 07:07:07"), 1, 0)
 	latestSnapshot := restic.TestCreateSnapshot(t, repo, parseTimeUTC("2019-09-09 09:09:09"), 1, 0)
 
-	id, err := restic.FindFilteredSnapshot(context.TODO(), repo.Backend(), repo, []string{"foo"}, []restic.TagList{}, []string{}, nil, "latest")
+	sn, err := restic.FindFilteredSnapshot(context.TODO(), repo.Backend(), repo, []string{"foo"}, []restic.TagList{}, []string{}, nil, "latest")
 	if err != nil {
 		t.Fatalf("FindLatestSnapshot returned error: %v", err)
 	}
 
-	if id != *latestSnapshot.ID() {
-		t.Errorf("FindLatestSnapshot returned wrong snapshot ID: %v", id)
+	if *sn.ID() != *latestSnapshot.ID() {
+		t.Errorf("FindLatestSnapshot returned wrong snapshot ID: %v", *sn.ID())
 	}
 }
 
@@ -36,12 +36,12 @@ func TestFindLatestSnapshotWithMaxTimestamp(t *testing.T) {
 
 	maxTimestamp := parseTimeUTC("2018-08-08 08:08:08")
 
-	id, err := restic.FindFilteredSnapshot(context.TODO(), repo.Backend(), repo, []string{"foo"}, []restic.TagList{}, []string{}, &maxTimestamp, "latest")
+	sn, err := restic.FindFilteredSnapshot(context.TODO(), repo.Backend(), repo, []string{"foo"}, []restic.TagList{}, []string{}, &maxTimestamp, "latest")
 	if err != nil {
 		t.Fatalf("FindLatestSnapshot returned error: %v", err)
 	}
 
-	if id != *desiredSnapshot.ID() {
-		t.Errorf("FindLatestSnapshot returned wrong snapshot ID: %v", id)
+	if *sn.ID() != *desiredSnapshot.ID() {
+		t.Errorf("FindLatestSnapshot returned wrong snapshot ID: %v", *sn.ID())
 	}
 }

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -27,22 +27,16 @@ type Restorer struct {
 var restorerAbortOnAllErrors = func(location string, err error) error { return err }
 
 // NewRestorer creates a restorer preloaded with the content from the snapshot id.
-func NewRestorer(ctx context.Context, repo restic.Repository, id restic.ID, sparse bool) (*Restorer, error) {
+func NewRestorer(ctx context.Context, repo restic.Repository, sn *restic.Snapshot, sparse bool) *Restorer {
 	r := &Restorer{
 		repo:         repo,
 		sparse:       sparse,
 		Error:        restorerAbortOnAllErrors,
 		SelectFilter: func(string, string, *restic.Node) (bool, bool) { return true, true },
+		sn:           sn,
 	}
 
-	var err error
-
-	r.sn, err = restic.LoadSnapshot(ctx, repo, id)
-	if err != nil {
-		return nil, err
-	}
-
-	return r, nil
+	return r
 }
 
 type treeVisitor struct {

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -19,7 +19,7 @@ func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
 	repo, cleanup := repository.TestRepository(t)
 	defer cleanup()
 
-	_, id := saveSnapshot(t, repo, Snapshot{
+	sn, _ := saveSnapshot(t, repo, Snapshot{
 		Nodes: map[string]Node{
 			"dirtest": Dir{
 				Nodes: map[string]Node{
@@ -30,8 +30,7 @@ func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
 		},
 	})
 
-	res, err := NewRestorer(context.TODO(), repo, id, false)
-	rtest.OK(t, err)
+	res := NewRestorer(context.TODO(), repo, sn, false)
 
 	res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
 		return true, true
@@ -43,7 +42,7 @@ func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err = res.RestoreTo(ctx, tempdir)
+	err := res.RestoreTo(ctx, tempdir)
 	rtest.OK(t, err)
 
 	f1, err := os.Stat(filepath.Join(tempdir, "dirtest/file1"))


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The code to filter snapshots is currently dispersed throughout the code. When loading a single snapshot, the special id "latest" must be handled manually (except for `ls` which used the code to load multiple snapshots). When loading multiple snapshots, half of the code was located in `cmd/restic/find.go` and the other half in `internal/restic/snapshot_find.go` which is rather confusing. Some of the snapshot functions also only returned the snapshot ID making it necessary to add code to load the snapshot each time.

This PR unifies the snapshot loading into three functions `FindSnapshot`, `FindFilteredSnapshot` and `FindFilteredSnapshots` as part of the restic package. This unification complements #3912, `initSingleSnapshotFilterOptions` is now always used together with `FindFilteredSnapshot` and `initMultiSnapshotFilterOptions` with `FindFilteredSnapshots`. This ensures consistent behavior across commands.

The user visible changes are rather minimal. The help text for `dump` has been fixed. And `ls` returns exit code 1 the snapshot cannot be loaded. Besides that some error messages have changed if a snapshot fails to load.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
