### PR TITLE
check: Document behavior of --with-cache a bit better

### DIFF
--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -65,7 +65,7 @@ func init() {
 		// MarkDeprecated only returns an error when the flag is not found
 		panic(err)
 	}
-	f.BoolVar(&checkOptions.WithCache, "with-cache", false, "use the cache")
+	f.BoolVar(&checkOptions.WithCache, "with-cache", false, "use existing cache, only read uncached data from repository")
 }
 
 func checkFlags(opts CheckOptions) error {


### PR DESCRIPTION
The behavior of `--with-cache` came as a surprise to me, let's make sure this is a bit easier to understand.

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds a sentence to the description of `check --with-cache`. Despite its name, it does not *only* use the cache for its operation, which is exactly what this PR adds in documentation.

I have auto-generated the files in `doc/man/` and committed the change. The contribution guideline says to not edit these files, and technically I didn't, I just committed the auto-generated change. I'm happy to remove that part of the commit if you wish.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Not really, but see the related discussion at https://forum.restic.net/t/how-to-speed-up-tiny-incremental-checks/5905

Checklist
---------

- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [X] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [/] I have added tests for all code changes. → not really applicable
- [X] I have added documentation for relevant changes (in the manual). → That's all this PR does.
- [/] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)). → I don't think this warrants a changelog entry, does it?
- [X] I have run `gofmt` on the code in all commits.
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [X] I'm done! This pull request is ready for review.
