### PR TITLE
gs: support other regions than us

### DIFF
--- a/changelog/unreleased/pull-4226
+++ b/changelog/unreleased/pull-4226
@@ -1,6 +1,7 @@
-Enhancement: Allow to specify region where a bucket should get created in the gcs backend
+Enhancement: Allow specifying the region of new buckets in the gcs backend
 
-Buckets used by the Google Cloud Storage backend would always get created in the "us" region.
-It is now possible to specify the region, where a bucket should get created.
+Buckets used by the Google Cloud Storage backend would always get created in
+the "us" region. It is now possible to specify the region, where a bucket
+should get created.
 
 https://github.com/restic/restic/pull/4226

--- a/changelog/unreleased/pull-4226
+++ b/changelog/unreleased/pull-4226
@@ -1,0 +1,6 @@
+Enhancement: Allow to specify region where a bucket should get created in the gcs backend
+
+Buckets used by the Google Cloud Storage backend would always get created in the "us" region.
+It is now possible to specify the region, where a bucket should get created.
+
+https://github.com/restic/restic/pull/4226

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -613,6 +613,8 @@ The number of concurrent connections to the GCS service can be set with the
 ``-o gs.connections=10`` switch. By default, at most five parallel connections are
 established.
 
+The region, where a bucket should be created, can be specified with the ``-o gs.region=us`` switch. By default, the region is set to ``us``.
+
 .. _service account: https://cloud.google.com/iam/docs/service-account-overview
 .. _create a service account key: https://cloud.google.com/iam/docs/keys-create-delete
 .. _default authentication material: https://cloud.google.com/docs/authentication#service-accounts

--- a/internal/backend/gs/config.go
+++ b/internal/backend/gs/config.go
@@ -16,13 +16,15 @@ type Config struct {
 	Bucket    string
 	Prefix    string
 
-	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	Connections uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	Region      string `option:"region" help:"region to create the bucket in (default: us)"`
 }
 
 // NewConfig returns a new Config with the default values filled in.
 func NewConfig() Config {
 	return Config{
 		Connections: 5,
+		Region:      "us",
 	}
 }
 

--- a/internal/backend/gs/config_test.go
+++ b/internal/backend/gs/config_test.go
@@ -10,16 +10,19 @@ var configTests = []struct {
 		Bucket:      "bucketname",
 		Prefix:      "",
 		Connections: 5,
+		Region:      "us",
 	}},
 	{"gs:bucketname:/prefix/directory", Config{
 		Bucket:      "bucketname",
 		Prefix:      "prefix/directory",
 		Connections: 5,
+		Region:      "us",
 	}},
 	{"gs:bucketname:/prefix/directory/", Config{
 		Bucket:      "bucketname",
 		Prefix:      "prefix/directory",
 		Connections: 5,
+		Region:      "us",
 	}},
 }
 

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -37,6 +37,7 @@ type Backend struct {
 	projectID    string
 	connections  uint
 	bucketName   string
+	region       string
 	bucket       *storage.BucketHandle
 	prefix       string
 	listMaxItems int
@@ -102,6 +103,7 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 		projectID:   cfg.ProjectID,
 		connections: cfg.Connections,
 		bucketName:  cfg.Bucket,
+		region:      cfg.Region,
 		bucket:      gcsClient.Bucket(cfg.Bucket),
 		prefix:      cfg.Prefix,
 		Layout: &layout.DefaultLayout{
@@ -142,8 +144,11 @@ func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (restic.Backe
 	}
 
 	if !exists {
+		bucketAttrs := &storage.BucketAttrs{
+			Location: cfg.Region,
+		}
 		// Bucket doesn't exist, try to create it.
-		if err := be.bucket.Create(ctx, be.projectID, nil); err != nil {
+		if err := be.bucket.Create(ctx, be.projectID, bucketAttrs); err != nil {
 			// Always an error, as the bucket definitely doesn't exist.
 			return nil, errors.Wrap(err, "service.Buckets.Insert")
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Add an option to set the region for a bucket in google cloud storage.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
