### PR TITLE
prune: make it clearer when prune is used in dry-run mode

### DIFF
--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -237,7 +237,11 @@ func runForget(ctx context.Context, opts ForgetOptions, gopts GlobalOptions, arg
 
 	if len(removeSnIDs) > 0 && opts.Prune {
 		if !gopts.JSON {
-			Verbosef("%d snapshots have been removed, running prune\n", len(removeSnIDs))
+			if opts.DryRun {
+				Verbosef("%d snapshots would be removed, running prune dry run\n", len(removeSnIDs))
+			} else {
+				Verbosef("%d snapshots have been removed, running prune\n", len(removeSnIDs))
+			}
 		}
 		pruneOptions.DryRun = opts.DryRun
 		return runPruneWithRepo(ctx, pruneOptions, gopts, repo, removeSnIDs)

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -196,6 +196,10 @@ func runPruneWithRepo(ctx context.Context, opts PruneOptions, gopts GlobalOption
 		return err
 	}
 
+	if opts.DryRun {
+		Verbosef("\nWould have made the following changes:")
+	}
+
 	err = printPruneStats(stats)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
See #4112

The output would now become the following.
```
Would have removed the following snapshots:
{55803c2c fdb6bcc0}

2 snapshots have been removed, running prune
loading indexes...
loading all snapshots...
finding data that is still in use for 4 snapshots
[0:09] 100.00%  4 / 4 snapshots
searching used packs...
collecting packs for deletion and repacking
[0:02] 100.00%  1407 / 1407 packs processed

Would have made the following changes:

to repack:         30606 blobs / 17.197 MiB
this removes:         39 blobs / 105.196 KiB
to delete:             0 blobs / 0 B
total prune:          39 blobs / 105.196 KiB
remaining:        254628 blobs / 22.621 GiB
unused size after prune: 122.595 MiB (0.53% of remaining size)
```

Alternatively, we could add a remark like "Not making any changes as prune is executed in dry-run mode" (or some better wording).

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
