### PR TITLE
bloblru: Upgrade to hashicorp/golang-lru/v2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/elithrar/simple-scrypt v1.3.0
 	github.com/go-ole/go-ole v1.2.6
 	github.com/google/go-cmp v0.5.9
-	github.com/hashicorp/golang-lru v0.5.4
+	github.com/hashicorp/golang-lru/v2 v2.0.1
 	github.com/juju/ratelimit v1.0.2
 	github.com/klauspost/compress v1.15.9
 	github.com/kurin/blazer v0.5.4-0.20211030221322-ba894c124ac6

--- a/go.sum
+++ b/go.sum
@@ -109,8 +109,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.2.0 h1:y8Yozv7SZtlU//QXbez
 github.com/googleapis/enterprise-certificate-proxy v0.2.0/go.mod h1:8C0jb7/mgJe/9KK8Lm7X9ctZC2t60YyIpYEI16jx0Qg=
 github.com/googleapis/gax-go/v2 v2.7.0 h1:IcsPKeInNvYi7eqSaDjiZqDDKu5rsmunY0Y1YupQSSQ=
 github.com/googleapis/gax-go/v2 v2.7.0/go.mod h1:TEop28CZZQ2y+c0VxMUmu1lV+fQx57QpBWsYpwqHJx8=
-github.com/hashicorp/golang-lru v0.5.4 h1:YDjusn29QI/Das2iO9M0BHnIbxPeyuCHsjMW+lJfyTc=
-github.com/hashicorp/golang-lru v0.5.4/go.mod h1:iADmTwqILo4mZ8BN3D2Q6+9jd8WM5uGBxy+E8yxSoD4=
+github.com/hashicorp/golang-lru/v2 v2.0.1 h1:5pv5N1lT1fjLg2VQ5KWc7kmucp2x/kvFOnxuVTqZ6x4=
+github.com/hashicorp/golang-lru/v2 v2.0.1/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/inconshreveable/mousetrap v1.0.1 h1:U3uMjPSQEBMNp1lFxmllqCPM6P5u/Xq7Pgzkat/bFNc=
 github.com/inconshreveable/mousetrap v1.0.1/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=

--- a/internal/bloblru/cache_test.go
+++ b/internal/bloblru/cache_test.go
@@ -1,6 +1,7 @@
 package bloblru
 
 import (
+	"math/rand"
 	"testing"
 
 	"github.com/restic/restic/internal/restic"
@@ -49,4 +50,30 @@ func TestCache(t *testing.T) {
 
 	rtest.Equals(t, cacheSize, c.size)
 	rtest.Equals(t, cacheSize, c.free)
+}
+
+func BenchmarkAdd(b *testing.B) {
+	const (
+		MiB    = 1 << 20
+		nblobs = 64
+	)
+
+	c := New(64 * MiB)
+
+	buf := make([]byte, 8*MiB)
+	ids := make([]restic.ID, nblobs)
+	sizes := make([]int, nblobs)
+
+	r := rand.New(rand.NewSource(100))
+	for i := range ids {
+		r.Read(ids[i][:])
+		sizes[i] = r.Intn(8 * MiB)
+	}
+
+	b.ResetTimer()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		c.Add(ids[i%nblobs], buf[:sizes[i%nblobs]])
+	}
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The new genericized LRU cache no longer needs to have the IDs separately allocated:

```
name   old time/op    new time/op    delta
Add-8     494ns ± 2%     388ns ± 2%  -21.46%  (p=0.000 n=10+9)

name   old alloc/op   new alloc/op   delta
Add-8      176B ± 0%      152B ± 0%  -13.64%  (p=0.000 n=10+10)

name   old allocs/op  new allocs/op  delta
Add-8      5.00 ± 0%      3.00 ± 0%  -40.00%  (p=0.000 n=10+10)
```

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

I mentioned this at https://github.com/restic/restic/pull/4041#issuecomment-1328107280

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
