### PR TITLE
doc: recommend `cat config` to check if a repository exists

### DIFF
--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -22,18 +22,18 @@ Check if a repository is already initialized
 
 You may find a need to check if a repository is already initialized,
 perhaps to prevent your script from initializing a repository multiple
-times. The command ``snapshots`` may be used for this purpose:
+times. The command ``cat config`` may be used for this purpose:
 
 .. code-block:: console
 
-    $ restic -r /srv/restic-repo snapshots
-    Fatal: unable to open config file: Stat: stat /srv/restic-repo/config: no such file or directory
+    $ restic -r /srv/restic-repo cat config
+    Fatal: unable to open config file: stat /srv/restic-repo/config: no such file or directory
     Is there a repository at the following location?
     /srv/restic-repo
 
 If a repository does not exist, restic will return a non-zero exit code
 and print an error message. Note that restic will also return a non-zero
 exit code if a different error is encountered (e.g.: incorrect password
-to ``snapshots``) and it may print a different error message. If there
-are no errors, restic will return a zero exit code and print all the
-snapshots.
+to ``cat config``) and it may print a different error message. If there
+are no errors, restic will return a zero exit code and print the repository
+metadata.


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
`snapshots` has to read every snapshot. But the only interesting information here is that the repository exists. Thus, just use `cat config`.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Suggested in #1690
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.`
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
