### PR TITLE
fix#4033 cmd: copy no longer lists skipped existing snapshots by default

### DIFF
--- a/changelog/unreleased/issue-4033
+++ b/changelog/unreleased/issue-4033
@@ -1,0 +1,20 @@
+# The first line must start with Bugfix:, Enhancement: or Change:,
+# including the colon. Use present tense. Remove lines starting with '#'
+# from this template.
+Change: copy command no longer prints skipped existing snapshots by default
+
+# Describe the problem in the past tense, the new behavior in the present
+# tense. Mention the affected commands, backends, operating systems, etc.
+# Focus on user-facing behavior, not the implementation.
+
+Restic copy always printed each skipped snapshot that existed on the remote and
+would bury the snapshots that were copied amongst the output.  The new default
+only outputs new copies.  Increase the verbose level to see skipped existing
+snapshots.
+
+# The last section is a list of issue, PR and forum URLs.
+# The first issue ID determines the filename for the changelog entry:
+# changelog/unreleased/issue-1234. If there are no relevant issue links,
+# use the PR ID and call the file pull-55555.
+
+https://github.com/restic/restic/issues/4033

--- a/changelog/unreleased/issue-4033
+++ b/changelog/unreleased/issue-4033
@@ -1,20 +1,9 @@
-# The first line must start with Bugfix:, Enhancement: or Change:,
-# including the colon. Use present tense. Remove lines starting with '#'
-# from this template.
 Change: copy command no longer prints skipped existing snapshots by default
-
-# Describe the problem in the past tense, the new behavior in the present
-# tense. Mention the affected commands, backends, operating systems, etc.
-# Focus on user-facing behavior, not the implementation.
 
 Restic copy always printed each skipped snapshot that existed on the remote and
 would bury the snapshots that were copied amongst the output.  The new default
 only outputs new copies.  Increase the verbose level to see skipped existing
 snapshots.
 
-# The last section is a list of issue, PR and forum URLs.
-# The first issue ID determines the filename for the changelog entry:
-# changelog/unreleased/issue-1234. If there are no relevant issue links,
-# use the PR ID and call the file pull-55555.
-
 https://github.com/restic/restic/issues/4033
+https://github.com/restic/restic/pull/4066

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -120,7 +120,6 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts GlobalOptions, args []
 	visitedTrees := restic.NewIDSet()
 
 	for sn := range FindFilteredSnapshots(ctx, srcSnapshotLister, srcRepo, opts.Hosts, opts.Tags, opts.Paths, args) {
-		Verbosef("\nsnapshot %s of %v at %s)\n", sn.ID().Str(), sn.Paths, sn.Time)
 
 		// check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
 		srcOriginal := *sn.ID()
@@ -131,7 +130,8 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts GlobalOptions, args []
 			isCopy := false
 			for _, originalSn := range originalSns {
 				if similarSnapshots(originalSn, sn) {
-					Verbosef("skipping source snapshot %s, was already copied to snapshot %s\n", sn.ID().Str(), originalSn.ID().Str())
+					Verboseff("\nsnapshot %s of %v at %s)\n", sn.ID().Str(), sn.Paths, sn.Time)
+					Verboseff("skipping source snapshot %s, was already copied to snapshot %s\n", sn.ID().Str(), originalSn.ID().Str())
 					isCopy = true
 					break
 				}
@@ -140,6 +140,7 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts GlobalOptions, args []
 				continue
 			}
 		}
+		Verbosef("\nsnapshot %s of %v at %s)\n", sn.ID().Str(), sn.Paths, sn.Time)
 		Verbosef("  copy started, this may take a while...\n")
 		if err := copyTree(ctx, srcRepo, dstRepo, visitedTrees, *sn.Tree, gopts.Quiet); err != nil {
 			return err


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Default behavior of `copy` command is too verbose.  No longer output snapshots that are skipped because they exist.  Turn up verbosity to see them again.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

#4033

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
