### PR TITLE
convert negative uid and gid to 0o7777777

### DIFF
--- a/changelog/unreleased/issue-4101
+++ b/changelog/unreleased/issue-4101
@@ -1,0 +1,11 @@
+Bugfix: fix restic dump of tar file with 32-bit binary 
+
+In restic up to 0.14.0, the restic dump from a 32-bit binary of a
+snapshot of standard input that was created in Windows has as a
+result a tar file whose content has a negative uid and gid. As a
+result gnu tar exits with failure status whenever it tries to
+access such a tar file. With this fix, the tar file that is now
+dumped from a 32-bit binary has content with positive uid and gid.
+
+https://github.com/restic/restic/issues/4101
+https://github.com/restic/restic/pull/4102

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -564,12 +564,23 @@ func lookupGroup(gid uint32) string {
 	return group
 }
 
+// substitute negative uid and gid that is returned in Windows
+// with maximum value that is allowed in v7 and ustar tar formats;
+// this avoids creating a tar with dump that has negative uid and gid
+func fixId(id int) int {
+	if id < 0 {
+		return 0o7777777
+	} else {
+		return id
+	}
+}
+
 func (node *Node) fillExtra(path string, fi os.FileInfo) error {
 	stat, ok := toStatT(fi.Sys())
 	if !ok {
 		// fill minimal info with current values for uid, gid
-		node.UID = uint32(os.Getuid())
-		node.GID = uint32(os.Getgid())
+		node.UID = uint32(fixId(os.Getuid()))
+		node.GID = uint32(fixId(os.Getgid()))
 		node.ChangeTime = node.ModTime
 		return nil
 	}


### PR DESCRIPTION
Substitute negative uid and gid that is returned from os.Getuid
and os.Getgid in Windows with maximum value that is allowed in
v7 and ustar tar formats, i.e., 0o7777777. See:
https://www.gnu.org/software/tar/manual/html_section/Formats.html

This fixes the issue of a 32-bit binary restic dump that creates
a tar file containing negative uid and gid files:
https://github.com/restic/restic/issues/4101

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
https://github.com/restic/restic/issues/4101

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
I have only created the relevant issue https://github.com/restic/restic/issues/4101.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

Comments on checklist: I did not write a new test, because the change is simple. I have run the tests though. The change is internal, so there is no change in the manual.

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
