### PR TITLE
Improve handling of invalid locks

### DIFF
--- a/changelog/unreleased/pull-4152
+++ b/changelog/unreleased/pull-4152
@@ -1,0 +1,16 @@
+Enhancement: Ignore empty lock files
+
+With restic 0.15.0 the checks for stale locks became much stricter than before.
+In particular, empty or unreadable locks were no longer ignored. This caused
+restic to complain about `Load(<lock/1234567812>, 0, 0) returned error,
+retrying after 552.330144ms: load(<lock/1234567812>): invalid data returned`
+and fail in the end.
+
+We have clarified the error message and changed the implementation to ignore
+empty lock files which are sometimes created as the result of a failed upload
+on some backends. Unreadable lock files still have to cleaned up manually. To
+do so, you can run `restic unlock --remove-all` which removes all existing lock
+files. But first make sure that no other restic process is currently running.
+
+https://github.com/restic/restic/issues/4143
+https://github.com/restic/restic/pull/4152

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -2,11 +2,11 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"sync"
 	"time"
 
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 )
 
@@ -45,7 +45,7 @@ func lockRepository(ctx context.Context, repo restic.Repository, exclusive bool)
 
 	lock, err := lockFn(ctx, repo)
 	if err != nil {
-		return nil, ctx, fmt.Errorf("unable to create lock in backend: %w", err)
+		return nil, ctx, errors.Fatalf("unable to create lock in backend: %v", err)
 	}
 	debug.Log("create lock %p (exclusive %v)", lock, exclusive)
 

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -44,6 +44,9 @@ func lockRepository(ctx context.Context, repo restic.Repository, exclusive bool)
 	}
 
 	lock, err := lockFn(ctx, repo)
+	if restic.IsInvalidLock(err) {
+		return nil, ctx, errors.Fatalf("%v\n\nthe `unlock --remove-all` command can be used to remove invalid locks. Make sure that no other restic process is accessing the repository when running the command", err)
+	}
 	if err != nil {
 		return nil, ctx, errors.Fatalf("unable to create lock in backend: %v", err)
 	}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -204,7 +204,8 @@ func (r *Repository) LoadUnpacked(ctx context.Context, t restic.FileType, id res
 			} else {
 				cancel()
 			}
-			return errors.Errorf("load(%v): invalid data returned", h)
+			return restic.ErrInvalidData
+
 		}
 		return nil
 	})

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/restic/restic/internal/backend/local"
 	"github.com/restic/restic/internal/backend/mem"
+	"github.com/restic/restic/internal/backend/retry"
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/test"
@@ -97,10 +98,13 @@ func TestRepositoryWithVersion(t testing.TB, version uint) restic.Repository {
 
 // TestOpenLocal opens a local repository.
 func TestOpenLocal(t testing.TB, dir string) (r restic.Repository) {
+	var be restic.Backend
 	be, err := local.Open(context.TODO(), local.Config{Path: dir, Connections: 2})
 	if err != nil {
 		t.Fatal(err)
 	}
+
+	be = retry.New(be, 3, nil, nil)
 
 	repo, err := New(be, Options{})
 	if err != nil {

--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -360,6 +360,12 @@ func ForAllLocks(ctx context.Context, repo Repository, excludeID *ID, fn func(ID
 		if excludeID != nil && id.Equal(*excludeID) {
 			return nil
 		}
+		if size == 0 {
+			// Ignore empty lock files as some backends do not guarantee atomic uploads.
+			// These may leave empty files behind if an upload was interrupted between
+			// creating the file and writing its data.
+			return nil
+		}
 		lock, err := LoadLock(ctx, repo, id)
 
 		m.Lock()

--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -146,7 +146,7 @@ func (l *Lock) checkForOtherLocks(ctx context.Context) error {
 				// if we cannot load a lock then it is unclear whether it can be ignored
 				// it could either be invalid or just unreadable due to network/permission problems
 				debug.Log("ignore lock %v: %v", id, err)
-				return errors.Fatal(err.Error())
+				return err
 			}
 
 			if l.Exclusive {

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -4,9 +4,13 @@ import (
 	"context"
 
 	"github.com/restic/restic/internal/crypto"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/ui/progress"
 	"golang.org/x/sync/errgroup"
 )
+
+// ErrInvalidData is used to report that a file is corrupted
+var ErrInvalidData = errors.New("invalid data returned")
 
 // Repository stores data in a backend. It provides high-level functions and
 // transparently encrypts/decrypts data.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
If locking a repository fails due to an invalid lock, restic now prints the following output:
```
repository a14e5863 opened (version 2, compression level auto)
Load(<lock/1234567812>, 0, 0) returned error, retrying after 552.330144ms: invalid data returned
Load(<lock/1234567812>, 0, 0) returned error, retrying after 720.254544ms: invalid data returned
Load(<lock/1234567812>, 0, 0) returned error, retrying after 582.280027ms: invalid data returned
Fatal: invalid lock file: load(<lock/1234567812>): invalid data returned

the `unlock --remove-all` command can be used to remove invalid locks. Make sure that no other restic process is accessing the repository when running the command
```

The old output was the following:
```
repository a14e5863 opened (version 2, compression level auto)
Load(<lock/1234567812>, 0, 0) returned error, retrying after 552.330144ms: load(<lock/1234567812>): invalid data returned
Load(<lock/1234567812>, 0, 0) returned error, retrying after 468.857094ms: load(<lock/1234567812>): invalid data returned
Load(<lock/1234567812>, 0, 0) returned error, retrying after 593.411537ms: load(<lock/1234567812>): invalid data returned
unable to create lock in backend: Fatal: context canceled
```

It now longer contains the duplicate information which lock failed: `Load(<lock/1234567812>, 0, 0) [...] load(<lock/1234567812>): [...]`. The fatal error now contains the actual error instead of `Fatal: context canceled`. And the output now contains help on how to resolve the problem.


For all backends which can atomically upload files, a single call to `unlock --remove-all` should permanently fix the problem.

Non-atomic backends are local/sftp for restic before 0.13.0, the rest-server before 0.11.0 (please upgrade ASAP if you use an older rest-server version) and some rclone backends. These might leave empty lock files behind if the upload is interrupted between creating the lock file and writing its data. Thus, simply ignore empty lock files. I'm unsure how much of a problem incomplete uploads of lock files actually are when using rclone. If these were common, then I'd expect more reports of restic failing e.g. due to an incomplete index. Thus, it might be an option to not merge the corresponding commit for now.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #4143
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
