### PR TITLE
restore: show progress

### DIFF
--- a/changelog/unreleased/issue-3627
+++ b/changelog/unreleased/issue-3627
@@ -1,0 +1,9 @@
+Enhancement: Show progress bar during restore
+
+The `restore` command now shows a progress report while restoring files.
+
+Example: [0:42]  5.76%  23 files 12.98 MiB, total 3456 files 23.54 GiB
+
+https://github.com/restic/restic/issues/3627
+https://github.com/restic/restic/pull/3991
+https://forum.restic.net/t/progress-bar-for-restore/5210

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -112,7 +112,7 @@ func testRunRestoreLatest(t testing.TB, gopts GlobalOptions, dir string, paths [
 		},
 	}
 
-	rtest.OK(t, runRestore(context.TODO(), opts, gopts, []string{"latest"}))
+	rtest.OK(t, runRestore(context.TODO(), opts, gopts, nil, []string{"latest"}))
 }
 
 func testRunRestoreExcludes(t testing.TB, gopts GlobalOptions, dir string, snapshotID restic.ID, excludes []string) {
@@ -121,7 +121,7 @@ func testRunRestoreExcludes(t testing.TB, gopts GlobalOptions, dir string, snaps
 		Exclude: excludes,
 	}
 
-	rtest.OK(t, runRestore(context.TODO(), opts, gopts, []string{snapshotID.String()}))
+	rtest.OK(t, runRestore(context.TODO(), opts, gopts, nil, []string{snapshotID.String()}))
 }
 
 func testRunRestoreIncludes(t testing.TB, gopts GlobalOptions, dir string, snapshotID restic.ID, includes []string) {
@@ -130,11 +130,11 @@ func testRunRestoreIncludes(t testing.TB, gopts GlobalOptions, dir string, snaps
 		Include: includes,
 	}
 
-	rtest.OK(t, runRestore(context.TODO(), opts, gopts, []string{snapshotID.String()}))
+	rtest.OK(t, runRestore(context.TODO(), opts, gopts, nil, []string{snapshotID.String()}))
 }
 
 func testRunRestoreAssumeFailure(t testing.TB, snapshotID string, opts RestoreOptions, gopts GlobalOptions) error {
-	err := runRestore(context.TODO(), opts, gopts, []string{snapshotID})
+	err := runRestore(context.TODO(), opts, gopts, nil, []string{snapshotID})
 
 	return err
 }

--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -150,7 +150,7 @@ func newTestRepo(content []TestFile) *TestRepo {
 func restoreAndVerify(t *testing.T, tempdir string, content []TestFile, files map[string]bool, sparse bool) {
 	repo := newTestRepo(content)
 
-	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2, sparse)
+	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2, sparse, nil)
 
 	if files == nil {
 		r.files = repo.files
@@ -265,7 +265,7 @@ func TestErrorRestoreFiles(t *testing.T) {
 		return loadError
 	}
 
-	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2, false)
+	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2, false, nil)
 	r.files = repo.files
 
 	err := r.restoreFiles(context.TODO())
@@ -304,7 +304,7 @@ func testPartialDownloadError(t *testing.T, part int) {
 		return loader(ctx, h, length, offset, fn)
 	}
 
