### PR TITLE
repository: Reuse buffers in Repository.LoadUnpacked

### DIFF
--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -72,7 +72,7 @@ func runCat(ctx context.Context, gopts GlobalOptions, args []string) error {
 		Println(string(buf))
 		return nil
 	case "index":
-		buf, err := repo.LoadUnpacked(ctx, restic.IndexFile, id, nil)
+		buf, err := repo.LoadUnpacked(ctx, restic.IndexFile, id)
 		if err != nil {
 			return err
 		}

--- a/internal/index/index_parallel.go
+++ b/internal/index/index_parallel.go
@@ -24,7 +24,7 @@ func ForAllIndexes(ctx context.Context, repo restic.Repository,
 		var idx *Index
 		oldFormat := false
 
-		buf, err := repo.LoadUnpacked(ctx, restic.IndexFile, id, nil)
+		buf, err := repo.LoadUnpacked(ctx, restic.IndexFile, id)
 		if err == nil {
 			idx, oldFormat, err = DecodeIndex(buf, id)
 		}

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -232,7 +232,7 @@ func benchmarkLoadUnpacked(b *testing.B, version uint) {
 	b.SetBytes(int64(length))
 
 	for i := 0; i < b.N; i++ {
-		data, err := repo.LoadUnpacked(context.TODO(), restic.PackFile, storageID, nil)
+		data, err := repo.LoadUnpacked(context.TODO(), restic.PackFile, storageID)
 		rtest.OK(b, err)
 
 		// See comment in BenchmarkLoadBlob.
@@ -261,7 +261,7 @@ func TestRepositoryLoadIndex(t *testing.T) {
 
 // loadIndex loads the index id from backend and returns it.
 func loadIndex(ctx context.Context, repo restic.Repository, id restic.ID) (*index.Index, error) {
-	buf, err := repo.LoadUnpacked(ctx, restic.IndexFile, id, nil)
+	buf, err := repo.LoadUnpacked(ctx, restic.IndexFile, id)
 	if err != nil {
 		return nil, err
 	}
@@ -289,7 +289,7 @@ func TestRepositoryLoadUnpackedBroken(t *testing.T) {
 	rtest.OK(t, err)
 
 	// without a retry backend this will just return an error that the file is broken
-	_, err = repo.LoadUnpacked(context.TODO(), restic.IndexFile, id, nil)
+	_, err = repo.LoadUnpacked(context.TODO(), restic.IndexFile, id)
 	if err == nil {
 		t.Fatal("missing expected error")
 	}

--- a/internal/restic/config_test.go
+++ b/internal/restic/config_test.go
@@ -21,11 +21,11 @@ func (s saver) Connections() uint {
 }
 
 type loader struct {
-	fn func(restic.FileType, restic.ID, []byte) ([]byte, error)
+	fn func(restic.FileType, restic.ID) ([]byte, error)
 }
 
-func (l loader) LoadUnpacked(ctx context.Context, t restic.FileType, id restic.ID, buf []byte) (data []byte, err error) {
-	return l.fn(t, id, buf)
+func (l loader) LoadUnpacked(ctx context.Context, t restic.FileType, id restic.ID) (data []byte, err error) {
+	return l.fn(t, id)
 }
 
 func (l loader) Connections() uint {
@@ -49,7 +49,7 @@ func TestConfig(t *testing.T) {
 	err = restic.SaveConfig(context.TODO(), saver{save}, cfg1)
 	rtest.OK(t, err)
 
-	load := func(tpe restic.FileType, id restic.ID, in []byte) ([]byte, error) {
+	load := func(tpe restic.FileType, id restic.ID) ([]byte, error) {
 		rtest.Assert(t, tpe == restic.ConfigFile,
 			"wrong backend type: got %v, wanted %v",
 			tpe, restic.ConfigFile)

--- a/internal/restic/json.go
+++ b/internal/restic/json.go
@@ -11,7 +11,7 @@ import (
 // LoadJSONUnpacked decrypts the data and afterwards calls json.Unmarshal on
 // the item.
 func LoadJSONUnpacked(ctx context.Context, repo LoaderUnpacked, t FileType, id ID, item interface{}) (err error) {
-	buf, err := repo.LoadUnpacked(ctx, t, id, nil)
+	buf, err := repo.LoadUnpacked(ctx, t, id)
 	if err != nil {
 		return err
 	}

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -51,10 +51,8 @@ type Repository interface {
 	StartPackUploader(ctx context.Context, wg *errgroup.Group)
 	Flush(context.Context) error
 
-	// LoadUnpacked loads and decrypts the file with the given type and ID,
-	// using the supplied buffer (which must be empty). If the buffer is nil, a
-	// new buffer will be allocated and returned.
-	LoadUnpacked(ctx context.Context, t FileType, id ID, buf []byte) (data []byte, err error)
+	// LoadUnpacked loads and decrypts the file with the given type and ID.
+	LoadUnpacked(ctx context.Context, t FileType, id ID) (data []byte, err error)
 	SaveUnpacked(context.Context, FileType, []byte) (ID, error)
 }
 
@@ -67,7 +65,7 @@ type Lister interface {
 type LoaderUnpacked interface {
 	// Connections returns the maximum number of concurrent backend operations
 	Connections() uint
-	LoadUnpacked(ctx context.Context, t FileType, id ID, buf []byte) (data []byte, err error)
+	LoadUnpacked(ctx context.Context, t FileType, id ID) (data []byte, err error)
 }
 
 // SaverUnpacked allows saving a blob not stored in a pack file


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Repository.LoadUnpacked had a buffer argument, but that was nil at all call sites. That's removed, and instead LoadUnpacked now reuses whatever it allocates inside its retry loop. Previously, it would try to reuse its nil argument if an error occurred in io.Copy.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
