### PR TITLE
fuse: Better inode generation

### DIFF
--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -182,7 +182,7 @@ func (d *dir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 		}
 
 		ret = append(ret, fuse.Dirent{
-			Inode: fs.GenerateDynamicInode(d.inode, name),
+			Inode: inodeFromNode(d.inode, node),
 			Type:  typ,
 			Name:  name,
 		})
@@ -206,13 +206,13 @@ func (d *dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	}
 	switch node.Type {
 	case "dir":
-		return newDir(d.root, fs.GenerateDynamicInode(d.inode, name), d.inode, node)
+		return newDir(d.root, inodeFromNode(d.inode, node), d.inode, node)
 	case "file":
-		return newFile(d.root, fs.GenerateDynamicInode(d.inode, name), node)
+		return newFile(d.root, inodeFromNode(d.inode, node), node)
 	case "symlink":
-		return newLink(d.root, fs.GenerateDynamicInode(d.inode, name), node)
+		return newLink(d.root, inodeFromNode(d.inode, node), node)
 	case "dev", "chardev", "fifo", "socket":
-		return newOther(d.root, fs.GenerateDynamicInode(d.inode, name), node)
+		return newOther(d.root, inodeFromNode(d.inode, node), node)
 	default:
 		debug.Log("  node %v has unknown type %v", name, node.Type)
 		return nil, fuse.ENOENT

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -204,15 +204,16 @@ func (d *dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 		debug.Log("  Lookup(%v) -> not found", name)
 		return nil, fuse.ENOENT
 	}
+	inode := inodeFromNode(d.inode, node)
 	switch node.Type {
 	case "dir":
-		return newDir(d.root, inodeFromNode(d.inode, node), d.inode, node)
+		return newDir(d.root, inode, d.inode, node)
 	case "file":
-		return newFile(d.root, inodeFromNode(d.inode, node), node)
+		return newFile(d.root, inode, node)
 	case "symlink":
-		return newLink(d.root, inodeFromNode(d.inode, node), node)
+		return newLink(d.root, inode, node)
 	case "dev", "chardev", "fifo", "socket":
-		return newOther(d.root, inodeFromNode(d.inode, node), node)
+		return newOther(d.root, inode, node)
 	default:
 		debug.Log("  node %v has unknown type %v", name, node.Type)
 		return nil, fuse.ENOENT

--- a/internal/fuse/inode.go
+++ b/internal/fuse/inode.go
@@ -1,0 +1,44 @@
+//go:build darwin || freebsd || linux
+// +build darwin freebsd linux
+
+package fuse
+
+import (
+	"encoding/binary"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/restic/restic/internal/restic"
+)
+
+// inodeFromName generates an inode number for a file in a meta dir.
+func inodeFromName(parent uint64, name string) uint64 {
+	inode := parent ^ xxhash.Sum64String(cleanupNodeName(name))
+
+	// Inode 0 is invalid and 1 is the root. Remap those.
+	if inode < 2 {
+		inode += 2
+	}
+	return inode
+}
+
+// inodeFromNode generates an inode number for a file within a snapshot.
+func inodeFromNode(parent uint64, node *restic.Node) (inode uint64) {
+	if node.Links > 1 && node.Type != "dir" {
+		// If node has hard links, give them all the same inode,
+		// irrespective of the parent.
+		var buf [16]byte
+		binary.LittleEndian.PutUint64(buf[:8], node.DeviceID)
+		binary.LittleEndian.PutUint64(buf[8:], node.Inode)
+		inode = xxhash.Sum64(buf[:])
+	} else {
+		// Else, use the name and the parent inode.
+		// node.{DeviceID,Inode} may not even be reliable.
+		inode = parent ^ xxhash.Sum64String(cleanupNodeName(node.Name))
+	}
+
+	// Inode 0 is invalid and 1 is the root. Remap those.
+	if inode < 2 {
+		inode += 2
+	}
+	return inode
+}

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -78,7 +78,7 @@ func (d *SnapshotsDir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 
 	for name, entry := range meta.names {
 		d := fuse.Dirent{
-			Inode: fs.GenerateDynamicInode(d.inode, name),
+			Inode: inodeFromName(d.inode, name),
 			Name:  name,
 			Type:  fuse.DT_Dir,
 		}
@@ -105,11 +105,11 @@ func (d *SnapshotsDir) Lookup(ctx context.Context, name string) (fs.Node, error)
 	entry := meta.names[name]
 	if entry != nil {
 		if entry.linkTarget != "" {
-			return newSnapshotLink(d.root, fs.GenerateDynamicInode(d.inode, name), entry.linkTarget, entry.snapshot)
+			return newSnapshotLink(d.root, inodeFromName(d.inode, name), entry.linkTarget, entry.snapshot)
 		} else if entry.snapshot != nil {
-			return newDirFromSnapshot(d.root, fs.GenerateDynamicInode(d.inode, name), entry.snapshot)
+			return newDirFromSnapshot(d.root, inodeFromName(d.inode, name), entry.snapshot)
 		} else {
-			return NewSnapshotsDir(d.root, fs.GenerateDynamicInode(d.inode, name), d.inode, d.dirStruct, d.prefix+"/"+name), nil
+			return NewSnapshotsDir(d.root, inodeFromName(d.inode, name), d.inode, d.dirStruct, d.prefix+"/"+name), nil
 		}
 	}
 

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -104,12 +104,13 @@ func (d *SnapshotsDir) Lookup(ctx context.Context, name string) (fs.Node, error)
 
 	entry := meta.names[name]
 	if entry != nil {
+		inode := inodeFromName(d.inode, name)
 		if entry.linkTarget != "" {
-			return newSnapshotLink(d.root, inodeFromName(d.inode, name), entry.linkTarget, entry.snapshot)
+			return newSnapshotLink(d.root, inode, entry.linkTarget, entry.snapshot)
 		} else if entry.snapshot != nil {
-			return newDirFromSnapshot(d.root, inodeFromName(d.inode, name), entry.snapshot)
+			return newDirFromSnapshot(d.root, inode, entry.snapshot)
 		} else {
-			return NewSnapshotsDir(d.root, inodeFromName(d.inode, name), d.inode, d.dirStruct, d.prefix+"/"+name), nil
+			return NewSnapshotsDir(d.root, inode, d.inode, d.dirStruct, d.prefix+"/"+name), nil
 		}
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Hard links to the same file now get the same inode within the FUSE mount. #4006 and backups from Windows are taken into account by using different hashing schemes for hard-linked files and everything else.

Also, inode generation is faster and, more importantly, no longer allocates.

Benchmarked on Linux/amd64. Old means the benchmark with

    sink = fs.GenerateDynamicInode(1, sub.node.Name)

instead of calling inodeFromNode. I don't get why this allocates in one case but not the other. fs.GenerateDynamicInode always calls runtime.stringtobyteslice. Results:

```
name                   old time/op    new time/op    delta
Inode/no_hard_links-8     137ns ± 4%      34ns ± 1%   -75.20%  (p=0.000 n=10+10)
Inode/hard_link-8        33.6ns ± 1%     9.5ns ± 0%   -71.82%  (p=0.000 n=9+8)

name                   old alloc/op   new alloc/op   delta
Inode/no_hard_links-8     48.0B ± 0%      0.0B       -100.00%  (p=0.000 n=10+10)
Inode/hard_link-8         0.00B          0.00B           ~     (all equal)

name                   old allocs/op  new allocs/op  delta
Inode/no_hard_links-8      1.00 ± 0%      0.00       -100.00%  (p=0.000 n=10+10)
Inode/hard_link-8          0.00           0.00           ~     (all equal)
```

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
