### PR TITLE
CI: Run the golang race checker

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -37,6 +37,13 @@ jobs:
             check_changelog: true
             install_verb: install
 
+          - job_name: Linux (race)
+            go: 1.19.x
+            os: ubuntu-latest
+            test_fuse: true
+            test_opts: "-race"
+            install_verb: install
+
           - job_name: Linux
             go: 1.18.x
             os: ubuntu-latest
@@ -152,7 +159,7 @@ jobs:
         env:
           RESTIC_TEST_FUSE: ${{ matrix.test_fuse }}
         run: |
-          go test -cover ./...
+          go test -cover ${{matrix.test_opts}} ./...
 
       - name: Test cloud backends
         env:

--- a/internal/restic/lock_unix.go
+++ b/internal/restic/lock_unix.go
@@ -29,7 +29,7 @@ func uidGidInt(u *user.User) (uid, gid uint32, err error) {
 // checkProcess will check if the process retaining the lock
 // exists and responds to SIGHUP signal.
 // Returns true if the process exists and responds.
-func (l Lock) processExists() bool {
+func (l *Lock) processExists() bool {
 	proc, err := os.FindProcess(l.PID)
 	if err != nil {
 		debug.Log("error searching for process %d: %v\n", l.PID, err)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
#4019 fixed a race condition which would have been detected by the golang race detector. Instead, it took several hours to home in on the bug. Thus, enable the race detector to hopefully notice such bugs before these are merged.

Besides enabling, the race detector this PR also fixes several race conditions in our tests which caused the race detector to fail. Adding a mutex to `restic.Lock` is not particularly pretty, but splitting the code into the (JSON) lock struct and a lock refresher is out of scope for this PR.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See #4019.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
