### PR TITLE
Return error if RESTIC_COMPRESSION env variable is invalid

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -67,9 +67,10 @@ type CompressionMode uint
 
 // Constants for the different compression levels.
 const (
-	CompressionAuto CompressionMode = 0
-	CompressionOff  CompressionMode = 1
-	CompressionMax  CompressionMode = 2
+	CompressionAuto    CompressionMode = 0
+	CompressionOff     CompressionMode = 1
+	CompressionMax     CompressionMode = 2
+	CompressionInvalid CompressionMode = 3
 )
 
 // Set implements the method needed for pflag command flag parsing.
@@ -82,6 +83,7 @@ func (c *CompressionMode) Set(s string) error {
 	case "max":
 		*c = CompressionMax
 	default:
+		*c = CompressionInvalid
 		return fmt.Errorf("invalid compression mode %q, must be one of (auto|off|max)", s)
 	}
 
@@ -107,6 +109,10 @@ func (c *CompressionMode) Type() string {
 
 // New returns a new repository with backend be.
 func New(be restic.Backend, opts Options) (*Repository, error) {
+	if opts.Compression == CompressionInvalid {
+		return nil, errors.Fatalf("invalid compression mode")
+	}
+
 	if opts.PackSize == 0 {
 		opts.PackSize = DefaultPackSize
 	}

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -679,3 +679,11 @@ func testStreamPack(t *testing.T, version uint) {
 		}
 	})
 }
+
+func TestInvalidCompression(t *testing.T) {
+	var comp repository.CompressionMode
+	err := comp.Set("nope")
+	rtest.Assert(t, err != nil, "missing error")
+	_, err = repository.New(nil, repository.Options{Compression: comp})
+	rtest.Assert(t, err != nil, "missing error")
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
restic currently does not return an error is the environment variable `RESTIC_COMPRESSION` is set to an invalid value. Instead it was silently ignored.

The underlying problem is that there is no nice way to return an error while setting the compression mode based on the environment variable. This PR changes the CompressionMode type to add an additional error status which is checked when creating a repository. The downside is that the code paths to check the compression mode are different depending on whether the parameter is set via command line or environment variable.

An alternative would be to extend the CompressionMode type to store the error, but that just feels wrong.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/3962 .
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
