### PR TITLE
Remove `Test()` method from Backend

### DIFF
--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1873,10 +1873,6 @@ type noCancelBackend struct {
 	restic.Backend
 }
 
-func (c *noCancelBackend) Test(ctx context.Context, h restic.Handle) (bool, error) {
-	return c.Backend.Test(context.Background(), h)
-}
-
 func (c *noCancelBackend) Remove(ctx context.Context, h restic.Handle) error {
 	return c.Backend.Remove(context.Background(), h)
 }

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -330,20 +330,6 @@ func (be *Backend) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, 
 	return fi, nil
 }
 
-// Test returns true if a blob of the given type and name exists in the backend.
-func (be *Backend) Test(ctx context.Context, h restic.Handle) (bool, error) {
-	objName := be.Filename(h)
-
-	be.sem.GetToken()
-	found, err := be.container.GetBlobReference(objName).Exists()
-	be.sem.ReleaseToken()
-
-	if err != nil {
-		return false, err
-	}
-	return found, nil
-}
-
 // Remove removes the blob with the given name and type.
 func (be *Backend) Remove(ctx context.Context, h restic.Handle) error {
 	objName := be.Filename(h)

--- a/internal/backend/azure/azure_test.go
+++ b/internal/backend/azure/azure_test.go
@@ -51,12 +51,12 @@ func newAzureTestSuite(t testing.TB) *test.Suite {
 				return nil, err
 			}
 
-			exists, err := be.Test(context.TODO(), restic.Handle{Type: restic.ConfigFile})
-			if err != nil {
+			_, err = be.Stat(context.TODO(), restic.Handle{Type: restic.ConfigFile})
+			if err != nil && !be.IsNotExist(err) {
 				return nil, err
 			}
 
-			if exists {
+			if err == nil {
 				return nil, errors.New("config already exists")
 			}
 

--- a/internal/backend/dryrun/dry_backend.go
+++ b/internal/backend/dryrun/dry_backend.go
@@ -86,7 +86,3 @@ func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset
 func (be *Backend) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, error) {
 	return be.b.Stat(ctx, h)
 }
-
-func (be *Backend) Test(ctx context.Context, h restic.Handle) (bool, error) {
-	return be.b.Test(ctx, h)
-}

--- a/internal/backend/dryrun/dry_backend_test.go
+++ b/internal/backend/dryrun/dry_backend_test.go
@@ -41,12 +41,9 @@ func TestDry(t *testing.T) {
 		{d, "stat", "a", "", "not found"},
 		{d, "list", "", "", ""},
 		{d, "save", "", "", "invalid"},
-		{d, "test", "a", "", ""},
 		{m, "save", "a", "baz", ""},  // save a directly to the mem backend
 		{d, "save", "b", "foob", ""}, // b is not saved
 		{d, "save", "b", "xxx", ""},  // no error as b is not saved
-		{d, "test", "a", "1", ""},
-		{d, "test", "b", "", ""},
 		{d, "stat", "", "", "invalid"},
 		{d, "stat", "a", "a 3", ""},
 		{d, "load", "a", "baz", ""},
@@ -65,17 +62,11 @@ func TestDry(t *testing.T) {
 
 	for i, step := range steps {
 		var err error
-		var boolRes bool
 
 		handle := restic.Handle{Type: restic.PackFile, Name: step.fname}
 		switch step.op {
 		case "save":
 			err = step.be.Save(ctx, handle, restic.NewByteReader([]byte(step.content), step.be.Hasher()))
-		case "test":
-			boolRes, err = step.be.Test(ctx, handle)
-			if boolRes != (step.content != "") {
-				t.Errorf("%d. Test(%q) = %v, want %v", i, step.fname, boolRes, step.content != "")
-			}
 		case "list":
 			fileList := []string{}
 			err = step.be.List(ctx, restic.PackFile, func(fi restic.FileInfo) error {

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -329,22 +329,6 @@ func (be *Backend) Stat(ctx context.Context, h restic.Handle) (bi restic.FileInf
 	return restic.FileInfo{Size: attr.Size, Name: h.Name}, nil
 }
 
-// Test returns true if a blob of the given type and name exists in the backend.
-func (be *Backend) Test(ctx context.Context, h restic.Handle) (bool, error) {
-	found := false
-	objName := be.Filename(h)
-
-	be.sem.GetToken()
-	_, err := be.bucket.Object(objName).Attrs(ctx)
-	be.sem.ReleaseToken()
-
-	if err == nil {
-		found = true
-	}
-	// If error, then not found
-	return found, nil
-}
-
 // Remove removes the blob with the given name and type.
 func (be *Backend) Remove(ctx context.Context, h restic.Handle) error {
 	objName := be.Filename(h)

--- a/internal/backend/gs/gs_test.go
+++ b/internal/backend/gs/gs_test.go
@@ -47,12 +47,12 @@ func newGSTestSuite(t testing.TB) *test.Suite {
 				return nil, err
 			}
 
-			exists, err := be.Test(context.TODO(), restic.Handle{Type: restic.ConfigFile})
-			if err != nil {
+			_, err = be.Stat(context.TODO(), restic.Handle{Type: restic.ConfigFile})
+			if err != nil && !be.IsNotExist(err) {
 				return nil, err
 			}
 
-			if exists {
+			if err == nil {
 				return nil, errors.New("config already exists")
 			}
 

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -269,24 +269,6 @@ func (b *Local) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, err
 	return restic.FileInfo{Size: fi.Size(), Name: h.Name}, nil
 }
 
-// Test returns true if a blob of the given type and name exists in the backend.
-func (b *Local) Test(ctx context.Context, h restic.Handle) (bool, error) {
-	debug.Log("Test %v", h)
-
-	b.sem.GetToken()
-	defer b.sem.ReleaseToken()
-
-	_, err := fs.Stat(b.Filename(h))
-	if err != nil {
-		if b.IsNotExist(err) {
-			return false, nil
-		}
-		return false, errors.WithStack(err)
-	}
-
-	return true, nil
-}
-
 // Remove removes the blob with the given name and type.
 func (b *Local) Remove(ctx context.Context, h restic.Handle) error {
 	debug.Log("Remove %v", h)

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -52,23 +52,6 @@ func New() *MemoryBackend {
 	return be
 }
 
-// Test returns whether a file exists.
-func (be *MemoryBackend) Test(ctx context.Context, h restic.Handle) (bool, error) {
-	be.sem.GetToken()
-	defer be.sem.ReleaseToken()
-
-	be.m.Lock()
-	defer be.m.Unlock()
-
-	debug.Log("Test %v", h)
-
-	if _, ok := be.data[h]; ok {
-		return true, ctx.Err()
-	}
-
-	return false, ctx.Err()
-}
-
 // IsNotExist returns true if the file does not exist.
 func (be *MemoryBackend) IsNotExist(err error) bool {
 	return errors.Is(err, errNotFound)

--- a/internal/backend/mem/mem_backend_test.go
+++ b/internal/backend/mem/mem_backend_test.go
@@ -26,12 +26,12 @@ func newTestSuite() *test.Suite {
 		Create: func(cfg interface{}) (restic.Backend, error) {
 			c := cfg.(*memConfig)
 			if c.be != nil {
-				ok, err := c.be.Test(context.TODO(), restic.Handle{Type: restic.ConfigFile})
-				if err != nil {
+				_, err := c.be.Stat(context.TODO(), restic.Handle{Type: restic.ConfigFile})
+				if err != nil && !c.be.IsNotExist(err) {
 					return nil, err
 				}
 
-				if ok {
+				if err == nil {
 					return nil, errors.New("config already exists")
 				}
 			}

--- a/internal/backend/mock/backend.go
+++ b/internal/backend/mock/backend.go
@@ -18,7 +18,6 @@ type Backend struct {
 	StatFn             func(ctx context.Context, h restic.Handle) (restic.FileInfo, error)
 	ListFn             func(ctx context.Context, t restic.FileType, fn func(restic.FileInfo) error) error
 	RemoveFn           func(ctx context.Context, h restic.Handle) error
-	TestFn             func(ctx context.Context, h restic.Handle) (bool, error)
 	DeleteFn           func(ctx context.Context) error
 	ConnectionsFn      func() uint
 	LocationFn         func() string
@@ -141,15 +140,6 @@ func (m *Backend) Remove(ctx context.Context, h restic.Handle) error {
 	}
 
 	return m.RemoveFn(ctx, h)
-}
-
-// Test for the existence of a specific item.
-func (m *Backend) Test(ctx context.Context, h restic.Handle) (bool, error) {
-	if m.TestFn == nil {
-		return false, errors.New("not implemented")
-	}
-
-	return m.TestFn(ctx, h)
 }
 
 // Delete all data.

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -308,16 +308,6 @@ func (b *Backend) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, e
 	return bi, nil
 }
 
-// Test returns true if a blob of the given type and name exists in the backend.
-func (b *Backend) Test(ctx context.Context, h restic.Handle) (bool, error) {
-	_, err := b.Stat(ctx, h)
-	if err != nil {
-		return false, nil
-	}
-
-	return true, nil
-}
-
 // Remove removes the blob with the given name and type.
 func (b *Backend) Remove(ctx context.Context, h restic.Handle) error {
 	if err := h.Valid(); err != nil {

--- a/internal/backend/retry/backend_retry.go
+++ b/internal/backend/retry/backend_retry.go
@@ -151,17 +151,6 @@ func (be *Backend) Remove(ctx context.Context, h restic.Handle) (err error) {
 	})
 }
 
-// Test a boolean value whether a File with the name and type exists.
-func (be *Backend) Test(ctx context.Context, h restic.Handle) (exists bool, err error) {
-	err = be.retry(ctx, fmt.Sprintf("Test(%v)", h), func() error {
-		var innerError error
-		exists, innerError = be.Backend.Test(ctx, h)
-
-		return innerError
-	})
-	return exists, err
-}
-
 // List runs fn for each file in the backend which has the type t. When an
 // error is returned by the underlying backend, the request is retried. When fn
 // returns an error, the operation is aborted and the error is returned to the

--- a/internal/backend/retry/backend_retry.go
+++ b/internal/backend/retry/backend_retry.go
@@ -139,6 +139,10 @@ func (be *Backend) Stat(ctx context.Context, h restic.Handle) (fi restic.FileInf
 			var innerError error
 			fi, innerError = be.Backend.Stat(ctx, h)
 
+			if be.Backend.IsNotExist(innerError) {
+				// do not retry if file is not found, as stat is usually used  to check whether a file exists
+				return backoff.Permanent(innerError)
+			}
 			return innerError
 		})
 	return fi, err

--- a/internal/backend/retry/backend_retry_test.go
+++ b/internal/backend/retry/backend_retry_test.go
@@ -289,9 +289,7 @@ func TestBackendCanceledContext(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
-	_, err := retryBackend.Test(ctx, h)
-	assertIsCanceled(t, err)
-	_, err = retryBackend.Stat(ctx, h)
+	_, err := retryBackend.Stat(ctx, h)
 	assertIsCanceled(t, err)
 
 	err = retryBackend.Save(ctx, h, restic.NewByteReader([]byte{}, nil))

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -392,23 +392,6 @@ func (be *Backend) Stat(ctx context.Context, h restic.Handle) (bi restic.FileInf
 	return restic.FileInfo{Size: fi.Size, Name: h.Name}, nil
 }
 
-// Test returns true if a blob of the given type and name exists in the backend.
-func (be *Backend) Test(ctx context.Context, h restic.Handle) (bool, error) {
-	found := false
-	objName := be.Filename(h)
-
-	be.sem.GetToken()
-	_, err := be.client.StatObject(ctx, be.cfg.Bucket, objName, minio.StatObjectOptions{})
-	be.sem.ReleaseToken()
-
-	if err == nil {
-		found = true
-	}
-
-	// If error, then not found
-	return found, nil
-}
-
 // Remove removes the blob with the given name and type.
 func (be *Backend) Remove(ctx context.Context, h restic.Handle) error {
 	objName := be.Filename(h)

--- a/internal/backend/s3/s3_test.go
+++ b/internal/backend/s3/s3_test.go
@@ -155,12 +155,12 @@ func newMinioTestSuite(ctx context.Context, t testing.TB) *test.Suite {
 				return nil, err
 			}
 
-			exists, err := be.Test(ctx, restic.Handle{Type: restic.ConfigFile})
-			if err != nil {
+			_, err = be.Stat(context.TODO(), restic.Handle{Type: restic.ConfigFile})
+			if err != nil && !be.IsNotExist(err) {
 				return nil, err
 			}
 
-			if exists {
+			if err == nil {
 				return nil, errors.New("config already exists")
 			}
 
@@ -254,12 +254,12 @@ func newS3TestSuite(t testing.TB) *test.Suite {
 				return nil, err
 			}
 
-			exists, err := be.Test(context.TODO(), restic.Handle{Type: restic.ConfigFile})
-			if err != nil {
+			_, err = be.Stat(context.TODO(), restic.Handle{Type: restic.ConfigFile})
+			if err != nil && !be.IsNotExist(err) {
 				return nil, err
 			}
 
-			if exists {
+			if err == nil {
 				return nil, errors.New("config already exists")
 			}
 

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -495,28 +495,6 @@ func (r *SFTP) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, erro
 	return restic.FileInfo{Size: fi.Size(), Name: h.Name}, nil
 }
 
-// Test returns true if a blob of the given type and name exists in the backend.
-func (r *SFTP) Test(ctx context.Context, h restic.Handle) (bool, error) {
-	debug.Log("Test(%v)", h)
-	if err := r.clientError(); err != nil {
-		return false, err
-	}
-
-	r.sem.GetToken()
-	defer r.sem.ReleaseToken()
-
-	_, err := r.c.Lstat(r.Filename(h))
-	if errors.Is(err, os.ErrNotExist) {
-		return false, nil
-	}
-
-	if err != nil {
-		return false, errors.Wrap(err, "Lstat")
-	}
-
-	return true, nil
-}
-
 // Remove removes the content stored at name.
 func (r *SFTP) Remove(ctx context.Context, h restic.Handle) error {
 	debug.Log("Remove(%v)", h)

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -226,25 +226,6 @@ func (be *beSwift) Stat(ctx context.Context, h restic.Handle) (bi restic.FileInf
 	return restic.FileInfo{Size: obj.Bytes, Name: h.Name}, nil
 }
 
-// Test returns true if a blob of the given type and name exists in the backend.
-func (be *beSwift) Test(ctx context.Context, h restic.Handle) (bool, error) {
-	objName := be.Filename(h)
-
-	be.sem.GetToken()
-	defer be.sem.ReleaseToken()
-
-	switch _, _, err := be.conn.Object(ctx, be.container, objName); err {
-	case nil:
-		return true, nil
-
-	case swift.ObjectNotFound:
-		return false, nil
-
-	default:
-		return false, errors.Wrap(err, "conn.Object")
-	}
-}
-
 // Remove removes the blob with the given name and type.
 func (be *beSwift) Remove(ctx context.Context, h restic.Handle) error {
 	objName := be.Filename(h)

--- a/internal/backend/swift/swift_test.go
+++ b/internal/backend/swift/swift_test.go
@@ -66,12 +66,12 @@ func newSwiftTestSuite(t testing.TB) *test.Suite {
 				return nil, err
 			}
 
-			exists, err := be.Test(context.TODO(), restic.Handle{Type: restic.ConfigFile})
-			if err != nil {
+			_, err = be.Stat(context.TODO(), restic.Handle{Type: restic.ConfigFile})
+			if err != nil && !be.IsNotExist(err) {
 				return nil, err
 			}
 
-			if exists {
+			if err == nil {
 				return nil, errors.New("config already exists")
 			}
 

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -738,11 +738,11 @@ func (r *Repository) Init(ctx context.Context, version uint, password string, ch
 		return fmt.Errorf("repository version %v too low", version)
 	}
 
-	has, err := r.be.Test(ctx, restic.Handle{Type: restic.ConfigFile})
-	if err != nil {
+	_, err := r.be.Stat(ctx, restic.Handle{Type: restic.ConfigFile})
+	if err != nil && !r.be.IsNotExist(err) {
 		return err
 	}
-	if has {
+	if err == nil {
 		return errors.New("repository master key and config already initialized")
 	}
 

--- a/internal/restic/backend.go
+++ b/internal/restic/backend.go
@@ -27,9 +27,6 @@ type Backend interface {
 	// HasAtomicReplace returns whether Save() can atomically replace files
 	HasAtomicReplace() bool
 
-	// Test a boolean value whether a File with the name and type exists.
-	Test(ctx context.Context, h Handle) (bool, error)
-
 	// Remove removes a File described  by h.
 	Remove(ctx context.Context, h Handle) error
 

--- a/internal/restic/lock_test.go
+++ b/internal/restic/lock_test.go
@@ -193,10 +193,11 @@ func TestLockStale(t *testing.T) {
 
 func lockExists(repo restic.Repository, t testing.TB, id restic.ID) bool {
 	h := restic.Handle{Type: restic.LockFile, Name: id.String()}
-	exists, err := repo.Backend().Test(context.TODO(), h)
-	rtest.OK(t, err)
-
-	return exists
+	_, err := repo.Backend().Stat(context.TODO(), h)
+	if err != nil && !repo.Backend().IsNotExist(err) {
+		t.Fatal(err)
+	}
+	return err == nil
 }
 
 func TestLockWithStaleLock(t *testing.T) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The `Test()` method was only used in exactly one place, namely when trying to create a new repository to check whether the `config` file already exists. This PR replaces it with a combination of `Stat()` and `IsNotExist()` instead. As a result this allows removing quite a bit of code.

The retry behavior of `Stat()` is different from `Test()`. Thus change the RetryBackend to not retry "file not found" errors for the Stat() method. In non test/debug code, `Stat()` is used exclusively to check whether a file exists. Thus, this won't cause unintended side-effects.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
