### PR TITLE
Fix documentation typos and build with Sphinx 6

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -90,7 +90,7 @@ command and enter the same password twice:
    data from a CIFS share is not recommended due to compatibility issues in
    older Linux kernels. Either use another backend or set the environment
    variable `GODEBUG` to `asyncpreemptoff=1`. Refer to GitHub issue
-   `#2659 <https://github.com/restic/restic/issues/2659>`_ for further explanations.
+   :issue:`2659` for further explanations.
 
 SFTP
 ****

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -216,6 +216,7 @@ Combined with ``--verbose``, you can see a list of changes:
     Would be added to the repository: 25.551 MiB
 
 .. _backup-excluding-files:
+
 Excluding Files
 ***************
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -106,5 +106,5 @@ html_static_path = ['_static']
 htmlhelp_basename = 'resticdoc'
 
 extlinks = {
-    'issue': ('https://github.com/restic/restic/issues/%s', '#'),
+    'issue': ('https://github.com/restic/restic/issues/%s', '#%s'),
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
While taking another look at #4210, I've noticed a broken link and that the documentation no longer built with Sphinx 6 due to https://github.com/sphinx-doc/sphinx/issues/11094 . This PR fixes both issues.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x[ I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
