### PR TITLE
Fix deadlock in Lock.Stale

### DIFF
--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -222,7 +222,7 @@ var StaleLockTimeout = 30 * time.Minute
 func (l *Lock) Stale() bool {
 	l.lock.Lock()
 	defer l.lock.Unlock()
-	debug.Log("testing if lock %v for process %d is stale", l, l.PID)
+	debug.Log("testing if lock %v for process %d is stale", l.lockID, l.PID)
 	if time.Since(l.Time) > StaleLockTimeout {
 		debug.Log("lock is stale, timestamp is too old: %v\n", l.Time)
 		return true


### PR DESCRIPTION
With debug logging enabled this method would take a lock and then format the lock as a string. Since PR #4022 landed the string formatting method has also taken the lock, so this deadlocks.

Instead just record the lock ID, as is done elsewhere.

Checklist
---------

- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [X] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] ~~I have added tests for all code changes.~~
- [ ] ~~I have added documentation for relevant changes (in the manual).~~
- [ ] ~~There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [X] I have run `gofmt` on the code in all commits.
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [X] I'm done! This pull request is ready for review.
