### PR TITLE
ui/progress: Load both values in a single Lock/Unlock

### DIFF
--- a/internal/restic/find_test.go
+++ b/internal/restic/find_test.go
@@ -110,7 +110,8 @@ func TestFindUsedBlobs(t *testing.T) {
 			continue
 		}
 
-		test.Equals(t, p.Get(), uint64(i+1))
+		v, _ := p.Get()
+		test.Equals(t, v, uint64(i+1))
 
 		goldenFilename := filepath.Join("testdata", fmt.Sprintf("used_blobs_snapshot%d", i))
 		want := loadIDSet(t, goldenFilename)
@@ -151,7 +152,8 @@ func TestMultiFindUsedBlobs(t *testing.T) {
 	for i := 1; i < 3; i++ {
 		err := restic.FindUsedBlobs(context.TODO(), repo, snapshotTrees, usedBlobs, p)
 		test.OK(t, err)
-		test.Equals(t, p.Get(), uint64(i*len(snapshotTrees)))
+		v, _ := p.Get()
+		test.Equals(t, v, uint64(i*len(snapshotTrees)))
 
 		if !want.Equals(usedBlobs) {
 			t.Errorf("wrong list of blobs returned:\n  missing blobs: %v\n  extra blobs: %v",


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

We always need both values from a Counter, except in a test, so we don't need to lock twice and risk scheduling in between.

Also, removed the resetting in Done. This copied a mutex, which isn't allowed. Static analyzers tend to trip over that. I'm surprised golangci-lint hasn't caught it yet.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
