### PR TITLE
remove duplicated init

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -179,7 +179,7 @@ with an error similar to the following:
 
 ::
 
-    $ restic init -r sftp:user@nas:/volume1/restic-repo init
+    $ restic -r sftp:user@nas:/volume1/restic-repo init
     create backend at sftp:user@nas:/volume1/restic-repo/ failed:
         mkdirAll(/volume1/restic-repo/index): unable to create directories: [...]
 
@@ -199,7 +199,7 @@ The following may work:
 
 ::
 
-    $ restic init -r sftp:user@nas:/restic-repo init
+    $ restic -r sftp:user@nas:/restic-repo init
 
 Why does restic perform so poorly on Windows?
 ---------------------------------------------


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The documentation includes a wrong command: https://restic.readthedocs.io/en/latest/faq.html?highlight=synology#creating-new-repository-on-a-synology-nas-via-sftp-fails

The commands in this section contain duplicated `init` commands. No code changes thus many items on the checklist are not relevant.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches). 
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] ~I have added tests for all code changes.~ (**No tests, just docu.**)
- [ ] ~I have added documentation for relevant changes (in the manual).~
- [ ] ~There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~
- [ ] ~I have run `gofmt` on the code in all commits.~
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
