### PR TITLE
Misc. cleanup

### DIFF
--- a/internal/restic/id.go
+++ b/internal/restic/id.go
@@ -82,19 +82,6 @@ func (id ID) Equal(other ID) bool {
 	return id == other
 }
 
-// EqualString compares this ID to another one, given as a string.
-func (id ID) EqualString(other string) (bool, error) {
-	s, err := hex.DecodeString(other)
-	if err != nil {
-		return false, errors.Wrap(err, "hex.DecodeString")
-	}
-
-	id2 := ID{}
-	copy(id2[:], s)
-
-	return id == id2, nil
-}
-
 // MarshalJSON returns the JSON encoding of id.
 func (id ID) MarshalJSON() ([]byte, error) {
 	buf := make([]byte, 2+hex.EncodedLen(len(id)))

--- a/internal/restic/id_test.go
+++ b/internal/restic/id_test.go
@@ -30,14 +30,6 @@ func TestID(t *testing.T) {
 			t.Errorf("ID.Equal() does not work as expected")
 		}
 
-		ret, err := id.EqualString(test.id)
-		if err != nil {
-			t.Error(err)
-		}
-		if !ret {
-			t.Error("ID.EqualString() returned wrong value")
-		}
-
 		// test json marshalling
 		buf, err := id.MarshalJSON()
 		if err != nil {

--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -126,7 +126,7 @@ func (l *Lock) fillUserInfo() error {
 	}
 	l.Username = usr.Username
 
-	l.UID, l.GID, err = uidGidInt(*usr)
+	l.UID, l.GID, err = uidGidInt(usr)
 	return err
 }
 

--- a/internal/restic/lock_unix.go
+++ b/internal/restic/lock_unix.go
@@ -9,25 +9,21 @@ import (
 	"strconv"
 	"syscall"
 
-	"github.com/restic/restic/internal/errors"
-
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 )
 
 // uidGidInt returns uid, gid of the user as a number.
-func uidGidInt(u user.User) (uid, gid uint32, err error) {
-	var ui, gi int64
-	ui, err = strconv.ParseInt(u.Uid, 10, 32)
+func uidGidInt(u *user.User) (uid, gid uint32, err error) {
+	ui, err := strconv.ParseUint(u.Uid, 10, 32)
 	if err != nil {
-		return uid, gid, errors.Wrap(err, "ParseInt")
+		return 0, 0, errors.Errorf("invalid UID %q", u.Uid)
 	}
-	gi, err = strconv.ParseInt(u.Gid, 10, 32)
+	gi, err := strconv.ParseUint(u.Gid, 10, 32)
 	if err != nil {
-		return uid, gid, errors.Wrap(err, "ParseInt")
+		return 0, 0, errors.Errorf("invalid GID %q", u.Gid)
 	}
-	uid = uint32(ui)
-	gid = uint32(gi)
-	return
+	return uint32(ui), uint32(gi), nil
 }
 
 // checkProcess will check if the process retaining the lock

--- a/internal/restic/lock_windows.go
+++ b/internal/restic/lock_windows.go
@@ -8,7 +8,7 @@ import (
 )
 
 // uidGidInt always returns 0 on Windows, since uid isn't numbers
-func uidGidInt(u user.User) (uid, gid uint32, err error) {
+func uidGidInt(u *user.User) (uid, gid uint32, err error) {
 	return 0, 0, nil
 }
 

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -154,7 +154,7 @@ func (sn *Snapshot) fillUserInfo() error {
 	sn.Username = usr.Username
 
 	// set userid and groupid
-	sn.UID, sn.GID, err = uidGidInt(*usr)
+	sn.UID, sn.GID, err = uidGidInt(usr)
 	return err
 }
 

--- a/internal/selfupdate/github.go
+++ b/internal/selfupdate/github.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/pkg/errors"
-	"golang.org/x/net/context/ctxhttp"
 )
 
 // Release collects data about a single release on GitHub.
@@ -53,7 +52,7 @@ func GitHubLatestRelease(ctx context.Context, owner, repo string) (Release, erro
 	defer cancel()
 
 	url := fmt.Sprintf("https://api.github.com/repos/%s/%s/releases/latest", owner, repo)
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return Release{}, err
 	}
@@ -61,7 +60,7 @@ func GitHubLatestRelease(ctx context.Context, owner, repo string) (Release, erro
 	// pin API version 3
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
 
-	res, err := ctxhttp.Do(ctx, http.DefaultClient, req)
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return Release{}, err
 	}
@@ -112,7 +111,7 @@ func GitHubLatestRelease(ctx context.Context, owner, repo string) (Release, erro
 }
 
 func getGithubData(ctx context.Context, url string) ([]byte, error) {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -120,7 +119,7 @@ func getGithubData(ctx context.Context, url string) ([]byte, error) {
 	// request binary data
 	req.Header.Set("Accept", "application/octet-stream")
 
-	res, err := ctxhttp.Do(ctx, http.DefaultClient, req)
+	res, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Two patches. One remove ctxhttp from HTTP-speaking packages, because it isn't necessary anymore. See the commit message for details. The other removes an unused interface type.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
