### PR TITLE
rewrite: Always set the Original field in a rewritten snapshot

### DIFF
--- a/changelog/unreleased/issue-14
+++ b/changelog/unreleased/issue-14
@@ -5,3 +5,4 @@ unwanted files.
 
 https://github.com/restic/restic/issues/14
 https://github.com/restic/restic/pull/2731
+https://github.com/restic/restic/pull/4079

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -123,10 +123,8 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *resti
 		return true, nil
 	}
 
-	// Retain the original snapshot id over all tag changes.
-	if sn.Original == nil {
-		sn.Original = sn.ID()
-	}
+	// Always set the original snapshot id as this essentially a new snapshot.
+	sn.Original = sn.ID()
 	*sn.Tree = filteredTree
 
 	if !opts.Forget {


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
See #4055

The Original field in a snapshot is meant to remember the original snapshot id if e.g. changing its tags. It was only set by the `rewrite` command if it was not set previously. However, a rewritten snapshot is potentially rather different from the original snapshot. Thus just always set the Original field. This also makes it easier to later on detect and potentially remove the original snapshots.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See #4055
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
