### PR TITLE
errors: Drop WithMessage

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -457,7 +457,7 @@ func collectTargets(opts BackupOptions, args []string) (targets []string, err er
 			var expanded []string
 			expanded, err := filepath.Glob(line)
 			if err != nil {
-				return nil, errors.WithMessage(err, fmt.Sprintf("pattern: %s", line))
+				return nil, fmt.Errorf("pattern: %s: %w", line, err)
 			}
 			if len(expanded) == 0 {
 				Warnf("pattern %q does not match any files, skipping\n", line)

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"sync"
 	"time"
 
 	"github.com/restic/restic/internal/debug"
-	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 )
 
@@ -45,7 +45,7 @@ func lockRepository(ctx context.Context, repo restic.Repository, exclusive bool)
 
 	lock, err := lockFn(ctx, repo)
 	if err != nil {
-		return nil, ctx, errors.WithMessage(err, "unable to create lock in backend")
+		return nil, ctx, fmt.Errorf("unable to create lock in backend: %w", err)
 	}
 	debug.Log("create lock %p (exclusive %v)", lock, exclusive)
 

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -420,7 +420,7 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 
 		// make sure it's still a file
 		if !fs.IsRegularFile(fi) {
-			err = errors.Errorf("file %v changed type, refusing to archive")
+			err = errors.Errorf("file %v changed type, refusing to archive", fi.Name())
 			_ = file.Close()
 			err = arch.error(abstarget, err)
 			if err != nil {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -290,7 +290,7 @@ type Error struct {
 	Err    error
 }
 
-func (e Error) Error() string {
+func (e *Error) Error() string {
 	if !e.TreeID.IsNull() {
 		return "tree " + e.TreeID.String() + ": " + e.Err.Error()
 	}
@@ -404,12 +404,12 @@ func (c *Checker) checkTree(id restic.ID, tree *restic.Tree) (errs []error) {
 		switch node.Type {
 		case "file":
 			if node.Content == nil {
-				errs = append(errs, Error{TreeID: id, Err: errors.Errorf("file %q has nil blob list", node.Name)})
+				errs = append(errs, &Error{TreeID: id, Err: errors.Errorf("file %q has nil blob list", node.Name)})
 			}
 
 			for b, blobID := range node.Content {
 				if blobID.IsNull() {
-					errs = append(errs, Error{TreeID: id, Err: errors.Errorf("file %q blob %d has null ID", node.Name, b)})
+					errs = append(errs, &Error{TreeID: id, Err: errors.Errorf("file %q blob %d has null ID", node.Name, b)})
 					continue
 				}
 				// Note that we do not use the blob size. The "obvious" check
@@ -420,7 +420,7 @@ func (c *Checker) checkTree(id restic.ID, tree *restic.Tree) (errs []error) {
 				_, found := c.repo.LookupBlobSize(blobID, restic.DataBlob)
 				if !found {
 					debug.Log("tree %v references blob %v which isn't contained in index", id, blobID)
-					errs = append(errs, Error{TreeID: id, Err: errors.Errorf("file %q blob %v not found in index", node.Name, blobID)})
+					errs = append(errs, &Error{TreeID: id, Err: errors.Errorf("file %q blob %v not found in index", node.Name, blobID)})
 				}
 			}
 
@@ -440,12 +440,12 @@ func (c *Checker) checkTree(id restic.ID, tree *restic.Tree) (errs []error) {
 
 		case "dir":
 			if node.Subtree == nil {
-				errs = append(errs, Error{TreeID: id, Err: errors.Errorf("dir node %q has no subtree", node.Name)})
+				errs = append(errs, &Error{TreeID: id, Err: errors.Errorf("dir node %q has no subtree", node.Name)})
 				continue
 			}
 
 			if node.Subtree.IsNull() {
-				errs = append(errs, Error{TreeID: id, Err: errors.Errorf("dir node %q subtree id is null", node.Name)})
+				errs = append(errs, &Error{TreeID: id, Err: errors.Errorf("dir node %q subtree id is null", node.Name)})
 				continue
 			}
 
@@ -453,11 +453,11 @@ func (c *Checker) checkTree(id restic.ID, tree *restic.Tree) (errs []error) {
 			// nothing to check
 
 		default:
-			errs = append(errs, Error{TreeID: id, Err: errors.Errorf("node %q with invalid type %q", node.Name, node.Type)})
+			errs = append(errs, &Error{TreeID: id, Err: errors.Errorf("node %q with invalid type %q", node.Name, node.Type)})
 		}
 
 		if node.Name == "" {
-			errs = append(errs, Error{TreeID: id, Err: errors.New("node with empty name")})
+			errs = append(errs, &Error{TreeID: id, Err: errors.New("node with empty name")})
 		}
 	}
 

--- a/internal/errors/errors.go
+++ b/internal/errors/errors.go
@@ -22,10 +22,6 @@ var Wrap = errors.Wrap
 // nil, Wrapf returns nil.
 var Wrapf = errors.Wrapf
 
-// WithMessage annotates err with a new message. If err is nil, WithMessage
-// returns nil.
-var WithMessage = errors.WithMessage
-
 var WithStack = errors.WithStack
 
 // Go 1.13-style error handling.

--- a/internal/restic/tree.go
+++ b/internal/restic/tree.go
@@ -145,7 +145,7 @@ func SaveTree(ctx context.Context, r BlobSaver, t *Tree) (ID, error) {
 	return id, err
 }
 
-var ErrTreeNotOrdered = errors.Errorf("nodes are not ordered or duplicate")
+var ErrTreeNotOrdered = errors.New("nodes are not ordered or duplicate")
 
 type TreeJSONBuilder struct {
 	buf      bytes.Buffer


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

errors.WithMessage doesn't add a stack trace, so it can be replaced by fmt.Errorf.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Follow-up to #3798, #3958

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
