### PR TITLE
self-upgrade: Fix handling of `--output` on windows

### DIFF
--- a/changelog/unreleased/pull-4163
+++ b/changelog/unreleased/pull-4163
@@ -1,0 +1,12 @@
+Bugfix: Repair `self-update --output new-file.exe` on Windows
+
+Since restic 0.14.0 `self-update` did not work when a custom output filename
+was specified via the `--output` option. This has been fixed.
+
+As a workaround either use an older restic version to run the self-update or
+create an empty file with the output filename before updating e.g. using CMD:
+`type nul > new-file.exe`
+`restic self-update --output new-file.exe`
+
+https://github.com/restic/restic/pull/4163
+https://forum.restic.net/t/self-update-windows-started-failing-after-release-of-0-15/5836

--- a/internal/selfupdate/download_test.go
+++ b/internal/selfupdate/download_test.go
@@ -1,0 +1,44 @@
+package selfupdate
+
+import (
+	"archive/zip"
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestExtractToFileZip(t *testing.T) {
+	printf := func(string, ...interface{}) {}
+	dir := t.TempDir()
+
+	ext := "zip"
+	data := []byte("Hello World!")
+
+	// create dummy archive
+	var archive bytes.Buffer
+	zw := zip.NewWriter(&archive)
+	w, err := zw.CreateHeader(&zip.FileHeader{
+		Name:               "example.exe",
+		UncompressedSize64: uint64(len(data)),
+	})
+	rtest.OK(t, err)
+	_, err = w.Write(data[:])
+	rtest.OK(t, err)
+	rtest.OK(t, zw.Close())
+
+	// run twice to test creating a new file and overwriting
+	for i := 0; i < 2; i++ {
+		outfn := filepath.Join(dir, ext+"-out")
+		rtest.OK(t, extractToFile(archive.Bytes(), "src."+ext, outfn, printf))
+
+		outdata, err := os.ReadFile(outfn)
+		rtest.OK(t, err)
+		rtest.Assert(t, bytes.Equal(data[:], outdata), "%v contains wrong data", outfn)
+
+		// overwrite to test the file is properly overwritten
+		rtest.OK(t, os.WriteFile(outfn, []byte{1, 2, 3}, 0))
+	}
+}

--- a/internal/selfupdate/download_windows.go
+++ b/internal/selfupdate/download_windows.go
@@ -7,11 +7,18 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/restic/restic/internal/errors"
 )
 
 // Rename (rather than remove) the running version. The running binary will be locked
 // on Windows and cannot be removed while still executing.
 func removeResticBinary(dir, target string) error {
+	// nothing to do if the target does not exist
+	if _, err := os.Stat(target); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
 	backup := filepath.Join(dir, filepath.Base(target)+".bak")
 	if _, err := os.Stat(backup); err == nil {
 		_ = os.Remove(backup)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The code always assumed that the upgrade happens in place. Thus writing the upgrade to a separate file fails, when trying to remove the file stored at that location.

I'm not entirely happy with the fix as this leads to different behavior when the output already exists: on Windows `self-update` will move the existing file to $fn.exe.bak and create the updated file at $fn.exe. On all other systems only $fn is created, without any .bak file.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://forum.restic.net/t/self-update-windows-started-failing-after-release-of-0-15/5836
Regressed in #3675 (included in restic 0.14.0)
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
