### PR TITLE
Fix: change error code in function isAccessDenied to AccessDenied

### DIFF
--- a/changelog/unreleased/issue-4085
+++ b/changelog/unreleased/issue-4085
@@ -1,0 +1,1 @@
+Fix error code in function isAccessDenied.

--- a/changelog/unreleased/issue-4085
+++ b/changelog/unreleased/issue-4085
@@ -1,1 +1,8 @@
-Fix error code in function isAccessDenied.
+Bugfix: Restic init ignores "Access Denied" errors when creating an S3 bucket
+
+In restic 0.9.0 through 0.13.0, some permission errors from S3 backends where ignored
+when trying to check the bucket existence, so that manually created buckets with custom permissions
+could be used for backups. This feature was broken in 0.14.0, but is now restored.
+
+https://github.com/restic/restic/issues/4085
+https://github.com/restic/restic/pull/4086

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -164,7 +164,7 @@ func isAccessDenied(err error) bool {
 	debug.Log("isAccessDenied(%T, %#v)", err, err)
 
 	var e minio.ErrorResponse
-	return errors.As(err, &e) && e.Code == "Access Denied"
+	return errors.As(err, &e) && e.Code == "AccessDenied"
 }
 
 // IsNotExist returns true if the error is caused by a not existing file.


### PR DESCRIPTION
Signed-off-by: Xun Jiang <blackpiglet@gmail.com>

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

It's used to fix issue #4085

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
