### PR TITLE
Normalize backend logging and connection limiting

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -801,7 +801,7 @@ func create(ctx context.Context, s string, opts options.Options) (restic.Backend
 	case "s3":
 		be, err = s3.Create(ctx, cfg.(s3.Config), rt)
 	case "gs":
-		be, err = gs.Create(cfg.(gs.Config), rt)
+		be, err = gs.Create(ctx, cfg.(gs.Config), rt)
 	case "azure":
 		be, err = azure.Create(ctx, cfg.(azure.Config), rt)
 	case "swift":

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -746,7 +746,7 @@ func open(ctx context.Context, s string, gopts GlobalOptions, opts options.Optio
 	}
 
 	// wrap with debug logging and connection limiting
-	be = logger.New(sema.New(be))
+	be = logger.New(sema.NewBackend(be))
 
 	// wrap backend if a test specified an inner hook
 	if gopts.backendInnerTestHook != nil {
@@ -821,5 +821,5 @@ func create(ctx context.Context, s string, opts options.Options) (restic.Backend
 		return nil, err
 	}
 
-	return logger.New(sema.New(be)), nil
+	return logger.New(sema.NewBackend(be)), nil
 }

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -20,6 +20,7 @@ import (
 	"github.com/restic/restic/internal/backend/limiter"
 	"github.com/restic/restic/internal/backend/local"
 	"github.com/restic/restic/internal/backend/location"
+	"github.com/restic/restic/internal/backend/logger"
 	"github.com/restic/restic/internal/backend/rclone"
 	"github.com/restic/restic/internal/backend/rest"
 	"github.com/restic/restic/internal/backend/retry"
@@ -743,6 +744,9 @@ func open(ctx context.Context, s string, gopts GlobalOptions, opts options.Optio
 		return nil, errors.Fatalf("unable to open repository at %v: %v", location.StripPassword(s), err)
 	}
 
+	// wrap with debug logging
+	be = logger.New(be)
+
 	// wrap backend if a test specified an inner hook
 	if gopts.backendInnerTestHook != nil {
 		be, err = gopts.backendInnerTestHook(be)
@@ -787,27 +791,34 @@ func create(ctx context.Context, s string, opts options.Options) (restic.Backend
 		return nil, err
 	}
 
+	var be restic.Backend
 	switch loc.Scheme {
 	case "local":
-		return local.Create(ctx, cfg.(local.Config))
+		be, err = local.Create(ctx, cfg.(local.Config))
 	case "sftp":
-		return sftp.Create(ctx, cfg.(sftp.Config))
+		be, err = sftp.Create(ctx, cfg.(sftp.Config))
 	case "s3":
-		return s3.Create(ctx, cfg.(s3.Config), rt)
+		be, err = s3.Create(ctx, cfg.(s3.Config), rt)
 	case "gs":
-		return gs.Create(cfg.(gs.Config), rt)
+		be, err = gs.Create(cfg.(gs.Config), rt)
 	case "azure":
-		return azure.Create(ctx, cfg.(azure.Config), rt)
+		be, err = azure.Create(ctx, cfg.(azure.Config), rt)
 	case "swift":
-		return swift.Open(ctx, cfg.(swift.Config), rt)
+		be, err = swift.Open(ctx, cfg.(swift.Config), rt)
 	case "b2":
-		return b2.Create(ctx, cfg.(b2.Config), rt)
+		be, err = b2.Create(ctx, cfg.(b2.Config), rt)
 	case "rest":
-		return rest.Create(ctx, cfg.(rest.Config), rt)
+		be, err = rest.Create(ctx, cfg.(rest.Config), rt)
 	case "rclone":
-		return rclone.Create(ctx, cfg.(rclone.Config))
+		be, err = rclone.Create(ctx, cfg.(rclone.Config))
+	default:
+		debug.Log("invalid repository scheme: %v", s)
+		return nil, errors.Fatalf("invalid scheme %q", loc.Scheme)
 	}
 
-	debug.Log("invalid repository scheme: %v", s)
-	return nil, errors.Fatalf("invalid scheme %q", loc.Scheme)
+	if err != nil {
+		return nil, err
+	}
+
+	return logger.New(be), nil
 }

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -300,17 +300,6 @@ func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset
 
 func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
-	if err := h.Valid(); err != nil {
-		return nil, backoff.Permanent(err)
-	}
-
-	if offset < 0 {
-		return nil, errors.New("offset is negative")
-	}
-
-	if length < 0 {
-		return nil, errors.Errorf("invalid length %d", length)
-	}
 
 	objName := be.Filename(h)
 	blockBlobClient := be.container.NewBlobClient(objName)

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -384,30 +384,9 @@ func (be *Backend) List(ctx context.Context, t restic.FileType, fn func(restic.F
 	return ctx.Err()
 }
 
-// Remove keys for a specified backend type.
-func (be *Backend) removeKeys(ctx context.Context, t restic.FileType) error {
-	return be.List(ctx, t, func(fi restic.FileInfo) error {
-		return be.Remove(ctx, restic.Handle{Type: t, Name: fi.Name})
-	})
-}
-
 // Delete removes all restic keys in the bucket. It will not remove the bucket itself.
 func (be *Backend) Delete(ctx context.Context) error {
-	alltypes := []restic.FileType{
-		restic.PackFile,
-		restic.KeyFile,
-		restic.LockFile,
-		restic.SnapshotFile,
-		restic.IndexFile}
-
-	for _, t := range alltypes {
-		err := be.removeKeys(ctx, t)
-		if err != nil {
-			return nil
-		}
-	}
-
-	return be.Remove(ctx, restic.Handle{Type: restic.ConfigFile})
+	return backend.DefaultDelete(ctx, be)
 }
 
 // Close does nothing

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -152,7 +152,6 @@ func (be *Backend) SetListMaxItems(i int) {
 
 // IsNotExist returns true if the error is caused by a not existing file.
 func (be *Backend) IsNotExist(err error) bool {
-	debug.Log("IsNotExist(%T, %#v)", err, err)
 	return bloberror.HasCode(err, bloberror.BlobNotFound)
 }
 
@@ -193,8 +192,6 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 
 	objName := be.Filename(h)
 
-	debug.Log("Save %v at %v", h, objName)
-
 	be.sem.GetToken()
 
 	debug.Log("InsertObject(%v, %v)", be.cfg.AccountName, objName)
@@ -209,8 +206,6 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 	}
 
 	be.sem.ReleaseToken()
-	debug.Log("%v, err %#v", objName, err)
-
 	return err
 }
 
@@ -299,8 +294,6 @@ func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset
 }
 
 func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
-
 	objName := be.Filename(h)
 	blockBlobClient := be.container.NewBlobClient(objName)
 
@@ -322,8 +315,6 @@ func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, 
 
 // Stat returns information about a blob.
 func (be *Backend) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, error) {
-	debug.Log("%v", h)
-
 	objName := be.Filename(h)
 	blobClient := be.container.NewBlobClient(objName)
 
@@ -332,7 +323,6 @@ func (be *Backend) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, 
 	be.sem.ReleaseToken()
 
 	if err != nil {
-		debug.Log("blob.GetProperties err %v", err)
 		return restic.FileInfo{}, errors.Wrap(err, "blob.GetProperties")
 	}
 
@@ -352,8 +342,6 @@ func (be *Backend) Remove(ctx context.Context, h restic.Handle) error {
 	_, err := blob.Delete(ctx, &azblob.DeleteBlobOptions{})
 	be.sem.ReleaseToken()
 
-	debug.Log("Remove(%v) at %v -> err %v", h, objName, err)
-
 	if be.IsNotExist(err) {
 		return nil
 	}
@@ -364,8 +352,6 @@ func (be *Backend) Remove(ctx context.Context, h restic.Handle) error {
 // List runs fn for each file in the backend which has the type t. When an
 // error occurs (or fn returns an error), List stops and returns it.
 func (be *Backend) List(ctx context.Context, t restic.FileType, fn func(restic.FileInfo) error) error {
-	debug.Log("listing %v", t)
-
 	prefix, _ := be.Basedir(t)
 
 	// make sure prefix ends with a slash

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -206,8 +206,6 @@ func (be *b2Backend) Load(ctx context.Context, h restic.Handle, length int, offs
 }
 
 func (be *b2Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
-
 	ctx, cancel := context.WithCancel(ctx)
 
 	be.sem.GetToken()
@@ -249,7 +247,6 @@ func (be *b2Backend) Save(ctx context.Context, h restic.Handle, rd restic.Rewind
 	// b2 always requires sha1 checksums for uploaded file parts
 	w := obj.NewWriter(ctx)
 	n, err := io.Copy(w, rd)
-	debug.Log("  saved %d bytes, err %v", n, err)
 
 	if err != nil {
 		_ = w.Close()
@@ -265,8 +262,6 @@ func (be *b2Backend) Save(ctx context.Context, h restic.Handle, rd restic.Rewind
 
 // Stat returns information about a blob.
 func (be *b2Backend) Stat(ctx context.Context, h restic.Handle) (bi restic.FileInfo, err error) {
-	debug.Log("Stat %v", h)
-
 	be.sem.GetToken()
 	defer be.sem.ReleaseToken()
 
@@ -274,7 +269,6 @@ func (be *b2Backend) Stat(ctx context.Context, h restic.Handle) (bi restic.FileI
 	obj := be.bucket.Object(name)
 	info, err := obj.Attrs(ctx)
 	if err != nil {
-		debug.Log("Attrs() err %v", err)
 		return restic.FileInfo{}, errors.Wrap(err, "Stat")
 	}
 	return restic.FileInfo{Size: info.Size, Name: h.Name}, nil
@@ -282,8 +276,6 @@ func (be *b2Backend) Stat(ctx context.Context, h restic.Handle) (bi restic.FileI
 
 // Remove removes the blob with the given name and type.
 func (be *b2Backend) Remove(ctx context.Context, h restic.Handle) error {
-	debug.Log("Remove %v", h)
-
 	be.sem.GetToken()
 	defer be.sem.ReleaseToken()
 
@@ -330,8 +322,6 @@ func (sm *semLocker) Unlock() { sm.ReleaseToken() }
 
 // List returns a channel that yields all names of blobs of type t.
 func (be *b2Backend) List(ctx context.Context, t restic.FileType, fn func(restic.FileInfo) error) error {
-	debug.Log("List %v", t)
-
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -356,7 +346,6 @@ func (be *b2Backend) List(ctx context.Context, t restic.FileType, fn func(restic
 		}
 	}
 	if err := iter.Err(); err != nil {
-		debug.Log("List: %v", err)
 		return err
 	}
 	return nil
@@ -364,7 +353,6 @@ func (be *b2Backend) List(ctx context.Context, t restic.FileType, fn func(restic
 
 // Remove keys for a specified backend type.
 func (be *b2Backend) removeKeys(ctx context.Context, t restic.FileType) error {
-	debug.Log("removeKeys %v", t)
 	return be.List(ctx, t, func(fi restic.FileInfo) error {
 		return be.Remove(ctx, restic.Handle{Type: t, Name: fi.Name})
 	})

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -312,34 +312,9 @@ func (be *b2Backend) List(ctx context.Context, t restic.FileType, fn func(restic
 	return nil
 }
 
-// Remove keys for a specified backend type.
-func (be *b2Backend) removeKeys(ctx context.Context, t restic.FileType) error {
-	return be.List(ctx, t, func(fi restic.FileInfo) error {
-		return be.Remove(ctx, restic.Handle{Type: t, Name: fi.Name})
-	})
-}
-
 // Delete removes all restic keys in the bucket. It will not remove the bucket itself.
 func (be *b2Backend) Delete(ctx context.Context) error {
-	alltypes := []restic.FileType{
-		restic.PackFile,
-		restic.KeyFile,
-		restic.LockFile,
-		restic.SnapshotFile,
-		restic.IndexFile}
-
-	for _, t := range alltypes {
-		err := be.removeKeys(ctx, t)
-		if err != nil {
-			return nil
-		}
-	}
-	err := be.Remove(ctx, restic.Handle{Type: restic.ConfigFile})
-	if err != nil && be.IsNotExist(err) {
-		err = nil
-	}
-
-	return err
+	return backend.DefaultDelete(ctx, be)
 }
 
 // Close does nothing

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -207,17 +207,6 @@ func (be *b2Backend) Load(ctx context.Context, h restic.Handle, length int, offs
 
 func (be *b2Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
-	if err := h.Valid(); err != nil {
-		return nil, backoff.Permanent(err)
-	}
-
-	if offset < 0 {
-		return nil, errors.New("offset is negative")
-	}
-
-	if length < 0 {
-		return nil, errors.Errorf("invalid length %d", length)
-	}
 
 	ctx, cancel := context.WithCancel(ctx)
 

--- a/internal/backend/dryrun/dry_backend.go
+++ b/internal/backend/dryrun/dry_backend.go
@@ -18,10 +18,9 @@ type Backend struct {
 	b restic.Backend
 }
 
-// statically ensure that RetryBackend implements restic.Backend.
+// statically ensure that Backend implements restic.Backend.
 var _ restic.Backend = &Backend{}
 
-// New returns a new backend that saves all data in a map in memory.
 func New(be restic.Backend) *Backend {
 	b := &Backend{b: be}
 	debug.Log("created new dry backend")

--- a/internal/backend/dryrun/dry_backend.go
+++ b/internal/backend/dryrun/dry_backend.go
@@ -34,8 +34,6 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 		return err
 	}
 
-	debug.Log("faked saving %v bytes at %v", rd.Length(), h)
-
 	// don't save anything, just return ok
 	return nil
 }

--- a/internal/backend/dryrun/dry_backend_test.go
+++ b/internal/backend/dryrun/dry_backend_test.go
@@ -40,11 +40,9 @@ func TestDry(t *testing.T) {
 		{d, "delete", "", "", ""},
 		{d, "stat", "a", "", "not found"},
 		{d, "list", "", "", ""},
-		{d, "save", "", "", "invalid"},
 		{m, "save", "a", "baz", ""},  // save a directly to the mem backend
 		{d, "save", "b", "foob", ""}, // b is not saved
 		{d, "save", "b", "xxx", ""},  // no error as b is not saved
-		{d, "stat", "", "", "invalid"},
 		{d, "stat", "a", "a 3", ""},
 		{d, "load", "a", "baz", ""},
 		{d, "load", "b", "", "not found"},

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -273,17 +273,7 @@ func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset
 
 func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
-	if err := h.Valid(); err != nil {
-		return nil, err
-	}
 
-	if offset < 0 {
-		return nil, errors.New("offset is negative")
-	}
-
-	if length < 0 {
-		return nil, errors.Errorf("invalid length %d", length)
-	}
 	if length == 0 {
 		// negative length indicates read till end to GCS lib
 		length = -1

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -286,7 +286,7 @@ func (be *Backend) Remove(ctx context.Context, h restic.Handle) error {
 
 	err := be.bucket.Object(objName).Delete(ctx)
 
-	if err == storage.ErrObjectNotExist {
+	if be.IsNotExist(err) {
 		err = nil
 	}
 

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -339,30 +339,9 @@ func (be *Backend) List(ctx context.Context, t restic.FileType, fn func(restic.F
 	return ctx.Err()
 }
 
-// Remove keys for a specified backend type.
-func (be *Backend) removeKeys(ctx context.Context, t restic.FileType) error {
-	return be.List(ctx, t, func(fi restic.FileInfo) error {
-		return be.Remove(ctx, restic.Handle{Type: t, Name: fi.Name})
-	})
-}
-
 // Delete removes all restic keys in the bucket. It will not remove the bucket itself.
 func (be *Backend) Delete(ctx context.Context) error {
-	alltypes := []restic.FileType{
-		restic.PackFile,
-		restic.KeyFile,
-		restic.LockFile,
-		restic.SnapshotFile,
-		restic.IndexFile}
-
-	for _, t := range alltypes {
-		err := be.removeKeys(ctx, t)
-		if err != nil {
-			return nil
-		}
-	}
-
-	return be.Remove(ctx, restic.Handle{Type: restic.ConfigFile})
+	return backend.DefaultDelete(ctx, be)
 }
 
 // Close does nothing.

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -124,14 +124,13 @@ func Open(cfg Config, rt http.RoundTripper) (restic.Backend, error) {
 //
 // The service account must have the "storage.buckets.create" permission to
 // create a bucket the does not yet exist.
-func Create(cfg Config, rt http.RoundTripper) (restic.Backend, error) {
+func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (restic.Backend, error) {
 	be, err := open(cfg, rt)
 	if err != nil {
 		return nil, errors.Wrap(err, "open")
 	}
 
 	// Try to determine if the bucket exists. If it does not, try to create it.
-	ctx := context.Background()
 	exists, err := be.bucketExists(ctx, be.bucket)
 	if err != nil {
 		if e, ok := err.(*googleapi.Error); ok && e.Code == http.StatusForbidden {

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -169,7 +169,6 @@ func (be *Backend) SetListMaxItems(i int) {
 
 // IsNotExist returns true if the error is caused by a not existing file.
 func (be *Backend) IsNotExist(err error) bool {
-	debug.Log("IsNotExist(%T, %#v)", err, err)
 	return errors.Is(err, storage.ErrObjectNotExist)
 }
 
@@ -209,8 +208,6 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 	}
 
 	objName := be.Filename(h)
-
-	debug.Log("Save %v at %v", h, objName)
 
 	be.sem.GetToken()
 
@@ -253,11 +250,9 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 	be.sem.ReleaseToken()
 
 	if err != nil {
-		debug.Log("%v: err %#v: %v", objName, err, err)
 		return errors.Wrap(err, "service.Objects.Insert")
 	}
 
-	debug.Log("%v -> %v bytes", objName, wbytes)
 	// sanity check
 	if wbytes != rd.Length() {
 		return errors.Errorf("wrote %d bytes instead of the expected %d bytes", wbytes, rd.Length())
@@ -272,8 +267,6 @@ func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset
 }
 
 func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
-
 	if length == 0 {
 		// negative length indicates read till end to GCS lib
 		length = -1
@@ -297,8 +290,6 @@ func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, 
 
 // Stat returns information about a blob.
 func (be *Backend) Stat(ctx context.Context, h restic.Handle) (bi restic.FileInfo, err error) {
-	debug.Log("%v", h)
-
 	objName := be.Filename(h)
 
 	be.sem.GetToken()
@@ -306,7 +297,6 @@ func (be *Backend) Stat(ctx context.Context, h restic.Handle) (bi restic.FileInf
 	be.sem.ReleaseToken()
 
 	if err != nil {
-		debug.Log("GetObjectAttributes() err %v", err)
 		return restic.FileInfo{}, errors.Wrap(err, "service.Objects.Get")
 	}
 
@@ -325,15 +315,12 @@ func (be *Backend) Remove(ctx context.Context, h restic.Handle) error {
 		err = nil
 	}
 
-	debug.Log("Remove(%v) at %v -> err %v", h, objName, err)
 	return errors.Wrap(err, "client.RemoveObject")
 }
 
 // List runs fn for each file in the backend which has the type t. When an
 // error occurs (or fn returns an error), List stops and returns it.
 func (be *Backend) List(ctx context.Context, t restic.FileType, fn func(restic.FileInfo) error) error {
-	debug.Log("listing %v", t)
-
 	prefix, _ := be.Basedir(t)
 
 	// make sure prefix ends with a slash

--- a/internal/backend/gs/gs_test.go
+++ b/internal/backend/gs/gs_test.go
@@ -42,7 +42,7 @@ func newGSTestSuite(t testing.TB) *test.Suite {
 		Create: func(config interface{}) (restic.Backend, error) {
 			cfg := config.(gs.Config)
 
-			be, err := gs.Create(cfg, tr)
+			be, err := gs.Create(context.Background(), cfg, tr)
 			if err != nil {
 				return nil, err
 			}

--- a/internal/backend/limiter/limiter_backend.go
+++ b/internal/backend/limiter/limiter_backend.go
@@ -46,6 +46,8 @@ func (r rateLimitedBackend) Load(ctx context.Context, h restic.Handle, length in
 	})
 }
 
+func (r rateLimitedBackend) Unwrap() restic.Backend { return r.Backend }
+
 type limitedReader struct {
 	io.Reader
 	writerTo io.WriterTo

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -114,7 +114,6 @@ func (b *Local) IsNotExist(err error) bool {
 
 // Save stores data in the backend at the handle.
 func (b *Local) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) (err error) {
-	debug.Log("Save %v", h)
 	if err := h.Valid(); err != nil {
 		return backoff.Permanent(err)
 	}
@@ -217,8 +216,6 @@ func (b *Local) Load(ctx context.Context, h restic.Handle, length int, offset in
 }
 
 func (b *Local) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-	debug.Log("Load %v, length %v, offset %v", h, length, offset)
-
 	b.sem.GetToken()
 	f, err := fs.Open(b.Filename(h))
 	if err != nil {
@@ -246,7 +243,6 @@ func (b *Local) openReader(ctx context.Context, h restic.Handle, length int, off
 
 // Stat returns information about a blob.
 func (b *Local) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, error) {
-	debug.Log("Stat %v", h)
 	if err := h.Valid(); err != nil {
 		return restic.FileInfo{}, backoff.Permanent(err)
 	}
@@ -264,7 +260,6 @@ func (b *Local) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, err
 
 // Remove removes the blob with the given name and type.
 func (b *Local) Remove(ctx context.Context, h restic.Handle) error {
-	debug.Log("Remove %v", h)
 	fn := b.Filename(h)
 
 	b.sem.GetToken()
@@ -282,8 +277,6 @@ func (b *Local) Remove(ctx context.Context, h restic.Handle) error {
 // List runs fn for each file in the backend which has the type t. When an
 // error occurs (or fn returns an error), List stops and returns it.
 func (b *Local) List(ctx context.Context, t restic.FileType, fn func(restic.FileInfo) error) (err error) {
-	debug.Log("List %v", t)
-
 	basedir, subdirs := b.Basedir(t)
 	if subdirs {
 		err = visitDirs(ctx, basedir, fn)
@@ -377,13 +370,11 @@ func visitFiles(ctx context.Context, dir string, fn func(restic.FileInfo) error,
 
 // Delete removes the repository and all files.
 func (b *Local) Delete(ctx context.Context) error {
-	debug.Log("Delete()")
 	return fs.RemoveAll(b.Path)
 }
 
 // Close closes all open files.
 func (b *Local) Close() error {
-	debug.Log("Close()")
 	// this does not need to do anything, all open files are closed within the
 	// same function.
 	return nil

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -218,13 +218,6 @@ func (b *Local) Load(ctx context.Context, h restic.Handle, length int, offset in
 
 func (b *Local) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
-	if err := h.Valid(); err != nil {
-		return nil, backoff.Permanent(err)
-	}
-
-	if offset < 0 {
-		return nil, errors.New("offset is negative")
-	}
 
 	b.sem.GetToken()
 	f, err := fs.Open(b.Filename(h))

--- a/internal/backend/logger/log.go
+++ b/internal/backend/logger/log.go
@@ -1,0 +1,77 @@
+package logger
+
+import (
+	"context"
+	"io"
+
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/restic"
+)
+
+type Backend struct {
+	restic.Backend
+}
+
+// statically ensure that Backend implements restic.Backend.
+var _ restic.Backend = &Backend{}
+
+func New(be restic.Backend) *Backend {
+	return &Backend{Backend: be}
+}
+
+func (be *Backend) IsNotExist(err error) bool {
+	isNotExist := be.Backend.IsNotExist(err)
+	debug.Log("IsNotExist(%T, %#v, %v)", err, err, isNotExist)
+	return isNotExist
+}
+
+// Save adds new Data to the backend.
+func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
+	debug.Log("Save(%v, %v)", h, rd.Length())
+	err := be.Backend.Save(ctx, h, rd)
+	debug.Log("  save err %v", err)
+	return err
+}
+
+// Remove deletes a file from the backend.
+func (be *Backend) Remove(ctx context.Context, h restic.Handle) error {
+	debug.Log("Remove(%v)", h)
+	err := be.Backend.Remove(ctx, h)
+	debug.Log("  remove err %v", err)
+	return err
+}
+
+func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(io.Reader) error) error {
+	debug.Log("Load(%v, length %v, offset %v)", h, length, offset)
+	err := be.Backend.Load(ctx, h, length, offset, fn)
+	debug.Log("  load err %v", err)
+	return err
+}
+
+func (be *Backend) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, error) {
+	debug.Log("Stat(%v)", h)
+	fi, err := be.Backend.Stat(ctx, h)
+	debug.Log("  stat err %v", err)
+	return fi, err
+}
+
+func (be *Backend) List(ctx context.Context, t restic.FileType, fn func(restic.FileInfo) error) error {
+	debug.Log("List(%v)", t)
+	err := be.Backend.List(ctx, t, fn)
+	debug.Log("  list err %v", err)
+	return err
+}
+
+func (be *Backend) Delete(ctx context.Context) error {
+	debug.Log("Delete()")
+	err := be.Backend.Delete(ctx)
+	debug.Log("  delete err %v", err)
+	return err
+}
+
+func (be *Backend) Close() error {
+	debug.Log("Close()")
+	err := be.Backend.Close()
+	debug.Log("  close err %v", err)
+	return err
+}

--- a/internal/backend/logger/log.go
+++ b/internal/backend/logger/log.go
@@ -75,3 +75,5 @@ func (be *Backend) Close() error {
 	debug.Log("  close err %v", err)
 	return err
 }
+
+func (be *Backend) Unwrap() restic.Backend { return be.Backend }

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -102,7 +102,6 @@ func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd restic.Re
 	}
 
 	be.data[h] = buf
-	debug.Log("saved %v bytes at %v", len(buf), h)
 
 	return ctx.Err()
 }
@@ -166,8 +165,6 @@ func (be *MemoryBackend) Stat(ctx context.Context, h restic.Handle) (restic.File
 	if h.Type == restic.ConfigFile {
 		h.Name = ""
 	}
-
-	debug.Log("stat %v", h)
 
 	e, ok := be.data[h]
 	if !ok {

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -144,8 +144,6 @@ func (be *MemoryBackend) Remove(ctx context.Context, h restic.Handle) error {
 	be.m.Lock()
 	defer be.m.Unlock()
 
-	debug.Log("Remove %v", h)
-
 	h.ContainedBlobType = restic.InvalidBlob
 	if _, ok := be.data[h]; !ok {
 		return errNotFound

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -10,12 +10,9 @@ import (
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/restic/restic/internal/backend"
-	"github.com/restic/restic/internal/backend/sema"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
-
-	"github.com/cenkalti/backoff/v4"
 )
 
 type memMap map[restic.Handle][]byte
@@ -32,19 +29,12 @@ const connectionCount = 2
 type MemoryBackend struct {
 	data memMap
 	m    sync.Mutex
-	sem  sema.Semaphore
 }
 
 // New returns a new backend that saves all data in a map in memory.
 func New() *MemoryBackend {
-	sem, err := sema.New(connectionCount)
-	if err != nil {
-		panic(err)
-	}
-
 	be := &MemoryBackend{
 		data: make(memMap),
-		sem:  sem,
 	}
 
 	debug.Log("created new memory backend")
@@ -59,13 +49,6 @@ func (be *MemoryBackend) IsNotExist(err error) bool {
 
 // Save adds new Data to the backend.
 func (be *MemoryBackend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
-	if err := h.Valid(); err != nil {
-		return backoff.Permanent(err)
-	}
-
-	be.sem.GetToken()
-	defer be.sem.ReleaseToken()
-
 	be.m.Lock()
 	defer be.m.Unlock()
 
@@ -113,8 +96,6 @@ func (be *MemoryBackend) Load(ctx context.Context, h restic.Handle, length int, 
 }
 
 func (be *MemoryBackend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-
-	be.sem.GetToken()
 	be.m.Lock()
 	defer be.m.Unlock()
 
@@ -123,21 +104,12 @@ func (be *MemoryBackend) openReader(ctx context.Context, h restic.Handle, length
 		h.Name = ""
 	}
 
-	debug.Log("Load %v offset %v len %v", h, offset, length)
-
-	if offset < 0 {
-		be.sem.ReleaseToken()
-		return nil, errors.New("offset is negative")
-	}
-
 	if _, ok := be.data[h]; !ok {
-		be.sem.ReleaseToken()
 		return nil, errNotFound
 	}
 
 	buf := be.data[h]
 	if offset > int64(len(buf)) {
-		be.sem.ReleaseToken()
 		return nil, errors.New("offset beyond end of file")
 	}
 
@@ -146,18 +118,11 @@ func (be *MemoryBackend) openReader(ctx context.Context, h restic.Handle, length
 		buf = buf[:length]
 	}
 
-	return be.sem.ReleaseTokenOnClose(io.NopCloser(bytes.NewReader(buf)), nil), ctx.Err()
+	return io.NopCloser(bytes.NewReader(buf)), ctx.Err()
 }
 
 // Stat returns information about a file in the backend.
 func (be *MemoryBackend) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, error) {
-	if err := h.Valid(); err != nil {
-		return restic.FileInfo{}, backoff.Permanent(err)
-	}
-
-	be.sem.GetToken()
-	defer be.sem.ReleaseToken()
-
 	be.m.Lock()
 	defer be.m.Unlock()
 
@@ -176,9 +141,6 @@ func (be *MemoryBackend) Stat(ctx context.Context, h restic.Handle) (restic.File
 
 // Remove deletes a file from the backend.
 func (be *MemoryBackend) Remove(ctx context.Context, h restic.Handle) error {
-	be.sem.GetToken()
-	defer be.sem.ReleaseToken()
-
 	be.m.Lock()
 	defer be.m.Unlock()
 

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -114,9 +114,6 @@ func (be *MemoryBackend) Load(ctx context.Context, h restic.Handle, length int, 
 }
 
 func (be *MemoryBackend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-	if err := h.Valid(); err != nil {
-		return nil, backoff.Permanent(err)
-	}
 
 	be.sem.GetToken()
 	be.m.Lock()

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -207,7 +207,6 @@ func (b *Backend) openReader(ctx context.Context, h restic.Handle, length int, o
 	}
 	req.Header.Set("Range", byteRange)
 	req.Header.Set("Accept", ContentTypeV2)
-	debug.Log("Load(%v) send range %v", h, byteRange)
 
 	resp, err := b.client.Do(req)
 

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -212,7 +212,6 @@ func (b *Backend) Load(ctx context.Context, h restic.Handle, length int, offset 
 }
 
 func (b *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 	if err := h.Valid(); err != nil {
 		return nil, backoff.Permanent(err)
 	}

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -11,6 +11,7 @@ import (
 	"path"
 	"strings"
 
+	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/layout"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
@@ -411,32 +412,7 @@ func (b *Backend) Close() error {
 	return nil
 }
 
-// Remove keys for a specified backend type.
-func (b *Backend) removeKeys(ctx context.Context, t restic.FileType) error {
-	return b.List(ctx, t, func(fi restic.FileInfo) error {
-		return b.Remove(ctx, restic.Handle{Type: t, Name: fi.Name})
-	})
-}
-
 // Delete removes all data in the backend.
 func (b *Backend) Delete(ctx context.Context) error {
-	alltypes := []restic.FileType{
-		restic.PackFile,
-		restic.KeyFile,
-		restic.LockFile,
-		restic.SnapshotFile,
-		restic.IndexFile}
-
-	for _, t := range alltypes {
-		err := b.removeKeys(ctx, t)
-		if err != nil {
-			return nil
-		}
-	}
-
-	err := b.Remove(ctx, restic.Handle{Type: restic.ConfigFile})
-	if err != nil && b.IsNotExist(err) {
-		return nil
-	}
-	return err
+	return backend.DefaultDelete(ctx, b)
 }

--- a/internal/backend/retry/backend_retry.go
+++ b/internal/backend/retry/backend_retry.go
@@ -191,3 +191,7 @@ func (be *Backend) List(ctx context.Context, t restic.FileType, fn func(restic.F
 
 	return err
 }
+
+func (be *Backend) Unwrap() restic.Backend {
+	return be.Backend
+}

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -271,7 +271,6 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 	// only use multipart uploads for very large files
 	opts.PartSize = 200 * 1024 * 1024
 
-	debug.Log("PutObject(%v, %v, %v)", be.cfg.Bucket, objName, rd.Length())
 	info, err := be.client.PutObject(ctx, be.cfg.Bucket, objName, io.NopCloser(rd), int64(rd.Length()), opts)
 
 	// sanity check
@@ -297,10 +296,8 @@ func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, 
 
 	var err error
 	if length > 0 {
-		debug.Log("range: %v-%v", offset, offset+int64(length)-1)
 		err = opts.SetRange(offset, offset+int64(length)-1)
 	} else if offset > 0 {
-		debug.Log("range: %v-", offset)
 		err = opts.SetRange(offset, 0)
 	}
 

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -312,17 +312,6 @@ func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset
 
 func (be *Backend) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v from %v", h, length, offset, be.Filename(h))
-	if err := h.Valid(); err != nil {
-		return nil, backoff.Permanent(err)
-	}
-
-	if offset < 0 {
-		return nil, errors.New("offset is negative")
-	}
-
-	if length < 0 {
-		return nil, errors.Errorf("invalid length %d", length)
-	}
 
 	objName := be.Filename(h)
 	opts := minio.GetObjectOptions{}

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -411,30 +411,9 @@ func (be *Backend) List(ctx context.Context, t restic.FileType, fn func(restic.F
 	return ctx.Err()
 }
 
-// Remove keys for a specified backend type.
-func (be *Backend) removeKeys(ctx context.Context, t restic.FileType) error {
-	return be.List(ctx, restic.PackFile, func(fi restic.FileInfo) error {
-		return be.Remove(ctx, restic.Handle{Type: t, Name: fi.Name})
-	})
-}
-
 // Delete removes all restic keys in the bucket. It will not remove the bucket itself.
 func (be *Backend) Delete(ctx context.Context) error {
-	alltypes := []restic.FileType{
-		restic.PackFile,
-		restic.KeyFile,
-		restic.LockFile,
-		restic.SnapshotFile,
-		restic.IndexFile}
-
-	for _, t := range alltypes {
-		err := be.removeKeys(ctx, t)
-		if err != nil {
-			return nil
-		}
-	}
-
-	return be.Remove(ctx, restic.Handle{Type: restic.ConfigFile})
+	return backend.DefaultDelete(ctx, be)
 }
 
 // Close does nothing

--- a/internal/backend/sema/backend.go
+++ b/internal/backend/sema/backend.go
@@ -18,8 +18,8 @@ type connectionLimitedBackend struct {
 	sem semaphore
 }
 
-// New creates a backend that limits the concurrent operations on the underlying backend
-func New(be restic.Backend) restic.Backend {
+// NewBackend creates a backend that limits the concurrent operations on the underlying backend
+func NewBackend(be restic.Backend) restic.Backend {
 	sem, err := newSemaphore(be.Connections())
 	if err != nil {
 		panic(err)

--- a/internal/backend/sema/backend.go
+++ b/internal/backend/sema/backend.go
@@ -1,0 +1,87 @@
+package sema
+
+import (
+	"context"
+	"io"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/restic"
+)
+
+// make sure that SemaphoreBackend implements restic.Backend
+var _ restic.Backend = &SemaphoreBackend{}
+
+// SemaphoreBackend limits the number of concurrent operations.
+type SemaphoreBackend struct {
+	restic.Backend
+	sem semaphore
+}
+
+// New creates a backend that limits the concurrent operations on the underlying backend
+func New(be restic.Backend) *SemaphoreBackend {
+	sem, err := newSemaphore(be.Connections())
+	if err != nil {
+		panic(err)
+	}
+
+	return &SemaphoreBackend{
+		Backend: be,
+		sem:     sem,
+	}
+}
+
+// Save adds new Data to the backend.
+func (be *SemaphoreBackend) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
+	if err := h.Valid(); err != nil {
+		return backoff.Permanent(err)
+	}
+
+	be.sem.GetToken()
+	defer be.sem.ReleaseToken()
+
+	return be.Backend.Save(ctx, h, rd)
+}
+
+// Load runs fn with a reader that yields the contents of the file at h at the
+// given offset.
+func (be *SemaphoreBackend) Load(ctx context.Context, h restic.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
+	if err := h.Valid(); err != nil {
+		return backoff.Permanent(err)
+	}
+	if offset < 0 {
+		return backoff.Permanent(errors.New("offset is negative"))
+	}
+	if length < 0 {
+		return backoff.Permanent(errors.Errorf("invalid length %d", length))
+	}
+
+	be.sem.GetToken()
+	defer be.sem.ReleaseToken()
+
+	return be.Backend.Load(ctx, h, length, offset, fn)
+}
+
+// Stat returns information about a file in the backend.
+func (be *SemaphoreBackend) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, error) {
+	if err := h.Valid(); err != nil {
+		return restic.FileInfo{}, backoff.Permanent(err)
+	}
+
+	be.sem.GetToken()
+	defer be.sem.ReleaseToken()
+
+	return be.Backend.Stat(ctx, h)
+}
+
+// Remove deletes a file from the backend.
+func (be *SemaphoreBackend) Remove(ctx context.Context, h restic.Handle) error {
+	if err := h.Valid(); err != nil {
+		return backoff.Permanent(err)
+	}
+
+	be.sem.GetToken()
+	defer be.sem.ReleaseToken()
+
+	return be.Backend.Remove(ctx, h)
+}

--- a/internal/backend/sema/backend.go
+++ b/internal/backend/sema/backend.go
@@ -85,3 +85,7 @@ func (be *SemaphoreBackend) Remove(ctx context.Context, h restic.Handle) error {
 
 	return be.Backend.Remove(ctx, h)
 }
+
+func (be *SemaphoreBackend) Unwrap() restic.Backend {
+	return be.Backend
+}

--- a/internal/backend/sema/backend_test.go
+++ b/internal/backend/sema/backend_test.go
@@ -1,0 +1,180 @@
+package sema_test
+
+import (
+	"context"
+	"io"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/backend/mock"
+	"github.com/restic/restic/internal/backend/sema"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/test"
+	"golang.org/x/sync/errgroup"
+)
+
+func TestParameterValidationSave(t *testing.T) {
+	m := mock.NewBackend()
+	m.SaveFn = func(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
+		return nil
+	}
+	be := sema.NewBackend(m)
+
+	err := be.Save(context.TODO(), restic.Handle{}, nil)
+	test.Assert(t, err != nil, "Save() with invalid handle did not return an error")
+}
+
+func TestParameterValidationLoad(t *testing.T) {
+	m := mock.NewBackend()
+	m.OpenReaderFn = func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+		return io.NopCloser(nil), nil
+	}
+
+	be := sema.NewBackend(m)
+	nilCb := func(rd io.Reader) error { return nil }
+
+	err := be.Load(context.TODO(), restic.Handle{}, 10, 0, nilCb)
+	test.Assert(t, err != nil, "Load() with invalid handle did not return an error")
+
+	h := restic.Handle{Type: restic.PackFile, Name: "foobar"}
+	err = be.Load(context.TODO(), h, 10, -1, nilCb)
+	test.Assert(t, err != nil, "Save() with negative offset did not return an error")
+	err = be.Load(context.TODO(), h, -1, 0, nilCb)
+	test.Assert(t, err != nil, "Save() with negative length did not return an error")
+}
+
+func TestParameterValidationStat(t *testing.T) {
+	m := mock.NewBackend()
+	m.StatFn = func(ctx context.Context, h restic.Handle) (restic.FileInfo, error) {
+		return restic.FileInfo{}, nil
+	}
+	be := sema.NewBackend(m)
+
+	_, err := be.Stat(context.TODO(), restic.Handle{})
+	test.Assert(t, err != nil, "Stat() with invalid handle did not return an error")
+}
+
+func TestParameterValidationRemove(t *testing.T) {
+	m := mock.NewBackend()
+	m.RemoveFn = func(ctx context.Context, h restic.Handle) error {
+		return nil
+	}
+	be := sema.NewBackend(m)
+
+	err := be.Remove(context.TODO(), restic.Handle{})
+	test.Assert(t, err != nil, "Remove() with invalid handle did not return an error")
+}
+
+func TestUnwrap(t *testing.T) {
+	m := mock.NewBackend()
+	be := sema.NewBackend(m)
+
+	unwrapper := be.(restic.BackendUnwrapper)
+	test.Assert(t, unwrapper.Unwrap() == m, "Unwrap() returned wrong backend")
+}
+
+func countingBlocker() (func(), func(int) int) {
+	ctr := int64(0)
+	blocker := make(chan struct{})
+
+	wait := func() {
+		// count how many goroutines were allowed by the semaphore
+		atomic.AddInt64(&ctr, 1)
+		// block until the test can retrieve the counter
+		<-blocker
+	}
+
+	unblock := func(expected int) int {
+		// give goroutines enough time to block
+		var blocked int64
+		for i := 0; i < 100 && blocked != int64(expected); i++ {
+			time.Sleep(100 * time.Microsecond)
+			blocked = atomic.LoadInt64(&ctr)
+		}
+		close(blocker)
+		return int(blocked)
+	}
+
+	return wait, unblock
+}
+
+func concurrencyTester(t *testing.T, setup func(m *mock.Backend), handler func(be restic.Backend) func() error, unblock func(int) int) {
+	expectBlocked := int(2)
+
+	m := mock.NewBackend()
+	setup(m)
+	m.ConnectionsFn = func() uint { return uint(expectBlocked) }
+	be := sema.NewBackend(m)
+
+	var wg errgroup.Group
+	for i := 0; i < int(expectBlocked+1); i++ {
+		wg.Go(handler(be))
+	}
+
+	blocked := unblock(expectBlocked)
+	test.Assert(t, blocked == expectBlocked, "Unexpected number of goroutines blocked: %v", blocked)
+	test.OK(t, wg.Wait())
+}
+
+func TestConcurrencyLimitSave(t *testing.T) {
+	wait, unblock := countingBlocker()
+	concurrencyTester(t, func(m *mock.Backend) {
+		m.SaveFn = func(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
+			wait()
+			return nil
+		}
+	}, func(be restic.Backend) func() error {
+		return func() error {
+			h := restic.Handle{Type: restic.PackFile, Name: "foobar"}
+			return be.Save(context.TODO(), h, nil)
+		}
+	}, unblock)
+}
+
+func TestConcurrencyLimitLoad(t *testing.T) {
+	wait, unblock := countingBlocker()
+	concurrencyTester(t, func(m *mock.Backend) {
+		m.OpenReaderFn = func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
+			wait()
+			return io.NopCloser(nil), nil
+		}
+	}, func(be restic.Backend) func() error {
+		return func() error {
+			h := restic.Handle{Type: restic.PackFile, Name: "foobar"}
+			nilCb := func(rd io.Reader) error { return nil }
+			return be.Load(context.TODO(), h, 10, 0, nilCb)
+		}
+	}, unblock)
+}
+
+func TestConcurrencyLimitStat(t *testing.T) {
+	wait, unblock := countingBlocker()
+	concurrencyTester(t, func(m *mock.Backend) {
+		m.StatFn = func(ctx context.Context, h restic.Handle) (restic.FileInfo, error) {
+			wait()
+			return restic.FileInfo{}, nil
+		}
+	}, func(be restic.Backend) func() error {
+		return func() error {
+			h := restic.Handle{Type: restic.PackFile, Name: "foobar"}
+			_, err := be.Stat(context.TODO(), h)
+			return err
+		}
+	}, unblock)
+}
+
+func TestConcurrencyLimitDelete(t *testing.T) {
+	wait, unblock := countingBlocker()
+	concurrencyTester(t, func(m *mock.Backend) {
+		m.RemoveFn = func(ctx context.Context, h restic.Handle) error {
+			wait()
+			return nil
+		}
+	}, func(be restic.Backend) func() error {
+		return func() error {
+			h := restic.Handle{Type: restic.PackFile, Name: "foobar"}
+			return be.Remove(context.TODO(), h)
+		}
+	}, unblock)
+}

--- a/internal/backend/sema/semaphore.go
+++ b/internal/backend/sema/semaphore.go
@@ -2,64 +2,30 @@
 package sema
 
 import (
-	"context"
-	"io"
-
+	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 )
 
-// A Semaphore limits access to a restricted resource.
-type Semaphore struct {
+// A semaphore limits access to a restricted resource.
+type semaphore struct {
 	ch chan struct{}
 }
 
-// New returns a new semaphore with capacity n.
-func New(n uint) (Semaphore, error) {
+// newSemaphore returns a new semaphore with capacity n.
+func newSemaphore(n uint) (semaphore, error) {
 	if n == 0 {
-		return Semaphore{}, errors.New("capacity must be a positive number")
+		return semaphore{}, errors.New("capacity must be a positive number")
 	}
-	return Semaphore{
+	return semaphore{
 		ch: make(chan struct{}, n),
 	}, nil
 }
 
 // GetToken blocks until a Token is available.
-func (s Semaphore) GetToken() { s.ch <- struct{}{} }
+func (s semaphore) GetToken() {
+	s.ch <- struct{}{}
+	debug.Log("acquired token")
+}
 
 // ReleaseToken returns a token.
-func (s Semaphore) ReleaseToken() { <-s.ch }
-
-// ReleaseTokenOnClose wraps an io.ReadCloser to return a token on Close.
-// Before returning the token, cancel, if not nil, will be run
-// to free up context resources.
-func (s Semaphore) ReleaseTokenOnClose(rc io.ReadCloser, cancel context.CancelFunc) io.ReadCloser {
-	return &wrapReader{ReadCloser: rc, sem: s, cancel: cancel}
-}
-
-type wrapReader struct {
-	io.ReadCloser
-	eofSeen bool
-	sem     Semaphore
-	cancel  context.CancelFunc
-}
-
-func (wr *wrapReader) Read(p []byte) (int, error) {
-	if wr.eofSeen { // XXX Why do we do this?
-		return 0, io.EOF
-	}
-
-	n, err := wr.ReadCloser.Read(p)
-	if err == io.EOF {
-		wr.eofSeen = true
-	}
-	return n, err
-}
-
-func (wr *wrapReader) Close() error {
-	err := wr.ReadCloser.Close()
-	if wr.cancel != nil {
-		wr.cancel()
-	}
-	wr.sem.ReleaseToken()
-	return err
-}
+func (s semaphore) ReleaseToken() { <-s.ch }

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/layout"
-	"github.com/restic/restic/internal/backend/sema"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
@@ -35,7 +34,6 @@ type SFTP struct {
 
 	posixRename bool
 
-	sem sema.Semaphore
 	layout.Layout
 	Config
 	backend.Modes
@@ -140,11 +138,7 @@ func Open(ctx context.Context, cfg Config) (*SFTP, error) {
 }
 
 func open(ctx context.Context, sftp *SFTP, cfg Config) (*SFTP, error) {
-	sem, err := sema.New(cfg.Connections)
-	if err != nil {
-		return nil, err
-	}
-
+	var err error
 	sftp.Layout, err = layout.ParseLayout(ctx, sftp, cfg.Layout, defaultLayout, cfg.Path)
 	if err != nil {
 		return nil, err
@@ -158,7 +152,6 @@ func open(ctx context.Context, sftp *SFTP, cfg Config) (*SFTP, error) {
 
 	sftp.Config = cfg
 	sftp.p = cfg.Path
-	sftp.sem = sem
 	sftp.Modes = m
 	return sftp, nil
 }
@@ -308,16 +301,9 @@ func (r *SFTP) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader
 		return err
 	}
 
-	if err := h.Valid(); err != nil {
-		return backoff.Permanent(err)
-	}
-
 	filename := r.Filename(h)
 	tmpFilename := filename + "-restic-temp-" + tempSuffix()
 	dirname := r.Dirname(h)
-
-	r.sem.GetToken()
-	defer r.sem.ReleaseToken()
 
 	// create new file
 	f, err := r.c.OpenFile(tmpFilename, os.O_CREATE|os.O_EXCL|os.O_WRONLY)
@@ -414,52 +400,27 @@ func (r *SFTP) Load(ctx context.Context, h restic.Handle, length int, offset int
 	return backend.DefaultLoad(ctx, h, length, offset, r.openReader, fn)
 }
 
-// wrapReader wraps an io.ReadCloser to run an additional function on Close.
-type wrapReader struct {
-	io.ReadCloser
-	io.WriterTo
-	f func()
-}
-
-func (wr *wrapReader) Close() error {
-	err := wr.ReadCloser.Close()
-	wr.f()
-	return err
-}
-
 func (r *SFTP) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-	r.sem.GetToken()
 	f, err := r.c.Open(r.Filename(h))
 	if err != nil {
-		r.sem.ReleaseToken()
 		return nil, err
 	}
 
 	if offset > 0 {
 		_, err = f.Seek(offset, 0)
 		if err != nil {
-			r.sem.ReleaseToken()
 			_ = f.Close()
 			return nil, err
 		}
 	}
 
-	// use custom close wrapper to also provide WriteTo() on the wrapper
-	rd := &wrapReader{
-		ReadCloser: f,
-		WriterTo:   f,
-		f: func() {
-			r.sem.ReleaseToken()
-		},
-	}
-
 	if length > 0 {
 		// unlimited reads usually use io.Copy which needs WriteTo support at the underlying reader
 		// limited reads are usually combined with io.ReadFull which reads all required bytes into a buffer in one go
-		return backend.LimitReadCloser(rd, int64(length)), nil
+		return backend.LimitReadCloser(f, int64(length)), nil
 	}
 
-	return rd, nil
+	return f, nil
 }
 
 // Stat returns information about a blob.
@@ -467,13 +428,6 @@ func (r *SFTP) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, erro
 	if err := r.clientError(); err != nil {
 		return restic.FileInfo{}, err
 	}
-
-	if err := h.Valid(); err != nil {
-		return restic.FileInfo{}, backoff.Permanent(err)
-	}
-
-	r.sem.GetToken()
-	defer r.sem.ReleaseToken()
 
 	fi, err := r.c.Lstat(r.Filename(h))
 	if err != nil {
@@ -489,9 +443,6 @@ func (r *SFTP) Remove(ctx context.Context, h restic.Handle) error {
 		return err
 	}
 
-	r.sem.GetToken()
-	defer r.sem.ReleaseToken()
-
 	return r.c.Remove(r.Filename(h))
 }
 
@@ -501,9 +452,7 @@ func (r *SFTP) List(ctx context.Context, t restic.FileType, fn func(restic.FileI
 	basedir, subdirs := r.Basedir(t)
 	walker := r.c.Walk(basedir)
 	for {
-		r.sem.GetToken()
 		ok := walker.Step()
-		r.sem.ReleaseToken()
 		if !ok {
 			break
 		}

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -304,7 +304,6 @@ func tempSuffix() string {
 
 // Save stores data in the backend at the handle.
 func (r *SFTP) Save(ctx context.Context, h restic.Handle, rd restic.RewindReader) error {
-	debug.Log("Save %v", h)
 	if err := r.clientError(); err != nil {
 		return err
 	}
@@ -429,8 +428,6 @@ func (wr *wrapReader) Close() error {
 }
 
 func (r *SFTP) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-	debug.Log("Load %v, length %v, offset %v", h, length, offset)
-
 	r.sem.GetToken()
 	f, err := r.c.Open(r.Filename(h))
 	if err != nil {
@@ -467,7 +464,6 @@ func (r *SFTP) openReader(ctx context.Context, h restic.Handle, length int, offs
 
 // Stat returns information about a blob.
 func (r *SFTP) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, error) {
-	debug.Log("Stat(%v)", h)
 	if err := r.clientError(); err != nil {
 		return restic.FileInfo{}, err
 	}
@@ -489,7 +485,6 @@ func (r *SFTP) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, erro
 
 // Remove removes the content stored at name.
 func (r *SFTP) Remove(ctx context.Context, h restic.Handle) error {
-	debug.Log("Remove(%v)", h)
 	if err := r.clientError(); err != nil {
 		return err
 	}
@@ -503,8 +498,6 @@ func (r *SFTP) Remove(ctx context.Context, h restic.Handle) error {
 // List runs fn for each file in the backend which has the type t. When an
 // error occurs (or fn returns an error), List stops and returns it.
 func (r *SFTP) List(ctx context.Context, t restic.FileType, fn func(restic.FileInfo) error) error {
-	debug.Log("List %v", t)
-
 	basedir, subdirs := r.Basedir(t)
 	walker := r.c.Walk(basedir)
 	for {
@@ -565,7 +558,6 @@ var closeTimeout = 2 * time.Second
 
 // Close closes the sftp connection and terminates the underlying command.
 func (r *SFTP) Close() error {
-	debug.Log("Close")
 	if r == nil {
 		return nil
 	}

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -430,13 +430,6 @@ func (wr *wrapReader) Close() error {
 
 func (r *SFTP) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
-	if err := h.Valid(); err != nil {
-		return nil, backoff.Permanent(err)
-	}
-
-	if offset < 0 {
-		return nil, errors.New("offset is negative")
-	}
 
 	r.sem.GetToken()
 	f, err := r.c.Open(r.Filename(h))

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -143,7 +143,6 @@ func (be *beSwift) Load(ctx context.Context, h restic.Handle, length int, offset
 }
 
 func (be *beSwift) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
-	debug.Log("Load %v, length %v, offset %v", h, length, offset)
 
 	objName := be.Filename(h)
 
@@ -163,7 +162,6 @@ func (be *beSwift) openReader(ctx context.Context, h restic.Handle, length int, 
 	be.sem.GetToken()
 	obj, _, err := be.conn.ObjectOpen(ctx, be.container, objName, false, headers)
 	if err != nil {
-		debug.Log("  err %v", err)
 		be.sem.ReleaseToken()
 		return nil, errors.Wrap(err, "conn.ObjectOpen")
 	}
@@ -179,8 +177,6 @@ func (be *beSwift) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 
 	objName := be.Filename(h)
 
-	debug.Log("Save %v at %v", h, objName)
-
 	be.sem.GetToken()
 	defer be.sem.ReleaseToken()
 
@@ -192,15 +188,12 @@ func (be *beSwift) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 		be.container, objName, rd, true, hex.EncodeToString(rd.Hash()),
 		encoding, hdr)
 	// swift does not return the upload length
-	debug.Log("%v, err %#v", objName, err)
 
 	return errors.Wrap(err, "client.PutObject")
 }
 
 // Stat returns information about a blob.
 func (be *beSwift) Stat(ctx context.Context, h restic.Handle) (bi restic.FileInfo, err error) {
-	debug.Log("%v", h)
-
 	objName := be.Filename(h)
 
 	be.sem.GetToken()
@@ -208,7 +201,6 @@ func (be *beSwift) Stat(ctx context.Context, h restic.Handle) (bi restic.FileInf
 
 	obj, _, err := be.conn.Object(ctx, be.container, objName)
 	if err != nil {
-		debug.Log("Object() err %v", err)
 		return restic.FileInfo{}, errors.Wrap(err, "conn.Object")
 	}
 
@@ -223,15 +215,12 @@ func (be *beSwift) Remove(ctx context.Context, h restic.Handle) error {
 	defer be.sem.ReleaseToken()
 
 	err := be.conn.ObjectDelete(ctx, be.container, objName)
-	debug.Log("Remove(%v) -> err %v", h, err)
 	return errors.Wrap(err, "conn.ObjectDelete")
 }
 
 // List runs fn for each file in the backend which has the type t. When an
 // error occurs (or fn returns an error), List stops and returns it.
 func (be *beSwift) List(ctx context.Context, t restic.FileType, fn func(restic.FileInfo) error) error {
-	debug.Log("listing %v", t)
-
 	prefix, _ := be.Basedir(t)
 	prefix += "/"
 

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -146,10 +146,6 @@ func (be *beSwift) openReader(ctx context.Context, h restic.Handle, length int, 
 		headers["Range"] = fmt.Sprintf("bytes=%d-%d", offset, offset+int64(length)-1)
 	}
 
-	if _, ok := headers["Range"]; ok {
-		debug.Log("Load(%v) send range %v", h, headers["Range"])
-	}
-
 	obj, _, err := be.conn.ObjectOpen(ctx, be.container, objName, false, headers)
 	if err != nil {
 		return nil, errors.Wrap(err, "conn.ObjectOpen")
@@ -163,7 +159,6 @@ func (be *beSwift) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 	objName := be.Filename(h)
 	encoding := "binary/octet-stream"
 
-	debug.Log("PutObject(%v, %v, %v)", be.container, objName, encoding)
 	hdr := swift.Headers{"Content-Length": strconv.FormatInt(rd.Length(), 10)}
 	_, err := be.conn.ObjectPut(ctx,
 		be.container, objName, rd, true, hex.EncodeToString(rd.Hash()),

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -231,13 +231,6 @@ func (be *beSwift) List(ctx context.Context, t restic.FileType, fn func(restic.F
 	return ctx.Err()
 }
 
-// Remove keys for a specified backend type.
-func (be *beSwift) removeKeys(ctx context.Context, t restic.FileType) error {
-	return be.List(ctx, t, func(fi restic.FileInfo) error {
-		return be.Remove(ctx, restic.Handle{Type: t, Name: fi.Name})
-	})
-}
-
 // IsNotExist returns true if the error is caused by a not existing file.
 func (be *beSwift) IsNotExist(err error) bool {
 	var e *swift.Error
@@ -247,26 +240,7 @@ func (be *beSwift) IsNotExist(err error) bool {
 // Delete removes all restic objects in the container.
 // It will not remove the container itself.
 func (be *beSwift) Delete(ctx context.Context) error {
-	alltypes := []restic.FileType{
-		restic.PackFile,
-		restic.KeyFile,
-		restic.LockFile,
-		restic.SnapshotFile,
-		restic.IndexFile}
-
-	for _, t := range alltypes {
-		err := be.removeKeys(ctx, t)
-		if err != nil {
-			return nil
-		}
-	}
-
-	err := be.Remove(ctx, restic.Handle{Type: restic.ConfigFile})
-	if err != nil && !be.IsNotExist(err) {
-		return err
-	}
-
-	return nil
+	return backend.DefaultDelete(ctx, be)
 }
 
 // Close does nothing

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -144,17 +144,6 @@ func (be *beSwift) Load(ctx context.Context, h restic.Handle, length int, offset
 
 func (be *beSwift) openReader(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error) {
 	debug.Log("Load %v, length %v, offset %v", h, length, offset)
-	if err := h.Valid(); err != nil {
-		return nil, backoff.Permanent(err)
-	}
-
-	if offset < 0 {
-		return nil, errors.New("offset is negative")
-	}
-
-	if length < 0 {
-		return nil, errors.Errorf("invalid length %d", length)
-	}
 
 	objName := be.Filename(h)
 

--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -124,17 +124,7 @@ func (s *Suite) TestLoad(t *testing.T) {
 	b := s.open(t)
 	defer s.close(t, b)
 
-	noop := func(rd io.Reader) error {
-		return nil
-	}
-
-	err := b.Load(context.TODO(), restic.Handle{}, 0, 0, noop)
-	if err == nil {
-		t.Fatalf("Load() did not return an error for invalid handle")
-	}
-	test.Assert(t, !b.IsNotExist(err), "IsNotExist() should not accept an invalid handle error: %v", err)
-
-	err = testLoad(b, restic.Handle{Type: restic.PackFile, Name: "foobar"}, 0, 0)
+	err := testLoad(b, restic.Handle{Type: restic.PackFile, Name: "foobar"}, 0, 0)
 	if err == nil {
 		t.Fatalf("Load() did not return an error for non-existing blob")
 	}
@@ -152,11 +142,6 @@ func (s *Suite) TestLoad(t *testing.T) {
 	}
 
 	t.Logf("saved %d bytes as %v", length, handle)
-
-	err = b.Load(context.TODO(), handle, 100, -1, noop)
-	if err == nil {
-		t.Fatalf("Load() returned no error for negative offset!")
-	}
 
 	err = b.Load(context.TODO(), handle, 0, 0, func(rd io.Reader) error {
 		_, err := io.Copy(io.Discard, rd)

--- a/internal/backend/utils.go
+++ b/internal/backend/utils.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 
-	"github.com/cenkalti/backoff/v4"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
@@ -63,15 +62,7 @@ func LimitReadCloser(r io.ReadCloser, n int64) *LimitedReadCloser {
 func DefaultLoad(ctx context.Context, h restic.Handle, length int, offset int64,
 	openReader func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error),
 	fn func(rd io.Reader) error) error {
-	if err := h.Valid(); err != nil {
-		return backoff.Permanent(err)
-	}
-	if offset < 0 {
-		return errors.New("offset is negative")
-	}
-	if length < 0 {
-		return errors.Errorf("invalid length %d", length)
-	}
+
 	rd, err := openReader(ctx, h, length, offset)
 	if err != nil {
 		return err

--- a/internal/backend/utils.go
+++ b/internal/backend/utils.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/cenkalti/backoff/v4"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
@@ -62,6 +63,15 @@ func LimitReadCloser(r io.ReadCloser, n int64) *LimitedReadCloser {
 func DefaultLoad(ctx context.Context, h restic.Handle, length int, offset int64,
 	openReader func(ctx context.Context, h restic.Handle, length int, offset int64) (io.ReadCloser, error),
 	fn func(rd io.Reader) error) error {
+	if err := h.Valid(); err != nil {
+		return backoff.Permanent(err)
+	}
+	if offset < 0 {
+		return errors.New("offset is negative")
+	}
+	if length < 0 {
+		return errors.Errorf("invalid length %d", length)
+	}
 	rd, err := openReader(ctx, h, length, offset)
 	if err != nil {
 		return err

--- a/internal/backend/utils.go
+++ b/internal/backend/utils.go
@@ -75,6 +75,31 @@ func DefaultLoad(ctx context.Context, h restic.Handle, length int, offset int64,
 	return rd.Close()
 }
 
+// DefaultDelete removes all restic keys in the bucket. It will not remove the bucket itself.
+func DefaultDelete(ctx context.Context, be restic.Backend) error {
+	alltypes := []restic.FileType{
+		restic.PackFile,
+		restic.KeyFile,
+		restic.LockFile,
+		restic.SnapshotFile,
+		restic.IndexFile}
+
+	for _, t := range alltypes {
+		err := be.List(ctx, t, func(fi restic.FileInfo) error {
+			return be.Remove(ctx, restic.Handle{Type: t, Name: fi.Name})
+		})
+		if err != nil {
+			return nil
+		}
+	}
+	err := be.Remove(ctx, restic.Handle{Type: restic.ConfigFile})
+	if err != nil && be.IsNotExist(err) {
+		err = nil
+	}
+
+	return err
+}
+
 type memorizedLister struct {
 	fileInfos []restic.FileInfo
 	tpe       restic.FileType

--- a/internal/cache/backend.go
+++ b/internal/cache/backend.go
@@ -211,3 +211,7 @@ func (b *Backend) Stat(ctx context.Context, h restic.Handle) (restic.FileInfo, e
 func (b *Backend) IsNotExist(err error) bool {
 	return b.Backend.IsNotExist(err)
 }
+
+func (b *Backend) Unwrap() restic.Backend {
+	return b.Backend
+}

--- a/internal/migrations/s3_layout_test.go
+++ b/internal/migrations/s3_layout_test.go
@@ -1,0 +1,27 @@
+package migrations
+
+import (
+	"testing"
+
+	"github.com/restic/restic/internal/backend/mock"
+	"github.com/restic/restic/internal/backend/s3"
+	"github.com/restic/restic/internal/cache"
+	"github.com/restic/restic/internal/test"
+)
+
+func TestS3UnwrapBackend(t *testing.T) {
+	// toS3Backend(b restic.Backend) *s3.Backend
+
+	m := mock.NewBackend()
+	test.Assert(t, toS3Backend(m) == nil, "mock backend is not an s3 backend")
+
+	// uninitialized fake backend for testing
+	s3 := &s3.Backend{}
+	test.Assert(t, toS3Backend(s3) == s3, "s3 was not returned")
+
+	c := &cache.Backend{Backend: s3}
+	test.Assert(t, toS3Backend(c) == s3, "failed to unwrap s3 backend")
+
+	c.Backend = m
+	test.Assert(t, toS3Backend(c) == nil, "a wrapped mock backend is not an s3 backend")
+}

--- a/internal/restic/backend.go
+++ b/internal/restic/backend.go
@@ -70,6 +70,11 @@ type Backend interface {
 	Delete(ctx context.Context) error
 }
 
+type BackendUnwrapper interface {
+	// Unwrap returns the underlying backend or nil if there is none.
+	Unwrap() Backend
+}
+
 // FileInfo is contains information about a file in the backend.
 type FileInfo struct {
 	Size int64


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The generic logging of backend operations is factored out into `logger.Backend`. Limiting the number of concurrent backend operations and the basic parameter validation now happens in `sema.SemaphoreBackend`. In addition, the `Delete()` method most backends now uses a generic implementation provided by `backend.DefaultDelete()`.

The unified logging now consistently logs the called operation and its result. This is complemented with a log entry by the SemaphoreBackend once a semaphore token has been acquired.

The `List()` operation of a Backend no longer counts towards the connections limit, but that should not make much of a difference as restic normally only runs one list operation at a time. The duration for which a semaphore token is held increases slightly, but I don't expect this to be a problem, as the bottleneck in a Backend is the necessary IO. The key simplification of the SemaphoreBackend is that the complex semaphore usage in `backend.DefaultLoad` and the corresponding `openReader()` method can simply be extracted into the `Load()` method. This allows a clean separation of the connection count limiting and the regular backend operation.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No, but this PR is a prerequisite to address #4199 without creating a big mess.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
