### PR TITLE
ui/backup: Replace channels with a mutex

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -555,11 +555,11 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 	} else {
 		progressPrinter = backup.NewTextProgress(term, gopts.verbosity)
 	}
-	progressReporter := backup.NewProgress(progressPrinter)
+	progressReporter := backup.NewProgress(progressPrinter,
+		calculateProgressInterval(!gopts.Quiet, gopts.JSON))
 
 	if opts.DryRun {
 		repo.SetDryRun()
-		progressReporter.SetDryRun()
 	}
 
 	// use the terminal for stdout/stderr
@@ -569,12 +569,10 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 	}()
 	gopts.stdout, gopts.stderr = progressPrinter.Stdout(), progressPrinter.Stderr()
 
-	progressReporter.SetMinUpdatePause(calculateProgressInterval(!gopts.Quiet, gopts.JSON))
-
 	wg, wgCtx := errgroup.WithContext(ctx)
 	cancelCtx, cancel := context.WithCancel(wgCtx)
 	defer cancel()
-	wg.Go(func() error { return progressReporter.Run(cancelCtx) })
+	wg.Go(func() error { progressReporter.Run(cancelCtx); return nil })
 
 	if !gopts.JSON {
 		progressPrinter.V("lock repository")
@@ -676,7 +674,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 	sc := archiver.NewScanner(targetFS)
 	sc.SelectByName = selectByNameFilter
 	sc.Select = selectFilter
-	sc.Error = progressReporter.ScannerError
+	sc.Error = progressPrinter.ScannerError
 	sc.Result = progressReporter.ReportTotal
 
 	if !gopts.JSON {
@@ -731,7 +729,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 	}
 
 	// Report finished execution
-	progressReporter.Finish(id)
+	progressReporter.Finish(id, opts.DryRun)
 	if !gopts.JSON && !opts.DryRun {
 		progressPrinter.P("snapshot %s saved\n", id.Str())
 	}

--- a/internal/ui/backup/progress_test.go
+++ b/internal/ui/backup/progress_test.go
@@ -1,0 +1,87 @@
+package backup
+
+import (
+	"context"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/archiver"
+	"github.com/restic/restic/internal/restic"
+)
+
+type mockPrinter struct {
+	sync.Mutex
+	dirUnchanged, fileNew bool
+	id                    restic.ID
+}
+
+func (p *mockPrinter) Update(total, processed Counter, errors uint, currentFiles map[string]struct{}, start time.Time, secs uint64) {
+}
+func (p *mockPrinter) Error(item string, err error) error        { return err }
+func (p *mockPrinter) ScannerError(item string, err error) error { return err }
+
+func (p *mockPrinter) CompleteItem(messageType string, item string, previous, current *restic.Node, s archiver.ItemStats, d time.Duration) {
+	p.Lock()
+	defer p.Unlock()
+
+	switch messageType {
+	case "dir unchanged":
+		p.dirUnchanged = true
+	case "file new":
+		p.fileNew = true
+	}
+}
+
+func (p *mockPrinter) ReportTotal(_ string, _ time.Time, _ archiver.ScanStats) {}
+func (p *mockPrinter) Finish(id restic.ID, _ time.Time, summary *Summary, dryRun bool) {
+	p.Lock()
+	defer p.Unlock()
+
+	_ = *summary // Should not be nil.
+	p.id = id
+}
+
+func (p *mockPrinter) Reset() {}
+
+func (p *mockPrinter) Stdout() io.WriteCloser { return nil }
+func (p *mockPrinter) Stderr() io.WriteCloser { return nil }
+
+func (p *mockPrinter) P(msg string, args ...interface{}) {}
+func (p *mockPrinter) V(msg string, args ...interface{}) {}
+
+func TestProgress(t *testing.T) {
+	t.Parallel()
+
+	prnt := &mockPrinter{}
+	prog := NewProgress(prnt, time.Millisecond)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go prog.Run(ctx)
+
+	prog.StartFile("foo")
+	prog.CompleteBlob(1024)
+
+	// "dir unchanged"
+	node := restic.Node{Type: "dir"}
+	prog.CompleteItem("foo", &node, &node, archiver.ItemStats{}, 0)
+	// "file new"
+	node.Type = "file"
+	prog.CompleteItem("foo", nil, &node, archiver.ItemStats{}, 0)
+
+	time.Sleep(10 * time.Millisecond)
+	cancel()
+	id := restic.NewRandomID()
+	prog.Finish(id, false)
+
+	if !prnt.dirUnchanged {
+		t.Error(`"dir unchanged" event not seen`)
+	}
+	if !prnt.fileNew {
+		t.Error(`"file new" event not seen`)
+	}
+	if prnt.id != id {
+		t.Errorf("id not stored (has %v)", prnt.id)
+	}
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Redoes the backup progress reporter using a single mutex instead of a multiple channels. This is not very pretty, but it seems to work. Once we can depend on Go 1.19, we can replace much of this with sync/atomic types to reduce the amount of code and maybe improve performance further.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Discussed at #3959.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
