### PR TITLE
Polish changelogs

### DIFF
--- a/changelog/unreleased/issue-3750
+++ b/changelog/unreleased/issue-3750
@@ -3,7 +3,7 @@ Bugfix: Remove `b2_download_file_by_name: 404` warning from B2 backend
 In some cases the B2 backend could print `b2_download_file_by_name: 404: :
 b2.b2err` warnings. These are only debug messages and can be safely ignored.
 
-We have updated the library used for accessing B2 to remove this warning.
+Restic now uses an updated library for accessing B2, which removes the warning.
 
 https://github.com/restic/restic/issues/3750
 https://github.com/restic/restic/issues/4144

--- a/changelog/unreleased/issue-4147
+++ b/changelog/unreleased/issue-4147
@@ -1,7 +1,7 @@
-Bugfix: Make `prune --quiet` not print progress
+Bugfix: Make `prune --quiet` not print progress bar
 
-We have fixed a regression in restic 0.15.0 which caused `prune --quiet` to
-show a progress bar while deciding how to process each pack files.
+A regression in restic 0.15.0 caused `prune --quiet` to show a progress bar
+while deciding how to process each pack files. This has now been fixed.
 
 https://github.com/restic/restic/issues/4147
 https://github.com/restic/restic/pull/4153

--- a/changelog/unreleased/pull-4152
+++ b/changelog/unreleased/pull-4152
@@ -1,16 +1,19 @@
 Enhancement: Ignore empty lock files
 
 With restic 0.15.0 the checks for stale locks became much stricter than before.
-In particular, empty or unreadable locks were no longer ignored. This caused
-restic to complain about `Load(<lock/1234567812>, 0, 0) returned error,
+In particular, empty or unreadable locks were no longer silently ignored. This
+made restic to complain with `Load(<lock/1234567812>, 0, 0) returned error,
 retrying after 552.330144ms: load(<lock/1234567812>): invalid data returned`
 and fail in the end.
 
-We have clarified the error message and changed the implementation to ignore
-empty lock files which are sometimes created as the result of a failed upload
-on some backends. Unreadable lock files still have to cleaned up manually. To
-do so, you can run `restic unlock --remove-all` which removes all existing lock
-files. But first make sure that no other restic process is currently running.
+The error message is now clarified and the implementation changed to ignore
+empty lock files which are sometimes created as the result of a failed uploads
+on some backends.
+
+Please note that unreadable lock files still have to cleaned up manually. To do
+so, you can run `restic unlock --remove-all` which removes all existing lock
+files. But first make sure that no other restic process is currently using the
+repository.
 
 https://github.com/restic/restic/issues/4143
 https://github.com/restic/restic/pull/4152

--- a/changelog/unreleased/pull-4163
+++ b/changelog/unreleased/pull-4163
@@ -1,10 +1,11 @@
-Bugfix: Repair `self-update --output new-file.exe` on Windows
+Bugfix: Make `self-update --output` work with new filename on Windows
 
-Since restic 0.14.0 `self-update` did not work when a custom output filename
-was specified via the `--output` option. This has been fixed.
+Since restic 0.14.0 the `self-update` command did not work when a custom output
+filename was specified via the `--output` option. This has now been fixed.
 
-As a workaround either use an older restic version to run the self-update or
+As a workaround, either use an older restic version to run the self-update or
 create an empty file with the output filename before updating e.g. using CMD:
+
 `type nul > new-file.exe`
 `restic self-update --output new-file.exe`
 

--- a/changelog/unreleased/pull-4167
+++ b/changelog/unreleased/pull-4167
@@ -1,6 +1,6 @@
-Bugfix: ETA was missing from `backup` progress bar
+Bugfix: Add missing ETA in `backup` progress bar
 
 A regression in restic 0.15.0 caused the ETA to be missing from the progress
-bar displayed by the `backup` command. This has been fixed.
+bar displayed by the `backup` command. This has now been fixed.
 
 https://github.com/restic/restic/pull/4167


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Polishes text in unreleased changelogs 🦄

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Nopette.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
