### PR TITLE
ui/backup: Fix percent and eta in backup progress

### DIFF
--- a/changelog/unreleased/pull-4167
+++ b/changelog/unreleased/pull-4167
@@ -1,0 +1,6 @@
+Bugfix: ETA was missing from `backup` progress bar
+
+A regression in restic 0.15.0 caused the ETA to be missing from the progress
+bar displayed by the `backup` command. This has been fixed.
+
+https://github.com/restic/restic/pull/4167

--- a/internal/ui/backup/progress.go
+++ b/internal/ui/backup/progress.go
@@ -199,6 +199,7 @@ func (p *Progress) ReportTotal(item string, s archiver.ScanStats) {
 	p.scanStarted = true
 
 	if item == "" {
+		p.scanFinished = true
 		p.printer.ReportTotal(item, p.start, s)
 	}
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

When changes were made to progress logic as part of https://github.com/restic/restic/pull/3977, the printing of percentage completion and eta stopped working. The reason was, the call to p.scanFinished = true was missing, which was causing the percent and eta to never get printed for backup even after the scan was finished.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Discussed at https://github.com/restic/restic/commit/04216eb9aa57cf45b8616442a86021e98e04eb18#r97600138

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
