### PR TITLE
Remove Exitf function

### DIFF
--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -141,7 +141,7 @@ func runDump(ctx context.Context, opts DumpOptions, gopts GlobalOptions, args []
 
 	sn, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Paths, opts.Tags, opts.Hosts, nil, snapshotIDString)
 	if err != nil {
-		Exitf(1, "failed to find snapshot: %v", err)
+		return errors.Fatalf("failed to find snapshot: %v", err)
 	}
 
 	err = repo.LoadIndex(ctx)
@@ -151,13 +151,13 @@ func runDump(ctx context.Context, opts DumpOptions, gopts GlobalOptions, args []
 
 	tree, err := restic.LoadTree(ctx, repo, *sn.Tree)
 	if err != nil {
-		Exitf(2, "loading tree for snapshot %q failed: %v", snapshotIDString, err)
+		return errors.Fatalf("loading tree for snapshot %q failed: %v", snapshotIDString, err)
 	}
 
 	d := dump.New(opts.Archive, repo, os.Stdout)
 	err = printFromTree(ctx, tree, repo, "/", splittedPath, d)
 	if err != nil {
-		Exitf(2, "cannot dump file: %v", err)
+		return errors.Fatalf("cannot dump file: %v", err)
 	}
 
 	return nil

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -133,7 +133,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions, a
 
 	sn, err := restic.FindFilteredSnapshot(ctx, repo.Backend(), repo, opts.Hosts, opts.Tags, opts.Paths, nil, snapshotIDString)
 	if err != nil {
-		Exitf(1, "failed to find snapshot: %v", err)
+		return errors.Fatalf("failed to find snapshot: %v", err)
 	}
 
 	err = repo.LoadIndex(ctx)

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -281,17 +281,6 @@ func Warnf(format string, args ...interface{}) {
 	}
 }
 
-// Exitf uses Warnf to write the message and then terminates the process with
-// the given exit code.
-func Exitf(exitcode int, format string, args ...interface{}) {
-	if !(strings.HasSuffix(format, "\n")) {
-		format += "\n"
-	}
-
-	Warnf(format, args...)
-	Exit(exitcode)
-}
-
 // resolvePassword determines the password to be used for opening the repository.
 func resolvePassword(opts GlobalOptions, envStr string) (string, error) {
 	if opts.PasswordFile != "" && opts.PasswordCommand != "" {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Commands should use the normal shutdown path. In addition, the Exitf function was only used by `dump` and `restore` but not any other command which introduces the risk of inconsistent behavior.

Strictly speaking the exit code for the `dump` command may change for some errors. However, this was undocumented behavior and exit code 2 is also used by the go runtime to signal problems.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
