### PR TITLE
Clean up error handling further

### DIFF
--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -268,7 +268,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 		if checker.IsOrphanedPack(err) {
 			orphanedPacks++
 			Verbosef("%v\n", err)
-		} else if _, ok := err.(*checker.ErrLegacyLayout); ok {
+		} else if err == checker.ErrLegacyLayout {
 			Verbosef("repository still uses the S3 legacy layout\nPlease run `restic migrate s3legacy` to correct this.\n")
 		} else {
 			errorsFound = true

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -183,7 +183,7 @@ func (arch *Archiver) nodeFromFileInfo(snPath, filename string, fi os.FileInfo) 
 	}
 	// overwrite name to match that within the snapshot
 	node.Name = path.Base(snPath)
-	return node, errors.Wrap(err, "NodeFromFileInfo")
+	return node, errors.WithStack(err)
 }
 
 // loadSubtree tries to load the subtree referenced by node. In case of an error, nil is returned.
@@ -352,7 +352,7 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 		debug.Log("lstat() for %v returned error: %v", target, err)
 		err = arch.error(abstarget, err)
 		if err != nil {
-			return FutureNode{}, false, errors.Wrap(err, "Lstat")
+			return FutureNode{}, false, errors.WithStack(err)
 		}
 		return FutureNode{}, true, nil
 	}
@@ -404,7 +404,7 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 			debug.Log("Openfile() for %v returned error: %v", target, err)
 			err = arch.error(abstarget, err)
 			if err != nil {
-				return FutureNode{}, false, errors.Wrap(err, "Lstat")
+				return FutureNode{}, false, errors.WithStack(err)
 			}
 			return FutureNode{}, true, nil
 		}
@@ -415,7 +415,7 @@ func (arch *Archiver) Save(ctx context.Context, snPath, target string, previous 
 			_ = file.Close()
 			err = arch.error(abstarget, err)
 			if err != nil {
-				return FutureNode{}, false, errors.Wrap(err, "Lstat")
+				return FutureNode{}, false, errors.WithStack(err)
 			}
 			return FutureNode{}, true, nil
 		}
