### PR TITLE
rclone: treat "file already closed" as command startup error

### DIFF
--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -239,7 +239,7 @@ func newBackend(cfg Config, lim limiter.Limiter) (*Backend, error) {
 		// wait for rclone to exit
 		wg.Wait()
 		// try to return the program exit code if communication with rclone has failed
-		if be.waitResult != nil && (errors.Is(err, context.Canceled) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.EPIPE)) {
+		if be.waitResult != nil && (errors.Is(err, context.Canceled) || errors.Is(err, io.ErrUnexpectedEOF) || errors.Is(err, syscall.EPIPE) || errors.Is(err, os.ErrClosed)) {
 			err = be.waitResult
 		}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Fix https://github.com/restic/restic/actions/runs/3559057863/jobs/5978162311
```
 internal_test.go:54: unexpected error: error talking HTTP to rclone: Get "http://localhost/file-8674665223082153551": write |1: file already closed

--- FAIL: TestRcloneFailedStart (0.01s)
```

Since #3940 the rclone backend returns the commands exit code if it fails to start. The list of expected errors was missing the "file already closed"-error which can occur, if the http test request first learns about the closed pipe to rclone, before noticing the canceled context.

Go internally makes sure that a file descriptor is unusable once it was closed, thus this cannot have unintended side effects (like accidentally reading from the wrong file due to a reused file descriptor).


<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
