### PR TITLE
archiver: Fix flaky TestArchiverAbortEarlyOnError

### DIFF
--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -2001,6 +2001,7 @@ func TestArchiverAbortEarlyOnError(t *testing.T) {
 		{
 			src: TestDir{
 				"dir": TestDir{
+					"file0": TestFile{Content: string(restictest.Random(0, 1024))},
 					"file1": TestFile{Content: string(restictest.Random(1, 1024))},
 					"file2": TestFile{Content: string(restictest.Random(2, 1024))},
 					"file3": TestFile{Content: string(restictest.Random(3, 1024))},
@@ -2013,15 +2014,15 @@ func TestArchiverAbortEarlyOnError(t *testing.T) {
 				},
 			},
 			wantOpen: map[string]uint{
+				filepath.FromSlash("dir/file0"): 1,
 				filepath.FromSlash("dir/file1"): 1,
 				filepath.FromSlash("dir/file2"): 1,
 				filepath.FromSlash("dir/file3"): 1,
-				filepath.FromSlash("dir/file4"): 1,
 				filepath.FromSlash("dir/file8"): 0,
 				filepath.FromSlash("dir/file9"): 0,
 			},
-			// fails four to six files were opened as the FileReadConcurrency allows for
-			// two queued files
+			// fails after four to seven files were opened, as the ReadConcurrency allows for
+			// two queued files and SaveBlobConcurrency for one blob queued for saving.
 			failAfter: 4,
 			err:       testErr,
 		},
@@ -2055,7 +2056,8 @@ func TestArchiverAbortEarlyOnError(t *testing.T) {
 
 			// at most two files may be queued
 			arch := New(testRepo, testFS, Options{
-				ReadConcurrency: 2,
+				ReadConcurrency:     2,
+				SaveBlobConcurrency: 1,
 			})
 
 			_, _, err := arch.Snapshot(ctx, []string{"."}, SnapshotOptions{Time: time.Now()})


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Saving the blobs of a file by now happens asynchronously to the processing in the FileSaver. Thus we have to account for the blobs queued for saving.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See https://github.com/restic/restic/actions/runs/3554529717/jobs/5970687531 and https://github.com/restic/restic/actions/runs/3558479192/jobs/5977170322 for failed test runs.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