@@ -524,7 +524,7 @@ func join(elem ...string) string {
 func (arch *Archiver) statDir(dir string) (os.FileInfo, error) {
 	fi, err := arch.FS.Stat(dir)
 	if err != nil {
-		return nil, errors.Wrap(err, "Lstat")
+		return nil, errors.WithStack(err)
 	}
 
 	tpe := fi.Mode() & (os.ModeType | os.ModeCharDevice)
@@ -626,7 +626,7 @@ func (arch *Archiver) SaveTree(ctx context.Context, snPath string, atree *Tree, 
 func readdirnames(filesystem fs.FS, dir string, flags int) ([]string, error) {
 	f, err := filesystem.OpenFile(dir, fs.O_RDONLY|flags, 0)
 	if err != nil {
-		return nil, errors.Wrap(err, "Open")
+		return nil, errors.WithStack(err)
 	}
 
 	entries, err := f.Readdirnames(-1)

--- a/internal/backend/rest/config.go
+++ b/internal/backend/rest/config.go
@@ -34,9 +34,8 @@ func ParseConfig(s string) (interface{}, error) {
 	s = prepareURL(s)
 
 	u, err := url.Parse(s)
-
 	if err != nil {
-		return nil, errors.Wrap(err, "url.Parse")
+		return nil, errors.WithStack(err)
 	}
 
 	cfg := NewConfig()

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -52,7 +52,7 @@ func ParseConfig(s string) (interface{}, error) {
 		// bucket name and prefix
 		url, err := url.Parse(s[3:])
 		if err != nil {
-			return nil, errors.Wrap(err, "url.Parse")
+			return nil, errors.WithStack(err)
 		}
 
 		if url.Path == "" {

--- a/internal/backend/sftp/config.go
+++ b/internal/backend/sftp/config.go
@@ -42,7 +42,7 @@ func ParseConfig(s string) (interface{}, error) {
 		// parse the "sftp://user@host/path" url format
 		url, err := url.Parse(s)
 		if err != nil {
-			return nil, errors.Wrap(err, "url.Parse")
+			return nil, errors.WithStack(err)
 		}
 		if url.User != nil {
 			user = url.User.Username()

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -59,11 +59,7 @@ func New(repo restic.Repository, trackUnused bool) *Checker {
 }
 
 // ErrLegacyLayout is returned when the repository uses the S3 legacy layout.
-type ErrLegacyLayout struct{}
-
-func (e *ErrLegacyLayout) Error() string {
-	return "repository uses S3 legacy layout"
-}
+var ErrLegacyLayout = errors.New("repository uses S3 legacy layout")
 
 // ErrDuplicatePacks is returned when a pack is found in more than one index.
 type ErrDuplicatePacks struct {
@@ -231,7 +227,7 @@ func (c *Checker) Packs(ctx context.Context, errChan chan<- error) {
 	defer close(errChan)
 
 	if isS3Legacy(c.repo.Backend()) {
-		errChan <- &ErrLegacyLayout{}
+		errChan <- ErrLegacyLayout
 	}
 
 	debug.Log("checking for %d packs", len(c.packs))

--- a/internal/fs/fs_reader_test.go
+++ b/internal/fs/fs_reader_test.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"os"
 	"path"
@@ -288,7 +289,7 @@ func TestFSReader(t *testing.T) {
 			name: "dir/Lstat-error-not-exist",
 			f: func(t *testing.T, fs FS) {
 				_, err := fs.Lstat("other")
-				if err != os.ErrNotExist {
+				if !errors.Is(err, os.ErrNotExist) {
 					t.Fatal(err)
 				}
 			},

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -110,7 +110,7 @@ func (r *packerManager) newPacker() (packer *Packer, err error) {
 	debug.Log("create new pack")
 	tmpfile, err := fs.TempFile("", "restic-temp-pack-")
 	if err != nil {
-		return nil, errors.Wrap(err, "fs.TempFile")
+		return nil, errors.WithStack(err)
 	}
 
 	bufWr := bufio.NewWriter(tmpfile)
@@ -183,7 +183,7 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packe
 	if runtime.GOOS != "windows" {
 		err = fs.RemoveIfExists(p.tmpfile.Name())
 		if err != nil {
-			return errors.Wrap(err, "Remove")
+			return errors.WithStack(err)
 		}
 	}
 

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -191,14 +191,14 @@ func (node Node) restoreMetadata(path string) error {
 			debug.Log("not running as root, ignoring lchown permission error for %v: %v",
 				path, err)
 		} else {
-			firsterr = errors.Wrap(err, "Lchown")
+			firsterr = errors.WithStack(err)
 		}
 	}
 
 	if node.Type != "symlink" {
 		if err := fs.Chmod(path, node.Mode); err != nil {
 			if firsterr != nil {
-				firsterr = errors.Wrap(err, "Chmod")
+				firsterr = errors.WithStack(err)
 			}
 		}
 	}
@@ -250,7 +250,7 @@ func (node Node) RestoreTimestamps(path string) error {
 func (node Node) createDirAt(path string) error {
 	err := fs.Mkdir(path, node.Mode)
 	if err != nil && !os.IsExist(err) {
-		return errors.Wrap(err, "Mkdir")
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -259,7 +259,7 @@ func (node Node) createDirAt(path string) error {
 func (node Node) createFileAt(ctx context.Context, path string, repo Repository) error {
 	f, err := fs.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0600)
 	if err != nil {
-		return errors.Wrap(err, "OpenFile")
+		return errors.WithStack(err)
 	}
 
 	err = node.writeNodeContent(ctx, repo, f)
@@ -270,7 +270,7 @@ func (node Node) createFileAt(ctx context.Context, path string, repo Repository)
 	}
 
 	if closeErr != nil {
-		return errors.Wrap(closeErr, "Close")
+		return errors.WithStack(closeErr)
 	}
 
 	return nil
@@ -286,7 +286,7 @@ func (node Node) writeNodeContent(ctx context.Context, repo Repository, f *os.Fi
 
 		_, err = f.Write(buf)
 		if err != nil {
-			return errors.Wrap(err, "Write")
+			return errors.WithStack(err)
 		}
 	}
 
@@ -300,7 +300,7 @@ func (node Node) createSymlinkAt(path string) error {
 	}
 
 	if err := fs.Symlink(node.LinkTarget, path); err != nil {
-		return errors.Wrap(err, "Symlink")
+		return errors.WithStack(err)
 	}
 
 	return nil
@@ -591,7 +591,7 @@ func (node *Node) fillExtra(path string, fi os.FileInfo) error {
 		node.LinkTarget, err = fs.Readlink(path)
 		node.Links = uint64(stat.nlink())
 		if err != nil {
-			return errors.Wrap(err, "Readlink")
+			return errors.WithStack(err)
 		}
 	case "dev":
 		node.Device = uint64(stat.rdev())

--- a/internal/restic/node_linux.go
+++ b/internal/restic/node_linux.go
@@ -13,7 +13,7 @@ import (
 func (node Node) restoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
 	dir, err := fs.Open(filepath.Dir(path))
 	if err != nil {
-		return errors.Wrap(err, "Open")
+		return errors.WithStack(err)
 	}
 
 	times := []unix.Timespec{

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -184,7 +184,7 @@ func (res *Restorer) restoreHardlinkAt(node *restic.Node, target, path, location
 	}
 	err := fs.Link(target, path)
 	if err != nil {
-		return errors.Wrap(err, "CreateHardlink")
+		return errors.WithStack(err)
 	}
 	// TODO investigate if hardlinks have separate metadata on any supported system
 	return res.restoreNodeMetadataTo(node, path, location)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Some error handling cleanup. See commit messages for details. Mostly I'm trying to get rid of errors.Wrap and friends in favor of some fmt.Errorf variant (with stack traces), but we're not there yet.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Followup to #3960.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
