### PR TITLE
archiver: Check that saved file does not have null IDs in content

### DIFF
--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1969,7 +1969,7 @@ type failSaveRepo struct {
 func (f *failSaveRepo) SaveBlob(ctx context.Context, t restic.BlobType, buf []byte, id restic.ID, storeDuplicate bool) (restic.ID, bool, int, error) {
 	val := atomic.AddInt32(&f.cnt, 1)
 	if val >= f.failAfter {
-		return restic.ID{}, false, 0, f.err
+		return restic.Hash(buf), false, 0, f.err
 	}
 
 	return f.Repository.SaveBlob(ctx, t, buf, id, storeDuplicate)

--- a/internal/archiver/file_saver.go
+++ b/internal/archiver/file_saver.go
@@ -128,6 +128,11 @@ func (s *FileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 			if isCompleted {
 				panic("completed twice")
 			}
+			for _, id := range fnr.node.Content {
+				if id.IsNull() {
+					panic("completed file with null ID")
+				}
+			}
 			isCompleted = true
 			finish(fnr)
 		}

--- a/internal/archiver/file_saver_test.go
+++ b/internal/archiver/file_saver_test.go
@@ -35,7 +35,12 @@ func startFileSaver(ctx context.Context, t testing.TB) (*FileSaver, context.Cont
 	wg, ctx := errgroup.WithContext(ctx)
 
 	saveBlob := func(ctx context.Context, tpe restic.BlobType, buf *Buffer, cb func(SaveBlobResponse)) {
-		cb(SaveBlobResponse{})
+		cb(SaveBlobResponse{
+			id:         restic.Hash(buf.Data),
+			length:     len(buf.Data),
+			sizeInRepo: len(buf.Data),
+			known:      false,
+		})
 	}
 
 	workers := uint(runtime.NumCPU())


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Null IDs in the file content indicate that something went wrong. Thus fails before saving the affected file.

I wonder whether the null IDs reported in #3999 are related to #3955. This PR adds sanity checks which cause restic to panic during the backup if that were to happen. That said, I have no clue how #3955 could cause tree blobs with null IDs to be used by a snapshot.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See #3999
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
