### PR TITLE
lock: Tweak timeouts for lock refresh test

### DIFF
--- a/cmd/restic/lock_test.go
+++ b/cmd/restic/lock_test.go
@@ -133,10 +133,11 @@ func TestLockSuccessfulRefresh(t *testing.T) {
 	repo, cleanup, _ := openTestRepo(t, nil)
 	defer cleanup()
 
+	t.Log("test for successful lock refresh")
 	// reduce locking intervals to be suitable for testing
 	ri, rt := refreshInterval, refreshabilityTimeout
-	refreshInterval = 20 * time.Millisecond
-	refreshabilityTimeout = 100 * time.Millisecond
+	refreshInterval = 40 * time.Millisecond
+	refreshabilityTimeout = 200 * time.Millisecond
 	defer func() {
 		refreshInterval, refreshabilityTimeout = ri, rt
 	}()


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The test which checks that lock refreshing works, for some reason fails from time to time, see e.g. https://github.com/restic/restic/pull/3997#issuecomment-1301336512 .

This PR increases the timeouts to hopefully avoid this issue.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3990
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
