### PR TITLE
Unify ForAllIndex/Snapshot/Lock functions

### DIFF
--- a/internal/index/index_parallel.go
+++ b/internal/index/index_parallel.go
@@ -5,9 +5,7 @@ import (
 	"runtime"
 	"sync"
 
-	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/restic"
-	"golang.org/x/sync/errgroup"
 )
 
 // ForAllIndexes loads all index files in parallel and calls the given callback.
@@ -16,68 +14,23 @@ import (
 func ForAllIndexes(ctx context.Context, repo restic.Repository,
 	fn func(id restic.ID, index *Index, oldFormat bool, err error) error) error {
 
-	debug.Log("Start")
-
-	type FileInfo struct {
-		restic.ID
-		Size int64
-	}
-
-	var m sync.Mutex
-
-	// track spawned goroutines using wg, create a new context which is
-	// cancelled as soon as an error occurs.
-	wg, ctx := errgroup.WithContext(ctx)
-
-	ch := make(chan FileInfo)
-	// send list of index files through ch, which is closed afterwards
-	wg.Go(func() error {
-		defer close(ch)
-		return repo.List(ctx, restic.IndexFile, func(id restic.ID, size int64) error {
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case ch <- FileInfo{id, size}:
-			}
-			return nil
-		})
-	})
-
-	// a worker receives an index ID from ch, loads the index, and sends it to indexCh
-	worker := func() error {
-		var buf []byte
-		for fi := range ch {
-			debug.Log("worker got file %v", fi.ID.Str())
-			var err error
-			var idx *Index
-			oldFormat := false
-
-			if cap(buf) < int(fi.Size) {
-				// overallocate a bit
-				buf = make([]byte, fi.Size+128*1024)
-			}
-			buf, err = repo.LoadUnpacked(ctx, restic.IndexFile, fi.ID, buf[:0])
-			if err == nil {
-				idx, oldFormat, err = DecodeIndex(buf, fi.ID)
-			}
-
-			m.Lock()
-			err = fn(fi.ID, idx, oldFormat, err)
-			m.Unlock()
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
 	// decoding an index can take quite some time such that this can be both CPU- or IO-bound
 	// as the whole index is kept in memory anyways, a few workers too much don't matter
-	workerCount := int(repo.Connections()) + runtime.GOMAXPROCS(0)
-	// run workers on ch
-	for i := 0; i < workerCount; i++ {
-		wg.Go(worker)
-	}
+	workerCount := repo.Connections() + uint(runtime.GOMAXPROCS(0))
 
-	return wg.Wait()
+	var m sync.Mutex
+	return restic.ParallelList(ctx, repo.Backend(), restic.IndexFile, workerCount, func(ctx context.Context, id restic.ID, size int64) error {
+		var err error
+		var idx *Index
+		oldFormat := false
+
+		buf, err := repo.LoadUnpacked(ctx, restic.IndexFile, id, nil)
+		if err == nil {
+			idx, oldFormat, err = DecodeIndex(buf, id)
+		}
+
+		m.Lock()
+		defer m.Unlock()
+		return fn(id, idx, oldFormat, err)
+	})
 }

--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -12,7 +12,6 @@ import (
 	"time"
 
 	"github.com/restic/restic/internal/errors"
-	"golang.org/x/sync/errgroup"
 
 	"github.com/restic/restic/internal/debug"
 )
@@ -320,50 +319,15 @@ func RemoveAllLocks(ctx context.Context, repo Repository) (uint, error) {
 func ForAllLocks(ctx context.Context, repo Repository, excludeID *ID, fn func(ID, *Lock, error) error) error {
 	var m sync.Mutex
 
-	// track spawned goroutines using wg, create a new context which is
-	// cancelled as soon as an error occurs.
-	wg, ctx := errgroup.WithContext(ctx)
-
-	ch := make(chan ID)
-
-	// send list of lock files through ch, which is closed afterwards
-	wg.Go(func() error {
-		defer close(ch)
-		return repo.List(ctx, LockFile, func(id ID, size int64) error {
-			if excludeID != nil && id.Equal(*excludeID) {
-				return nil
-			}
-
-			select {
-			case <-ctx.Done():
-				return nil
-			case ch <- id:
-			}
-			return nil
-		})
-	})
-
-	// a worker receives an snapshot ID from ch, loads the snapshot
-	// and runs fn with id, the snapshot and the error
-	worker := func() error {
-		for id := range ch {
-			debug.Log("load lock %v", id)
-			lock, err := LoadLock(ctx, repo, id)
-
-			m.Lock()
-			err = fn(id, lock, err)
-			m.Unlock()
-			if err != nil {
-				return err
-			}
-		}
-		return nil
-	}
-
 	// For locks decoding is nearly for free, thus just assume were only limited by IO
-	for i := 0; i < int(repo.Connections()); i++ {
-		wg.Go(worker)
-	}
+	return ParallelList(ctx, repo.Backend(), LockFile, repo.Connections(), func(ctx context.Context, id ID, size int64) error {
+		if excludeID != nil && id.Equal(*excludeID) {
+			return nil
+		}
+		lock, err := LoadLock(ctx, repo, id)
 
-	return wg.Wait()
+		m.Lock()
+		defer m.Unlock()
+		return fn(id, lock, err)
+	})
 }

--- a/internal/restic/parallel.go
+++ b/internal/restic/parallel.go
@@ -1,0 +1,59 @@
+package restic
+
+import (
+	"context"
+
+	"github.com/restic/restic/internal/debug"
+	"golang.org/x/sync/errgroup"
+)
+
+func ParallelList(ctx context.Context, r Lister, t FileType, parallelism uint, fn func(context.Context, ID, int64) error) error {
+
+	type FileIDInfo struct {
+		ID
+		Size int64
+	}
+
+	// track spawned goroutines using wg, create a new context which is
+	// cancelled as soon as an error occurs.
+	wg, ctx := errgroup.WithContext(ctx)
+
+	ch := make(chan FileIDInfo)
+	// send list of index files through ch, which is closed afterwards
+	wg.Go(func() error {
+		defer close(ch)
+		return r.List(ctx, t, func(fi FileInfo) error {
+			id, err := ParseID(fi.Name)
+			if err != nil {
+				debug.Log("unable to parse %v as an ID", fi.Name)
+				return nil
+			}
+
+			select {
+			case <-ctx.Done():
+				return nil
+			case ch <- FileIDInfo{id, fi.Size}:
+			}
+			return nil
+		})
+	})
+
+	// a worker receives an index ID from ch, loads the index, and sends it to indexCh
+	worker := func() error {
+		for fi := range ch {
+			debug.Log("worker got file %v", fi.ID.Str())
+			err := fn(ctx, fi.ID, fi.Size)
+			if err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// run workers on ch
+	for i := uint(0); i < parallelism; i++ {
+		wg.Go(worker)
+	}
+
+	return wg.Wait()
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The ForAllIndex/Snapshot/Lock functions use the same code pattern, thus introduce an new `ParallelList` function to deduplicate the implementation. This also allows to easily parallelize a few more List usages.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
