### PR TITLE
backup: fix stuck status bar

### DIFF
--- a/internal/ui/backup/progress.go
+++ b/internal/ui/backup/progress.go
@@ -102,7 +102,7 @@ func (p *Progress) Run(ctx context.Context) {
 		}
 
 		p.mu.Lock()
-		if p.scanStarted {
+		if !p.scanStarted {
 			p.mu.Unlock()
 			continue
 		}
@@ -231,11 +231,10 @@ func (p *Progress) ReportTotal(item string, s archiver.ScanStats) {
 	defer p.mu.Unlock()
 
 	p.total = Counter{Files: uint64(s.Files), Dirs: uint64(s.Dirs), Bytes: s.Bytes}
+	p.scanStarted = true
 
 	if item == "" {
 		p.printer.ReportTotal(item, p.start, s)
-		p.scanStarted = true
-		return
 	}
 }
 


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The status bar got stuck once the first error was reported, the scanner completed or some file was backed up. Either case sets a flag that the scanner has started.

This flag is used to hide the progress bar until the flag is set. Due to an inverted condition, the opposite happened and the status stopped refreshing once the flag was set.

In addition, the scannerStarted flag was not set when the scanner just reported progress information.


<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Regressed in #3977
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
