### PR TITLE
dry-run: introduce environment RESTIC_DRY_RUN

### DIFF
--- a/changelog/issue-4073
+++ b/changelog/issue-4073
@@ -1,0 +1,24 @@
+# The first line must start with Bugfix:, Enhancement: or Change:,
+# including the colon. Use present tense. Remove lines starting with '#'
+# from this template.
+Enhancement: Deduce --dry-mode from environment variable RESTIC_DRY_MODE
+
+# Describe the problem in the past tense, the new behavior in the present
+# tense. Mention the affected commands, backends, operating systems, etc.
+# Focus on user-facing behavior, not the implementation.
+
+Various commands support the --dry-run flag. When restic is used as part of a
+scripted chain, adding/removing "--dry-run" to check the chain is tedious.
+This enhancement introduces the evaluation of the environment variable
+RESTIC_DRY_RUN. If set, "--dry-run=true" is assumed. It applies to commands
+"backup", "forget", "prune" and "rewrite".
+
+The system-wide bar is still the default.
+
+# The last section is a list of issue, PR and forum URLs.
+# The first issue ID determines the filename for the changelog entry:
+# changelog/unreleased/issue-1234. If there are no relevant issue links,
+# use the PR ID and call the file pull-55555.
+
+https://github.com/restic/restic/issues/4073
+https://github.com/restic/restic/pull/4072

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -146,6 +146,8 @@ func init() {
 	// parse read concurrency from env, on error the default value will be used
 	readConcurrency, _ := strconv.ParseUint(os.Getenv("RESTIC_READ_CONCURRENCY"), 10, 32)
 	backupOptions.ReadConcurrency = uint(readConcurrency)
+
+	backupOptions.DryRun = isDryRunByEnv(backupOptions.DryRun)
 }
 
 // filterExisting returns a slice of all existing items, or an error if no

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -97,6 +97,8 @@ func init() {
 
 	f.SortFlags = false
 	addPruneOptions(cmdForget)
+
+	backupOptions.DryRun = isDryRunByEnv(backupOptions.DryRun)
 }
 
 func runForget(ctx context.Context, opts ForgetOptions, gopts GlobalOptions, args []string) error {

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -66,6 +66,8 @@ func init() {
 	f.BoolVarP(&pruneOptions.DryRun, "dry-run", "n", false, "do not modify the repository, just print what would be done")
 	f.StringVarP(&pruneOptions.UnsafeNoSpaceRecovery, "unsafe-recover-no-free-space", "", "", "UNSAFE, READ THE DOCUMENTATION BEFORE USING! Try to recover a repository stuck with no free space. Do not use without trying out 'prune --max-repack-size 0' first.")
 	addPruneOptions(cmdPrune)
+
+	backupOptions.DryRun = isDryRunByEnv(backupOptions.DryRun)
 }
 
 func addPruneOptions(c *cobra.Command) {

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -66,6 +66,8 @@ func init() {
 
 	initMultiSnapshotFilterOptions(f, &rewriteOptions.snapshotFilterOptions, true)
 	initExcludePatternOptions(f, &rewriteOptions.excludePatternOptions)
+
+	backupOptions.DryRun = isDryRunByEnv(backupOptions.DryRun)
 }
 
 func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *restic.Snapshot, opts RewriteOptions) (bool, error) {

--- a/cmd/restic/dry_run.go
+++ b/cmd/restic/dry_run.go
@@ -1,0 +1,10 @@
+package main
+
+import "os"
+
+func isDryRunByEnv(dryRun bool) bool {
+	if _, exists := os.LookupEnv("RESTIC_DRY_RUN"); exists {
+		return true
+	}
+	return dryRun
+}

--- a/cmd/restic/dry_run_test.go
+++ b/cmd/restic/dry_run_test.go
@@ -1,0 +1,35 @@
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func Test_IsDryRun(t *testing.T) {
+
+	defer os.Unsetenv("RESTIC_DRY_RUN")
+
+	os.Unsetenv("RESTIC_DRY_RUN")
+	if isDryRunByEnv(true) != true {
+		t.Fatal("expected 'true', got 'false'")
+	}
+	if isDryRunByEnv(false) != false {
+		t.Fatal("expected 'false', got 'true'")
+	}
+
+	os.Setenv("RESTIC_DRY_RUN", "")
+	if isDryRunByEnv(true) != true {
+		t.Fatal("expected 'true', got 'false'")
+	}
+	if isDryRunByEnv(false) != true {
+		t.Fatal("expected 'true', got 'false'")
+	}
+
+	os.Setenv("RESTIC_DRY_RUN", "true")
+	if isDryRunByEnv(true) != true {
+		t.Fatal("expected 'true', got 'false'")
+	}
+	if isDryRunByEnv(false) != true {
+		t.Fatal("expected 'true', got 'false'")
+	}
+}

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -195,6 +195,8 @@ modifying the repository.
 
 -  ``--dry-run``/``-n`` Report what would be done, without writing to the repository
 
+Alternatively, you can set the environment variable RESTIC_DRY_RUN.
+
 Combined with ``--verbose``, you can see a list of changes:
 
 .. code-block:: console

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -226,9 +226,9 @@ repository. Run the ``prune`` command afterwards to remove the now unreferenced
 data (just like when having used the ``forget`` command).
 
 In order to preview the changes which ``rewrite`` would make, you can use the
-``--dry-run`` option. This will simulate the rewriting process without actually
-modifying the repository. Instead restic will only print the actions it would
-perform.
+``--dry-run`` option or set the environment variable $RESTIC_DRY_RUN. This
+will simulate the rewriting process without actually modifying the repository.
+Instead restic will only print the actions it would perform.
 
 
 Checking integrity and consistency

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -164,9 +164,10 @@ yearly snapshots to keep, and any other snapshots will be removed.
     removal, some security considerations are important. Please refer to the
     section below for more information.
 
-.. note:: You can always use the ``--dry-run`` option of the ``forget`` command,
-    which instructs restic to not remove anything but instead just print what
-    actions would be performed.
+.. note:: You can always use the ``--dry-run`` option of the ``forget``
+    command or set the environment variable RESTIC_DRY_RUN, which instructs
+    restic to not remove anything but instead just print what actions would be
+    performed.
 
 The ``forget`` command accepts the following policy options:
 
@@ -443,7 +444,8 @@ The ``prune`` command accepts the following options:
   your repository exceeds the value given by ``--max-unused``.
   The default value is false.
 
--  ``--dry-run`` only show what ``prune`` would do.
+-  ``--dry-run`` only show what ``prune`` would do. Alternatively, set the
+  environment variable RESTIC_DRY_RUN
 
 -  ``--verbose`` increased verbosity shows additional statistics for ``prune``.
 

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -95,7 +95,7 @@ command:
       restic backup [flags] [FILE/DIR] ...
 
     Flags:
-      -n, --dry-run                                do not upload or write any data, just show what would be done
+      -n, --dry-run                                do not upload or write any data, just show what would be done (or set $RESTIC_DRY_MODE)
       -e, --exclude pattern                        exclude a pattern (can be specified multiple times)
           --exclude-caches                         excludes cache directories that are marked with a CACHEDIR.TAG file. See https://bford.info/cachedir/ for the Cache Directory Tagging Standard
           --exclude-file file                      read exclude patterns from a file (can be specified multiple times)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

#4073 

Various commands support the --dry-run flag. When restic is used as part of a scripted chain, adding/removing "--dry-run" to check the chain is tedious.

This commit introduces the evaluation of the environment variable RESTIC_DRY_RUN. If set, "--dry-run=true" is assumed. It applies to commands "backup", "forget", "prune" and "rewrite".

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
