### PR TITLE
lock: Improve debug logging in the test

### DIFF
--- a/cmd/restic/lock_test.go
+++ b/cmd/restic/lock_test.go
@@ -136,7 +136,9 @@ type loggingBackend struct {
 
 func (b *loggingBackend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
 	b.t.Logf("save %v @ %v", h, time.Now())
-	return b.Backend.Save(ctx, h, rd)
+	err := b.Backend.Save(ctx, h, rd)
+	b.t.Logf("save finished %v @ %v", h, time.Now())
+	return err
 }
 
 func TestLockSuccessfulRefresh(t *testing.T) {
@@ -161,7 +163,8 @@ func TestLockSuccessfulRefresh(t *testing.T) {
 
 	select {
 	case <-wrappedCtx.Done():
-		t.Fatal("lock refresh failed")
+		// don't call t.Fatal to allow the lock to be properly cleaned up
+		t.Error("lock refresh failed", time.Now())
 	case <-time.After(2 * refreshabilityTimeout):
 		// expected lock refresh to work
 	}

--- a/cmd/restic/lock_test.go
+++ b/cmd/restic/lock_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"testing"
 	"time"
 
@@ -165,6 +166,13 @@ func TestLockSuccessfulRefresh(t *testing.T) {
 	case <-wrappedCtx.Done():
 		// don't call t.Fatal to allow the lock to be properly cleaned up
 		t.Error("lock refresh failed", time.Now())
+
+		// Dump full stacktrace
+		buf := make([]byte, 1024*1024)
+		n := runtime.Stack(buf, true)
+		buf = buf[:n]
+		t.Log(string(buf))
+
 	case <-time.After(2 * refreshabilityTimeout):
 		// expected lock refresh to work
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The `TestLockSuccessfulRefresh` currently fails far too often. This PRs add a bit more debug logging and also dumps the stacktrace if the test times out. Maybe it becomes necessary to retry the test if the backend operations turn out to be too slow from time to time.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
