### PR TITLE
init: Add --copy-chunker-params verbose msg

### DIFF
--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -102,7 +102,12 @@ func runInit(ctx context.Context, opts InitOptions, gopts GlobalOptions, args []
 	}
 
 	if !gopts.JSON {
-		Verbosef("created restic repository %v at %s\n", s.Config().ID[:10], location.StripPassword(gopts.Repo))
+		Verbosef("created restic repository %v at %s", s.Config().ID[:10], location.StripPassword(gopts.Repo))
+		if opts.CopyChunkerParameters && chunkerPolynomial != nil {
+			Verbosef(" with chunker parameters copied from secondary repository\n")
+		} else {
+			Verbosef("\n")
+		}
 		Verbosef("\n")
 		Verbosef("Please note that knowledge of your password is required to access\n")
 		Verbosef("the repository. Losing your password means that your data is\n")


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds one line of verbose output when `init` is used with option `--copy-chunker-params`, confirming that chunker parameters have been copied from the specified repository:

```
$ ./restic init -r tmp/r2 --from-repo tmp/r1 --copy-chunker-params
enter password for source repository: 
repository fab1d3dc opened (version 2, compression level auto)
created new cache in /Users/thndrbrrr/Library/Caches/restic
copied chunker parameters from repository fab1d3dc89 at tmp/r1                    <-------- added msg
enter password for new repository: 
enter password again: 
created restic repository 2ff633cbff at tmp/r2

Please note that knowledge of your password is required to access
the repository. Losing your password means that your data is
irrecoverably lost.
```

The rationale being that when I'm using a non-trivial option that affects what I'm about to do then it's good practice to have the program's output reflect that, as a confirmation so to speak. In this particular case it eliminates the question "Well I told `restic` to copy the chunker parameters ... but did it actually do it?" ;-)

No tests have been added since it seems like `restic`'s stdout messages are not covered by tests (which makes sense).

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Not to my knowledge.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
