### PR TITLE
Implemented a web server to browse a repository (snapshots, files)

### DIFF
--- a/changelog/unreleased/pull-4276
+++ b/changelog/unreleased/pull-4276
@@ -1,0 +1,13 @@
+Enhancement: Implement web server to browse snapshots
+
+Currently the canonical way of browsing a repository's snapshots to view
+or restore files is `mount`. Unfortunately `mount` depends on fuse which
+is not available on all operating systems.
+
+The new `restic serve` command presents a web interface to browse a
+repository's snapshots. It allows to view and download files individually
+or as a group (as a tar archive) from snapshots.
+
+https://github.com/restic/restic/pull/4276
+https://github.com/restic/restic/issues/60
+ 

--- a/cmd/restic/cmd_serve.go
+++ b/cmd/restic/cmd_serve.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"context"
+	"html/template"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/restic/restic/internal/dump"
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/walker"
+)
+
+var cmdServe = &cobra.Command{
+	Use:   "serve",
+	Short: "runs a web server to browse a repository",
+	Long: `
+The serve command runs a web server to browse a repository.
+`,
+	DisableAutoGenTag: true,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runWebServer(cmd.Context(), serveOptions, globalOptions, args)
+	},
+}
+
+type ServeOptions struct {
+	Listen string
+}
+
+var serveOptions ServeOptions
+
+func init() {
+	cmdRoot.AddCommand(cmdServe)
+	cmdFlags := cmdServe.Flags()
+	cmdFlags.StringVarP(&serveOptions.Listen, "listen", "l", "localhost:3080", "set the listen host name and `address`")
+}
+
+type fileNode struct {
+	Path string
+	Node *restic.Node
+}
+
+func listNodes(ctx context.Context, repo restic.Repository, tree restic.ID, path string) ([]fileNode, error) {
+	var files []fileNode
+	err := walker.Walk(ctx, repo, tree, nil, func(_ restic.ID, nodepath string, node *restic.Node, err error) (bool, error) {
+		if err != nil || node == nil {
+			return false, err
+		}
+		if fs.HasPathPrefix(path, nodepath) {
+			files = append(files, fileNode{nodepath, node})
+		}
+		if node.Type == "dir" && !fs.HasPathPrefix(nodepath, path) {
+			return false, walker.ErrSkipNode
+		}
+		return false, nil
+	})
+	return files, err
+}
+
+func runWebServer(ctx context.Context, opts ServeOptions, gopts GlobalOptions, args []string) error {
+	if len(args) > 0 {
+		return errors.Fatal("this command does not accept additional arguments")
+	}
+
+	repo, err := OpenRepository(ctx, gopts)
+	if err != nil {
+		return err
+	}
+
+	if !gopts.NoLock {
+		var lock *restic.Lock
+		lock, ctx, err = lockRepo(ctx, repo)
+		defer unlockRepo(lock)
+		if err != nil {
+			return err
+		}
+	}
+
+	err = repo.LoadIndex(ctx)
+	if err != nil {
+		return err
+	}
+
+	funcMap := template.FuncMap{
+		"FormatTime": func(time time.Time) string { return time.Format(TimeFormat) },
+	}
+	indexPage := template.Must(template.New("index").Funcs(funcMap).Parse(indexPageTpl))
+	treePage := template.Must(template.New("tree").Funcs(funcMap).Parse(treePageTpl))
+
+	http.HandleFunc("/tree/", func(w http.ResponseWriter, r *http.Request) {
+		snapshotID, curPath, _ := strings.Cut(r.URL.Path[6:], "/")
+		curPath = "/" + strings.Trim(curPath, "/")
+		_ = r.ParseForm()
+
+		sn, err := restic.FindSnapshot(ctx, repo.Backend(), repo, snapshotID)
+		if err != nil {
+			http.Error(w, "Snapshot not found: "+err.Error(), http.StatusNotFound)
+			return
+		}
+
+		files, err := listNodes(ctx, repo, *sn.Tree, curPath)
+		if err != nil || len(files) == 0 {
+			http.Error(w, "Path not found in snapshot", http.StatusNotFound)
+			return
+		}
+
+		if r.Form.Get("action") == "dump" {
+			var tree restic.Tree
+			for _, file := range files {
+				for _, name := range r.Form["name"] {
+					if name == file.Node.Name {
+						tree.Nodes = append(tree.Nodes, file.Node)
+					}
+				}
+			}
+			if len(tree.Nodes) > 0 {
+				filename := strings.ReplaceAll(strings.Trim(snapshotID+curPath, "/"), "/", "_") + ".tar.gz"
+				w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+				// For now it's hardcoded to tar because it's the only format that supports all node types correctly
+				if err := dump.New("tar", repo, w).DumpTree(ctx, &tree, "/"); err != nil {
+					http.Error(w, err.Error(), http.StatusInternalServerError)
+				}
+				return
+			}
+		}
+
+		if len(files) == 1 && files[0].Node.Type == "file" {
+			if err := dump.New("zip", repo, w).WriteNode(ctx, files[0].Node); err != nil {
+				http.Error(w, err.Error(), http.StatusInternalServerError)
+			}
+			return
+		}
+
+		var rows []treePageRow
+		for _, item := range files {
+			if item.Path != curPath {
+				rows = append(rows, treePageRow{"/tree/" + snapshotID + item.Path, item.Node.Name, item.Node.Type, item.Node.Size, item.Node.ModTime})
+			}
+		}
+		sort.SliceStable(rows, func(i, j int) bool {
+			return strings.ToLower(rows[i].Name) < strings.ToLower(rows[j].Name)
+		})
+		sort.SliceStable(rows, func(i, j int) bool {
+			return rows[i].Type == "dir" && rows[j].Type != "dir"
+		})
+		parent := "/tree/" + snapshotID + curPath + "/.."
+		if curPath == "/" {
+			parent = "/"
+		}
+		if err := treePage.Execute(w, treePageData{snapshotID + ": " + curPath, parent, rows}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/" {
+			http.NotFound(w, r)
+			return
+		}
+		var rows []indexPageRow
+		for sn := range FindFilteredSnapshots(ctx, repo.Backend(), repo, &restic.SnapshotFilter{}, nil) {
+			rows = append(rows, indexPageRow{"/tree/" + sn.ID().Str() + "/", sn.ID().Str(), sn.Time, sn.Hostname, sn.Tags, sn.Paths})
+		}
+		sort.Slice(rows, func(i, j int) bool {
+			return rows[i].Time.After(rows[j].Time)
+		})
+		if err := indexPage.Execute(w, indexPageData{"Snapshots", rows}); err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
+	http.HandleFunc("/style.css", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Cache-Control", "max-age=300")
+		_, _ = w.Write([]byte(stylesheetTxt))
+	})
+
+	Printf("Now serving the repository at http://%s\n", opts.Listen)
+	Printf("When finished, quit with Ctrl-c here.\n")
+
+	return http.ListenAndServe(opts.Listen, nil)
+}
+
+type indexPageRow struct {
+	Link  string
+	ID    string
+	Time  time.Time
+	Host  string
+	Tags  []string
+	Paths []string
+}
+
+type indexPageData struct {
+	Title string
+	Rows  []indexPageRow
+}
+
+type treePageRow struct {
+	Link string
+	Name string
+	Type string
+	Size uint64
+	Time time.Time
+}
+
+type treePageData struct {
+	Title  string
+	Parent string
+	Rows   []treePageRow
+}
+
+const indexPageTpl = `<html>
+<head>
+<link rel="stylesheet" href="/style.css">
+<title>{{.Title}} :: restic</title>
+</head>
+<body>
+<h1>{{.Title}}</h1>
+<table>
+<thead><tr><th>ID</th><th>Time</th><th>Host</th><th>Tags</th><th>Paths</th></tr></thead>
+<tbody>
+{{range .Rows}}
+<tr><td><a href="{{.Link}}">{{.ID}}</a></td><td>{{.Time | FormatTime}}</td><td>{{.Host}}</td><td>{{.Tags}}</td><td>{{.Paths}}</td></tr>
+{{end}}
+</tbody>
+</table>
+</body>
+</html>`
+
+const treePageTpl = `<html>
+<head>
+<link rel="stylesheet" href="/style.css">
+<title>{{.Title}} :: restic</title>
+</head>
+<body>
+<h1>{{.Title}}</h1>
+<form method="post">
+<table>
+<thead><tr><th><input type="checkbox" onclick="document.querySelectorAll('.content input[type=checkbox]').forEach(cb => cb.checked = this.checked)"></th><th>Name</th><th>Type</th><th>Size</th><th>Date modified</th></tr></thead>
+<tbody class="content">
+{{if .Parent}}<tr><td></td><td><a href="{{.Parent}}">..</a></td><td>parent</td><td></td><td></tr>{{end}}
+{{range .Rows}}
+<tr><td><input type="checkbox" name="name" value="{{.Name}}"></td><td><a class="{{.Type}}" href="{{.Link}}">{{.Name}}</a></td><td>{{.Type}}</td><td>{{.Size}}</td><td>{{.Time | FormatTime}}</td></td></tr>
+{{end}}
+</tbody>
+<tbody class="actions">
+<tr><td colspan="100"><button name="action" value="dump" type="submit">Download selection</button></td></tr>
+</tbody>
+</table>
+</form>
+</body>
+</html>`
+ 
+const stylesheetTxt = `
+h1,h2,h3 {text-align:center; margin: 0.5em;}
+table {margin: 0 auto;border-collapse: collapse; }
+thead th {text-align: left; font-weight: bold;}
+tbody.content tr:hover {background: #eee;}
+tbody.content a.file:before {content: '\1F4C4'}
+tbody.content a.dir:before {content: '\1F4C1'}
+tbody.actions td {padding:.5em;}
+table, td, tr, th { border: 1px solid black; padding: .1em .5em;}
+`

--- a/cmd/restic/cmd_serve.go
+++ b/cmd/restic/cmd_serve.go
@@ -2,19 +2,13 @@ package main
 
 import (
 	"context"
-	"html/template"
 	"net/http"
-	"sort"
-	"strings"
-	"time"
 
 	"github.com/spf13/cobra"
 
-	"github.com/restic/restic/internal/dump"
 	"github.com/restic/restic/internal/errors"
-	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/restic"
-	"github.com/restic/restic/internal/walker"
+	"github.com/restic/restic/internal/server"
 )
 
 var cmdServe = &cobra.Command{
@@ -41,30 +35,6 @@ func init() {
 	cmdFlags.StringVarP(&serveOptions.Listen, "listen", "l", "localhost:3080", "set the listen host name and `address`")
 }
 
-type fileNode struct {
-	Path string
-	Node *restic.Node
-}
-
-func listNodes(ctx context.Context, repo restic.Repository, tree restic.ID, path string) ([]fileNode, error) {
-	var files []fileNode
-	err := walker.Walk(ctx, repo, tree, walker.WalkVisitor{
-		ProcessNode: func(_ restic.ID, nodepath string, node *restic.Node, err error) error {
-			if err != nil || node == nil {
-				return err
-			}
-			if fs.HasPathPrefix(path, nodepath) {
-				files = append(files, fileNode{nodepath, node})
-			}
-			if node.Type == "dir" && !fs.HasPathPrefix(nodepath, path) {
-				return walker.ErrSkipNode
-			}
-			return nil
-		},
-	})
-	return files, err
-}
-
 func runWebServer(ctx context.Context, opts ServeOptions, gopts GlobalOptions, args []string) error {
 	if len(args) > 0 {
 		return errors.Fatal("this command does not accept additional arguments")
@@ -87,195 +57,10 @@ func runWebServer(ctx context.Context, opts ServeOptions, gopts GlobalOptions, a
 		return err
 	}
 
-	funcMap := template.FuncMap{
-		"FormatTime": func(time time.Time) string { return time.Format(TimeFormat) },
-	}
-	indexPage := template.Must(template.New("index").Funcs(funcMap).Parse(indexPageTpl))
-	treePage := template.Must(template.New("tree").Funcs(funcMap).Parse(treePageTpl))
-
-	http.HandleFunc("/tree/", func(w http.ResponseWriter, r *http.Request) {
-		snapshotID, curPath, _ := strings.Cut(r.URL.Path[6:], "/")
-		curPath = "/" + strings.Trim(curPath, "/")
-		_ = r.ParseForm()
-
-		sn, _, err := restic.FindSnapshot(ctx, snapshotLister, repo, snapshotID)
-		if err != nil {
-			http.Error(w, "Snapshot not found: "+err.Error(), http.StatusNotFound)
-			return
-		}
-
-		files, err := listNodes(ctx, repo, *sn.Tree, curPath)
-		if err != nil || len(files) == 0 {
-			http.Error(w, "Path not found in snapshot", http.StatusNotFound)
-			return
-		}
-
-		if r.Form.Get("action") == "dump" {
-			var tree restic.Tree
-			for _, file := range files {
-				for _, name := range r.Form["name"] {
-					if name == file.Node.Name {
-						tree.Nodes = append(tree.Nodes, file.Node)
-					}
-				}
-			}
-			if len(tree.Nodes) > 0 {
-				filename := strings.ReplaceAll(strings.Trim(snapshotID+curPath, "/"), "/", "_") + ".tar.gz"
-				w.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
-				// For now it's hardcoded to tar because it's the only format that supports all node types correctly
-				if err := dump.New("tar", repo, w).DumpTree(ctx, &tree, "/"); err != nil {
-					http.Error(w, err.Error(), http.StatusInternalServerError)
-				}
-				return
-			}
-		}
-
-		if len(files) == 1 && files[0].Node.Type == "file" {
-			if err := dump.New("zip", repo, w).WriteNode(ctx, files[0].Node); err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
-			}
-			return
-		}
-
-		var rows []treePageRow
-		for _, item := range files {
-			if item.Path != curPath {
-				rows = append(rows, treePageRow{
-					Link: "/tree/" + snapshotID + item.Path,
-					Name: item.Node.Name,
-					Type: item.Node.Type,
-					Size: item.Node.Size,
-					Time: item.Node.ModTime,
-				})
-			}
-		}
-		sort.SliceStable(rows, func(i, j int) bool {
-			return strings.ToLower(rows[i].Name) < strings.ToLower(rows[j].Name)
-		})
-		sort.SliceStable(rows, func(i, j int) bool {
-			return rows[i].Type == "dir" && rows[j].Type != "dir"
-		})
-		parent := "/tree/" + snapshotID + curPath + "/.."
-		if curPath == "/" {
-			parent = "/"
-		}
-		if err := treePage.Execute(w, treePageData{snapshotID + ": " + curPath, parent, rows}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	})
-
-	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/" {
-			http.NotFound(w, r)
-			return
-		}
-		var rows []indexPageRow
-		for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &restic.SnapshotFilter{}, nil) {
-			rows = append(rows, indexPageRow{
-				Link:  "/tree/" + sn.ID().Str() + "/",
-				ID:    sn.ID().Str(),
-				Time:  sn.Time,
-				Host:  sn.Hostname,
-				Tags:  sn.Tags,
-				Paths: sn.Paths,
-			})
-		}
-		sort.Slice(rows, func(i, j int) bool {
-			return rows[i].Time.After(rows[j].Time)
-		})
-		if err := indexPage.Execute(w, indexPageData{"Snapshots", rows}); err != nil {
-			http.Error(w, err.Error(), http.StatusInternalServerError)
-		}
-	})
-
-	http.HandleFunc("/style.css", func(w http.ResponseWriter, _ *http.Request) {
-		w.Header().Set("Cache-Control", "max-age=300")
-		_, _ = w.Write([]byte(stylesheetTxt))
-	})
+	srv := server.New(repo, snapshotLister, TimeFormat)
 
 	Printf("Now serving the repository at http://%s\n", opts.Listen)
 	Printf("When finished, quit with Ctrl-c here.\n")
 
