### PR TITLE
lock: fix flaky TestLockFailedRefresh

### DIFF
--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -121,7 +121,7 @@ func refreshLocks(ctx context.Context, lock *restic.Lock, lockInfo *lockContext,
 func monitorLockRefresh(ctx context.Context, lock *restic.Lock, lockInfo *lockContext, refreshed <-chan struct{}) {
 	// time.Now() might use a monotonic timer which is paused during standby
 	// convert to unix time to ensure we compare real time values
-	lastRefresh := time.Now().Unix()
+	lastRefresh := time.Now().UnixNano()
 	pollDuration := 1 * time.Second
 	if refreshInterval < pollDuration {
 		// require for TestLockFailedRefresh
@@ -145,7 +145,7 @@ func monitorLockRefresh(ctx context.Context, lock *restic.Lock, lockInfo *lockCo
 		case <-refreshed:
 			lastRefresh = time.Now().Unix()
 		case <-timer.C:
-			if float64(time.Now().Unix()-lastRefresh) < refreshabilityTimeout.Seconds() {
+			if time.Now().UnixNano()-lastRefresh < refreshabilityTimeout.Nanoseconds() {
 				// restart timer
 				timer.Reset(pollDuration)
 				continue


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The comparison of the current time and the last lock refresh were using seconds represented as integers. As the test only waits for up to one second, the associated number truncation can cause the test to take longer than once second and thus to fail.

Switch to milliseconds to avoid this problem. This also slightly speeds up the test.

Example of a test failure: https://github.com/restic/restic/actions/runs/3256057712/jobs/5346027375

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
