### PR TITLE
repository: Remove empty cleanup functions in tests

### DIFF
--- a/internal/archiver/testing_test.go
+++ b/internal/archiver/testing_test.go
@@ -465,8 +465,7 @@ func TestTestEnsureSnapshot(t *testing.T) {
 			back := restictest.Chdir(t, tempdir)
 			defer back()
 
-			repo, cleanup := repository.TestRepository(t)
-			defer cleanup()
+			repo := repository.TestRepository(t)
 
 			arch := New(repo, fs.Local{}, Options{})
 			opts := SnapshotOptions{

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -340,9 +340,7 @@ func induceError(data []byte) {
 }
 
 func TestCheckerModifiedData(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
-
+	repo := repository.TestRepository(t)
 	sn := archiver.TestSnapshot(t, repo, ".", nil)
 	t.Logf("archived as %v", sn.ID().Str())
 
@@ -457,8 +455,7 @@ func TestCheckerBlobTypeConfusion(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	damagedNode := &restic.Node{
 		Name:    "damaged",

--- a/internal/dump/common_test.go
+++ b/internal/dump/common_test.go
@@ -12,13 +12,13 @@ import (
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func prepareTempdirRepoSrc(t testing.TB, src archiver.TestDir) (tempdir string, repo restic.Repository, cleanup func()) {
-	tempdir = rtest.TempDir(t)
-	repo, removeRepository := repository.TestRepository(t)
+func prepareTempdirRepoSrc(t testing.TB, src archiver.TestDir) (string, restic.Repository) {
+	tempdir := rtest.TempDir(t)
+	repo := repository.TestRepository(t)
 
 	archiver.TestCreateFiles(t, tempdir, src)
 
-	return tempdir, repo, removeRepository
+	return tempdir, repo
 }
 
 type CheckDump func(t *testing.T, testDir string, testDump *bytes.Buffer) error
@@ -72,9 +72,7 @@ func WriteTest(t *testing.T, format string, cd CheckDump) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			tmpdir, repo, cleanup := prepareTempdirRepoSrc(t, tt.args)
-			defer cleanup()
-
+			tmpdir, repo := prepareTempdirRepoSrc(t, tt.args)
 			arch := archiver.New(repo, fs.Track{FS: fs.Local{}}, archiver.Options{})
 
 			back := rtest.Chdir(t, tmpdir)

--- a/internal/fuse/fuse_test.go
+++ b/internal/fuse/fuse_test.go
@@ -65,8 +65,7 @@ func loadTree(t testing.TB, repo restic.Repository, id restic.ID) *restic.Tree {
 }
 
 func TestFuseFile(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -148,8 +147,7 @@ func TestFuseFile(t *testing.T) {
 }
 
 func TestFuseDir(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	root := &Root{repo: repo, blobCache: bloblru.New(blobCacheSize)}
 
@@ -180,9 +178,7 @@ func TestFuseDir(t *testing.T) {
 
 // Test top-level directories for their UID and GID.
 func TestTopUIDGID(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
-
+	repo := repository.TestRepository(t)
 	restic.TestCreateSnapshot(t, repo, time.Unix(1460289341, 207401672), 0, 0)
 
 	testTopUIDGID(t, Config{}, repo, uint32(os.Getuid()), uint32(os.Getgid()))

--- a/internal/index/master_index_test.go
+++ b/internal/index/master_index_test.go
@@ -328,14 +328,13 @@ var (
 	depth        = 3
 )
 
-func createFilledRepo(t testing.TB, snapshots int, dup float32, version uint) (restic.Repository, func()) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
+func createFilledRepo(t testing.TB, snapshots int, dup float32, version uint) restic.Repository {
+	repo := repository.TestRepositoryWithVersion(t, version)
 
 	for i := 0; i < 3; i++ {
 		restic.TestCreateSnapshot(t, repo, snapshotTime.Add(time.Duration(i)*time.Second), depth, dup)
 	}
-
-	return repo, cleanup
+	return repo
 }
 
 func TestIndexSave(t *testing.T) {
@@ -343,8 +342,7 @@ func TestIndexSave(t *testing.T) {
 }
 
 func testIndexSave(t *testing.T, version uint) {
-	repo, cleanup := createFilledRepo(t, 3, 0, version)
-	defer cleanup()
+	repo := createFilledRepo(t, 3, 0, version)
 
 	err := repo.LoadIndex(context.TODO())
 	if err != nil {

--- a/internal/migrations/upgrade_repo_v2_test.go
+++ b/internal/migrations/upgrade_repo_v2_test.go
@@ -14,9 +14,7 @@ import (
 )
 
 func TestUpgradeRepoV2(t *testing.T) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, 1)
-	defer cleanup()
-
+	repo := repository.TestRepositoryWithVersion(t, 1)
 	if repo.Config().Version != 1 {
 		t.Fatal("test repo has wrong version")
 	}
@@ -63,8 +61,7 @@ func (be *failBackend) Save(ctx context.Context, h restic.Handle, rd restic.Rewi
 }
 
 func TestUpgradeRepoV2Failure(t *testing.T) {
-	be, cleanup := repository.TestBackend(t)
-	defer cleanup()
+	be := repository.TestBackend(t)
 
 	// wrap backend so that it fails upgrading the config after the initial write
 	be = &failBackend{
@@ -72,9 +69,7 @@ func TestUpgradeRepoV2Failure(t *testing.T) {
 		Backend:                   be,
 	}
 
-	repo, cleanup := repository.TestRepositoryWithBackend(t, be, 1)
-	defer cleanup()
-
+	repo := repository.TestRepositoryWithBackend(t, be, 1)
 	if repo.Config().Version != 1 {
 		t.Fatal("test repo has wrong version")
 	}

--- a/internal/repository/fuzz_test.go
+++ b/internal/repository/fuzz_test.go
@@ -19,7 +19,7 @@ func FuzzSaveLoadBlob(f *testing.F) {
 		}
 
 		id := restic.Hash(blob)
-		repo, _ := TestRepositoryWithBackend(t, mem.New(), 2)
+		repo := TestRepositoryWithBackend(t, mem.New(), 2)
 
 		var wg errgroup.Group
 		repo.StartPackUploader(context.TODO(), &wg)

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -223,8 +223,7 @@ func TestRepack(t *testing.T) {
 }
 
 func testRepack(t *testing.T, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
+	repo := repository.TestRepositoryWithVersion(t, version)
 
 	seed := time.Now().UnixNano()
 	rand.Seed(seed)
@@ -302,10 +301,8 @@ func (r oneConnectionRepo) Connections() uint {
 }
 
 func testRepackCopy(t *testing.T, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
-	dstRepo, dstCleanup := repository.TestRepositoryWithVersion(t, version)
-	defer dstCleanup()
+	repo := repository.TestRepositoryWithVersion(t, version)
+	dstRepo := repository.TestRepositoryWithVersion(t, version)
 
 	// test with minimal possible connection count
 	repoWrapped := &oneConnectionRepo{repo}
@@ -349,8 +346,7 @@ func TestRepackWrongBlob(t *testing.T) {
 }
 
 func testRepackWrongBlob(t *testing.T, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
+	repo := repository.TestRepositoryWithVersion(t, version)
 
 	seed := time.Now().UnixNano()
 	rand.Seed(seed)
@@ -375,8 +371,7 @@ func TestRepackBlobFallback(t *testing.T) {
 }
 
 func testRepackBlobFallback(t *testing.T, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
+	repo := repository.TestRepositoryWithVersion(t, version)
 
 	seed := time.Now().UnixNano()
 	rand.Seed(seed)

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -35,8 +35,7 @@ func TestSave(t *testing.T) {
 }
 
 func testSave(t *testing.T, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
+	repo := repository.TestRepositoryWithVersion(t, version)
 
 	for _, size := range testSizes {
 		data := make([]byte, size)
@@ -77,8 +76,7 @@ func TestSaveFrom(t *testing.T) {
 }
 
 func testSaveFrom(t *testing.T, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
+	repo := repository.TestRepositoryWithVersion(t, version)
 
 	for _, size := range testSizes {
 		data := make([]byte, size)
@@ -117,9 +115,7 @@ func BenchmarkSaveAndEncrypt(t *testing.B) {
 }
 
 func benchmarkSaveAndEncrypt(t *testing.B, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
-
+	repo := repository.TestRepositoryWithVersion(t, version)
 	size := 4 << 20 // 4MiB
 
 	data := make([]byte, size)
@@ -145,9 +141,7 @@ func TestLoadBlob(t *testing.T) {
 }
 
 func testLoadBlob(t *testing.T, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
-
+	repo := repository.TestRepositoryWithVersion(t, version)
 	length := 1000000
 	buf := crypto.NewBlobBuffer(length)
 	_, err := io.ReadFull(rnd, buf)
@@ -181,9 +175,7 @@ func BenchmarkLoadBlob(b *testing.B) {
 }
 
 func benchmarkLoadBlob(b *testing.B, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(b, version)
-	defer cleanup()
-
+	repo := repository.TestRepositoryWithVersion(b, version)
 	length := 1000000
 	buf := crypto.NewBlobBuffer(length)
 	_, err := io.ReadFull(rnd, buf)
@@ -224,9 +216,7 @@ func BenchmarkLoadUnpacked(b *testing.B) {
 }
 
 func benchmarkLoadUnpacked(b *testing.B, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(b, version)
-	defer cleanup()
-
+	repo := repository.TestRepositoryWithVersion(b, version)
 	length := 1000000
 	buf := crypto.NewBlobBuffer(length)
 	_, err := io.ReadFull(rnd, buf)
@@ -345,9 +335,7 @@ func BenchmarkLoadIndex(b *testing.B) {
 func benchmarkLoadIndex(b *testing.B, version uint) {
 	repository.TestUseLowSecurityKDFParameters(b)
 
-	repo, cleanup := repository.TestRepositoryWithVersion(b, version)
-	defer cleanup()
-
+	repo := repository.TestRepositoryWithVersion(b, version)
 	idx := index.NewIndex()
 
 	for i := 0; i < 5000; i++ {
@@ -398,10 +386,7 @@ func TestRepositoryIncrementalIndex(t *testing.T) {
 }
 
 func testRepositoryIncrementalIndex(t *testing.T, version uint) {
-	r, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
-
-	repo := r.(*repository.Repository)
+	repo := repository.TestRepositoryWithVersion(t, version).(*repository.Repository)
 
 	index.IndexFull = func(*index.Index, bool) bool { return true }
 

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -33,8 +33,8 @@ func TestUseLowSecurityKDFParameters(t logger) {
 }
 
 // TestBackend returns a fully configured in-memory backend.
-func TestBackend(t testing.TB) (be restic.Backend, cleanup func()) {
-	return mem.New(), func() {}
+func TestBackend(t testing.TB) restic.Backend {
+	return mem.New()
 }
 
 const TestChunkerPol = chunker.Pol(0x3DA3358B4DC173)
@@ -42,14 +42,13 @@ const TestChunkerPol = chunker.Pol(0x3DA3358B4DC173)
 // TestRepositoryWithBackend returns a repository initialized with a test
 // password. If be is nil, an in-memory backend is used. A constant polynomial
 // is used for the chunker and low-security test parameters.
-func TestRepositoryWithBackend(t testing.TB, be restic.Backend, version uint) (r restic.Repository, cleanup func()) {
+func TestRepositoryWithBackend(t testing.TB, be restic.Backend, version uint) restic.Repository {
 	t.Helper()
 	TestUseLowSecurityKDFParameters(t)
 	restic.TestDisableCheckPolynomial(t)
 
-	var beCleanup func()
 	if be == nil {
-		be, beCleanup = TestBackend(t)
+		be = TestBackend(t)
 	}
 
 	repo, err := New(be, Options{})
@@ -63,23 +62,19 @@ func TestRepositoryWithBackend(t testing.TB, be restic.Backend, version uint) (r
 		t.Fatalf("TestRepository(): initialize repo failed: %v", err)
 	}
 
-	return repo, func() {
-		if beCleanup != nil {
-			beCleanup()
-		}
-	}
+	return repo
 }
 
 // TestRepository returns a repository initialized with a test password on an
 // in-memory backend. When the environment variable RESTIC_TEST_REPO is set to
 // a non-existing directory, a local backend is created there and this is used
 // instead. The directory is not removed, but left there for inspection.
-func TestRepository(t testing.TB) (r restic.Repository, cleanup func()) {
+func TestRepository(t testing.TB) restic.Repository {
 	t.Helper()
 	return TestRepositoryWithVersion(t, 0)
 }
 
-func TestRepositoryWithVersion(t testing.TB, version uint) (r restic.Repository, cleanup func()) {
+func TestRepositoryWithVersion(t testing.TB, version uint) restic.Repository {
 	t.Helper()
 	dir := os.Getenv("RESTIC_TEST_REPO")
 	if dir != "" {

--- a/internal/restic/find_test.go
+++ b/internal/restic/find_test.go
@@ -84,8 +84,7 @@ const (
 var findTestTime = time.Unix(1469960361, 23)
 
 func TestFindUsedBlobs(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	var snapshots []*restic.Snapshot
 	for i := 0; i < findTestSnapshots; i++ {
@@ -128,8 +127,7 @@ func TestFindUsedBlobs(t *testing.T) {
 }
 
 func TestMultiFindUsedBlobs(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	var snapshotTrees restic.IDs
 	for i := 0; i < findTestSnapshots; i++ {
@@ -177,8 +175,7 @@ func (r ForbiddenRepo) Connections() uint {
 }
 
 func TestFindUsedBlobsSkipsSeenBlobs(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	snapshot := restic.TestCreateSnapshot(t, repo, findTestTime, findTestDepth, 0)
 	t.Logf("snapshot %v saved, tree %v", snapshot.ID().Str(), snapshot.Tree.Str())
@@ -196,8 +193,7 @@ func TestFindUsedBlobsSkipsSeenBlobs(t *testing.T) {
 }
 
 func BenchmarkFindUsedBlobs(b *testing.B) {
-	repo, cleanup := repository.TestRepository(b)
-	defer cleanup()
+	repo := repository.TestRepository(b)
 
 	sn := restic.TestCreateSnapshot(b, repo, findTestTime, findTestDepth, 0)
 

--- a/internal/restic/lock_test.go
+++ b/internal/restic/lock_test.go
@@ -15,8 +15,7 @@ import (
 )
 
 func TestLock(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	lock, err := restic.NewLock(context.TODO(), repo)
 	rtest.OK(t, err)
@@ -25,8 +24,7 @@ func TestLock(t *testing.T) {
 }
 
 func TestDoubleUnlock(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	lock, err := restic.NewLock(context.TODO(), repo)
 	rtest.OK(t, err)
@@ -39,8 +37,7 @@ func TestDoubleUnlock(t *testing.T) {
 }
 
 func TestMultipleLock(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	lock1, err := restic.NewLock(context.TODO(), repo)
 	rtest.OK(t, err)
@@ -65,8 +62,7 @@ func (be *failLockLoadingBackend) Load(ctx context.Context, h restic.Handle, len
 
 func TestMultipleLockFailure(t *testing.T) {
 	be := &failLockLoadingBackend{Backend: mem.New()}
-	repo, cleanup := repository.TestRepositoryWithBackend(t, be, 0)
-	defer cleanup()
+	repo := repository.TestRepositoryWithBackend(t, be, 0)
 
 	lock1, err := restic.NewLock(context.TODO(), repo)
 	rtest.OK(t, err)
@@ -78,8 +74,7 @@ func TestMultipleLockFailure(t *testing.T) {
 }
 
 func TestLockExclusive(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	elock, err := restic.NewExclusiveLock(context.TODO(), repo)
 	rtest.OK(t, err)
@@ -87,8 +82,7 @@ func TestLockExclusive(t *testing.T) {
 }
 
 func TestLockOnExclusiveLockedRepo(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	elock, err := restic.NewExclusiveLock(context.TODO(), repo)
 	rtest.OK(t, err)
@@ -104,8 +98,7 @@ func TestLockOnExclusiveLockedRepo(t *testing.T) {
 }
 
 func TestExclusiveLockOnLockedRepo(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	elock, err := restic.NewLock(context.TODO(), repo)
 	rtest.OK(t, err)
@@ -201,8 +194,7 @@ func lockExists(repo restic.Repository, t testing.TB, id restic.ID) bool {
 }
 
 func TestLockWithStaleLock(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	id1, err := createFakeLock(repo, time.Now().Add(-time.Hour), os.Getpid())
 	rtest.OK(t, err)
@@ -230,8 +222,7 @@ func TestLockWithStaleLock(t *testing.T) {
 }
 
 func TestRemoveAllLocks(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	id1, err := createFakeLock(repo, time.Now().Add(-time.Hour), os.Getpid())
 	rtest.OK(t, err)
@@ -257,8 +248,7 @@ func TestRemoveAllLocks(t *testing.T) {
 }
 
 func TestLockRefresh(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	lock, err := restic.NewLock(context.TODO(), repo)
 	rtest.OK(t, err)

--- a/internal/restic/snapshot_find_test.go
+++ b/internal/restic/snapshot_find_test.go
@@ -9,9 +9,7 @@ import (
 )
 
 func TestFindLatestSnapshot(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
-
+	repo := repository.TestRepository(t)
 	restic.TestCreateSnapshot(t, repo, parseTimeUTC("2015-05-05 05:05:05"), 1, 0)
 	restic.TestCreateSnapshot(t, repo, parseTimeUTC("2017-07-07 07:07:07"), 1, 0)
 	latestSnapshot := restic.TestCreateSnapshot(t, repo, parseTimeUTC("2019-09-09 09:09:09"), 1, 0)
@@ -27,9 +25,7 @@ func TestFindLatestSnapshot(t *testing.T) {
 }
 
 func TestFindLatestSnapshotWithMaxTimestamp(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
-
+	repo := repository.TestRepository(t)
 	restic.TestCreateSnapshot(t, repo, parseTimeUTC("2015-05-05 05:05:05"), 1, 0)
 	desiredSnapshot := restic.TestCreateSnapshot(t, repo, parseTimeUTC("2017-07-07 07:07:07"), 1, 0)
 	restic.TestCreateSnapshot(t, repo, parseTimeUTC("2019-09-09 09:09:09"), 1, 0)

--- a/internal/restic/snapshot_test.go
+++ b/internal/restic/snapshot_test.go
@@ -32,8 +32,7 @@ func TestLoadJSONUnpacked(t *testing.T) {
 }
 
 func testLoadJSONUnpacked(t *testing.T, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
+	repo := repository.TestRepositoryWithVersion(t, version)
 
 	// archive a snapshot
 	sn := restic.Snapshot{}

--- a/internal/restic/testing_test.go
+++ b/internal/restic/testing_test.go
@@ -37,9 +37,7 @@ func loadAllSnapshots(ctx context.Context, repo restic.Repository, excludeIDs re
 }
 
 func TestCreateSnapshot(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
-
+	repo := repository.TestRepository(t)
 	for i := 0; i < testCreateSnapshots; i++ {
 		restic.TestCreateSnapshot(t, repo, testSnapshotTime.Add(time.Duration(i)*time.Second), testDepth, 0)
 	}
@@ -70,8 +68,7 @@ func TestCreateSnapshot(t *testing.T) {
 }
 
 func BenchmarkTestCreateSnapshot(t *testing.B) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	t.ResetTimer()
 

--- a/internal/restic/tree_test.go
+++ b/internal/restic/tree_test.go
@@ -97,8 +97,7 @@ func TestNodeComparison(t *testing.T) {
 }
 
 func TestEmptyLoadTree(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	var wg errgroup.Group
 	repo.StartPackUploader(context.TODO(), &wg)
@@ -177,14 +176,12 @@ func TestLoadTree(t *testing.T) {
 }
 
 func testLoadTree(t *testing.T, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
-
 	if rtest.BenchArchiveDirectory == "" {
 		t.Skip("benchdir not set, skipping")
 	}
 
 	// archive a few files
+	repo := repository.TestRepositoryWithVersion(t, version)
 	sn := archiver.TestSnapshot(t, repo, rtest.BenchArchiveDirectory, nil)
 	rtest.OK(t, repo.Flush(context.Background()))
 
@@ -197,14 +194,12 @@ func BenchmarkLoadTree(t *testing.B) {
 }
 
 func benchmarkLoadTree(t *testing.B, version uint) {
-	repo, cleanup := repository.TestRepositoryWithVersion(t, version)
-	defer cleanup()
-
 	if rtest.BenchArchiveDirectory == "" {
 		t.Skip("benchdir not set, skipping")
 	}
 
 	// archive a few files
+	repo := repository.TestRepositoryWithVersion(t, version)
 	sn := archiver.TestSnapshot(t, repo, rtest.BenchArchiveDirectory, nil)
 	rtest.OK(t, repo.Flush(context.Background()))
 

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -321,8 +321,7 @@ func TestRestorer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			repo, cleanup := repository.TestRepository(t)
-			defer cleanup()
+			repo := repository.TestRepository(t)
 			sn, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
 
@@ -438,8 +437,7 @@ func TestRestorerRelative(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			repo, cleanup := repository.TestRepository(t)
-			defer cleanup()
+			repo := repository.TestRepository(t)
 
 			sn, id := saveSnapshot(t, repo, test.Snapshot)
 			t.Logf("snapshot saved as %v", id.Str())
@@ -447,7 +445,7 @@ func TestRestorerRelative(t *testing.T) {
 			res := NewRestorer(context.TODO(), repo, sn, false)
 
 			tempdir := rtest.TempDir(t)
-			cleanup = rtest.Chdir(t, tempdir)
+			cleanup := rtest.Chdir(t, tempdir)
 			defer cleanup()
 
 			errors := make(map[string]string)
@@ -670,8 +668,7 @@ func TestRestorerTraverseTree(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
-			repo, cleanup := repository.TestRepository(t)
-			defer cleanup()
+			repo := repository.TestRepository(t)
 			sn, _ := saveSnapshot(t, repo, test.Snapshot)
 
 			res := NewRestorer(context.TODO(), repo, sn, false)
@@ -717,8 +714,7 @@ func checkConsistentInfo(t testing.TB, file string, fi os.FileInfo, modtime time
 func TestRestorerConsistentTimestampsAndPermissions(t *testing.T) {
 	timeForTest := time.Date(2019, time.January, 9, 1, 46, 40, 0, time.UTC)
 
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	sn, _ := saveSnapshot(t, repo, Snapshot{
 		Nodes: map[string]Node{
@@ -803,9 +799,7 @@ func TestVerifyCancel(t *testing.T) {
 		},
 	}
 
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
-
+	repo := repository.TestRepository(t)
 	sn, _ := saveSnapshot(t, repo, snapshot)
 
 	res := NewRestorer(context.TODO(), repo, sn, false)
@@ -832,8 +826,7 @@ func TestVerifyCancel(t *testing.T) {
 }
 
 func TestRestorerSparseFiles(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	var zeros [1<<20 + 13]byte
 

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -16,8 +16,7 @@ import (
 )
 
 func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
-	repo, cleanup := repository.TestRepository(t)
-	defer cleanup()
+	repo := repository.TestRepository(t)
 
 	sn, _ := saveSnapshot(t, repo, Snapshot{
 		Nodes: map[string]Node{


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

TestRepository and its variants always returned no-op cleanup functions. If they ever do need to do cleanup, using testing.T.Cleanup is easier than passing these functions around.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Followup to #4077.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
