### PR TITLE
cmd: Don't read password from stdin for backup --stdin

### DIFF
--- a/changelog/unreleased/issue-2591
+++ b/changelog/unreleased/issue-2591
@@ -1,0 +1,22 @@
+Bugfix: Don't read password from stdin for backup --stdin
+
+Restic backup previously tried to read first the password, then the data
+to be backed up from standard input. This meant it would often confuse part
+of the data for the password.
+
+From now on, restic backup --stdin will exit with the message
+
+    Fatal: cannot read both password and data from stdin
+
+unless the password is passed in some other way (--restic-password-file,
+RESTIC_PASSWORD, etc.). To enter the password interactively, a password
+command has to be used. For example, on Linux,
+
+    mysqldump somedatabase |
+        restic backup --stdin \
+            --password-command='sh -c "systemd-ask-password < /dev/tty"'
+
+securely reads the password from the terminal.
+
+https://github.com/restic/restic/issues/2591
+https://github.com/restic/restic/pull/4011

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -262,6 +262,10 @@ func readFilenamesRaw(r io.Reader) (names []string, err error) {
 // Check returns an error when an invalid combination of options was set.
 func (opts BackupOptions) Check(gopts GlobalOptions, args []string) error {
 	if gopts.password == "" {
+		if opts.Stdin {
+			return errors.Fatal("cannot read both password and data from stdin")
+		}
+
 		filesFrom := append(append(opts.FilesFrom, opts.FilesFromVerbatim...), opts.FilesFromRaw...)
 		for _, filename := range filesFrom {
 			if filename == "-" {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

restic backup --stdin now refuses to read the password from standard input.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes #2591. Supersedes #2593. I didn't implement reading from /dev/tty instead, but put a note on to do that with a separate command in the changelog.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
