### PR TITLE
doc: Move and update documentation for --no-scan

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -204,16 +204,6 @@ Combined with ``--verbose``, you can see a list of changes:
     modified  /archive.tar.gz, saved in 0.140s (25.542 MiB added)
     Would be added to the repository: 25.551 MiB
 
-Disabling Backup Progress Estimation
-************************************
-
-When you start a backup, restic will concurrently count the number of
-files and their total size, which is used to estimate how long it will
-take.  This will cause some extra I/O, which can slow down backup of
-network file systems or fuse mounts.
-
--  ``--no-scan``  Do not run scanner to estimate size of backup
-
 .. _backup-excluding-files:
 Excluding Files
 ***************

--- a/doc/047_tuning_backup_parameters.rst
+++ b/doc/047_tuning_backup_parameters.rst
@@ -19,6 +19,15 @@ values. As the restic commands evolve over time, the optimal value for each para
 can also change across restic versions.
 
 
+Disabling Backup Progress Estimation
+************************************
+
+When you start a backup, restic will concurrently count the number of files and
+their total size, which is used to estimate how long it will take. This will
+cause some extra I/O, which can slow down backups of network file systems or
+FUSE mounts. To avoid this overhead at the cost of not seeing a progress
+estimate, use the ``--no-scan`` option which disables this file scanning.
+
 Backend Connections
 ===================
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Just moves and adjusts the docs for `--no-scan`.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Nooo.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
