### PR TITLE
backup: print full snapshot id in JSON summary

### DIFF
--- a/changelog/unreleased/issue-2724
+++ b/changelog/unreleased/issue-2724
@@ -1,0 +1,9 @@
+Change: Include full snapshot ID in JSON output of the bacukp command
+
+We have changed the JSON output of the backup command to include the full snapshot ID instead of just a shortened version.
+The latter can be ambiguous in rare cases.
+
+To derive the short ID, truncate the full ID down to 8 characters.
+
+https://github.com/restic/restic/issues/2724
+https://github.com/restic/restic/pull/3993

--- a/internal/ui/backup/json.go
+++ b/internal/ui/backup/json.go
@@ -191,7 +191,7 @@ func (b *JSONProgress) Finish(snapshotID restic.ID, start time.Time, summary *Su
 		TotalFilesProcessed: summary.Files.New + summary.Files.Changed + summary.Files.Unchanged,
 		TotalBytesProcessed: summary.ProcessedBytes,
 		TotalDuration:       time.Since(start).Seconds(),
-		SnapshotID:          snapshotID.Str(),
+		SnapshotID:          snapshotID.String(),
 		DryRun:              dryRun,
 	})
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The JSON output only included the shortened ID of the snapshot and not the full ID. The shortened ID could be ambiguous in rare cases and always has to be expanded first before restic can use it. As the JSON output is intended to be machine readable, there is no use in shortening the ID before printing it.

Strictly speaking, this change is not backwards compatible, but I don't expect much fall-out. In the worst case users have to explicitly truncate the ID down to 8 characters.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #2724
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
