### PR TITLE
fuse: Report fuse.Attr.Blocks correctly

### DIFF
--- a/changelog/unreleased/issue-4239
+++ b/changelog/unreleased/issue-4239
@@ -1,0 +1,11 @@
+Bugfix: Correct number of blocks reported in mount point
+
+Restic mount points incorrectly reported the number of 512-byte (POSIX
+standard) blocks for files and links, due to a rounding bug. In particular,
+empty files were reported as taking one block instead of zero.
+
+The rounding is now fixed: the number of blocks reported is the file size
+(or link target size), divided by 512 and rounded up to a whole number.
+
+https://github.com/restic/restic/issues/4239
+https://github.com/restic/restic/pull/4240

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -50,7 +50,7 @@ func (f *file) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Inode = f.inode
 	a.Mode = f.node.Mode
 	a.Size = f.node.Size
-	a.Blocks = (f.node.Size / blockSize) + 1
+	a.Blocks = (f.node.Size + blockSize - 1) / blockSize
 	a.BlockSize = blockSize
 	a.Nlink = uint32(f.node.Links)
 

--- a/internal/fuse/link.go
+++ b/internal/fuse/link.go
@@ -42,7 +42,7 @@ func (l *link) Attr(ctx context.Context, a *fuse.Attr) error {
 
 	a.Nlink = uint32(l.node.Links)
 	a.Size = uint64(len(l.node.LinkTarget))
-	a.Blocks = 1 + a.Size/blockSize
+	a.Blocks = (a.Size + blockSize - 1) / blockSize
 
 	return nil
 }

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -142,7 +142,7 @@ func (l *snapshotLink) Attr(ctx context.Context, a *fuse.Attr) error {
 	a.Inode = l.inode
 	a.Mode = os.ModeSymlink | 0777
 	a.Size = uint64(len(l.target))
-	a.Blocks = 1 + a.Size/blockSize
+	a.Blocks = (a.Size + blockSize - 1) / blockSize
 	a.Uid = l.root.uid
 	a.Gid = l.root.gid
 	a.Atime = l.snapshot.Time


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Fixes #4239.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
