### PR TITLE
doc: Fix links, focus less on implementation details

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -40,7 +40,7 @@ package from the official community repos, e.g. using ``apk``:
 Arch Linux
 ==========
 
-On `Arch Linux <https://www.archlinux.org/>`__, there is a package called ``restic``
+On `Arch Linux <https://archlinux.org/>`__, there is a package called ``restic``
 installed from the official community repos, e.g. with ``pacman -S``:
 
 .. code-block:: console
@@ -271,7 +271,7 @@ From Source
 restic is written in the Go programming language and you need at least
 Go version 1.18. Building restic may also work with older versions of Go,
 but that's not supported. See the `Getting
-started <https://golang.org/doc/install>`__ guide of the Go project for
+started <https://go.dev/doc/install>`__ guide of the Go project for
 instructions how to install Go.
 
 In order to build restic from source, execute the following steps:

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -290,7 +290,7 @@ like this: ``s3:http://server:port/bucket_name``.
 Minio Server
 ************
 
-`Minio <https://www.minio.io>`__ is an Open Source Object Storage,
+`Minio <https://www.min.io>`__ is an Open Source Object Storage,
 written in Go and compatible with Amazon S3 API.
 
 -  Download and Install `Minio
@@ -350,7 +350,7 @@ this command.
 Alibaba Cloud (Aliyun) Object Storage System (OSS)
 **************************************************
 
-`Alibaba OSS <https://www.alibabacloud.com/product/oss/>`__ is an
+`Alibaba OSS <https://www.alibabacloud.com/product/object-storage-service>`__ is an
 encrypted, secure, cost-effective, and easy-to-use object storage
 service that enables you to store, back up, and archive large amounts
 of data in the cloud.
@@ -616,7 +616,7 @@ established.
 
 .. _service account: https://cloud.google.com/iam/docs/service-accounts
 .. _create a service account key: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#iam-service-account-keys-create-console
-.. _default authentication material: https://cloud.google.com/docs/authentication/production
+.. _default authentication material: https://cloud.google.com/docs/authentication#service-accounts
 
 .. _other-services:
 

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -253,14 +253,14 @@ This instructs restic to exclude files matching the following criteria:
  * All files matching ``*.go`` (second line in ``excludes.txt``)
  * All files and sub-directories named ``bar`` which reside somewhere below a directory called ``foo`` (fourth line in ``excludes.txt``)
 
-Patterns use `filepath.Glob <https://golang.org/pkg/path/filepath/#Glob>`__ internally,
-see `filepath.Match <https://golang.org/pkg/path/filepath/#Match>`__ for
-syntax. Patterns are tested against the full path of a file/dir to be saved,
+Patterns use the syntax of the Go function
+`filepath.Match <https://pkg.go.dev/path/filepath#Match>`__
+and are tested against the full path of a file/dir to be saved,
 even if restic is passed a relative path to save. Empty lines and lines
 starting with a ``#`` are ignored.
 
 Environment variables in exclude files are expanded with `os.ExpandEnv
-<https://golang.org/pkg/os/#ExpandEnv>`__, so ``/home/$USER/foo`` will be
+<https://pkg.go.dev/os#ExpandEnv>`__, so ``/home/$USER/foo`` will be
 expanded to ``/home/bob/foo`` for the user ``bob``. To get a literal dollar
 sign, write ``$$`` to the file - this has to be done even when there's no
 matching environment variable for the word following a single ``$``. Note
@@ -380,7 +380,7 @@ contains one *pattern* per line. The file must be encoded as UTF-8, or UTF-16
 with a byte-order mark. Leading and trailing whitespace is removed from the
 patterns. Empty lines and lines starting with a ``#`` are ignored and each
 pattern is expanded when read, such that special characters in it are expanded
-using the Go function `filepath.Glob <https://golang.org/pkg/path/filepath/#Glob>`__
+using the Go function `filepath.Glob <https://pkg.go.dev/path/filepath#Glob>`__
 - please see its documentation for the syntax you can use in the patterns.
 
 The argument passed to ``--files-from-verbatim`` must be the name of a text file

--- a/doc/070_encryption.rst
+++ b/doc/070_encryption.rst
@@ -19,7 +19,7 @@ Encryption
 the implementation looks sane and I guess the deduplication trade-off is worth
 it. So… I’m going to use restic for my personal backups.*" `Filippo Valsorda`_
 
-.. _Filippo Valsorda: https://blog.filippo.io/restic-cryptography/
+.. _Filippo Valsorda: https://words.filippo.io/restic-cryptography/
 
 **********************
 Manage repository keys

--- a/doc/090_participating.rst
+++ b/doc/090_participating.rst
@@ -33,8 +33,8 @@ The debug log will always contain all log messages restic generates. You
 can also instruct restic to print some or all debug messages to stderr.
 These can also be limited to e.g. a list of source files or a list of
 patterns for function names. The patterns are globbing patterns (see the
-documentation for `path.Glob <https://golang.org/pkg/path/#Glob>`__), multiple
-patterns are separated by commas. Patterns are case sensitive.
+documentation for `filepath.Match <https://pkg.go.dev/path/filepath#Match>`__).
+Multiple patterns are separated by commas. Patterns are case sensitive.
 
 Printing all log messages to the console can be achieved by setting the
 file filter to ``*``:

--- a/doc/developer_information.rst
+++ b/doc/developer_information.rst
@@ -10,7 +10,7 @@ refer to the documentation for the respective version. The binary produced
 depends on the following things:
 
  * The source code for the release
- * The exact version of the official `Go compiler <https://golang.org>`__ used to produce the binaries (running ``restic version`` will print this)
+ * The exact version of the official `Go compiler <https://go.dev>`__ used to produce the binaries (running ``restic version`` will print this)
  * The architecture and operating system the Go compiler runs on (Linux, ``amd64``)
  * The build tags (for official binaries, it's the tag ``selfupdate``)
  * The path where the source code is extracted to (``/restic``)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The godoc for filepath.Match has the syntax, which is what is important for writing patterns. Use pkg.go.dev instead of golang.org/pkg.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

The links are listed at #4245.

Checklist
---------

- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
