### PR TITLE
index: Optimize generatePackList

### DIFF
--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -3,6 +3,7 @@ package index_test
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math/rand"
 	"sync"
 	"testing"
@@ -403,6 +404,26 @@ func BenchmarkDecodeIndexParallel(b *testing.B) {
 			rtest.OK(b, err)
 		}
 	})
+}
+
+func BenchmarkEncodeIndex(b *testing.B) {
+	for _, n := range []int{100, 1000, 10000} {
+		idx, _ := createRandomIndex(rand.New(rand.NewSource(0)), n)
+
+		b.Run(fmt.Sprint(n), func(b *testing.B) {
+			buf := new(bytes.Buffer)
+			err := idx.Encode(buf)
+			rtest.OK(b, err)
+
+			b.ResetTimer()
+			b.ReportAllocs()
+
+			for i := 0; i < b.N; i++ {
+				buf.Reset()
+				_ = idx.Encode(buf)
+			}
+		})
+	}
 }
 
 func TestIndexUnserializeOld(t *testing.T) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Speeds up generating JSON from indexes, and especially cuts down the allocation rate. By using a []int instead of a map from ID's to pointers, it's also easier on the GC.

```
name                 old time/op    new time/op    delta
EncodeIndex/100-8      1.56ms ± 2%    1.40ms ± 3%  -10.38%  (p=0.000 n=10+9)
EncodeIndex/1000-8     14.5ms ± 2%    12.5ms ± 4%  -13.56%  (p=0.000 n=9+10)
EncodeIndex/10000-8     120ms ± 2%     110ms ± 5%   -8.38%  (p=0.000 n=10+10)

name                 old alloc/op   new alloc/op   delta
EncodeIndex/100-8       306kB ± 1%     260kB ± 1%  -15.01%  (p=0.000 n=10+10)
EncodeIndex/1000-8     3.69MB ±11%    2.91MB ± 4%  -21.12%  (p=0.000 n=10+10)
EncodeIndex/10000-8    35.9MB ±11%    31.0MB ±23%  -13.60%  (p=0.015 n=10+10)

name                 old allocs/op  new allocs/op  delta
EncodeIndex/100-8       3.39k ± 0%     2.37k ± 0%  -30.08%  (p=0.000 n=10+10)
EncodeIndex/1000-8      32.6k ± 0%     22.9k ± 0%  -29.81%  (p=0.000 n=10+10)
EncodeIndex/10000-8      326k ± 0%      229k ± 0%  -29.80%  (p=0.000 n=10+10)
```

The bulk of the allocation rate improvement comes from just removing the debug.Log calls: every one of those copied a restic.ID to the heap.

The remaining allocations are mostly within the JSON encoder.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

#838 discusses JSON performance. (Any other format would still have to do this transformation, though.)

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
