### PR TITLE
backend/local: Ignore ENOTTY for fsync on Mac

### DIFF
--- a/changelog/unreleased/issue-4016
+++ b/changelog/unreleased/issue-4016
@@ -1,0 +1,8 @@
+Bugfix: Support ExFAT-formatted local backends on macOS Ventura
+
+ExFAT-formatted disks could not be used as local backends starting from macOS
+Ventura. Restic commands would fail with "inappropriate ioctl for device". This
+has been fixed.
+
+https://github.com/restic/restic/issues/4016
+https://github.com/restic/restic/pull/4021

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -177,7 +177,7 @@ func (b *Local) Save(ctx context.Context, h restic.Handle, rd restic.RewindReade
 
 	// Ignore error if filesystem does not support fsync.
 	err = f.Sync()
-	syncNotSup := errors.Is(err, syscall.ENOTSUP)
+	syncNotSup := err != nil && (errors.Is(err, syscall.ENOTSUP) || isMacENOTTY(err))
 	if err != nil && !syncNotSup {
 		return errors.WithStack(err)
 	}

--- a/internal/backend/local/local_unix.go
+++ b/internal/backend/local/local_unix.go
@@ -6,6 +6,7 @@ package local
 import (
 	"errors"
 	"os"
+	"runtime"
 	"syscall"
 
 	"github.com/restic/restic/internal/fs"
@@ -19,7 +20,9 @@ func fsyncDir(dir string) error {
 	}
 
 	err = d.Sync()
-	if errors.Is(err, syscall.ENOTSUP) || errors.Is(err, syscall.ENOENT) || errors.Is(err, syscall.EINVAL) {
+	if err != nil &&
+		(errors.Is(err, syscall.ENOTSUP) || errors.Is(err, syscall.ENOENT) ||
+			errors.Is(err, syscall.EINVAL) || isMacENOTTY(err)) {
 		err = nil
 	}
 
@@ -29,6 +32,15 @@ func fsyncDir(dir string) error {
 	}
 
 	return err
+}
+
+// The ExFAT driver on some versions of macOS can return ENOTTY,
+// "inappropriate ioctl for device", for fsync.
+//
+// https://github.com/restic/restic/issues/4016
+// https://github.com/realm/realm-core/issues/5789
+func isMacENOTTY(err error) bool {
+	return runtime.GOOS == "darwin" && errors.Is(err, syscall.ENOTTY)
 }
 
 // set file to readonly

--- a/internal/backend/local/local_windows.go
+++ b/internal/backend/local/local_windows.go
@@ -7,6 +7,9 @@ import (
 // Can't explicitly flush directory changes on Windows.
 func fsyncDir(dir string) error { return nil }
 
+// Windows is not macOS.
+func isMacENOTTY(err error) bool { return false }
+
 // We don't modify read-only on windows,
 // since it will make us unable to delete the file,
 // and this isn't common practice on this platform.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Catches ENOTTY as an error from fsync to ignore, on the Mac.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes #4016, I hope. Will add a changelog entry if it does.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
