### PR TITLE
Fix parent snapshot selection for relative paths

### DIFF
--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -71,6 +71,7 @@ func testRunBackupAssumeFailure(t testing.TB, dir string, target []string, opts 
 		defer cleanup()
 	}
 
+	opts.GroupBy = restic.SnapshotGroupByOptions{Host: true, Path: true}
 	backupErr := runBackup(ctx, opts, gopts, term, target)
 
 	cancel()

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -46,6 +46,7 @@ func (f *SnapshotFilter) findLatest(ctx context.Context, be Lister, loader Loade
 		}
 		absTargets = append(absTargets, filepath.Clean(target))
 	}
+	f.Paths = absTargets
 
 	var latest *Snapshot
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
#4212 accidentally changed the snapshot filtering for relative paths. As a consequence `restic backup relative-path` no longer selected a parent snapshot. Since #4081 (which introduce --group-by) the parent snapshot selection just accepted any snapshot instead of filtering by host and path as before. This obscured the changed behavior for relative paths.

The conversion of relative paths to absolute ones should be moved out of `findLatest()` but that is out of scope for this PR.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
