### PR TITLE
lock: Use the correct duration to check for expired locks

### DIFF
--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -145,7 +145,7 @@ func monitorLockRefresh(ctx context.Context, lock *restic.Lock, lockInfo *lockCo
 		case <-refreshed:
 			lastRefresh = time.Now().Unix()
 		case <-timer.C:
-			if float64(time.Now().Unix()-lastRefresh) < refreshInterval.Seconds() {
+			if float64(time.Now().Unix()-lastRefresh) < refreshabilityTimeout.Seconds() {
 				// restart timer
 				timer.Reset(pollDuration)
 				continue


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
When checking whether a lock is refreshed in time, it makes no sense to use to basic refresh interval (5min). Instead the timeout after which a lock is considered stale (30mins - a small of buffer) must be used. Otherwise normal operations could just break.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Regressed in #3569
Fixes #3954
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
