### PR TITLE
backup: extract StdioWrapper from ProgressPrinters

### DIFF
--- a/internal/ui/backup/json.go
+++ b/internal/ui/backup/json.go
@@ -15,7 +15,6 @@ import (
 // JSONProgress reports progress for the `backup` command in JSON.
 type JSONProgress struct {
 	*ui.Message
-	*ui.StdioWrapper
 
 	term *termstatus.Terminal
 	v    uint
@@ -27,10 +26,9 @@ var _ ProgressPrinter = &JSONProgress{}
 // NewJSONProgress returns a new backup progress reporter.
 func NewJSONProgress(term *termstatus.Terminal, verbosity uint) *JSONProgress {
 	return &JSONProgress{
-		Message:      ui.NewMessage(term, verbosity),
-		StdioWrapper: ui.NewStdioWrapper(term),
-		term:         term,
-		v:            verbosity,
+		Message: ui.NewMessage(term, verbosity),
+		term:    term,
+		v:       verbosity,
 	}
 }
 

--- a/internal/ui/backup/progress.go
+++ b/internal/ui/backup/progress.go
@@ -2,7 +2,6 @@ package backup
 
 import (
 	"context"
-	"io"
 	"sync"
 	"time"
 
@@ -21,10 +20,6 @@ type ProgressPrinter interface {
 	ReportTotal(item string, start time.Time, s archiver.ScanStats)
 	Finish(snapshotID restic.ID, start time.Time, summary *Summary, dryRun bool)
 	Reset()
-
-	// ui.StdioWrapper
-	Stdout() io.WriteCloser
-	Stderr() io.WriteCloser
 
 	P(msg string, args ...interface{})
 	V(msg string, args ...interface{})

--- a/internal/ui/backup/progress_test.go
+++ b/internal/ui/backup/progress_test.go
@@ -2,7 +2,6 @@ package backup
 
 import (
 	"context"
-	"io"
 	"sync"
 	"testing"
 	"time"
@@ -44,9 +43,6 @@ func (p *mockPrinter) Finish(id restic.ID, _ time.Time, summary *Summary, dryRun
 }
 
 func (p *mockPrinter) Reset() {}
-
-func (p *mockPrinter) Stdout() io.WriteCloser { return nil }
-func (p *mockPrinter) Stderr() io.WriteCloser { return nil }
 
 func (p *mockPrinter) P(msg string, args ...interface{}) {}
 func (p *mockPrinter) V(msg string, args ...interface{}) {}

--- a/internal/ui/backup/text.go
+++ b/internal/ui/backup/text.go
@@ -14,7 +14,6 @@ import (
 // TextProgress reports progress for the `backup` command.
 type TextProgress struct {
 	*ui.Message
-	*ui.StdioWrapper
 
 	term *termstatus.Terminal
 }
@@ -25,9 +24,8 @@ var _ ProgressPrinter = &TextProgress{}
 // NewTextProgress returns a new backup progress reporter.
 func NewTextProgress(term *termstatus.Terminal, verbosity uint) *TextProgress {
 	return &TextProgress{
-		Message:      ui.NewMessage(term, verbosity),
-		StdioWrapper: ui.NewStdioWrapper(term),
-		term:         term,
+		Message: ui.NewMessage(term, verbosity),
+		term:    term,
 	}
 }
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Extract the StdioWrapper from ProgressPrinters. The StdioWrapper is not used at all by the ProgressPrinters. It is now called a bit earlier than previously. However, as the password prompt directly accessed stdin/stdout this doesn't cause problems.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
