### PR TITLE
ui/progress: Extract progress updater

### DIFF
--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -37,7 +37,7 @@ func newProgressMax(show bool, max uint64, description string) *progress.Counter
 	interval := calculateProgressInterval(show, false)
 	canUpdateStatus := stdoutCanUpdateStatus()
 
-	return progress.New(interval, max, func(v uint64, max uint64, d time.Duration, final bool) {
+	return progress.NewCounter(interval, max, func(v uint64, max uint64, d time.Duration, final bool) {
 		var status string
 		if max == 0 {
 			status = fmt.Sprintf("[%s]          %d %s",

--- a/internal/restic/find_test.go
+++ b/internal/restic/find_test.go
@@ -93,7 +93,7 @@ func TestFindUsedBlobs(t *testing.T) {
 		snapshots = append(snapshots, sn)
 	}
 
-	p := progress.New(time.Second, findTestSnapshots, func(value uint64, total uint64, runtime time.Duration, final bool) {})
+	p := progress.NewCounter(time.Second, findTestSnapshots, func(value uint64, total uint64, runtime time.Duration, final bool) {})
 	defer p.Done()
 
 	for i, sn := range snapshots {
@@ -142,7 +142,7 @@ func TestMultiFindUsedBlobs(t *testing.T) {
 		want.Merge(loadIDSet(t, goldenFilename))
 	}
 
-	p := progress.New(time.Second, findTestSnapshots, func(value uint64, total uint64, runtime time.Duration, final bool) {})
+	p := progress.NewCounter(time.Second, findTestSnapshots, func(value uint64, total uint64, runtime time.Duration, final bool) {})
 	defer p.Done()
 
 	// run twice to check progress bar handling of duplicate tree roots

--- a/internal/ui/backup/progress_test.go
+++ b/internal/ui/backup/progress_test.go
@@ -1,7 +1,6 @@
 package backup
 
 import (
-	"context"
 	"sync"
 	"testing"
 	"time"
@@ -53,9 +52,6 @@ func TestProgress(t *testing.T) {
 	prnt := &mockPrinter{}
 	prog := NewProgress(prnt, time.Millisecond)
 
-	ctx, cancel := context.WithCancel(context.Background())
-	go prog.Run(ctx)
-
 	prog.StartFile("foo")
 	prog.CompleteBlob(1024)
 
@@ -67,7 +63,6 @@ func TestProgress(t *testing.T) {
 	prog.CompleteItem("foo", nil, &node, archiver.ItemStats{}, 0)
 
 	time.Sleep(10 * time.Millisecond)
-	cancel()
 	id := restic.NewRandomID()
 	prog.Finish(id, false)
 

--- a/internal/ui/progress/counter_test.go
+++ b/internal/ui/progress/counter_test.go
@@ -35,7 +35,7 @@ func TestCounter(t *testing.T) {
 		lastTotal = total
 		ncalls++
 	}
-	c := progress.New(10*time.Millisecond, startTotal, report)
+	c := progress.NewCounter(10*time.Millisecond, startTotal, report)
 
 	done := make(chan struct{})
 	go func() {
@@ -63,24 +63,6 @@ func TestCounterNil(t *testing.T) {
 	// Shouldn't panic.
 	var c *progress.Counter
 	c.Add(1)
+	c.SetMax(42)
 	c.Done()
-}
-
-func TestCounterNoTick(t *testing.T) {
-	finalSeen := false
-	otherSeen := false
-
-	report := func(value, total uint64, d time.Duration, final bool) {
-		if final {
-			finalSeen = true
-		} else {
-			otherSeen = true
-		}
-	}
-	c := progress.New(0, 1, report)
-	time.Sleep(time.Millisecond)
-	c.Done()
-
-	test.Assert(t, finalSeen, "final call did not happen")
-	test.Assert(t, !otherSeen, "unexpected status update")
 }

--- a/internal/ui/progress/updater.go
+++ b/internal/ui/progress/updater.go
@@ -1,0 +1,84 @@
+package progress
+
+import (
+	"time"
+
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/ui/signals"
+)
+
+// An UpdateFunc is a callback for a (progress) Updater.
+//
+// The final argument is true if Updater.Done has been called,
+// which means that the current call will be the last.
+type UpdateFunc func(runtime time.Duration, final bool)
+
+// An Updater controls a goroutine that periodically calls an UpdateFunc.
+//
+// The UpdateFunc is also called when SIGUSR1 (or SIGINFO, on BSD) is received.
+type Updater struct {
+	report  UpdateFunc
+	start   time.Time
+	stopped chan struct{} // Closed by run.
+	stop    chan struct{} // Close to stop run.
+	tick    *time.Ticker
+}
+
+// NewUpdater starts a new Updater.
+func NewUpdater(interval time.Duration, report UpdateFunc) *Updater {
+	c := &Updater{
+		report:  report,
+		start:   time.Now(),
+		stopped: make(chan struct{}),
+		stop:    make(chan struct{}),
+	}
+
+	if interval > 0 {
+		c.tick = time.NewTicker(interval)
+	}
+
+	go c.run()
+	return c
+}
+
+// Done tells an Updater to stop and waits for it to report its final value.
+// Later calls do nothing.
+func (c *Updater) Done() {
+	if c == nil || c.stop == nil {
+		return
+	}
+	if c.tick != nil {
+		c.tick.Stop()
+	}
+	close(c.stop)
+	<-c.stopped // Wait for last progress report.
+	c.stop = nil
+}
+
+func (c *Updater) run() {
+	defer close(c.stopped)
+	defer func() {
+		// Must be a func so that time.Since isn't called at defer time.
+		c.report(time.Since(c.start), true)
+	}()
+
+	var tick <-chan time.Time
+	if c.tick != nil {
+		tick = c.tick.C
+	}
+	signalsCh := signals.GetProgressChannel()
+	for {
+		var now time.Time
+
+		select {
+		case now = <-tick:
+		case sig := <-signalsCh:
+			debug.Log("Signal received: %v\n", sig)
+			now = time.Now()
+		case <-c.stop:
+			return
+		}
+
+		c.report(now.Sub(c.start), false)
+	}
+}

--- a/internal/ui/progress/updater_test.go
+++ b/internal/ui/progress/updater_test.go
@@ -1,0 +1,52 @@
+package progress_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/ui/progress"
+)
+
+func TestUpdater(t *testing.T) {
+	finalSeen := false
+	var ncalls int
+
+	report := func(d time.Duration, final bool) {
+		if final {
+			finalSeen = true
+		}
+		ncalls++
+	}
+	c := progress.NewUpdater(10*time.Millisecond, report)
+	time.Sleep(100 * time.Millisecond)
+	c.Done()
+
+	test.Assert(t, finalSeen, "final call did not happen")
+	test.Assert(t, ncalls > 0, "no progress was reported")
+}
+
+func TestUpdaterStopTwice(t *testing.T) {
+	c := progress.NewUpdater(0, func(runtime time.Duration, final bool) {})
+	c.Done()
+	c.Done()
+}
+
+func TestUpdaterNoTick(t *testing.T) {
+	finalSeen := false
+	otherSeen := false
+
+	report := func(d time.Duration, final bool) {
+		if final {
+			finalSeen = true
+		} else {
+			otherSeen = true
+		}
+	}
+	c := progress.NewUpdater(0, report)
+	time.Sleep(time.Millisecond)
+	c.Done()
+
+	test.Assert(t, finalSeen, "final call did not happen")
+	test.Assert(t, !otherSeen, "unexpected status update")
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Currently the common structure of our progress bar implementations is to have a struct which tracks the operation progress (ProgressTracker) and one or more ways to print that progress (ProgressPrinter). For example ui/backup contains `Progress` as ProgressTracker and the JSON/Text output as ProgressPrinter. ui/progress with its counter follows a similar structure: the `Counter` maps to the ProgressTracker and callback function is the ProgressPrinter. And soon another similar progress bar for the `restore` command will be added by #3991.

This PR focuses on the ProgressTracker part and extracts the common functionality which is responsible for driving the progress bar upgrade into a reusable `Updater` which periodically runs a provided callback to update the progress bar.

The Updater is currently embedded into the progress bar implementations. To simplify testing it might be useful to introduce an additional wrapper which combines the progress bar and the updater. However, this apparently would require additional code to e.g. allow the nil `Counter` to work as before.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Complements #3991.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
