### PR TITLE
prune: Don't show "packs processed" for quiet runs

### DIFF
--- a/changelog/unreleased/issue-4147
+++ b/changelog/unreleased/issue-4147
@@ -1,0 +1,7 @@
+Bugfix: Make `prune --quiet` not print progress
+
+We have fixed a regression in restic 0.15.0 which caused `prune --quiet` to
+show a progress bar while deciding how to process each pack files.
+
+https://github.com/restic/restic/issues/4147
+https://github.com/restic/restic/pull/4153

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -473,7 +473,7 @@ func decidePackAction(ctx context.Context, opts PruneOptions, repo restic.Reposi
 	}
 
 	// loop over all packs and decide what to do
-	bar := newProgressMax(quiet, uint64(len(indexPack)), "packs processed")
+	bar := newProgressMax(!quiet, uint64(len(indexPack)), "packs processed")
 	err := repo.List(ctx, restic.PackFile, func(id restic.ID, packSize int64) error {
 		p, ok := indexPack[id]
 		if !ok {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Prune showed the `packs processed` progress bar only when running in quiet mode.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

I've tried to add a regression test, however, the progress bar currently outputs directly to os.Stdout which would require changes to the progress bar for proper testing.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Regressed in #4069
Fixes #4147
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