-	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2, false)
+	r := newFileRestorer(tempdir, repo.loader, repo.key, repo.Lookup, 2, false, nil)
 	r.files = repo.files
 	r.Error = func(s string, e error) error {
 		// ignore errors as in the `restore` command

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -325,7 +325,7 @@ func TestRestorer(t *testing.T) {
 			sn, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res := NewRestorer(context.TODO(), repo, sn, false)
+			res := NewRestorer(context.TODO(), repo, sn, false, nil)
 
 			tempdir := rtest.TempDir(t)
 			// make sure we're creating a new subdir of the tempdir
@@ -442,7 +442,7 @@ func TestRestorerRelative(t *testing.T) {
 			sn, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
-			res := NewRestorer(context.TODO(), repo, sn, false)
+			res := NewRestorer(context.TODO(), repo, sn, false, nil)
 
 			tempdir := rtest.TempDir(t)
 			cleanup := rtest.Chdir(t, tempdir)
@@ -671,7 +671,7 @@ func TestRestorerTraverseTree(t *testing.T) {
 			repo := repository.TestRepository(t)
 			sn, _ := saveSnapshot(t, repo, test.Snapshot)
 
-			res := NewRestorer(context.TODO(), repo, sn, false)
+			res := NewRestorer(context.TODO(), repo, sn, false, nil)
 
 			res.SelectFilter = test.Select
 
@@ -747,7 +747,7 @@ func TestRestorerConsistentTimestampsAndPermissions(t *testing.T) {
 		},
 	})
 
-	res := NewRestorer(context.TODO(), repo, sn, false)
+	res := NewRestorer(context.TODO(), repo, sn, false, nil)
 
 	res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
 		switch filepath.ToSlash(item) {
@@ -802,7 +802,7 @@ func TestVerifyCancel(t *testing.T) {
 	repo := repository.TestRepository(t)
 	sn, _ := saveSnapshot(t, repo, snapshot)
 
-	res := NewRestorer(context.TODO(), repo, sn, false)
+	res := NewRestorer(context.TODO(), repo, sn, false, nil)
 
 	tempdir := rtest.TempDir(t)
 	ctx, cancel := context.WithCancel(context.Background())
@@ -844,7 +844,7 @@ func TestRestorerSparseFiles(t *testing.T) {
 		archiver.SnapshotOptions{})
 	rtest.OK(t, err)
 
-	res := NewRestorer(context.TODO(), repo, sn, true)
+	res := NewRestorer(context.TODO(), repo, sn, true, nil)
 
 	tempdir := rtest.TempDir(t)
 	ctx, cancel := context.WithCancel(context.Background())

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -29,7 +29,7 @@ func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
 		},
 	})
 
-	res := NewRestorer(context.TODO(), repo, sn, false)
+	res := NewRestorer(context.TODO(), repo, sn, false, nil)
 
 	res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
 		return true, true

--- a/internal/ui/restore/progressformatter.go
+++ b/internal/ui/restore/progressformatter.go
@@ -1,0 +1,131 @@
+package restore
+
+import (
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/restic/restic/internal/ui"
+	"github.com/restic/restic/internal/ui/progress"
+)
+
+type Progress struct {
+	updater progress.Updater
+	m       sync.Mutex
+
+	progressInfoMap map[string]progressInfoEntry
+	filesFinished   uint64
+	filesTotal      uint64
+	allBytesWritten uint64
+	allBytesTotal   uint64
+	started         time.Time
+
+	printer ProgressPrinter
+}
+
+type progressInfoEntry struct {
+	bytesWritten uint64
+	bytesTotal   uint64
+}
+
+type ProgressPrinter interface {
+	Update(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration)
+	Finish(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration)
+}
+
+func NewProgress(printer ProgressPrinter, interval time.Duration) *Progress {
+	p := &Progress{
+		progressInfoMap: make(map[string]progressInfoEntry),
+		started:         time.Now(),
+		printer:         printer,
+	}
+	p.updater = *progress.NewUpdater(interval, p.update)
+	return p
+}
+
+func (p *Progress) update(runtime time.Duration, final bool) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if !final {
+		p.printer.Update(p.filesFinished, p.filesTotal, p.allBytesWritten, p.allBytesTotal, runtime)
+	} else {
+		p.printer.Finish(p.filesFinished, p.filesTotal, p.allBytesWritten, p.allBytesTotal, runtime)
+	}
+}
+
+// AddFile starts tracking a new file with the given size
+func (p *Progress) AddFile(size uint64) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.filesTotal++
+	p.allBytesTotal += size
+}
+
+// AddProgress accumulates the number of bytes written for a file
+func (p *Progress) AddProgress(name string, bytesWrittenPortion uint64, bytesTotal uint64) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	entry, exists := p.progressInfoMap[name]
+	if !exists {
+		entry.bytesTotal = bytesTotal
+	}
+	entry.bytesWritten += bytesWrittenPortion
+	p.progressInfoMap[name] = entry
+
+	p.allBytesWritten += bytesWrittenPortion
+	if entry.bytesWritten == entry.bytesTotal {
+		delete(p.progressInfoMap, name)
+		p.filesFinished++
+	}
+}
+
+func (p *Progress) Finish() {
+	p.updater.Done()
+}
+
+type term interface {
+	Print(line string)
+	SetStatus(lines []string)
+}
+
+type textPrinter struct {
+	terminal term
+}
+
+func NewProgressPrinter(terminal term) ProgressPrinter {
+	return &textPrinter{
+		terminal: terminal,
+	}
+}
+
+func (t *textPrinter) Update(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration) {
+	timeLeft := ui.FormatDuration(duration)
+	formattedAllBytesWritten := ui.FormatBytes(allBytesWritten)
+	formattedAllBytesTotal := ui.FormatBytes(allBytesTotal)
+	allPercent := ui.FormatPercent(allBytesWritten, allBytesTotal)
+	progress := fmt.Sprintf("[%s] %s  %v files %s, total %v files %v",
+		timeLeft, allPercent, filesFinished, formattedAllBytesWritten, filesTotal, formattedAllBytesTotal)
+
+	t.terminal.SetStatus([]string{progress})
+}
+
+func (t *textPrinter) Finish(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration) {
+	t.terminal.SetStatus([]string{})
+
+	timeLeft := ui.FormatDuration(duration)
+	formattedAllBytesTotal := ui.FormatBytes(allBytesTotal)
+
+	var summary string
+	if filesFinished == filesTotal && allBytesWritten == allBytesTotal {
+		summary = fmt.Sprintf("Summary: Restored %d Files (%s) in %s", filesTotal, formattedAllBytesTotal, timeLeft)
+	} else {
+		formattedAllBytesWritten := ui.FormatBytes(allBytesWritten)
+		summary = fmt.Sprintf("Summary: Restored %d / %d Files (%s / %s) in %s",
+			filesFinished, filesTotal, formattedAllBytesWritten, formattedAllBytesTotal, timeLeft)
+	}
+
+	t.terminal.Print(summary)
+}

