### PR TITLE
backup: Use buffered channels to collect backup status

### DIFF
--- a/internal/ui/backup/progress.go
+++ b/internal/ui/backup/progress.go
@@ -87,10 +87,13 @@ func NewProgress(printer ProgressPrinter) *Progress {
 		MinUpdatePause: time.Second / 60,
 		start:          time.Now(),
 
-		totalCh:     make(chan Counter),
-		processedCh: make(chan Counter),
+		// use buffered channels for the information used to update the status
+		// the shutdown of the `Run()` method is somewhat racy, but won't affect
+		// the final backup statistics
+		totalCh:     make(chan Counter, 100),
+		processedCh: make(chan Counter, 100),
 		errCh:       make(chan struct{}),
-		workerCh:    make(chan fileWorkerMessage),
+		workerCh:    make(chan fileWorkerMessage, 100),
 		closed:      make(chan struct{}),
 
 		summary: &Summary{},


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
While working on #3955 I've noticed that the block profile of go reported that the two FileSaver were in total blocked for 0.8 seconds while reporting progress. For comparison, the whole backup run took less than 4 seconds. Thus, add a small buffer to the channels used to report status information to prevent blocking. This also has the benefit of reducing the stress on the golang runtime scheduler.

As the status information is purely informational, it doesn't matter that the status reporting shutdown is somewhat racy and could miss a few final updates.

Click on the image below, to see the full block profile (look for `FileSaver` calls).
![profile001](https://user-images.githubusercontent.com/9106997/194717706-25a5a7fc-2960-400e-998b-2754d797488e.svg)

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
