### PR TITLE
repository: Increase zstd max window size

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -365,9 +365,6 @@ func (r *Repository) getZstdEncoder() *zstd.Encoder {
 			// Disable CRC, we have enough checks in place, makes the
 			// compressed data four bytes shorter.
 			zstd.WithEncoderCRC(false),
-			// Set a window of 512kbyte, so we have good lookbehind for usual
-			// blob sizes.
-			zstd.WithWindowSize(512 * 1024),
 		}
 
 		enc, err := zstd.NewWriter(nil, opts...)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The default window size is 8MiB for --compression=auto/zstd.SpeedDefault and 32MiB for --compression=max/zstd.SpeedBestCompression. This gives slightly better compression than the custom 512KiB we had. To test this, I backed up an Ubuntu installer image of 2.274GiB (after deduplication):

```
                stored      ratio
auto+512K       943.92M     2.46652
auto+default    934.61M     2.47173
max+512K        900.59M     2.58518
max+default     898.59M     2.59094
```

Memory use in the decoder should not matter, since we always decompress to memory and blocks have bounded size.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
