### PR TITLE
rewrite: log snapshot saved before removal of the old snapshot

### DIFF
--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -136,6 +136,7 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *resti
 	if err != nil {
 		return false, err
 	}
+	Verbosef("saved new snapshot %v\n", id.Str())
 
 	if opts.Forget {
 		h := restic.Handle{Type: restic.SnapshotFile, Name: sn.ID().String()}
@@ -145,7 +146,6 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *resti
 		debug.Log("removed old snapshot %v", sn.ID())
 		Verbosef("removed old snapshot %v\n", sn.ID().Str())
 	}
-	Verbosef("saved new snapshot %v\n", id.Str())
 	return true, nil
 }
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The snapshot was already saved before removing the old snapshot. Only the log messages were printed in the wrong order.

Before:
```
removed old snapshot c682c238
saved new snapshot 0d58bbaa
```
After:
```
saved new snapshot 0d58bbaa
removed old snapshot c682c238
```
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #4295
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
