### PR TITLE
sftp: Fix ENOSPC check

### DIFF
--- a/changelog/unreleased/issue-3336
+++ b/changelog/unreleased/issue-3336
@@ -1,0 +1,12 @@
+Bugfix: SFTP backend now checks for disk space
+
+A backup to an SFTP backend would spew repeated SSH_FX_FAILURE messages when
+the remote disk is full. Restic now reports "sftp: no space left on device"
+and exits immediately when it detects this condition.
+
+A fix for this issue was promised in restic 0.12.1, but the fix itself
+contained a bug that prevented it from triggering.
+
+https://github.com/restic/restic/issues/3336
+https://github.com/restic/restic/pull/3345
+https://github.com/restic/restic/pull/4075


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

There were two bugs in the "no space left on device" check in the SFTP backend. With this patch, we check for space that is not reserved for the root user on the remote, and the check is no longer in a defer block because that wouldn't fire. Some change in the surrounding code may have led the deferred function to capture the wrong err variable.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes #3336. Tested on Linux by backing up to an 8MiB ext2 image that has 50% space reserved for root.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
