### PR TITLE
doc: Correct broken links

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -93,7 +93,7 @@ You may also install it using `MacPorts <https://www.macports.org/>`__:
 Nix & NixOS
 ===========
 
-If you are using `Nix <https://nixos.org/nix/>`__ or `NixOS <https://nixos.org/>`__
+If you are using `Nix / NixOS <https://nixos.org>`__
 there is a package available named ``restic``.
 It can be installed using ``nix-env``:
 

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -273,7 +273,7 @@ For an S3-compatible server that is not Amazon (like Minio, see below),
 or is only available via HTTP, you can specify the URL to the server
 like this: ``s3:http://server:port/bucket_name``.
           
-.. note:: restic expects `path-style URLs <https://docs.aws.amazon.com/AmazonS3/latest/dev/UsingBucket.html#access-bucket-intro>`__
+.. note:: restic expects `path-style URLs <https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html>`__
           like for example ``s3.us-west-2.amazonaws.com/bucket_name``.
           Virtual-hosted–style URLs like ``bucket_name.s3.us-west-2.amazonaws.com``,
           where the bucket name is part of the hostname are not supported. These must
@@ -290,12 +290,11 @@ like this: ``s3:http://server:port/bucket_name``.
 Minio Server
 ************
 
-`Minio <https://www.min.io>`__ is an Open Source Object Storage,
+`Minio <https://min.io/>`__ is an Open Source Object Storage,
 written in Go and compatible with Amazon S3 API.
 
--  Download and Install `Minio
-   Server <https://minio.io/downloads/#minio-server>`__.
--  You can also refer to https://docs.minio.io for step by step guidance
+-  Download and Install `Minio Download <https://min.io/download#/linux>`__.
+-  You can also refer to `Minio Docs <https://min.io/docs/minio/linux/>`__ for step by step guidance
    on installation and getting started on Minio Client and Minio Server.
 
 You must first setup the following environment variables with the
@@ -358,7 +357,7 @@ of data in the cloud.
 Alibaba OSS is S3 compatible so it can be used as a storage provider
 for a restic repository with a couple of extra parameters.
 
--  Determine the correct `Alibaba OSS region endpoint <https://www.alibabacloud.com/help/doc-detail/31837.htm>`__ - this will be something like ``oss-eu-west-1.aliyuncs.com``
+-  Determine the correct `Alibaba OSS region endpoint <https://www.alibabacloud.com/help/en/object-storage-service/latest/regions-and-endpoints>`__ - this will be something like ``oss-eu-west-1.aliyuncs.com``
 -  You'll need the region name too - this will be something like ``oss-eu-west-1``
 
 You must first setup the following environment variables with the
@@ -441,7 +440,7 @@ the naming convention of those variables follows the official Python Swift clien
 
 
 Restic should be compatible with an `OpenStack RC file
-<https://docs.openstack.org/user-guide/common/cli-set-environment-variables-using-openstack-rc.html>`__
+<https://docs.openstack.org/ocata/admin-guide/common/cli-set-environment-variables-using-openstack-rc.html>`__
 in most cases.
 
 Once environment variables are set up, a new repository can be created. The
@@ -614,8 +613,8 @@ The number of concurrent connections to the GCS service can be set with the
 ``-o gs.connections=10`` switch. By default, at most five parallel connections are
 established.
 
-.. _service account: https://cloud.google.com/iam/docs/service-accounts
-.. _create a service account key: https://cloud.google.com/iam/docs/creating-managing-service-account-keys#iam-service-account-keys-create-console
+.. _service account: https://cloud.google.com/iam/docs/service-account-overview
+.. _create a service account key: https://cloud.google.com/iam/docs/keys-create-delete
 .. _default authentication material: https://cloud.google.com/docs/authentication#service-accounts
 
 .. _other-services:
@@ -748,7 +747,7 @@ Password prompt on Windows
 
 At the moment, restic only supports the default Windows console
 interaction. If you use emulation environments like
-`MSYS2 <https://msys2.github.io/>`__ or
+`MSYS2 <https://www.msys2.org/>`__ or
 `Cygwin <https://www.cygwin.com/>`__, which use terminals like
 ``Mintty`` or ``rxvt``, you may get a password error.
 

--- a/doc/110_talks.rst
+++ b/doc/110_talks.rst
@@ -26,11 +26,11 @@ The following talks will be or have been given about restic:
    Public lecture in German at `CCC Cologne
    e.V. <https://koeln.ccc.de>`__ in Cologne, Germany
 -  2015-08-23: `A Solution to the Backup
-   Inconvenience <https://programm.froscon.de/2015/events/1515.html>`__:
-   Lecture at `FROSCON 2015 <https://www.froscon.de>`__ in Bonn, Germany
+   Inconvenience <https://programm.froscon.org/2015/events/1515.html>`__:
+   Lecture at `FROSCON 2015 <https://www.froscon.org/>`__ in Bonn, Germany
 -  2015-02-01: `Lightning Talk at FOSDEM
    2015 <https://www.youtube.com/watch?v=oM-MfeflUZ8&t=11m40s>`__: A
    short introduction (with slightly outdated command line)
 -  2015-01-27: `Talk about restic at CCC
-   Aachen <https://videoag.fsmpi.rwth-aachen.de/?view=player&lectureid=4442#content>`__
+   Aachen <https://video.fsmpi.rwth-aachen.de/cccac/4442>`__
    (in German)

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -224,7 +224,7 @@ locks with the following command:
     d369ccc7d126594950bf74f0a348d5d98d9e99f3215082eb69bf02dc9b3e464c
 
 The ``find`` command searches for a given
