### PR TITLE
JSON logging: output "unchanged" only if level -vv

### DIFF
--- a/changelog/unreleased/pull-4132
+++ b/changelog/unreleased/pull-4132
@@ -1,0 +1,12 @@
+Enhancement: JSON logging: output "unchanged" only if level -vv
+
+JSON logging now outputs "action": "unchanged" only, if the log level is at least -vv.
+Previously, this also happened on log level -v.
+
+Other actions like "new" and "modified" will still be printed
+on log-level -v. That way it is possible to opt out of the
+large amount of messages regarding "unchanged" files and dirs,
+which might not be of interest and still get all the information
+regarding what has changed to the previous snapshot.
+
+https://github.com/restic/restic/pull/4132

--- a/internal/ui/backup/json.go
+++ b/internal/ui/backup/json.go
@@ -119,11 +119,13 @@ func (b *JSONProgress) CompleteItem(messageType, item string, previous, current 
 			MetadataSizeInRepo: s.TreeSizeInRepo,
 		})
 	case "dir unchanged":
-		b.print(verboseUpdate{
-			MessageType: "verbose_status",
-			Action:      "unchanged",
-			Item:        item,
-		})
+		if b.v > 2 {
+			b.print(verboseUpdate{
+				MessageType: "verbose_status",
+				Action:      "unchanged",
+				Item:        item,
+			})
+		}
 	case "dir modified":
 		b.print(verboseUpdate{
 			MessageType:        "verbose_status",
@@ -145,11 +147,13 @@ func (b *JSONProgress) CompleteItem(messageType, item string, previous, current 
 			DataSizeInRepo: s.DataSizeInRepo,
 		})
 	case "file unchanged":
-		b.print(verboseUpdate{
-			MessageType: "verbose_status",
-			Action:      "unchanged",
-			Item:        item,
-		})
+		if b.v > 2 {
+			b.print(verboseUpdate{
+				MessageType: "verbose_status",
+				Action:      "unchanged",
+				Item:        item,
+			})
+		}
 	case "file modified":
 		b.print(verboseUpdate{
 			MessageType:    "verbose_status",


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This patch changes json logging so that it outputs "action": "unchanged" only, if the log level is at least -vv.

Other actions like "new" and "modified" will still be printed on log-level -v. That way it is possible to opt out of the large amount of messages regarding "unchanged" files and dirs, which might not be of interest and still get all the information regarding what has changed to the previous snapshot.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
