### PR TITLE
Increase timeouts for lock refresh tests

### DIFF
--- a/cmd/restic/lock_test.go
+++ b/cmd/restic/lock_test.go
@@ -156,8 +156,8 @@ func TestLockSuccessfulRefresh(t *testing.T) {
 	t.Logf("test for successful lock refresh %v", time.Now())
 	// reduce locking intervals to be suitable for testing
 	ri, rt := refreshInterval, refreshabilityTimeout
-	refreshInterval = 40 * time.Millisecond
-	refreshabilityTimeout = 200 * time.Millisecond
+	refreshInterval = 60 * time.Millisecond
+	refreshabilityTimeout = 500 * time.Millisecond
 	defer func() {
 		refreshInterval, refreshabilityTimeout = ri, rt
 	}()
@@ -189,7 +189,7 @@ func TestLockWaitTimeout(t *testing.T) {
 	elock, _, err := lockRepoExclusive(context.TODO(), repo, env.gopts.RetryLock, env.gopts.JSON)
 	test.OK(t, err)
 
-	retryLock := 100 * time.Millisecond
+	retryLock := 200 * time.Millisecond
 
 	start := time.Now()
 	lock, _, err := lockRepo(context.TODO(), repo, retryLock, env.gopts.JSON)
@@ -199,7 +199,7 @@ func TestLockWaitTimeout(t *testing.T) {
 		"create normal lock with exclusively locked repo didn't return an error")
 	test.Assert(t, strings.Contains(err.Error(), "repository is already locked exclusively"),
 		"create normal lock with exclusively locked repo didn't return the correct error")
-	test.Assert(t, retryLock <= duration && duration < retryLock+50*time.Millisecond,
+	test.Assert(t, retryLock <= duration && duration < retryLock*3/2,
 		"create normal lock with exclusively locked repo didn't wait for the specified timeout")
 
 	test.OK(t, lock.Unlock())
@@ -212,7 +212,7 @@ func TestLockWaitCancel(t *testing.T) {
 	elock, _, err := lockRepoExclusive(context.TODO(), repo, env.gopts.RetryLock, env.gopts.JSON)
 	test.OK(t, err)
 
-	retryLock := 100 * time.Millisecond
+	retryLock := 200 * time.Millisecond
 	cancelAfter := 40 * time.Millisecond
 
 	ctx, cancel := context.WithCancel(context.TODO())
@@ -226,7 +226,7 @@ func TestLockWaitCancel(t *testing.T) {
 		"create normal lock with exclusively locked repo didn't return an error")
 	test.Assert(t, strings.Contains(err.Error(), "context canceled"),
 		"create normal lock with exclusively locked repo didn't return the correct error")
-	test.Assert(t, cancelAfter <= duration && duration < cancelAfter+50*time.Millisecond,
+	test.Assert(t, cancelAfter <= duration && duration < retryLock-10*time.Millisecond,
 		"create normal lock with exclusively locked repo didn't return in time")
 
 	test.OK(t, lock.Unlock())
@@ -240,7 +240,7 @@ func TestLockWaitSuccess(t *testing.T) {
 	elock, _, err := lockRepoExclusive(context.TODO(), repo, env.gopts.RetryLock, env.gopts.JSON)
 	test.OK(t, err)
 
-	retryLock := 100 * time.Millisecond
+	retryLock := 200 * time.Millisecond
 	unlockAfter := 40 * time.Millisecond
 
 	time.AfterFunc(unlockAfter, func() {


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The `TestLockSuccessfulRefresh` and some other locking related tests fail far too often.

When saving files to the local backend, in some cases the used fsync calls are slow enough to cause the tests to time out. Thus, increase the test timeouts as a stopgap measure until we can use the mem backend for these tests.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No?
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
