### PR TITLE
Replace ioutil usage

### DIFF
--- a/build.go
+++ b/build.go
@@ -43,7 +43,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -179,7 +178,7 @@ func test(cwd string, env map[string]string, args ...string) error {
 // getVersion returns the version string from the file VERSION in the current
 // directory.
 func getVersionFromFile() string {
-	buf, err := ioutil.ReadFile("VERSION")
+	buf, err := os.ReadFile("VERSION")
 	if err != nil {
 		verbosePrintf("error reading file VERSION: %v\n", err)
 		return ""

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -185,7 +184,7 @@ func readLines(filename string) ([]string, error) {
 	)
 
 	if filename == "-" {
-		data, err = ioutil.ReadAll(os.Stdin)
+		data, err = io.ReadAll(os.Stdin)
 	} else {
 		data, err = textfile.Read(filename)
 	}

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -2,8 +2,8 @@ package main
 
 import (
 	"context"
-	"io/ioutil"
 	"math/rand"
+	"os"
 	"strconv"
 	"strings"
 	"sync"
@@ -171,7 +171,7 @@ func prepareCheckCache(opts CheckOptions, gopts *GlobalOptions) (cleanup func())
 	}
 
 	// use a cache in a temporary directory
-	tempdir, err := ioutil.TempDir(cachedir, "restic-check-cache-")
+	tempdir, err := os.MkdirTemp(cachedir, "restic-check-cache-")
 	if err != nil {
 		// if an error occurs, don't use any cache
 		Warnf("unable to create temporary directory for cache during check, disabling cache: %v\n", err)

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
 	"os"
 	"strings"
 	"sync"
@@ -255,7 +254,7 @@ func runKey(ctx context.Context, gopts GlobalOptions, args []string) error {
 }
 
 func loadPasswordFromFile(pwdFile string) (string, error) {
-	s, err := ioutil.ReadFile(pwdFile)
+	s, err := os.ReadFile(pwdFile)
 	if os.IsNotExist(err) {
 		return "", errors.Fatalf("%s does not exist", pwdFile)
 	}

--- a/cmd/restic/exclude_test.go
+++ b/cmd/restic/exclude_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -89,13 +88,13 @@ func TestIsExcludedByFile(t *testing.T) {
 			defer cleanup()
 
 			foo := filepath.Join(tempDir, "foo")
-			err := ioutil.WriteFile(foo, []byte("foo"), 0666)
+			err := os.WriteFile(foo, []byte("foo"), 0666)
 			if err != nil {
 				t.Fatalf("could not write file: %v", err)
 			}
 			if tc.tagFile != "" {
 				tagFile := filepath.Join(tempDir, tc.tagFile)
-				err = ioutil.WriteFile(tagFile, []byte(tc.content), 0666)
+				err = os.WriteFile(tagFile, []byte(tc.content), 0666)
 				if err != nil {
 					t.Fatalf("could not write tagfile: %v", err)
 				}
@@ -150,7 +149,7 @@ func TestMultipleIsExcludedByFile(t *testing.T) {
 		// create directories first, then the file
 		p := filepath.Join(tempDir, filepath.FromSlash(f.path))
 		errs = append(errs, os.MkdirAll(filepath.Dir(p), 0700))
-		errs = append(errs, ioutil.WriteFile(p, []byte(f.path), 0600))
+		errs = append(errs, os.WriteFile(p, []byte(f.path), 0600))
 	}
 	test.OKs(t, errs) // see if anything went wrong during the creation
 

--- a/cmd/restic/flags_test.go
+++ b/cmd/restic/flags_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"io"
 	"testing"
 )
 
@@ -10,7 +10,7 @@ import (
 func TestFlags(t *testing.T) {
 	for _, cmd := range cmdRoot.Commands() {
 		t.Run(cmd.Name(), func(t *testing.T) {
-			cmd.Flags().SetOutput(ioutil.Discard)
+			cmd.Flags().SetOutput(io.Discard)
 			err := cmd.ParseFlags([]string{"--help"})
 			if err.Error() == "pflag: help requested" {
 				err = nil

--- a/cmd/restic/global_test.go
+++ b/cmd/restic/global_test.go
@@ -2,7 +2,7 @@ package main
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -43,7 +43,7 @@ func TestReadRepo(t *testing.T) {
 
 	// test --repository-file option
 	foo := filepath.Join(tempDir, "foo")
-	err = ioutil.WriteFile(foo, []byte(tempDir+"\n"), 0666)
+	err = os.WriteFile(foo, []byte(tempDir+"\n"), 0666)
 	rtest.OK(t, err)
 
 	var opts2 GlobalOptions

--- a/cmd/restic/integration_filter_pattern_test.go
+++ b/cmd/restic/integration_filter_pattern_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -39,7 +39,7 @@ func TestBackupFailsWhenUsingInvalidPatternsFromFile(t *testing.T) {
 
 	// Create an exclude file with some invalid patterns
 	excludeFile := env.base + "/excludefile"
-	fileErr := ioutil.WriteFile(excludeFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
+	fileErr := os.WriteFile(excludeFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
 	if fileErr != nil {
 		t.Fatalf("Could not write exclude file: %v", fileErr)
 	}

--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -174,7 +173,7 @@ func withTestEnvironment(t testing.TB) (env *testEnvironment, cleanup func()) {
 	restic.TestDisableCheckPolynomial(t)
 	retry.TestFastRetries(t)
 
-	tempdir, err := ioutil.TempDir(rtest.TestTempDir, "restic-test-")
+	tempdir, err := os.MkdirTemp(rtest.TestTempDir, "restic-test-")
 	rtest.OK(t, err)
 
 	env = &testEnvironment{

--- a/cmd/restic/integration_helpers_unix_test.go
+++ b/cmd/restic/integration_helpers_unix_test.go
@@ -6,7 +6,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -57,7 +56,7 @@ func nlink(info os.FileInfo) uint64 {
 func createFileSetPerHardlink(dir string) map[uint64][]string {
 	var stat syscall.Stat_t
 	linkTests := make(map[uint64][]string)
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil
 	}

--- a/cmd/restic/integration_helpers_windows_test.go
+++ b/cmd/restic/integration_helpers_windows_test.go
@@ -6,7 +6,6 @@ package main
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -39,7 +38,7 @@ func inode(info os.FileInfo) uint64 {
 
 func createFileSetPerHardlink(dir string) map[uint64][]string {
 	linkTests := make(map[uint64][]string)
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil
 	}

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	mrand "math/rand"
 	"os"
 	"path/filepath"
@@ -65,7 +64,7 @@ func testRunBackupAssumeFailure(t testing.TB, dir string, target []string, opts 
 	term := termstatus.New(gopts.stdout, gopts.stderr, gopts.Quiet)
 	wg.Go(func() error { term.Run(ctx); return nil })
 
-	gopts.stdout = ioutil.Discard
+	gopts.stdout = io.Discard
 	t.Logf("backing up %v in %v", target, dir)
 	if dir != "" {
 		cleanup := rtest.Chdir(t, dir)
@@ -183,7 +182,7 @@ func testRunDiffOutput(gopts GlobalOptions, firstSnapshotID string, secondSnapsh
 }
 
 func testRunRebuildIndex(t testing.TB, gopts GlobalOptions) {
-	globalOptions.stdout = ioutil.Discard
+	globalOptions.stdout = io.Discard
 	defer func() {
 		globalOptions.stdout = os.Stdout
 	}()
@@ -419,7 +418,7 @@ func TestBackupNonExistingFile(t *testing.T) {
 	defer cleanup()
 
 	testSetupBackupData(t, env)
-	globalOptions.stderr = ioutil.Discard
+	globalOptions.stderr = io.Discard
 	defer func() {
 		globalOptions.stderr = os.Stderr
 	}()
@@ -641,7 +640,7 @@ func TestBackupErrors(t *testing.T) {
 	}()
 	opts := BackupOptions{}
 	gopts := env.gopts
-	gopts.stderr = ioutil.Discard
+	gopts.stderr = io.Discard
 	err := testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"testdata"}, opts, gopts)
 	rtest.Assert(t, err != nil, "Assumed failure, but no error occurred.")
 	rtest.Assert(t, err == ErrInvalidSourceData, "Wrong error returned")
@@ -1243,7 +1242,7 @@ func TestRestoreLatest(t *testing.T) {
 	opts := BackupOptions{}
 
 	// chdir manually here so we can get the current directory. This is not the
-	// same as the temp dir returned by ioutil.TempDir() on darwin.
+	// same as the temp dir returned by os.MkdirTemp() on darwin.
 	back := rtest.Chdir(t, filepath.Dir(env.testdata))
 	defer back()
 
@@ -1308,7 +1307,7 @@ func TestRestoreWithPermissionFailure(t *testing.T) {
 	rtest.Assert(t, len(snapshots) > 0,
 		"no snapshots found in repo (%v)", datafile)
 
-	globalOptions.stderr = ioutil.Discard
+	globalOptions.stderr = io.Discard
 	defer func() {
 		globalOptions.stderr = os.Stderr
 	}()
@@ -1542,7 +1541,7 @@ func TestRebuildIndexFailsOnAppendOnly(t *testing.T) {
 	datafile := filepath.Join("..", "..", "internal", "checker", "testdata", "duplicate-packs-in-index-test-repo.tar.gz")
 	rtest.SetupTarTestFixture(t, env.base, datafile)
 
-	globalOptions.stdout = ioutil.Discard
+	globalOptions.stdout = io.Discard
 	defer func() {
 		globalOptions.stdout = os.Stdout
 	}()

--- a/cmd/restic/secondary_repo_test.go
+++ b/cmd/restic/secondary_repo_test.go
@@ -1,7 +1,7 @@
 package main
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -167,7 +167,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 	defer cleanup()
 
 	//Create temporary password file
-	err := ioutil.WriteFile(filepath.Join(dir, "passwordFileDst"), []byte("secretDst"), 0666)
+	err := os.WriteFile(filepath.Join(dir, "passwordFileDst"), []byte("secretDst"), 0666)
 	rtest.OK(t, err)
 
 	// Test all valid cases

--- a/helpers/prepare-release/main.go
+++ b/helpers/prepare-release/main.go
@@ -73,13 +73,13 @@ func run(cmd string, args ...string) {
 func replace(filename, from, to string) {
 	reg := regexp.MustCompile(from)
 
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	if err != nil {
 		die("error reading file %v: %v", filename, err)
 	}
 
 	buf = reg.ReplaceAll(buf, []byte(to))
-	err = ioutil.WriteFile(filename, buf, 0644)
+	err = os.WriteFile(filename, buf, 0644)
 	if err != nil {
 		die("error writing file %v: %v", filename, err)
 	}
@@ -308,7 +308,7 @@ var versionPattern = `var version = ".*"`
 const versionCodeFile = "cmd/restic/global.go"
 
 func updateVersion() {
-	err := ioutil.WriteFile("VERSION", []byte(opts.Version+"\n"), 0644)
+	err := os.WriteFile("VERSION", []byte(opts.Version+"\n"), 0644)
 	if err != nil {
 		die("unable to write version to file: %v", err)
 	}
@@ -420,7 +420,7 @@ func updateDocker(outputDir, version string) {
 }
 
 func tempdir(prefix string) string {
-	dir, err := ioutil.TempDir(getwd(), prefix)
+	dir, err := os.MkdirTemp(getwd(), prefix)
 	if err != nil {
 		die("unable to create temp dir %q: %v", prefix, err)
 	}

--- a/helpers/prepare-release/main.go
+++ b/helpers/prepare-release/main.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -366,7 +365,7 @@ func runBuild(sourceDir, outputDir, version string) {
 }
 
 func readdir(dir string) []string {
-	fis, err := ioutil.ReadDir(dir)
+	fis, err := os.ReadDir(dir)
 	if err != nil {
 		die("readdir %v failed: %v", dir, err)
 	}

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -189,7 +188,7 @@ func TestArchiverSaveFileReaderFS(t *testing.T) {
 				ModTime:    ts,
 				Mode:       0123,
 				Name:       filename,
-				ReadCloser: ioutil.NopCloser(strings.NewReader(test.Data)),
+				ReadCloser: io.NopCloser(strings.NewReader(test.Data)),
 			}
 
 			node, stats := saveFile(t, repo, filename, readerFs)
@@ -304,7 +303,7 @@ func TestArchiverSaveReaderFS(t *testing.T) {
 				ModTime:    ts,
 				Mode:       0123,
 				Name:       filename,
-				ReadCloser: ioutil.NopCloser(strings.NewReader(test.Data)),
+				ReadCloser: io.NopCloser(strings.NewReader(test.Data)),
 			}
 
 			arch := New(repo, readerFs, Options{})

--- a/internal/archiver/file_saver_test.go
+++ b/internal/archiver/file_saver_test.go
@@ -3,7 +3,6 @@ package archiver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -21,7 +20,7 @@ func createTestFiles(t testing.TB, num int) (files []string, cleanup func()) {
 
 	for i := 0; i < 15; i++ {
 		filename := fmt.Sprintf("testfile-%d", i)
-		err := ioutil.WriteFile(filepath.Join(tempdir, filename), []byte(filename), 0600)
+		err := os.WriteFile(filepath.Join(tempdir, filename), []byte(filename), 0600)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/archiver/testing.go
+++ b/internal/archiver/testing.go
@@ -2,7 +2,6 @@ package archiver
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -73,7 +72,7 @@ func TestCreateFiles(t testing.TB, target string, dir TestDir) {
 
 		switch it := item.(type) {
 		case TestFile:
-			err := ioutil.WriteFile(targetPath, []byte(it.Content), 0644)
+			err := os.WriteFile(targetPath, []byte(it.Content), 0644)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -152,7 +151,7 @@ func TestEnsureFiles(t testing.TB, target string, dir TestDir) {
 				return nil
 			}
 
-			content, err := ioutil.ReadFile(path)
+			content, err := os.ReadFile(path)
 			if err != nil {
 				return err
 			}

--- a/internal/archiver/testing_test.go
+++ b/internal/archiver/testing_test.go
@@ -3,7 +3,6 @@ package archiver
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -62,7 +61,7 @@ func createFilesAt(t testing.TB, targetdir string, files map[string]interface{})
 
 		switch it := item.(type) {
 		case TestFile:
-			err := ioutil.WriteFile(target, []byte(it.Content), 0600)
+			err := os.WriteFile(target, []byte(it.Content), 0600)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -129,7 +128,7 @@ func TestTestCreateFiles(t *testing.T) {
 						continue
 					}
 
-					content, err := ioutil.ReadFile(targetPath)
+					content, err := os.ReadFile(targetPath)
 					if err != nil {
 						t.Error(err)
 						continue

--- a/internal/backend/dryrun/dry_backend_test.go
+++ b/internal/backend/dryrun/dry_backend_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"sort"
 	"strings"
 	"testing"
@@ -109,7 +108,7 @@ func TestDry(t *testing.T) {
 		case "load":
 			data := ""
 			err = step.be.Load(ctx, handle, 100, 0, func(rd io.Reader) error {
-				buf, err := ioutil.ReadAll(rd)
+				buf, err := io.ReadAll(rd)
 				data = string(buf)
 				return err
 			})

--- a/internal/backend/http_transport.go
+++ b/internal/backend/http_transport.go
@@ -4,9 +4,9 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"net"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -30,7 +30,7 @@ type TransportOptions struct {
 // readPEMCertKey reads a file and returns the PEM encoded certificate and key
 // blocks.
 func readPEMCertKey(filename string) (certs []byte, key []byte, err error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, nil, errors.Wrap(err, "ReadFile")
 	}
@@ -105,7 +105,7 @@ func Transport(opts TransportOptions) (http.RoundTripper, error) {
 			if filename == "" {
 				return nil, errors.Errorf("empty filename for root certificate supplied")
 			}
-			b, err := ioutil.ReadFile(filename)
+			b, err := os.ReadFile(filename)
 			if err != nil {
 				return nil, errors.Errorf("unable to read root certificate: %v", err)
 			}

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"hash"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -209,7 +208,7 @@ func (b *Local) Save(ctx context.Context, h restic.Handle, rd restic.RewindReade
 	return nil
 }
 
-var tempFile = ioutil.TempFile // Overridden by test.
+var tempFile = os.CreateTemp // Overridden by test.
 
 // Load runs fn with a reader that yields the contents of the file at h at the
 // given offset.

--- a/internal/backend/local/local_test.go
+++ b/internal/backend/local/local_test.go
@@ -2,7 +2,6 @@ package local_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -17,7 +16,7 @@ func newTestSuite(t testing.TB) *test.Suite {
 	return &test.Suite{
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
 		NewConfig: func() (interface{}, error) {
-			dir, err := ioutil.TempDir(rtest.TestTempDir, "restic-test-local-")
+			dir, err := os.MkdirTemp(rtest.TestTempDir, "restic-test-local-")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -6,7 +6,6 @@ import (
 	"encoding/base64"
 	"hash"
 	"io"
-	"io/ioutil"
 	"sync"
 
 	"github.com/cespare/xxhash/v2"
@@ -96,7 +95,7 @@ func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd restic.Re
 		return errors.New("file already exists")
 	}
 
-	buf, err := ioutil.ReadAll(rd)
+	buf, err := io.ReadAll(rd)
 	if err != nil {
 		return err
 	}
@@ -168,7 +167,7 @@ func (be *MemoryBackend) openReader(ctx context.Context, h restic.Handle, length
 		buf = buf[:length]
 	}
 
-	return be.sem.ReleaseTokenOnClose(ioutil.NopCloser(bytes.NewReader(buf)), nil), ctx.Err()
+	return be.sem.ReleaseTokenOnClose(io.NopCloser(bytes.NewReader(buf)), nil), ctx.Err()
 }
 
 // Stat returns information about a file in the backend.

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/url"
 	"path"
@@ -89,7 +88,7 @@ func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (*Backend, er
 		return nil, errors.Fatalf("server response unexpected: %v (%v)", resp.Status, resp.StatusCode)
 	}
 
-	_, err = io.Copy(ioutil.Discard, resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +132,7 @@ func (b *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRea
 
 	// make sure that client.Post() cannot close the reader by wrapping it
 	req, err := http.NewRequestWithContext(ctx,
-		http.MethodPost, b.Filename(h), ioutil.NopCloser(rd))
+		http.MethodPost, b.Filename(h), io.NopCloser(rd))
 	if err != nil {
 		return errors.WithStack(err)
 	}
@@ -150,7 +149,7 @@ func (b *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRea
 
 	var cerr error
 	if resp != nil {
-		_, _ = io.Copy(ioutil.Discard, resp.Body)
+		_, _ = io.Copy(io.Discard, resp.Body)
 		cerr = resp.Body.Close()
 	}
 
@@ -245,7 +244,7 @@ func (b *Backend) openReader(ctx context.Context, h restic.Handle, length int, o
 
 	if err != nil {
 		if resp != nil {
-			_, _ = io.Copy(ioutil.Discard, resp.Body)
+			_, _ = io.Copy(io.Discard, resp.Body)
 			_ = resp.Body.Close()
 		}
 		return nil, errors.Wrap(err, "client.Do")
@@ -283,7 +282,7 @@ func (b *Backend) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, e
 		return restic.FileInfo{}, errors.WithStack(err)
 	}
 
-	_, _ = io.Copy(ioutil.Discard, resp.Body)
+	_, _ = io.Copy(io.Discard, resp.Body)
 	if err = resp.Body.Close(); err != nil {
 		return restic.FileInfo{}, errors.Wrap(err, "Close")
 	}
@@ -348,7 +347,7 @@ func (b *Backend) Remove(ctx context.Context, h restic.Handle) error {
 		return errors.Errorf("blob not removed, server response: %v (%v)", resp.Status, resp.StatusCode)
 	}
 
-	_, err = io.Copy(ioutil.Discard, resp.Body)
+	_, err = io.Copy(io.Discard, resp.Body)
 	if err != nil {
 		return errors.Wrap(err, "Copy")
 	}

--- a/internal/backend/retry/backend_retry_test.go
+++ b/internal/backend/retry/backend_retry_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -22,7 +21,7 @@ func TestBackendSaveRetry(t *testing.T) {
 		SaveFn: func(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 			if errcount == 0 {
 				errcount++
-				_, err := io.CopyN(ioutil.Discard, rd, 120)
+				_, err := io.CopyN(io.Discard, rd, 120)
 				if err != nil {
 					return err
 				}
@@ -267,7 +266,7 @@ func TestBackendLoadRetry(t *testing.T) {
 
 	var buf []byte
 	err := retryBackend.Load(context.TODO(), restic.Handle{}, 0, 0, func(rd io.Reader) (err error) {
-		buf, err = ioutil.ReadAll(rd)
+		buf, err = io.ReadAll(rd)
 		return err
 	})
 	test.OK(t, err)

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"hash"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -296,7 +295,7 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 	opts.PartSize = 200 * 1024 * 1024
 
 	debug.Log("PutObject(%v, %v, %v)", be.cfg.Bucket, objName, rd.Length())
-	info, err := be.client.PutObject(ctx, be.cfg.Bucket, objName, ioutil.NopCloser(rd), int64(rd.Length()), opts)
+	info, err := be.client.PutObject(ctx, be.cfg.Bucket, objName, io.NopCloser(rd), int64(rd.Length()), opts)
 
 	debug.Log("%v -> %v bytes, err %#v: %v", objName, info.Size, err, err)
 

--- a/internal/backend/sftp/sftp_test.go
+++ b/internal/backend/sftp/sftp_test.go
@@ -3,7 +3,6 @@ package sftp_test
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -34,7 +33,7 @@ func newTestSuite(t testing.TB) *test.Suite {
 	return &test.Suite{
 		// NewConfig returns a config for a new temporary backend that will be used in tests.
 		NewConfig: func() (interface{}, error) {
-			dir, err := ioutil.TempDir(rtest.TestTempDir, "restic-test-sftp-")
+			dir, err := os.MkdirTemp(rtest.TestTempDir, "restic-test-sftp-")
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"reflect"
@@ -148,7 +147,7 @@ func (s *Suite) TestLoad(t *testing.T) {
 	}
 
 	err = b.Load(context.TODO(), handle, 0, 0, func(rd io.Reader) error {
-		_, err := io.Copy(ioutil.Discard, rd)
+		_, err := io.Copy(io.Discard, rd)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -189,7 +188,7 @@ func (s *Suite) TestLoad(t *testing.T) {
 
 		var buf []byte
 		err := b.Load(context.TODO(), handle, getlen, int64(o), func(rd io.Reader) (ierr error) {
-			buf, ierr = ioutil.ReadAll(rd)
+			buf, ierr = io.ReadAll(rd)
 			return ierr
 		})
 		if err != nil {
@@ -522,7 +521,7 @@ func (s *Suite) TestSave(t *testing.T) {
 	}
 
 	// test saving from a tempfile
-	tmpfile, err := ioutil.TempFile("", "restic-backend-save-test-")
+	tmpfile, err := os.CreateTemp("", "restic-backend-save-test-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -678,7 +677,7 @@ func store(t testing.TB, b restic.Backend, tpe restic.FileType, data []byte) res
 // testLoad loads a blob (but discards its contents).
 func testLoad(b restic.Backend, h restic.Handle, length int, offset int64) error {
 	return b.Load(context.TODO(), h, 0, 0, func(rd io.Reader) (ierr error) {
-		_, ierr = io.Copy(ioutil.Discard, rd)
+		_, ierr = io.Copy(io.Discard, rd)
 		return ierr
 	})
 }

--- a/internal/backend/utils_test.go
+++ b/internal/backend/utils_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"testing"
 
@@ -79,7 +78,7 @@ func TestLoadAllBroken(t *testing.T) {
 	data[0] ^= 0xff
 
 	b.OpenReaderFn = func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-		return ioutil.NopCloser(bytes.NewReader(data)), nil
+		return io.NopCloser(bytes.NewReader(data)), nil
 	}
 
 	// must fail on first try

--- a/internal/cache/backend_test.go
+++ b/internal/cache/backend_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"sync"
 	"testing"
@@ -203,7 +202,7 @@ func TestBackendRemoveBroken(t *testing.T) {
 		_ = rd.Close()
 	}()
 	test.OK(t, err)
-	cached, err := ioutil.ReadAll(rd)
+	cached, err := io.ReadAll(rd)
 	test.OK(t, err)
 	if !bytes.Equal(cached, data) {
 		t.Fatalf("wrong data cache")

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -26,7 +25,7 @@ const dirMode = 0700
 const fileMode = 0644
 
 func readVersion(dir string) (v uint, err error) {
-	buf, err := ioutil.ReadFile(filepath.Join(dir, "version"))
+	buf, err := os.ReadFile(filepath.Join(dir, "version"))
 	if errors.Is(err, os.ErrNotExist) {
 		return 0, nil
 	}
@@ -130,7 +129,7 @@ func New(id string, basedir string) (c *Cache, err error) {
 	}
 
 	if v < cacheVersion {
-		err = ioutil.WriteFile(filepath.Join(cachedir, "version"), []byte(fmt.Sprintf("%d", cacheVersion)), fileMode)
+		err = os.WriteFile(filepath.Join(cachedir, "version"), []byte(fmt.Sprintf("%d", cacheVersion)), fileMode)
 		if err != nil {
 			return nil, errors.WithStack(err)
 		}

--- a/internal/cache/file.go
+++ b/internal/cache/file.go
@@ -2,7 +2,6 @@ package cache
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -106,7 +105,7 @@ func (c *Cache) Save(h restic.Handle, rd io.Reader) error {
 
 	// First save to a temporary location. This allows multiple concurrent
 	// restics to use a single cache dir.
-	f, err := ioutil.TempFile(dir, "tmp-")
+	f, err := os.CreateTemp(dir, "tmp-")
 	if err != nil {
 		return err
 	}

--- a/internal/cache/file_test.go
+++ b/internal/cache/file_test.go
@@ -3,7 +3,7 @@ package cache
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"runtime"
@@ -55,7 +55,7 @@ func load(t testing.TB, c *Cache, h restic.Handle) []byte {
 		t.Fatalf("load() returned nil reader")
 	}
 
-	buf, err := ioutil.ReadAll(rd)
+	buf, err := io.ReadAll(rd)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -174,7 +174,7 @@ func TestFileLoad(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			buf, err := ioutil.ReadAll(rd)
+			buf, err := io.ReadAll(rd)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -258,7 +258,7 @@ func TestFileSaveConcurrent(t *testing.T) {
 			}
 			defer func() { _ = f.Close() }()
 
-			read, err := ioutil.ReadAll(f)
+			read, err := io.ReadAll(f)
 			if err == nil && !bytes.Equal(read, data) {
 				err = errors.New("mismatch between Save and Load")
 			}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"runtime"
 	"sort"
 	"sync"
@@ -556,7 +555,7 @@ func checkPack(ctx context.Context, r restic.Repository, id restic.ID, blobs []r
 			}
 
 			// read remainder, which should be the pack header
-			hdrBuf, err = ioutil.ReadAll(bufRd)
+			hdrBuf, err = io.ReadAll(bufRd)
 			if err != nil {
 				return err
 			}

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -3,7 +3,6 @@ package checker_test
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -208,7 +207,7 @@ func TestModifiedIndex(t *testing.T) {
 		Name: "90f838b4ac28735fda8644fe6a08dbc742e57aaf81b30977b4fefa357010eafd",
 	}
 
-	tmpfile, err := ioutil.TempFile("", "restic-test-mod-index-")
+	tmpfile, err := os.CreateTemp("", "restic-test-mod-index-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/debug/round_tripper.go
+++ b/internal/debug/round_tripper.go
@@ -3,7 +3,6 @@ package debug
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -30,7 +29,7 @@ func (rd *eofDetectReader) Read(p []byte) (n int, err error) {
 
 func (rd *eofDetectReader) Close() error {
 	if !rd.eofSeen {
-		buf, err := ioutil.ReadAll(rd)
+		buf, err := io.ReadAll(rd)
 		msg := fmt.Sprintf("body not drained, %d bytes not read", len(buf))
 		if err != nil {
 			msg += fmt.Sprintf(", error: %v", err)

--- a/internal/dump/tar_test.go
+++ b/internal/dump/tar_test.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -91,7 +90,7 @@ func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {
 			if match.Size() != hdr.Size {
 				return fmt.Errorf("size does not match got %v want %v", hdr.Size, match.Size())
 			}
-			contentsFile, err := ioutil.ReadFile(matchPath)
+			contentsFile, err := os.ReadFile(matchPath)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/dump/zip_test.go
+++ b/internal/dump/zip_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/zip"
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -107,7 +106,7 @@ func checkZip(t *testing.T, testDir string, srcZip *bytes.Buffer) error {
 			if uint64(match.Size()) != f.UncompressedSize64 {
 				return fmt.Errorf("size does not match got %v want %v", f.UncompressedSize64, match.Size())
 			}
-			contentsFile, err := ioutil.ReadFile(matchPath)
+			contentsFile, err := os.ReadFile(matchPath)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/fs/file_unix.go
+++ b/internal/fs/file_unix.go
@@ -4,7 +4,6 @@
 package fs
 
 import (
-	"io/ioutil"
 	"os"
 	"syscall"
 )
@@ -18,7 +17,7 @@ func fixpath(name string) string {
 // TempFile creates a temporary file which has already been deleted (on
 // supported platforms)
 func TempFile(dir, prefix string) (f *os.File, err error) {
-	f, err = ioutil.TempFile(dir, prefix)
+	f, err = os.CreateTemp(dir, prefix)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/fs/file_windows.go
+++ b/internal/fs/file_windows.go
@@ -36,7 +36,7 @@ func fixpath(name string) string {
 
 // TempFile creates a temporary file which is marked as delete-on-close
 func TempFile(dir, prefix string) (f *os.File, err error) {
-	// slightly modified implementation of ioutil.TempFile(dir, prefix) to allow us to add
+	// slightly modified implementation of os.CreateTemp(dir, prefix) to allow us to add
 	// the FILE_ATTRIBUTE_TEMPORARY | FILE_FLAG_DELETE_ON_CLOSE flags.
 	// These provide two large benefits:
 	// FILE_ATTRIBUTE_TEMPORARY tells Windows to keep the file in memory only if possible

--- a/internal/fs/fs_reader_test.go
+++ b/internal/fs/fs_reader_test.go
@@ -2,7 +2,7 @@ package fs
 
 import (
 	"bytes"
-	"io/ioutil"
+	"io"
 	"os"
 	"path"
 	"sort"
@@ -20,7 +20,7 @@ func verifyFileContentOpen(t testing.TB, fs FS, filename string, want []byte) {
 		t.Fatal(err)
 	}
 
-	buf, err := ioutil.ReadAll(f)
+	buf, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +41,7 @@ func verifyFileContentOpenFile(t testing.TB, fs FS, filename string, want []byte
 		t.Fatal(err)
 	}
 
-	buf, err := ioutil.ReadAll(f)
+	buf, err := io.ReadAll(f)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -320,7 +320,7 @@ func TestFSReader(t *testing.T) {
 	for _, test := range tests {
 		fs := &Reader{
 			Name:       filename,
-			ReadCloser: ioutil.NopCloser(bytes.NewReader(data)),
+			ReadCloser: io.NopCloser(bytes.NewReader(data)),
 
 			Mode:    0644,
 			Size:    int64(len(data)),
@@ -355,7 +355,7 @@ func TestFSReaderDir(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fs := &Reader{
 				Name:       test.filename,
-				ReadCloser: ioutil.NopCloser(bytes.NewReader(data)),
+				ReadCloser: io.NopCloser(bytes.NewReader(data)),
 
 				Mode:    0644,
 				Size:    int64(len(data)),
@@ -410,7 +410,7 @@ func TestFSReaderMinFileSize(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			fs := &Reader{
 				Name:           "testfile",
-				ReadCloser:     ioutil.NopCloser(strings.NewReader(test.data)),
+				ReadCloser:     io.NopCloser(strings.NewReader(test.data)),
 				Mode:           0644,
 				ModTime:        time.Now(),
 				AllowEmptyFile: test.allowEmpty,
@@ -421,7 +421,7 @@ func TestFSReaderMinFileSize(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			buf, err := ioutil.ReadAll(f)
+			buf, err := io.ReadAll(f)
 			if test.readMustErr {
 				if err == nil {
 					t.Fatal("expected error not found, got nil")

--- a/internal/fs/setflags_linux_test.go
+++ b/internal/fs/setflags_linux_test.go
@@ -2,7 +2,6 @@ package fs
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"testing"
 	"time"
@@ -13,7 +12,7 @@ import (
 )
 
 func TestNoatime(t *testing.T) {
-	f, err := ioutil.TempFile("", "restic-test-noatime")
+	f, err := os.CreateTemp("", "restic-test-noatime")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/fs/stat_test.go
+++ b/internal/fs/stat_test.go
@@ -1,7 +1,7 @@
 package fs
 
 import (
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 
@@ -13,7 +13,7 @@ func TestExtendedStat(t *testing.T) {
 	defer cleanup()
 
 	filename := filepath.Join(tempdir, "file")
-	err := ioutil.WriteFile(filename, []byte("foobar"), 0640)
+	err := os.WriteFile(filename, []byte("foobar"), 0640)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/hashing/reader_test.go
+++ b/internal/hashing/reader_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"io"
-	"io/ioutil"
 	"testing"
 )
 
@@ -22,7 +21,7 @@ func TestReader(t *testing.T) {
 		expectedHash := sha256.Sum256(data)
 
 		rd := NewReader(bytes.NewReader(data), sha256.New())
-		n, err := io.Copy(ioutil.Discard, rd)
+		n, err := io.Copy(io.Discard, rd)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -54,7 +53,7 @@ func BenchmarkReader(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		rd := NewReader(bytes.NewReader(buf), sha256.New())
-		n, err := io.Copy(ioutil.Discard, rd)
+		n, err := io.Copy(io.Discard, rd)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/internal/hashing/writer_test.go
+++ b/internal/hashing/writer_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"io"
-	"io/ioutil"
 	"testing"
 )
 
@@ -21,7 +20,7 @@ func TestWriter(t *testing.T) {
 
 		expectedHash := sha256.Sum256(data)
 
-		wr := NewWriter(ioutil.Discard, sha256.New())
+		wr := NewWriter(io.Discard, sha256.New())
 
 		n, err := io.Copy(wr, bytes.NewReader(data))
 		if err != nil {
@@ -54,7 +53,7 @@ func BenchmarkWriter(b *testing.B) {
 	b.SetBytes(int64(len(buf)))
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		wr := NewWriter(ioutil.Discard, sha256.New())
+		wr := NewWriter(io.Discard, sha256.New())
 		n, err := io.Copy(wr, bytes.NewReader(buf))
 		if err != nil {
 			b.Fatal(err)

--- a/internal/migrations/upgrade_repo_v2.go
+++ b/internal/migrations/upgrade_repo_v2.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -81,7 +80,7 @@ func (*UpgradeRepoV2) upgrade(ctx context.Context, repo restic.Repository) error
 }
 
 func (m *UpgradeRepoV2) Apply(ctx context.Context, repo restic.Repository) error {
-	tempdir, err := ioutil.TempDir("", "restic-migrate-upgrade-repo-v2-")
+	tempdir, err := os.MkdirTemp("", "restic-migrate-upgrade-repo-v2-")
 	if err != nil {
 		return fmt.Errorf("create temp dir failed: %w", err)
 	}
@@ -91,7 +90,7 @@ func (m *UpgradeRepoV2) Apply(ctx context.Context, repo restic.Repository) error
 	// read raw config file and save it to a temp dir, just in case
 	var rawConfigFile []byte
 	err = repo.Backend().Load(ctx, h, 0, 0, func(rd io.Reader) (err error) {
-		rawConfigFile, err = ioutil.ReadAll(rd)
+		rawConfigFile, err = io.ReadAll(rd)
 		return err
 	})
 	if err != nil {
@@ -99,7 +98,7 @@ func (m *UpgradeRepoV2) Apply(ctx context.Context, repo restic.Repository) error
 	}
 
 	backupFileName := filepath.Join(tempdir, "config")
-	err = ioutil.WriteFile(backupFileName, rawConfigFile, 0600)
+	err = os.WriteFile(backupFileName, rawConfigFile, 0600)
 	if err != nil {
 		return fmt.Errorf("write config file backup to %v failed: %w", tempdir, err)
 	}

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -4,7 +4,6 @@ import (
 	"bufio"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"runtime"
 	"sync"
@@ -151,7 +150,7 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packe
 	}
 
 	hr := hashing.NewReader(rd, sha256.New())
-	_, err = io.Copy(ioutil.Discard, hr)
+	_, err = io.Copy(io.Discard, hr)
 	if err != nil {
 		return err
 	}

--- a/internal/restic/node_test.go
+++ b/internal/restic/node_test.go
@@ -2,7 +2,6 @@ package restic_test
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -14,7 +13,7 @@ import (
 )
 
 func BenchmarkNodeFillUser(t *testing.B) {
-	tempfile, err := ioutil.TempFile("", "restic-test-temp-")
+	tempfile, err := os.CreateTemp("", "restic-test-temp-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +37,7 @@ func BenchmarkNodeFillUser(t *testing.B) {
 }
 
 func BenchmarkNodeFromFileInfo(t *testing.B) {
-	tempfile, err := ioutil.TempFile("", "restic-test-temp-")
+	tempfile, err := os.CreateTemp("", "restic-test-temp-")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -167,7 +166,7 @@ var nodeTests = []restic.Node{
 }
 
 func TestNodeRestoreAt(t *testing.T) {
-	tempdir, err := ioutil.TempDir(rtest.TestTempDir, "restic-test-")
+	tempdir, err := os.MkdirTemp(rtest.TestTempDir, "restic-test-")
 	rtest.OK(t, err)
 
 	defer func() {

--- a/internal/restic/rewind_reader_test.go
+++ b/internal/restic/rewind_reader_test.go
@@ -5,7 +5,6 @@ import (
 	"crypto/md5"
 	"hash"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -32,7 +31,7 @@ func TestFileReader(t *testing.T) {
 	defer cleanup()
 
 	filename := filepath.Join(d, "file-reader-test")
-	err := ioutil.WriteFile(filename, buf, 0600)
+	err := os.WriteFile(filename, buf, 0600)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/restic/snapshot_policy_test.go
+++ b/internal/restic/snapshot_policy_test.go
@@ -3,7 +3,7 @@ package restic_test
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 	"testing"
 	"time"
@@ -61,7 +61,7 @@ type ApplyPolicyResult struct {
 }
 
 func loadGoldenFile(t testing.TB, filename string) (res ApplyPolicyResult) {
-	buf, err := ioutil.ReadFile(filename)
+	buf, err := os.ReadFile(filename)
 	if err != nil {
 		t.Fatalf("error loading golden file %v: %v", filename, err)
 	}
@@ -85,7 +85,7 @@ func saveGoldenFile(t testing.TB, filename string, keep restic.Snapshots, reason
 		t.Fatalf("error marshaling result: %v", err)
 	}
 
-	if err = ioutil.WriteFile(filename, buf, 0644); err != nil {
+	if err = os.WriteFile(filename, buf, 0644); err != nil {
 		t.Fatalf("unable to update golden file: %v", err)
 	}
 }

--- a/internal/restic/tree_test.go
+++ b/internal/restic/tree_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -27,7 +26,7 @@ var testFiles = []struct {
 }
 
 func createTempDir(t *testing.T) string {
-	tempdir, err := ioutil.TempDir(rtest.TestTempDir, "restic-test-")
+	tempdir, err := os.MkdirTemp(rtest.TestTempDir, "restic-test-")
 	rtest.OK(t, err)
 
 	for _, test := range testFiles {

--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/restic/restic/internal/crypto"
@@ -171,7 +171,7 @@ func restoreAndVerify(t *testing.T, tempdir string, content []TestFile, files ma
 func verifyRestore(t *testing.T, r *fileRestorer, repo *TestRepo) {
 	for _, file := range r.files {
 		target := r.targetPath(file.location)
-		data, err := ioutil.ReadFile(target)
+		data, err := os.ReadFile(target)
 		if err != nil {
 			t.Errorf("unable to read file %v: %v", file.location, err)
 			continue

--- a/internal/restorer/fileswriter_test.go
+++ b/internal/restorer/fileswriter_test.go
@@ -1,7 +1,7 @@
 package restorer
 
 import (
-	"io/ioutil"
+	"os"
 	"testing"
 
 	rtest "github.com/restic/restic/internal/test"
@@ -28,11 +28,11 @@ func TestFilesWriterBasic(t *testing.T) {
 	rtest.OK(t, w.writeToFile(f2, []byte{2}, 1, -1, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 
-	buf, err := ioutil.ReadFile(f1)
+	buf, err := os.ReadFile(f1)
 	rtest.OK(t, err)
 	rtest.Equals(t, []byte{1, 1}, buf)
 
-	buf, err = ioutil.ReadFile(f2)
+	buf, err = os.ReadFile(f2)
 	rtest.OK(t, err)
 	rtest.Equals(t, []byte{2, 2}, buf)
 }

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -3,7 +3,7 @@ package restorer
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"math"
 	"os"
 	"path/filepath"
@@ -401,7 +401,7 @@ func TestRestorer(t *testing.T) {
 			}
 
 			for filename, content := range test.Files {
-				data, err := ioutil.ReadFile(filepath.Join(tempdir, filepath.FromSlash(filename)))
+				data, err := os.ReadFile(filepath.Join(tempdir, filepath.FromSlash(filename)))
 				if err != nil {
 					t.Errorf("unable to read file %v: %v", filename, err)
 					continue
@@ -477,7 +477,7 @@ func TestRestorerRelative(t *testing.T) {
 			}
 
 			for filename, content := range test.Files {
-				data, err := ioutil.ReadFile(filepath.Join(tempdir, "restore", filepath.FromSlash(filename)))
+				data, err := os.ReadFile(filepath.Join(tempdir, "restore", filepath.FromSlash(filename)))
 				if err != nil {
 					t.Errorf("unable to read file %v: %v", filename, err)
 					continue
@@ -825,7 +825,7 @@ func TestVerifyCancel(t *testing.T) {
 	defer cancel()
 
 	rtest.OK(t, res.RestoreTo(ctx, tempdir))
-	err := ioutil.WriteFile(filepath.Join(tempdir, "foo"), []byte("bar"), 0644)
+	err := os.WriteFile(filepath.Join(tempdir, "foo"), []byte("bar"), 0644)
 	rtest.OK(t, err)
 
 	var errs []error
@@ -850,7 +850,7 @@ func TestRestorerSparseFiles(t *testing.T) {
 	target := &fs.Reader{
 		Mode:       0600,
 		Name:       "/zeros",
-		ReadCloser: ioutil.NopCloser(bytes.NewReader(zeros[:])),
+		ReadCloser: io.NopCloser(bytes.NewReader(zeros[:])),
 	}
 	sc := archiver.NewScanner(target)
 	err := sc.Scan(context.TODO(), []string{"/zeros"})
@@ -873,7 +873,7 @@ func TestRestorerSparseFiles(t *testing.T) {
 	rtest.OK(t, err)
 
 	filename := filepath.Join(tempdir, "zeros")
-	content, err := ioutil.ReadFile(filename)
+	content, err := os.ReadFile(filename)
 	rtest.OK(t, err)
 
 	rtest.Equals(t, len(zeros[:]), len(content))

--- a/internal/selfupdate/download.go
+++ b/internal/selfupdate/download.go
@@ -10,7 +10,6 @@ import (
 	"encoding/hex"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -69,7 +68,7 @@ func extractToFile(buf []byte, filename, target string, printf func(string, ...i
 
 	// Write everything to a temp file
 	dir := filepath.Dir(target)
-	new, err := ioutil.TempFile(dir, "restic")
+	new, err := os.CreateTemp(dir, "restic")
 	if err != nil {
 		return err
 	}

--- a/internal/selfupdate/github.go
+++ b/internal/selfupdate/github.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
@@ -80,7 +80,7 @@ func GitHubLatestRelease(ctx context.Context, owner, repo string) (Release, erro
 		return Release{}, fmt.Errorf("unexpected status %v (%v) returned", res.StatusCode, res.Status)
 	}
 
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		_ = res.Body.Close()
 		return Release{}, err
@@ -128,7 +128,7 @@ func getGithubData(ctx context.Context, url string) ([]byte, error) {
 		return nil, fmt.Errorf("unexpected status %v (%v) returned", res.StatusCode, res.Status)
 	}
 
-	buf, err := ioutil.ReadAll(res.Body)
+	buf, err := io.ReadAll(res.Body)
 	if err != nil {
 		_ = res.Body.Close()
 		return nil, err

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -5,7 +5,6 @@ import (
 	"compress/gzip"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -131,7 +130,7 @@ func SetupTarTestFixture(t testing.TB, outputDir, tarFile string) {
 // Env creates a test environment and extracts the repository fixture.
 // Returned is the repo path and a cleanup function.
 func Env(t testing.TB, repoFixture string) (repodir string, cleanup func()) {
-	tempdir, err := ioutil.TempDir(TestTempDir, "restic-test-env-")
+	tempdir, err := os.MkdirTemp(TestTempDir, "restic-test-env-")
 	OK(t, err)
 
 	fd, err := os.Open(repoFixture)
@@ -195,7 +194,7 @@ func RemoveAll(t testing.TB, path string) {
 // TempDir returns a temporary directory that is removed when cleanup is
 // called, except if TestCleanupTempDirs is set to false.
 func TempDir(t testing.TB) (path string, cleanup func()) {
-	tempdir, err := ioutil.TempDir(TestTempDir, "restic-test-")
+	tempdir, err := os.MkdirTemp(TestTempDir, "restic-test-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/textfile/read.go
+++ b/internal/textfile/read.go
@@ -4,7 +4,7 @@ package textfile
 
 import (
 	"bytes"
-	"io/ioutil"
+	"os"
 
 	"golang.org/x/text/encoding/unicode"
 )
@@ -34,7 +34,7 @@ func Decode(data []byte) ([]byte, error) {
 
 // Read returns the contents of the file, converted to UTF-8, stripped of any BOM.
 func Read(filename string) ([]byte, error) {
-	data, err := ioutil.ReadFile(filename)
+	data, err := os.ReadFile(filename)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/textfile/read_test.go
+++ b/internal/textfile/read_test.go
@@ -3,7 +3,6 @@ package textfile
 import (
 	"bytes"
 	"encoding/hex"
-	"io/ioutil"
 	"os"
 	"testing"
 )
@@ -13,7 +12,7 @@ import (
 func writeTempfile(t testing.TB, data []byte) (string, func()) {
 	t.Helper()
 
-	f, err := ioutil.TempFile("", "restic-test-textfile-read-")
+	f, err := os.CreateTemp("", "restic-test-textfile-read-")
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Replace all usages of the deprecated ioutil package. The ioutil functions are only wrappers by now, thus just call the underlying function.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
