### PR TITLE
Fix bug in lock refresh monitoring 

### DIFF
--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -143,7 +143,7 @@ func monitorLockRefresh(ctx context.Context, lock *restic.Lock, lockInfo *lockCo
 			debug.Log("terminate expiry monitoring")
 			return
 		case <-refreshed:
-			lastRefresh = time.Now().Unix()
+			lastRefresh = time.Now().UnixNano()
 		case <-timer.C:
 			if time.Now().UnixNano()-lastRefresh < refreshabilityTimeout.Nanoseconds() {
 				// restart timer


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Lock refresh monitoring timestamps were changed from seconds to nanoseconds. However there was one place where this change wasn't made. This causes restic backups to stop about after 5 minutes because trying to subtract seconds from nanoseconds.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