-	return http.ListenAndServe(opts.Listen, nil)
+	return http.ListenAndServe(opts.Listen, srv)
 }
-
-type indexPageRow struct {
-	Link  string
-	ID    string
-	Time  time.Time
-	Host  string
-	Tags  []string
-	Paths []string
-}
-
-type indexPageData struct {
-	Title string
-	Rows  []indexPageRow
-}
-
-type treePageRow struct {
-	Link string
-	Name string
-	Type string
-	Size uint64
-	Time time.Time
-}
-
-type treePageData struct {
-	Title  string
-	Parent string
-	Rows   []treePageRow
-}
-
-const indexPageTpl = `<html>
-<head>
-<link rel="stylesheet" href="/style.css">
-<title>{{.Title}} :: restic</title>
-</head>
-<body>
-<h1>{{.Title}}</h1>
-<table>
-<thead><tr><th>ID</th><th>Time</th><th>Host</th><th>Tags</th><th>Paths</th></tr></thead>
-<tbody>
-{{range .Rows}}
-<tr><td><a href="{{.Link}}">{{.ID}}</a></td><td>{{.Time | FormatTime}}</td><td>{{.Host}}</td><td>{{.Tags}}</td><td>{{.Paths}}</td></tr>
-{{end}}
-</tbody>
-</table>
-</body>
-</html>`
-
-const treePageTpl = `<html>
-<head>
-<link rel="stylesheet" href="/style.css">
-<title>{{.Title}} :: restic</title>
-</head>
-<body>
-<h1>{{.Title}}</h1>
-<form method="post">
-<table>
-<thead><tr><th><input type="checkbox" onclick="document.querySelectorAll('.content input[type=checkbox]').forEach(cb => cb.checked = this.checked)"></th><th>Name</th><th>Type</th><th>Size</th><th>Date modified</th></tr></thead>
-<tbody class="content">
-{{if .Parent}}<tr><td></td><td><a href="{{.Parent}}">..</a></td><td>parent</td><td></td><td></tr>{{end}}
-{{range .Rows}}
-<tr><td><input type="checkbox" name="name" value="{{.Name}}"></td><td><a class="{{.Type}}" href="{{.Link}}">{{.Name}}</a></td><td>{{.Type}}</td><td>{{.Size}}</td><td>{{.Time | FormatTime}}</td></td></tr>
-{{end}}
-</tbody>
-<tbody class="actions">
-<tr><td colspan="100"><button name="action" value="dump" type="submit">Download selection</button></td></tr>
-</tbody>
-</table>
-</form>
-</body>
-</html>`
-
-const stylesheetTxt = `
-h1,h2,h3 {text-align:center; margin: 0.5em;}
-table {margin: 0 auto;border-collapse: collapse; }
-thead th {text-align: left; font-weight: bold;}
-tbody.content tr:hover {background: #eee;}
-tbody.content a.file:before {content: '\1F4C4'}
-tbody.content a.dir:before {content: '\1F4C1'}
-tbody.actions td {padding:.5em;}
-table, td, tr, th { border: 1px solid black; padding: .1em .5em;}
-`

