### PR TITLE
archiver: Fix race condition resulting in files containing null IDs

### DIFF
--- a/internal/archiver/blob_saver_test.go
+++ b/internal/archiver/blob_saver_test.go
@@ -48,14 +48,19 @@ func TestBlobSaver(t *testing.T) {
 
 	var wait sync.WaitGroup
 	var results []SaveBlobResponse
+	var lock sync.Mutex
 
 	wait.Add(20)
 	for i := 0; i < 20; i++ {
 		buf := &Buffer{Data: []byte(fmt.Sprintf("foo%d", i))}
 		idx := i
+		lock.Lock()
 		results = append(results, SaveBlobResponse{})
+		lock.Unlock()
 		b.Save(ctx, restic.DataBlob, buf, func(res SaveBlobResponse) {
+			lock.Lock()
 			results[idx] = res
+			lock.Unlock()
 			wait.Done()
 		})
 	}

--- a/internal/archiver/file_saver.go
+++ b/internal/archiver/file_saver.go
@@ -199,7 +199,10 @@ func (s *FileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 
 		// add a place to store the saveBlob result
 		pos := idx
+
+		lock.Lock()
 		node.Content = append(node.Content, restic.ID{})
+		lock.Unlock()
 
 		s.saveBlob(ctx, restic.DataBlob, buf, func(sbr SaveBlobResponse) {
 			lock.Lock()


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
In some rare cases files could be created which contain blob with ID null (all zero). This was caused by a race condition between growing the `Content` slice and inserting the blob IDs into it. In some cases the blob ID was written to the old slice, which a short time afterwards was replaced with a larger copy, that did not yet contain the blob ID.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3999
Regressed by #3955
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