-`pattern <https://golang.org/pkg/path/filepath/#Match>`__ in the
+`pattern <https://pkg.go.dev/path/filepath#Match>`__ in the
 repository.
 
 .. code-block:: console


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Fixes broken or otherwise change-worthy links in the documentation.

Note that there are still some links/URLs which are either blocked by the link checker or have a temporary redirect. One URL I couldn't find a canonical URL for that was not version-specific, so I haven't changed that (it's the OpenStack related one for the RC file). Also the key URL for pgp.mit.edu has always been problematic, the server doesn't always respond. Regardless, I checked all URLs that were not OK.

~~~
(020_installation: line   43) ok        https://archlinux.org/
(      040_backup: line  228) ok        https://bford.info/cachedir/
(020_installation: line  245) ok        https://beta.restic.net/?sort=time&order=desc
(    080_examples: line   31) ok        https://aws.amazon.com/
(      040_backup: line  507) ok        http://redsymbol.net/articles/unofficial-bash-strict-mode/
(    080_examples: line   31) ok        https://aws.amazon.com/free/
(020_installation: line   80) ok        https://brew.sh/
(       110_talks: line   20) ok        https://changelog.com/podcast/434
(    080_examples: line   41) redirect  https://console.aws.amazon.com - with Found to https://console.aws.amazon.com/console/home
(030_preparing_a_new_repo: line  583) ok        https://cloud.google.com/docs/authentication#service-accounts
(030_preparing_a_new_repo: line  572) ok        https://cloud.google.com/iam/docs/keys-create-delete
(030_preparing_a_new_repo: line  563) ok        https://cloud.google.com/iam/docs/service-account-overview
(  100_references: line  318) ok        https://cr.yp.to/mac/poly1305-20050329.pdf
(030_preparing_a_new_repo: line  276) ok        https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-bucket-intro.html
(090_participating: line   92) ok        https://dave.cheney.net/2016/03/12/suggestions-for-contributing-to-an-open-source-project
(030_preparing_a_new_repo: line  442) ok        https://docs.openstack.org/ocata/admin-guide/common/cli-set-environment-variables-using-openstack-rc.html
(developer_information: line   65) ok        https://github.com/restic/builder
(030_preparing_a_new_repo: line  191) ok        https://github.com/restic/rest-server
(090_participating: line   87) ok        https://github.com/restic/restic/blob/master/CONTRIBUTING.md
(      060_forget: line  347) ok        https://github.com/restic/rest-server/
(030_preparing_a_new_repo: line   47) ok        https://github.com/restic/restic/blob/master/doc/design.rst
(090_participating: line   92) ok        https://github.com/restic/restic/labels/help%3A%20wanted
(020_installation: line  191) redirect  https://github.com/restic/restic/releases/latest - with Found to https://github.com/restic/restic/releases/tag/v0.15.1
(             faq: line  110) ok        https://github.com/restic/restic/issues/533
(030_preparing_a_new_repo: line   89) ok        https://github.com/restic/restic/issues/2659
(030_preparing_a_new_repo: line  754) ok        https://github.com/rprichard/winpty
(030_preparing_a_new_repo: line  692) broken    https://github.com/restic/restic/pull/1657#issuecomment-377707486 - Anchor 'issuecomment-377707486' not found
(developer_information: line   13) ok        https://go.dev
(020_installation: line  271) ok        https://go.dev/doc/install
(developer_information: line   65) broken    https://hub.docker.com/r/restic/builder - HTTPSConnectionPool(host='hub.docker.com', port=443): Max retries exceeded with url: /r/restic/builder (Caused by SSLError(SSLEOFError(8, 'EOF occurred in violation of protocol (_ssl.c:997)')))
(       110_talks: line   24) ok        https://koeln.ccc.de
( troubleshooting: line   97) redirect  https://go.dev/pkg/runtime/#hdr-Environment_Variables - temporarily to https://pkg.go.dev/runtime#hdr-Environment_Variables
(030_preparing_a_new_repo: line  474) broken    https://help.backblaze.com/hc/en-us/articles/360047425453-Getting-Started-with-the-S3-Compatible-API - 403 Client Error: Forbidden for url: https://help.backblaze.com/hc/en-us/articles/360047425453-Getting-Started-with-the-S3-Compatible-API
(             faq: line  143) ok        https://linux.die.net/man/1/ionice
(       110_talks: line   24) ok        https://media.ccc.de/v/c4.openchaos.2016.01.restic
(030_preparing_a_new_repo: line  326) ok        https://console.wasabisys.com
(             faq: line  155) ok        https://linux.die.net/man/1/nice
(030_preparing_a_new_repo: line  297) ok        https://min.io/docs/minio/linux/
(020_installation: line   96) ok        https://nixos.org
(030_preparing_a_new_repo: line  293) ok        https://min.io/
(030_preparing_a_new_repo: line  787) redirect  https://manpages.debian.org/latest/passwd/passwd.5.en.html - temporarily to https://manpages.debian.org/bullseye/passwd/passwd.5.en.html
(     050_restore: line   87) ok        https://osxfuse.github.io/
(030_preparing_a_new_repo: line  296) broken    https://min.io/download#/linux - Anchor '/linux' not found
(      040_backup: line  379) ok        https://pkg.go.dev/path/filepath#Glob
(  100_references: line  511) ok        https://pkg.go.dev/io/fs#FileMode
(      040_backup: line  263) ok        https://pkg.go.dev/os#ExpandEnv
(030_preparing_a_new_repo: line  625) ok        https://rclone.org/
(      040_backup: line  257) ok        https://pkg.go.dev/path/filepath#Match
(      060_forget: line  347) ok        https://rclone.org/commands/rclone_serve_restic/
(  100_references: line  507) ok        https://pkg.go.dev/strconv#Quote
(       110_talks: line   28) ok        https://programm.froscon.org/2015/events/1515.html
(030_preparing_a_new_repo: line  625) ok        https://rclone.org/docs/
(090_participating: line   87) ok        https://restic.readthedocs.io/en/latest/design.html
(030_preparing_a_new_repo: line  676) ok        https://rclone.org/docs/#environment-variables
(020_installation: line  198) ok        https://restic.net/gpg-key-alex.asc
(020_installation: line  173) ok        https://scoop.sh/
(030_preparing_a_new_repo: line  725) ok        https://ruderich.org/simon/notes/append-only-backups-with-restic-and-rclone
(     manual_rest: line  365) ok        https://stedolan.github.io/jq/
(developer_information: line  119) ok        https://semver.org/
(090_participating: line  120) ok        https://semver.org
(             faq: line  117) ok        https://security.stackexchange.com/questions/14000/environment-variable-accessibility-in-linux/14009#14009
(090_participating: line  137) redirect  https://virtualenv.pypa.io - with Found to https://virtualenv.pypa.io/en/latest/
(       110_talks: line   34) ok        https://video.fsmpi.rwth-aachen.de/cccac/4442
(030_preparing_a_new_repo: line  323) ok        https://wasabi.com
(  070_encryption: line   18) ok        https://words.filippo.io/restic-cryptography/
(030_preparing_a_new_repo: line  327) broken    https://wasabi-support.zendesk.com/hc/en-us/articles/360015106031-What-are-the-service-URLs-for-Wasabi-s-different-regions- - 403 Client Error: Forbidden for url: https://wasabi-support.zendesk.com/hc/en-us/articles/360015106031-What-are-the-service-URLs-for-Wasabi-s-different-regions-
(020_installation: line   33) ok        https://www.alpinelinux.org
(030_preparing_a_new_repo: line  497) ok        https://www.backblaze.com/b2/docs/application_keys.html
(090_participating: line  103) broken    https://pgp.mit.edu/pks/lookup?op=get&search=0xCF8F18F2844575973F79D4E191A6868BD3F7A907 - HTTPSConnectionPool(host='pgp.mit.edu', port=443): Max retries exceeded with url: /pks/lookup?op=get&search=0xCF8F18F2844575973F79D4E191A6868BD3F7A907 (Caused by NewConnectionError('<urllib3.connection.HTTPSConnection object at 0xffffb696af80>: Failed to establish a new connection: [Errno 111] Connection refused'))
(030_preparing_a_new_repo: line  352) ok        https://www.alibabacloud.com/product/object-storage-service
(020_installation: line   87) ok        https://www.macports.org/
(030_preparing_a_new_repo: line  748) ok        https://www.msys2.org/
(030_preparing_a_new_repo: line  754) ok        https://www.msys2.org/wiki/Porting/
(030_preparing_a_new_repo: line  748) ok        https://www.cygwin.com/
(       110_talks: line   28) ok        https://www.froscon.org/
(090_participating: line  137) redirect  https://www.sphinx-doc.org - with Found to https://www.sphinx-doc.org/en/master/
(       110_talks: line   31) ok        https://www.youtube.com/watch?v=oM-MfeflUZ8&t=11m40s
(030_preparing_a_new_repo: line  360) ok        https://www.alibabacloud.com/help/en/object-storage-service/latest/regions-and-endpoints
~~~

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #4245 which was also addressed by #4246.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