--- a/cmd/restic/cmd_serve.go
+++ b/cmd/restic/cmd_serve.go
@@ -80,6 +80,7 @@ func runWebServer(ctx context.Context, opts ServeOptions, gopts GlobalOptions, a
 	if err != nil {
 		return err
 	}
+
 	bar := newIndexProgress(gopts.Quiet, gopts.JSON)
 	err = repo.LoadIndex(ctx, bar)
 	if err != nil {
@@ -139,7 +140,13 @@ func runWebServer(ctx context.Context, opts ServeOptions, gopts GlobalOptions, a
 		var rows []treePageRow
 		for _, item := range files {
 			if item.Path != curPath {
-				rows = append(rows, treePageRow{"/tree/" + snapshotID + item.Path, item.Node.Name, item.Node.Type, item.Node.Size, item.Node.ModTime})
+				rows = append(rows, treePageRow{
+					Link: "/tree/" + snapshotID + item.Path,
+					Name: item.Node.Name,
+					Type: item.Node.Type,
+					Size: item.Node.Size,
+					Time: item.Node.ModTime,
+				})
 			}
 		}
 		sort.SliceStable(rows, func(i, j int) bool {
@@ -164,7 +171,14 @@ func runWebServer(ctx context.Context, opts ServeOptions, gopts GlobalOptions, a
 		}
 		var rows []indexPageRow
 		for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &restic.SnapshotFilter{}, nil) {
-			rows = append(rows, indexPageRow{"/tree/" + sn.ID().Str() + "/", sn.ID().Str(), sn.Time, sn.Hostname, sn.Tags, sn.Paths})
+			rows = append(rows, indexPageRow{
+				Link:  "/tree/" + sn.ID().Str() + "/",
+				ID:    sn.ID().Str(),
+				Time:  sn.Time,
+				Host:  sn.Hostname,
+				Tags:  sn.Tags,
+				Paths: sn.Paths,
+			})
 		}
 		sort.Slice(rows, func(i, j int) bool {
 			return rows[i].Time.After(rows[j].Time)

--- a/cmd/restic/cmd_serve.go
+++ b/cmd/restic/cmd_serve.go
@@ -49,7 +49,7 @@ type fileNode struct {
 func listNodes(ctx context.Context, repo restic.Repository, tree restic.ID, path string) ([]fileNode, error) {
 	var files []fileNode
 	err := walker.Walk(ctx, repo, tree, walker.WalkVisitor{
-		ProcessNode: func(parentTreeID restic.ID, nodepath string, node *restic.Node, err error) error {
+		ProcessNode: func(_ restic.ID, nodepath string, node *restic.Node, err error) error {
 			if err != nil || node == nil {
 				return err
 			}
@@ -188,7 +188,7 @@ func runWebServer(ctx context.Context, opts ServeOptions, gopts GlobalOptions, a
 		}
 	})
 
-	http.HandleFunc("/style.css", func(w http.ResponseWriter, r *http.Request) {
+	http.HandleFunc("/style.css", func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("Cache-Control", "max-age=300")
 		_, _ = w.Write([]byte(stylesheetTxt))
 	})

--- a/cmd/restic/cmd_serve.go
+++ b/cmd/restic/cmd_serve.go
@@ -45,7 +45,7 @@ func runWebServer(ctx context.Context, opts ServeOptions, gopts GlobalOptions, a
 		return errors.Fatal("this command does not accept additional arguments")
 	}
 
-	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, gopts.NoLock)
+	ctx, repo, unlock, err := openWithReadLock(ctx, gopts, gopts.NoLock)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_serve.go
+++ b/cmd/restic/cmd_serve.go
@@ -62,12 +62,17 @@ func runWebServer(ctx context.Context, opts ServeOptions, gopts GlobalOptions, a
 		return err
 	}
 
+	handler, err := server.New(repo, snapshotLister, TimeFormat)
+	if err != nil {
+		return err
+	}
+
 	srv := http.Server{
 		BaseContext: func(l net.Listener) context.Context {
 			// just return the global context
 			return ctx
 		},
-		Handler: server.New(repo, snapshotLister, TimeFormat),
+		Handler: handler,
 	}
 
 	listener, err := net.Listen("tcp", opts.Listen)

--- a/internal/server/assets/fs.go
+++ b/internal/server/assets/fs.go
@@ -1,0 +1,6 @@
+package assets
+
+import "embed"
+
+//go:embed *
+var FS embed.FS

--- a/internal/server/assets/fs.go
+++ b/internal/server/assets/fs.go
@@ -2,5 +2,5 @@ package assets
 
 import "embed"
 
-//go:embed *
+//go:embed *.html *.css
 var FS embed.FS

--- a/internal/server/assets/fs.go
+++ b/internal/server/assets/fs.go
@@ -1,6 +1,0 @@
-package assets
-
-import "embed"
-
-//go:embed *.html *.css
-var FS embed.FS

--- a/internal/server/assets/index.html
+++ b/internal/server/assets/index.html
@@ -1,0 +1,34 @@
+<html>
+
+<head>
+    <link rel="stylesheet" href="/style.css">
+    <title>{{.Title}} :: restic</title>
+</head>
+
+<body>
+    <h1>{{.Title}}</h1>
+    <table>
+        <thead>
+            <tr>
+                <th>ID</th>
+                <th>Time</th>
+                <th>Host</th>
+                <th>Tags</th>
+                <th>Paths</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{range .Rows}}
+            <tr>
+                <td><a href="{{.Link}}">{{.ID}}</a></td>
+                <td>{{.Time | FormatTime}}</td>
+                <td>{{.Host}}</td>
+                <td>{{.Tags}}</td>
+                <td>{{.Paths}}</td>
+            </tr>
+            {{end}}
+        </tbody>
+    </table>
+</body>
+
+</html>

--- a/internal/server/assets/style.css
+++ b/internal/server/assets/style.css
@@ -1,0 +1,40 @@
+h1,
+h2,
+h3 {
+    text-align: center;
+    margin: 0.5em;
+}
+
+table {
+    margin: 0 auto;
+    border-collapse: collapse;
+}
+
+thead th {
+    text-align: left;
+    font-weight: bold;
+}
+
+tbody.content tr:hover {
+    background: #eee;
+}
+
+tbody.content a.file:before {
+    content: '\1F4C4'
+}
+
+tbody.content a.dir:before {
+    content: '\1F4C1'
+}
+
+tbody.actions td {
+    padding: .5em;
+}
+
+table,
+td,
+tr,
+th {
+    border: 1px solid black;
+    padding: .1em .5em;
+}

--- a/internal/server/assets/tree.html
+++ b/internal/server/assets/tree.html
@@ -1,0 +1,51 @@
+<html>
+
+<head>
+    <link rel="stylesheet" href="/style.css">
+    <title>{{.Title}} :: restic</title>
+</head>
+
+<body>
+    <h1>{{.Title}}</h1>
+    <form method="post">
+        <table>
+            <thead>
+                <tr>
+                    <th><input type="checkbox"
+                            onclick="document.querySelectorAll('.content input[type=checkbox]').forEach(cb => cb.checked = this.checked)">
+                    </th>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Size</th>
+                    <th>Date modified</th>
+                </tr>
+            </thead>
+            <tbody class="content">
+                {{if .Parent}}<tr>
+                    <td></td>
+                    <td><a href="{{.Parent}}">..</a></td>
+                    <td>parent</td>
+                    <td></td>
+                    <td>
+                </tr>{{end}}
+                {{range .Rows}}
+                <tr>
+                    <td><input type="checkbox" name="name" value="{{.Name}}"></td>
+                    <td><a class="{{.Type}}" href="{{.Link}}">{{.Name}}</a></td>
+                    <td>{{.Type}}</td>
+                    <td>{{.Size}}</td>
+                    <td>{{.Time | FormatTime}}</td>
+                    </td>
+                </tr>
+                {{end}}
+            </tbody>
+            <tbody class="actions">
+                <tr>
+                    <td colspan="100"><button name="action" value="dump" type="submit">Download selection</button></td>
+                </tr>
+            </tbody>
+        </table>
+    </form>
+</body>
+
+</html>

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,231 @@
+// Package server contains an HTTP server which can serve content from a repo.
+package server
+
+import (
+	"context"
+	"fmt"
+	"io/fs"
+	"net/http"
+	"sort"
+	"strings"
+	"text/template"
+	"time"
+
+	"github.com/restic/restic/internal/dump"
+	rfs "github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/server/assets"
+	"github.com/restic/restic/internal/walker"
+)
+
+// New returns a new HTTP server.
+func New(repo restic.Repository, snapshotLister restic.Lister, timeFormat string) http.Handler {
+	funcs := template.FuncMap{
+		"FormatTime": func(time time.Time) string { return time.Format(timeFormat) },
+	}
+
+	templates := template.Must(template.New("").Funcs(funcs).ParseFS(assets.FS, "*.html"))
+
+	mux := http.NewServeMux()
+
+	indexPage := templates.Lookup("index.html")
+	if indexPage == nil {
+		panic("index.html not found")
+	}
+
+	treePage := templates.Lookup("tree.html")
+	if treePage == nil {
+		panic("tree.html not found")
+	}
+
+	mux.HandleFunc("/tree/", func(rw http.ResponseWriter, req *http.Request) {
+		snapshotID, curPath, _ := strings.Cut(req.URL.Path[6:], "/")
+		curPath = "/" + strings.Trim(curPath, "/")
+		_ = req.ParseForm()
+
+		sn, _, err := restic.FindSnapshot(req.Context(), snapshotLister, repo, snapshotID)
+		if err != nil {
+			http.Error(rw, "Snapshot not found: "+err.Error(), http.StatusNotFound)
+			return
+		}
+
+		files, err := listNodes(req.Context(), repo, *sn.Tree, curPath)
+		if err != nil || len(files) == 0 {
+			http.Error(rw, "Path not found in snapshot", http.StatusNotFound)
+			return
+		}
+
+		if req.Form.Get("action") == "dump" {
+			var tree restic.Tree
+			for _, file := range files {
+				for _, name := range req.Form["name"] {
+					if name == file.Node.Name {
+						tree.Nodes = append(tree.Nodes, file.Node)
+					}
+				}
+			}
+			if len(tree.Nodes) > 0 {
+				filename := strings.ReplaceAll(strings.Trim(snapshotID+curPath, "/"), "/", "_") + ".tar.gz"
+				rw.Header().Set("Content-Disposition", "attachment; filename=\""+filename+"\"")
+				// For now it's hardcoded to tar because it's the only format that supports all node types correctly
+				if err := dump.New("tar", repo, rw).DumpTree(req.Context(), &tree, "/"); err != nil {
+					http.Error(rw, err.Error(), http.StatusInternalServerError)
+				}
+				return
+			}
+		}
+
+		if len(files) == 1 && files[0].Node.Type == "file" {
+			if err := dump.New("zip", repo, rw).WriteNode(req.Context(), files[0].Node); err != nil {
+				http.Error(rw, err.Error(), http.StatusInternalServerError)
+			}
+			return
+		}
+
+		var rows []treePageRow
+		for _, item := range files {
+			if item.Path != curPath {
+				rows = append(rows, treePageRow{
+					Link: "/tree/" + snapshotID + item.Path,
+					Name: item.Node.Name,
+					Type: item.Node.Type,
+					Size: item.Node.Size,
+					Time: item.Node.ModTime,
+				})
+			}
+		}
+		sort.SliceStable(rows, func(i, j int) bool {
+			return strings.ToLower(rows[i].Name) < strings.ToLower(rows[j].Name)
+		})
+		sort.SliceStable(rows, func(i, j int) bool {
+			return rows[i].Type == "dir" && rows[j].Type != "dir"
+		})
+		parent := "/tree/" + snapshotID + curPath + "/.."
+		if curPath == "/" {
+			parent = "/"
+		}
+		if err := treePage.Execute(rw, treePageData{snapshotID + ": " + curPath, parent, rows}); err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
+	http.HandleFunc("/", func(rw http.ResponseWriter, req *http.Request) {
+		if req.URL.Path != "/" {
+			http.NotFound(rw, req)
+			return
+		}
+		var rows []indexPageRow
+		for sn := range findFilteredSnapshots(req.Context(), snapshotLister, repo, &restic.SnapshotFilter{}, nil) {
+			rows = append(rows, indexPageRow{
+				Link:  "/tree/" + sn.ID().Str() + "/",
+				ID:    sn.ID().Str(),
+				Time:  sn.Time,
+				Host:  sn.Hostname,
+				Tags:  sn.Tags,
+				Paths: sn.Paths,
+			})
+		}
+		sort.Slice(rows, func(i, j int) bool {
+			return rows[i].Time.After(rows[j].Time)
+		})
+		if err := indexPage.Execute(rw, indexPageData{"Snapshots", rows}); err != nil {
+			http.Error(rw, err.Error(), http.StatusInternalServerError)
+		}
+	})
+
+	http.HandleFunc("/style.css", func(rw http.ResponseWriter, _ *http.Request) {
+		rw.Header().Set("Cache-Control", "max-age=300")
+		buf, err := fs.ReadFile(assets.FS, "style.css")
+		if err == nil {
+			rw.WriteHeader(http.StatusInternalServerError)
+			fmt.Fprintf(rw, "error: %v", err)
+			return
+		}
+
+		_, _ = rw.Write(buf)
+	})
+
+	return mux
+}
+
+type fileNode struct {
+	Path string
+	Node *restic.Node
+}
+
+func listNodes(ctx context.Context, repo restic.Repository, tree restic.ID, path string) ([]fileNode, error) {
+	var files []fileNode
+	err := walker.Walk(ctx, repo, tree, walker.WalkVisitor{
+		ProcessNode: func(_ restic.ID, nodepath string, node *restic.Node, err error) error {
+			if err != nil || node == nil {
+				return err
+			}
+			if rfs.HasPathPrefix(path, nodepath) {
+				files = append(files, fileNode{nodepath, node})
+			}
+			if node.Type == "dir" && !rfs.HasPathPrefix(nodepath, path) {
+				return walker.ErrSkipNode
+			}
+			return nil
+		},
+	})
+	return files, err
+}
+
+type indexPageRow struct {
+	Link  string
+	ID    string
+	Time  time.Time
+	Host  string
+	Tags  []string
+	Paths []string
+}
+
+type indexPageData struct {
+	Title string
+	Rows  []indexPageRow
+}
+
+type treePageRow struct {
+	Link string
+	Name string
+	Type string
+	Size uint64
+	Time time.Time
+}
+
+type treePageData struct {
+	Title  string
+	Parent string
+	Rows   []treePageRow
+}
+
+// findFilteredSnapshots yields Snapshots, either given explicitly by `snapshotIDs` or filtered from the list of all snapshots.
+func findFilteredSnapshots(ctx context.Context, be restic.Lister, loader restic.LoaderUnpacked, f *restic.SnapshotFilter, snapshotIDs []string) <-chan *restic.Snapshot {
+	out := make(chan *restic.Snapshot)
+	go func() {
+		defer close(out)
+		be, err := restic.MemorizeList(ctx, be, restic.SnapshotFile)
+		if err != nil {
+			// Warnf("could not load snapshots: %v\n", err)
+			return
+		}
+
+		err = f.FindAll(ctx, be, loader, snapshotIDs, func(id string, sn *restic.Snapshot, err error) error {
+			if err != nil {
+				// Warnf("Ignoring %q: %v\n", id, err)
+			} else {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case out <- sn:
+				}
+			}
+			return nil
+		})
+		if err != nil {
+			// Warnf("could not load snapshots: %v\n", err)
+		}
+	}()
+	return out
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It adds a web server to browse a repository (snapshots, files). Overall it is a very simple patch and requires no additional dependencies but it might be very useful for people who can't use fuse mount.

It allows to browse snapshots, view files, and cherry pick files to download an archive.

Usage: `restic -r repo serve` and open your web browser to http://localhost:3080/

https://github.com/restic/restic/assets/13711380/aff76e96-85e0-40b5-a047-c9fd19f31956

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

It is related to #60 but after reading the discussion I don't know if this PR would be enough to close it.


Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
