### PR TITLE
backend, fs, options: Minor cleanup

### DIFF
--- a/internal/backend/azure/config.go
+++ b/internal/backend/azure/config.go
@@ -43,14 +43,13 @@ func ParseConfig(s string) (interface{}, error) {
 
 	// use the first entry of the path as the bucket name and the
 	// remainder as prefix
-	data := strings.SplitN(s, ":", 2)
-	if len(data) < 2 {
+	container, prefix, colon := strings.Cut(s, ":")
+	if !colon {
 		return nil, errors.New("azure: invalid format: bucket name or path not found")
 	}
-	container, path := data[0], path.Clean(data[1])
-	path = strings.TrimPrefix(path, "/")
+	prefix = strings.TrimPrefix(path.Clean(prefix), "/")
 	cfg := NewConfig()
 	cfg.Container = container
-	cfg.Prefix = path
+	cfg.Prefix = prefix
 	return cfg, nil
 }

--- a/internal/backend/b2/config.go
+++ b/internal/backend/b2/config.go
@@ -37,7 +37,7 @@ var bucketName = regexp.MustCompile("^[a-zA-Z0-9-]+$")
 // https://help.backblaze.com/hc/en-us/articles/217666908-What-you-need-to-know-about-B2-Bucket-names
 func checkBucketName(name string) error {
 	if name == "" {
-		return errors.New("bucket name is empty")
+		return errors.New("bucket name not found")
 	}
 
 	if len(name) < 6 {
@@ -64,30 +64,18 @@ func ParseConfig(s string) (interface{}, error) {
 	}
 
 	s = s[3:]
-	data := strings.SplitN(s, ":", 2)
-	if len(data) == 0 || len(data[0]) == 0 {
-		return nil, errors.New("bucket name not found")
-	}
-
-	cfg := NewConfig()
-	cfg.Bucket = data[0]
-
-	if err := checkBucketName(cfg.Bucket); err != nil {
+	bucket, prefix, _ := strings.Cut(s, ":")
+	if err := checkBucketName(bucket); err != nil {
 		return nil, err
 	}
 
-	if len(data) == 2 {
-		p := data[1]
-		if len(p) > 0 {
-			p = path.Clean(p)
-		}
-
-		if len(p) > 0 && path.IsAbs(p) {
-			p = p[1:]
-		}
-
-		cfg.Prefix = p
+	if len(prefix) > 0 {
+		prefix = strings.TrimPrefix(path.Clean(prefix), "/")
 	}
+
+	cfg := NewConfig()
+	cfg.Bucket = bucket
+	cfg.Prefix = prefix
 
 	return cfg, nil
 }

--- a/internal/backend/gs/config.go
+++ b/internal/backend/gs/config.go
@@ -42,17 +42,15 @@ func ParseConfig(s string) (interface{}, error) {
 
 	// use the first entry of the path as the bucket name and the
 	// remainder as prefix
-	data := strings.SplitN(s, ":", 2)
-	if len(data) < 2 {
+	bucket, prefix, colon := strings.Cut(s, ":")
+	if !colon {
 		return nil, errors.New("gs: invalid format: bucket name or path not found")
 	}
 
-	bucket, path := data[0], path.Clean(data[1])
-
-	path = strings.TrimPrefix(path, "/")
+	prefix = strings.TrimPrefix(path.Clean(prefix), "/")
 
 	cfg := NewConfig()
 	cfg.Bucket = bucket
-	cfg.Prefix = path
+	cfg.Prefix = prefix
 	return cfg, nil
 }

--- a/internal/backend/location/location.go
+++ b/internal/backend/location/location.go
@@ -127,6 +127,6 @@ func StripPassword(s string) string {
 }
 
 func extractScheme(s string) string {
-	data := strings.SplitN(s, ":", 2)
-	return data[0]
+	scheme, _, _ := strings.Cut(s, ":")
+	return scheme
 }

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -59,8 +59,8 @@ func ParseConfig(s string) (interface{}, error) {
 			return nil, errors.New("s3: bucket name not found")
 		}
 
-		path := strings.SplitN(url.Path[1:], "/", 2)
-		return createConfig(url.Host, path, url.Scheme == "http")
+		bucket, path, _ := strings.Cut(url.Path[1:], "/")
+		return createConfig(url.Host, bucket, path, url.Scheme == "http")
 	case strings.HasPrefix(s, "s3://"):
 		s = s[5:]
 	case strings.HasPrefix(s, "s3:"):
@@ -70,24 +70,24 @@ func ParseConfig(s string) (interface{}, error) {
 	}
 	// use the first entry of the path as the endpoint and the
 	// remainder as bucket name and prefix
-	path := strings.SplitN(s, "/", 3)
-	return createConfig(path[0], path[1:], false)
+	endpoint, rest, _ := strings.Cut(s, "/")
+	bucket, prefix, _ := strings.Cut(rest, "/")
+	return createConfig(endpoint, bucket, prefix, false)
 }
 
-func createConfig(endpoint string, p []string, useHTTP bool) (interface{}, error) {
-	if len(p) < 1 {
+func createConfig(endpoint, bucket, prefix string, useHTTP bool) (interface{}, error) {
+	if endpoint == "" {
 		return nil, errors.New("s3: invalid format, host/region or bucket name not found")
 	}
 
-	var prefix string
-	if len(p) > 1 && p[1] != "" {
-		prefix = path.Clean(p[1])
+	if prefix != "" {
+		prefix = path.Clean(prefix)
 	}
 
 	cfg := NewConfig()
 	cfg.Endpoint = endpoint
 	cfg.UseHTTP = useHTTP
-	cfg.Bucket = p[0]
+	cfg.Bucket = bucket
 	cfg.Prefix = prefix
 	return cfg, nil
 }

--- a/internal/backend/s3/config_test.go
+++ b/internal/backend/s3/config_test.go
@@ -1,6 +1,9 @@
 package s3
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 var configTests = []struct {
 	s   string
@@ -108,6 +111,17 @@ func TestParseConfig(t *testing.T) {
 			t.Errorf("test %d:\ninput:\n  %s\n wrong config, want:\n  %v\ngot:\n  %v",
 				i, test.s, test.cfg, cfg)
 			continue
+		}
+	}
+}
+
+func TestParseError(t *testing.T) {
+	const prefix = "s3: invalid format,"
+
+	for _, s := range []string{"", "/", "//", "/bucket/prefix"} {
+		_, err := ParseConfig("s3://" + s)
+		if err == nil || !strings.HasPrefix(err.Error(), prefix) {
+			t.Errorf("expected %q, got %q", prefix, err)
 		}
 	}
 }

--- a/internal/backend/sftp/config.go
+++ b/internal/backend/sftp/config.go
@@ -60,14 +60,13 @@ func ParseConfig(s string) (interface{}, error) {
 		// "user@host:path" in s
 		s = s[5:]
 		// split user@host and path at the colon
-		data := strings.SplitN(s, ":", 2)
-		if len(data) < 2 {
+		var colon bool
+		host, dir, colon = strings.Cut(s, ":")
+		if !colon {
 			return nil, errors.New("sftp: invalid format, hostname or path not found")
 		}
-		host = data[0]
-		dir = data[1]
 		// split user and host at the "@"
-		data = strings.SplitN(host, "@", 3)
+		data := strings.SplitN(host, "@", 3)
 		if len(data) == 3 {
 			user = data[0] + "@" + data[1]
 			host = data[2]

--- a/internal/backend/swift/config.go
+++ b/internal/backend/swift/config.go
@@ -51,17 +51,13 @@ func NewConfig() Config {
 
 // ParseConfig parses the string s and extract swift's container name and prefix.
 func ParseConfig(s string) (interface{}, error) {
-	data := strings.SplitN(s, ":", 3)
-	if len(data) != 3 {
+	if !strings.HasPrefix(s, "swift:") {
 		return nil, errors.New("invalid URL, expected: swift:container-name:/[prefix]")
 	}
+	s = strings.TrimPrefix(s, "swift:")
 
-	scheme, container, prefix := data[0], data[1], data[2]
-	if scheme != "swift" {
-		return nil, errors.Errorf("unexpected prefix: %s", data[0])
-	}
-
-	if len(prefix) == 0 {
+	container, prefix, _ := strings.Cut(s, ":")
+	if prefix == "" {
 		return nil, errors.Errorf("prefix is empty")
 	}
 

--- a/internal/fs/stat_bsd.go
+++ b/internal/fs/stat_bsd.go
@@ -4,7 +4,6 @@
 package fs
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 	"time"
@@ -12,10 +11,7 @@ import (
 
 // extendedStat extracts info into an ExtendedFileInfo for unix based operating systems.
 func extendedStat(fi os.FileInfo) ExtendedFileInfo {
-	s, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		panic(fmt.Sprintf("conversion to syscall.Stat_t failed, type is %T", fi.Sys()))
-	}
+	s := fi.Sys().(*syscall.Stat_t)
 
 	extFI := ExtendedFileInfo{
 		FileInfo:  fi,

--- a/internal/fs/stat_unix.go
+++ b/internal/fs/stat_unix.go
@@ -4,7 +4,6 @@
 package fs
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 	"time"
@@ -12,10 +11,7 @@ import (
 
 // extendedStat extracts info into an ExtendedFileInfo for unix based operating systems.
 func extendedStat(fi os.FileInfo) ExtendedFileInfo {
-	s, ok := fi.Sys().(*syscall.Stat_t)
-	if !ok {
-		panic(fmt.Sprintf("conversion to syscall.Stat_t failed, type is %T", fi.Sys()))
-	}
+	s := fi.Sys().(*syscall.Stat_t)
 
 	extFI := ExtendedFileInfo{
 		FileInfo:  fi,

--- a/internal/options/options.go
+++ b/internal/options/options.go
@@ -92,14 +92,10 @@ func (h helpList) Swap(i, j int) {
 
 // splitKeyValue splits at the first equals (=) sign.
 func splitKeyValue(s string) (key string, value string) {
-	data := strings.SplitN(s, "=", 2)
-	key = strings.ToLower(strings.TrimSpace(data[0]))
-	if len(data) == 1 {
-		// no equals sign is treated as the empty value
-		return key, ""
-	}
-
-	return key, strings.TrimSpace(data[1])
+	key, value, _ = strings.Cut(s, "=")
+	key = strings.ToLower(strings.TrimSpace(key))
+	value = strings.TrimSpace(value)
+	return key, value
 }
 
 // Parse takes a slice of key=value pairs and returns an Options type.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Removes some custom type checks from fs that the compiler can generate for us.

Replaces some strings.SplitN calls in backend and options that are better handled with strings.Cut. The code becomes shorter, with fewer generic "data" variables to hold intermediate slices. Also realigned the various backend spec parsers.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
