### PR TITLE
Fix scan_finished JSON MessageType

### DIFF
--- a/changelog/unreleased/pull-4176
+++ b/changelog/unreleased/pull-4176
@@ -1,0 +1,7 @@
+Change: Fix JSON message type of `scan_finished` for the `backup` command
+
+Restic incorrectly set the `message_type` of the `scan_finished` message to
+`status` instead of `verbose_status`. This has now been corrected so that
+the messages report the correct type.
+
+https://github.com/restic/restic/pull/4176

--- a/internal/ui/backup/json.go
+++ b/internal/ui/backup/json.go
@@ -164,7 +164,7 @@ func (b *JSONProgress) CompleteItem(messageType, item string, previous, current 
 func (b *JSONProgress) ReportTotal(item string, start time.Time, s archiver.ScanStats) {
 	if b.v >= 2 {
 		b.print(verboseUpdate{
-			MessageType: "status",
+			MessageType: "verbose_status",
 			Action:      "scan_finished",
 			Duration:    time.Since(start).Seconds(),
 			DataSize:    s.Bytes,


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR corrects the `MessageType` of the `verboseUpdate` struct which is printed by the `ReportTotal` function, the `MessageType` is currently set to `status` instead of `verbose_status`, This causes the message to be misidentified as a `statusUpdate` when deserializing JSON.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Not that I'm aware of.

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
