### PR TITLE
errors: Drop Cause in favor of Go 1.13 error handling

### DIFF
--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -1197,7 +1197,7 @@ func TestRestoreFilter(t *testing.T) {
 			if ok, _ := filter.Match(pat, filepath.Base(testFile.name)); !ok {
 				rtest.OK(t, err)
 			} else {
-				rtest.Assert(t, os.IsNotExist(errors.Cause(err)),
+				rtest.Assert(t, os.IsNotExist(err),
 					"expected %v to not exist in restore step %v, but it exists, err %v", testFile.name, i+1, err)
 			}
 		}
@@ -1283,15 +1283,15 @@ func TestRestoreLatest(t *testing.T) {
 
 	testRunRestoreLatest(t, env.gopts, filepath.Join(env.base, "restore1"), []string{filepath.Dir(p1)}, nil)
 	rtest.OK(t, testFileSize(p1rAbs, int64(102)))
-	if _, err := os.Stat(p2rAbs); os.IsNotExist(errors.Cause(err)) {
-		rtest.Assert(t, os.IsNotExist(errors.Cause(err)),
+	if _, err := os.Stat(p2rAbs); os.IsNotExist(err) {
+		rtest.Assert(t, os.IsNotExist(err),
 			"expected %v to not exist in restore, but it exists, err %v", p2rAbs, err)
 	}
 
 	testRunRestoreLatest(t, env.gopts, filepath.Join(env.base, "restore2"), []string{filepath.Dir(p2)}, nil)
 	rtest.OK(t, testFileSize(p2rAbs, int64(103)))
-	if _, err := os.Stat(p1rAbs); os.IsNotExist(errors.Cause(err)) {
-		rtest.Assert(t, os.IsNotExist(errors.Cause(err)),
+	if _, err := os.Stat(p1rAbs); os.IsNotExist(err) {
+		rtest.Assert(t, os.IsNotExist(err),
 			"expected %v to not exist in restore, but it exists, err %v", p1rAbs, err)
 	}
 }
@@ -1861,7 +1861,7 @@ func TestHardLink(t *testing.T) {
 
 	datafile := filepath.Join("testdata", "test.hl.tar.gz")
 	fd, err := os.Open(datafile)
-	if os.IsNotExist(errors.Cause(err)) {
+	if os.IsNotExist(err) {
 		t.Skipf("unable to find data file %q, skipping", datafile)
 		return
 	}

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -174,13 +174,8 @@ func (be *Backend) IsNotExist(err error) bool {
 		return true
 	}
 
-	if er, ok := err.(*googleapi.Error); ok {
-		if er.Code == 404 {
-			return true
-		}
-	}
-
-	return false
+	var gerr *googleapi.Error
+	return errors.As(err, &gerr) && gerr.Code == 404
 }
 
 // Join combines path components with slashes.

--- a/internal/backend/layout.go
+++ b/internal/backend/layout.go
@@ -71,7 +71,7 @@ var backendFilename = regexp.MustCompile(fmt.Sprintf("^[a-fA-F0-9]{%d}$", backen
 
 func hasBackendFile(ctx context.Context, fs Filesystem, dir string) (bool, error) {
 	entries, err := fs.ReadDir(ctx, dir)
-	if err != nil && fs.IsNotExist(errors.Cause(err)) {
+	if err != nil && fs.IsNotExist(err) {
 		return false, nil
 	}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -1,9 +1,8 @@
 package errors
 
 import (
-	"net/url"
+	stderrors "errors"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/errors"
 )
 
@@ -29,29 +28,10 @@ var WithMessage = errors.WithMessage
 
 var WithStack = errors.WithStack
 
-// Cause returns the cause of an error. It will also unwrap certain errors,
-// e.g. *url.Error returned by the net/http client.
-func Cause(err error) error {
-	type Causer interface {
-		Cause() error
-	}
-
-	for {
-		switch e := err.(type) {
-		case Causer: // github.com/pkg/errors
-			err = e.Cause()
-		case *backoff.PermanentError:
-			err = e.Err
-		case *url.Error:
-			err = e.Err
-		default:
-			return err
-		}
-	}
-}
-
 // Go 1.13-style error handling.
 
-func As(err error, tgt interface{}) bool { return errors.As(err, tgt) }
+func As(err error, tgt interface{}) bool { return stderrors.As(err, tgt) }
 
-func Is(x, y error) bool { return errors.Is(x, y) }
+func Is(x, y error) bool { return stderrors.Is(x, y) }
+
+func Unwrap(err error) error { return stderrors.Unwrap(err) }

--- a/internal/errors/fatal.go
+++ b/internal/errors/fatal.go
@@ -1,6 +1,9 @@
 package errors
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // fatalError is an error that should be printed to the user, then the program
 // should exit with an error code.
@@ -10,31 +13,19 @@ func (e fatalError) Error() string {
 	return string(e)
 }
 
-func (e fatalError) Fatal() bool {
-	return true
-}
-
-// Fataler is an error which should be printed to the user directly.
-// Afterwards, the program should exit with an error.
-type Fataler interface {
-	Fatal() bool
-}
-
 // IsFatal returns true if err is a fatal message that should be printed to the
 // user. Then, the program should exit.
 func IsFatal(err error) bool {
-	// unwrap "Wrap" method
-	err = Cause(err)
-	e, ok := err.(Fataler)
-	return ok && e.Fatal()
+	var fatal fatalError
+	return errors.As(err, &fatal)
 }
 
-// Fatal returns a wrapped error which implements the Fataler interface.
+// Fatal returns an error that is marked fatal.
 func Fatal(s string) error {
 	return Wrap(fatalError(s), "Fatal")
 }
 
-// Fatalf returns an error which implements the Fataler interface.
+// Fatalf returns an error that is marked fatal.
 func Fatalf(s string, data ...interface{}) error {
 	return Wrap(fatalError(fmt.Sprintf(s, data...)), "Fatal")
 }

--- a/internal/restic/backend.go
+++ b/internal/restic/backend.go
@@ -64,6 +64,9 @@ type Backend interface {
 
 	// IsNotExist returns true if the error was caused by a non-existing file
 	// in the backend.
+	//
+	// The argument may be a wrapped error. The implementation is responsible
+	// for unwrapping it.
 	IsNotExist(err error) bool
 
 	// Delete removes all data in the backend.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It removes the errors.Cause function, which did pkg/errors-style error unwrapping with hacks to support some non-pkg/errors types.

The only use cases in the code were in errors.IsFatal, backend/b2, which needs a workaround, and backend.ParseLayout. The latter requires all backends to implement error unwrapping in IsNotExist. All backends except gs already did that.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Follow-up to #3798.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
