### PR TITLE
Tweak debug logs

### DIFF
--- a/internal/archiver/tree_saver.go
+++ b/internal/archiver/tree_saver.go
@@ -105,14 +105,15 @@ func (s *TreeSaver) save(ctx context.Context, job *saveTreeJob) (*restic.Node, I
 			continue
 		}
 
-		debug.Log("insert %v", fnr.node.Name)
 		err := builder.AddNode(fnr.node)
 		if err != nil && errors.Is(err, restic.ErrTreeNotOrdered) && lastNode != nil && fnr.node.Equals(*lastNode) {
+			debug.Log("insert %v failed: %v", fnr.node.Name, err)
 			// ignore error if an _identical_ node already exists, but nevertheless issue a warning
 			_ = s.errFn(fnr.target, err)
 			err = nil
 		}
 		if err != nil {
+			debug.Log("insert %v failed: %v", fnr.node.Name, err)
 			return nil, stats, err
 		}
 		lastNode = fnr.node

--- a/internal/restic/parallel.go
+++ b/internal/restic/parallel.go
@@ -41,7 +41,7 @@ func ParallelList(ctx context.Context, r Lister, t FileType, parallelism uint, f
 	// a worker receives an index ID from ch, loads the index, and sends it to indexCh
 	worker := func() error {
 		for fi := range ch {
-			debug.Log("worker got file %v", fi.ID.Str())
+			debug.Log("worker got file %v/%v", t, fi.ID.Str())
 			err := fn(ctx, fi.ID, fi.Size)
 			if err != nil {
 				return err

--- a/internal/walker/rewriter.go
+++ b/internal/walker/rewriter.go
@@ -37,7 +37,7 @@ func FilterTree(ctx context.Context, repo BlobLoadSaver, nodepath string, nodeID
 		return restic.ID{}, err
 	}
 	if nodeID != testID {
-		return restic.ID{}, fmt.Errorf("cannot encode tree at %q without loosing information", nodepath)
+		return restic.ID{}, fmt.Errorf("cannot encode tree at %q without losing information", nodepath)
 	}
 
 	debug.Log("filterTree: %s, nodeId: %s\n", nodepath, nodeID.Str())


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
While saving a Node in the `TreeSaver` the regular file names are not particularly interesting. Thus, only log errors.

The other changes fix a typo and make the debug log for `ParallelList` slightly more readable
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No/
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
