### PR TITLE
ui/termstatus: Optimize Truncate

### DIFF
--- a/internal/ui/termstatus/status_test.go
+++ b/internal/ui/termstatus/status_test.go
@@ -49,11 +49,15 @@ func BenchmarkTruncateASCII(b *testing.B) {
 func BenchmarkTruncateUnicode(b *testing.B) {
 	s := "Hello World or Καλημέρα κόσμε or こんにちは 世界"
 	w := 0
-	for _, r := range s {
+	for i := 0; i < len(s); {
 		w++
-		if wideRune(r) {
+		wide, utfsize := wideRune(s[i:])
+		if wide {
 			w++
 		}
+		i += int(utfsize)
 	}
+	b.ResetTimer()
+
 	benchmarkTruncate(b, s, w-1)
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Speeds up temstatus.Truncate a bit. It handles invalid UTF-8 encodings differently, but that doesn't matter once we have #4192.

Benchmark results, with b.ResetTimer introduced first:

    name               old time/op  new time/op  delta
    TruncateASCII-8    69.7ns ± 1%  55.2ns ± 1%  -20.90%  (p=0.000 n=20+18)
    TruncateUnicode-8   350ns ± 1%   171ns ± 1%  -51.05%  (p=0.000 n=20+19)

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
