### PR TITLE
Run tests with Go 1.20

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -261,7 +261,7 @@ jobs:
           version: v1.49
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true
-          args: --verbose --timeout 5m
+          args: --verbose --timeout 10m
 
         # only run golangci-lint for pull requests, otherwise ALL hints get
         # reported. We need to slowly address all issues until we can enable

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ on:
   pull_request:
 
 env:
-  latest_go: "1.19.x"
+  latest_go: "1.20.x"
   GO111MODULE: on
 
 jobs:
@@ -19,26 +19,31 @@ jobs:
         # list of jobs to run:
         include:
           - job_name: Windows
-            go: 1.19.x
+            go: 1.20.x
             os: windows-latest
 
           - job_name: macOS
-            go: 1.19.x
+            go: 1.20.x
             os: macOS-latest
             test_fuse: false
 
           - job_name: Linux
-            go: 1.19.x
+            go: 1.20.x
             os: ubuntu-latest
             test_cloud_backends: true
             test_fuse: true
             check_changelog: true
 
           - job_name: Linux (race)
-            go: 1.19.x
+            go: 1.20.x
             os: ubuntu-latest
             test_fuse: true
             test_opts: "-race"
+
+          - job_name: Linux
+            go: 1.19.x
+            os: ubuntu-latest
+            test_fuse: true
 
           - job_name: Linux
             go: 1.18.x

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -258,7 +258,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.49
+          version: v1.51
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           only-new-issues: true
           args: --verbose --timeout 10m


### PR DESCRIPTION

What does this PR change? What problem does it solve?
-----------------------------------------------------

Run Tests for Go 1.20.
