### PR TITLE
backup: Clean up progress reporting code

### DIFF
--- a/internal/ui/backup/progress.go
+++ b/internal/ui/backup/progress.go
@@ -40,7 +40,6 @@ type fileWorkerMessage struct {
 }
 
 type Summary struct {
-	sync.Mutex
 	Files, Dirs struct {
 		New       uint
 		Changed   uint
@@ -52,10 +51,8 @@ type Summary struct {
 
 // Progress reports progress for the `backup` command.
 type Progress struct {
-	MinUpdatePause time.Duration
-
-	start time.Time
-	dry   bool
+	interval time.Duration
+	start    time.Time
 
 	totalCh     chan Counter
 	processedCh chan Counter
@@ -63,15 +60,17 @@ type Progress struct {
 	workerCh    chan fileWorkerMessage
 	closed      chan struct{}
 
-	summary *Summary
+	summary struct {
+		sync.Mutex
+		Summary
+	}
 	printer ProgressPrinter
 }
 
-func NewProgress(printer ProgressPrinter) *Progress {
+func NewProgress(printer ProgressPrinter, interval time.Duration) *Progress {
 	return &Progress{
-		// limit to 60fps by default
-		MinUpdatePause: time.Second / 60,
-		start:          time.Now(),
+		interval: interval,
+		start:    time.Now(),
 
 		// use buffered channels for the information used to update the status
 		// the shutdown of the `Run()` method is somewhat racy, but won't affect
@@ -81,8 +80,6 @@ func NewProgress(printer ProgressPrinter) *Progress {
 		errCh:       make(chan struct{}),
 		workerCh:    make(chan fileWorkerMessage, 100),
 		closed:      make(chan struct{}),
-
-		summary: &Summary{},
 
 		printer: printer,
 	}
@@ -149,19 +146,13 @@ func (p *Progress) Run(ctx context.Context) error {
 		}
 
 		// limit update frequency
-		if !forceUpdate && (time.Since(lastUpdate) < p.MinUpdatePause || p.MinUpdatePause == 0) {
+		if !forceUpdate && (p.interval == 0 || time.Since(lastUpdate) < p.interval) {
 			continue
 		}
 		lastUpdate = time.Now()
 
 		p.printer.Update(total, processed, errors, currentFiles, p.start, secondsRemaining)
 	}
-}
-
-// ScannerError is the error callback function for the scanner, it prints the
-// error in verbose mode and returns nil.
-func (p *Progress) ScannerError(item string, err error) error {
-	return p.printer.ScannerError(item, err)
 }
 
 // Error is the error callback function for the archiver, it prints the error and returns nil.
@@ -214,23 +205,12 @@ func (p *Progress) CompleteItem(item string, previous, current *restic.Node, s a
 	}
 
 	switch current.Type {
-	case "file":
-		select {
-		case p.processedCh <- Counter{Files: 1}:
-		case <-p.closed:
-		}
-		select {
-		case p.workerCh <- fileWorkerMessage{filename: item, done: true}:
-		case <-p.closed:
-		}
 	case "dir":
 		select {
 		case p.processedCh <- Counter{Dirs: 1}:
 		case <-p.closed:
 		}
-	}
 
-	if current.Type == "dir" {
 		if previous == nil {
 			p.printer.CompleteItem("dir new", item, previous, current, s, d)
 			p.summary.Lock()
@@ -251,9 +231,13 @@ func (p *Progress) CompleteItem(item string, previous, current *restic.Node, s a
 			p.summary.Unlock()
 		}
 
-	} else if current.Type == "file" {
+	case "file":
 		select {
-		case p.workerCh <- fileWorkerMessage{done: true, filename: item}:
+		case p.processedCh <- Counter{Files: 1}:
+		case <-p.closed:
+		}
+		select {
+		case p.workerCh <- fileWorkerMessage{filename: item, done: true}:
 		case <-p.closed:
 		}
 
@@ -294,18 +278,8 @@ func (p *Progress) ReportTotal(item string, s archiver.ScanStats) {
 }
 
 // Finish prints the finishing messages.
-func (p *Progress) Finish(snapshotID restic.ID) {
+func (p *Progress) Finish(snapshotID restic.ID, dryrun bool) {
 	// wait for the status update goroutine to shut down
 	<-p.closed
-	p.printer.Finish(snapshotID, p.start, p.summary, p.dry)
-}
-
-// SetMinUpdatePause sets b.MinUpdatePause.
-func (p *Progress) SetMinUpdatePause(d time.Duration) {
-	p.MinUpdatePause = d
-}
-
-// SetDryRun marks the backup as a "dry run".
-func (p *Progress) SetDryRun() {
-	p.dry = true
+	p.printer.Finish(snapshotID, p.start, &p.summary.Summary, dryrun)
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Some more cleanup for the ui/backup package. This is preliminary work for a redesign of the ui/backup.Progress.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Discussed at #3959.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
