### PR TITLE
More compact data structure for Index.EachByPack

### DIFF
--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -127,6 +127,8 @@ func benchmarkSaveAndEncrypt(t *testing.B, version uint) {
 	rtest.OK(t, err)
 
 	id := restic.ID(sha256.Sum256(data))
+	var wg errgroup.Group
+	repo.StartPackUploader(context.Background(), &wg)
 
 	t.ReportAllocs()
 	t.ResetTimer()


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Replaced a map[restic.ID][][]*indexEntry by a map[restic.ID][restic.NumBlobTypes][]*indexEntry, to get rid of one level of indirection and a slice header.

I have no benchmark results for this change. The relevant code is only used by restic prune.

I also fixed a benchmark that I found broken while looking for one that exercises this code.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