--- a/internal/ui/restore/progressformatter_test.go
+++ b/internal/ui/restore/progressformatter_test.go
@@ -1,0 +1,170 @@
+package restore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/test"
+)
+
+type printerTraceEntry struct {
+	filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64
+
+	duration   time.Duration
+	isFinished bool
+}
+
+type printerTrace []printerTraceEntry
+
+type mockPrinter struct {
+	trace printerTrace
+}
+
+const mockFinishDuration = 42 * time.Second
+
+func (p *mockPrinter) Update(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration) {
+	p.trace = append(p.trace, printerTraceEntry{filesFinished, filesTotal, allBytesWritten, allBytesTotal, duration, false})
+}
+func (p *mockPrinter) Finish(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration) {
+	p.trace = append(p.trace, printerTraceEntry{filesFinished, filesTotal, allBytesWritten, allBytesTotal, mockFinishDuration, true})
+}
+
+func testProgress(fn func(progress *Progress) bool) printerTrace {
+	printer := &mockPrinter{}
+	progress := NewProgress(printer, 0)
+	final := fn(progress)
+	progress.update(0, final)
+	trace := append(printerTrace{}, printer.trace...)
+	// cleanup to avoid goroutine leak, but copy trace first
+	progress.Finish()
+	return trace
+}
+
+func TestNew(t *testing.T) {
+	result := testProgress(func(progress *Progress) bool {
+		return false
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{0, 0, 0, 0, 0, false},
+	}, result)
+}
+
+func TestAddFile(t *testing.T) {
+	fileSize := uint64(100)
+
+	result := testProgress(func(progress *Progress) bool {
+		progress.AddFile(fileSize)
+		return false
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{0, 1, 0, fileSize, 0, false},
+	}, result)
+}
+
+func TestFirstProgressOnAFile(t *testing.T) {
+	expectedBytesWritten := uint64(5)
+	expectedBytesTotal := uint64(100)
+
+	result := testProgress(func(progress *Progress) bool {
+		progress.AddFile(expectedBytesTotal)
+		progress.AddProgress("test", expectedBytesWritten, expectedBytesTotal)
+		return false
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{0, 1, expectedBytesWritten, expectedBytesTotal, 0, false},
+	}, result)
+}
+
+func TestLastProgressOnAFile(t *testing.T) {
+	fileSize := uint64(100)
+
+	result := testProgress(func(progress *Progress) bool {
+		progress.AddFile(fileSize)
+		progress.AddProgress("test", 30, fileSize)
+		progress.AddProgress("test", 35, fileSize)
+		progress.AddProgress("test", 35, fileSize)
+		return false
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{1, 1, fileSize, fileSize, 0, false},
+	}, result)
+}
+
+func TestLastProgressOnLastFile(t *testing.T) {
+	fileSize := uint64(100)
+
+	result := testProgress(func(progress *Progress) bool {
+		progress.AddFile(fileSize)
+		progress.AddFile(50)
+		progress.AddProgress("test1", 50, 50)
+		progress.AddProgress("test2", 50, fileSize)
+		progress.AddProgress("test2", 50, fileSize)
+		return false
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{2, 2, 50 + fileSize, 50 + fileSize, 0, false},
+	}, result)
+}
+
+func TestSummaryOnSuccess(t *testing.T) {
+	fileSize := uint64(100)
+
+	result := testProgress(func(progress *Progress) bool {
+		progress.AddFile(fileSize)
+		progress.AddFile(50)
+		progress.AddProgress("test1", 50, 50)
+		progress.AddProgress("test2", fileSize, fileSize)
+		return true
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{2, 2, 50 + fileSize, 50 + fileSize, mockFinishDuration, true},
+	}, result)
+}
+
+func TestSummaryOnErrors(t *testing.T) {
+	fileSize := uint64(100)
+
+	result := testProgress(func(progress *Progress) bool {
+		progress.AddFile(fileSize)
+		progress.AddFile(50)
+		progress.AddProgress("test1", 50, 50)
+		progress.AddProgress("test2", fileSize/2, fileSize)
+		return true
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{1, 2, 50 + fileSize/2, 50 + fileSize, mockFinishDuration, true},
+	}, result)
+}
+
+type mockTerm struct {
+	output []string
+}
+
+func (m *mockTerm) Print(line string) {
+	m.output = append(m.output, line)
+}
+
+func (m *mockTerm) SetStatus(lines []string) {
+	m.output = append([]string{}, lines...)
+}
+
+func TestPrintUpdate(t *testing.T) {
+	term := &mockTerm{}
+	printer := NewProgressPrinter(term)
+	printer.Update(3, 11, 29, 47, 5*time.Second)
+	test.Equals(t, []string{"[0:05] 61.70%  3 files 29 B, total 11 files 47 B"}, term.output)
+}
+
+func TestPrintSummaryOnSuccess(t *testing.T) {
+	term := &mockTerm{}
+	printer := NewProgressPrinter(term)
+	printer.Finish(11, 11, 47, 47, 5*time.Second)
+	test.Equals(t, []string{"Summary: Restored 11 Files (47 B) in 0:05"}, term.output)
+}
+
+func TestPrintSummaryOnErrors(t *testing.T) {
+	term := &mockTerm{}
+	printer := NewProgressPrinter(term)
+	printer.Finish(3, 11, 29, 47, 5*time.Second)
+	test.Equals(t, []string{"Summary: Restored 3 / 11 Files (29 B / 47 B) in 0:05"}, term.output)
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

After merging this PR restic will show progress details while restoring. \
Example: [0:42]  23 / 3456 Files,  12.98 MiB / 23.54 GiB,  5.76 %

The progress details line updates in-place and does not exist with -q option. \
The progress details line updates on each blob written.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Yes

* Issue [Progress for restore operation, 3627](https://github.com/restic/restic/issues/3627)
* Forum Thread [Progress bar for restore](https://forum.restic.net/t/progress-bar-for-restore/5210)

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
      (Nothing relevant)
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
