### PR TITLE
dump: Report filename with tar.ErrFieldTooLong

### DIFF
--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -3,6 +3,7 @@ package dump
 import (
 	"archive/tar"
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -94,9 +95,8 @@ func (d *Dumper) dumpNodeTar(ctx context.Context, node *restic.Node, w *tar.Writ
 
 	err = w.WriteHeader(header)
 	if err != nil {
-		return errors.Wrap(err, "TarHeader")
+		return fmt.Errorf("writing header for %q: %w", node.Path, err)
 	}
-
 	return d.writeNode(ctx, w, node)
 }
 

--- a/internal/dump/tar_test.go
+++ b/internal/dump/tar_test.go
@@ -3,6 +3,8 @@ package dump
 import (
 	"archive/tar"
 	"bytes"
+	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -12,6 +14,8 @@ import (
 	"time"
 
 	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
 )
 
 func TestWriteTar(t *testing.T) {
@@ -111,4 +115,30 @@ func checkTar(t *testing.T, testDir string, srcTar *bytes.Buffer) error {
 	}
 
 	return nil
+}
+
+// #4307.
+func TestFieldTooLong(t *testing.T) {
+	const maxSpecialFileSize = 1 << 20 // Unexported limit in archive/tar.
+
+	node := restic.Node{
+		Name: "file_with_xattr",
+		Path: "/file_with_xattr",
+		Type: "file",
+		Mode: 0644,
+		ExtendedAttributes: []restic.ExtendedAttribute{
+			{
+				Name:  "user.way_too_large",
+				Value: make([]byte, 2*maxSpecialFileSize),
+			},
+		},
+	}
+
+	d := Dumper{format: "tar"}
+	err := d.dumpNodeTar(context.Background(), &node, tar.NewWriter(io.Discard))
+
+	// We want a tar.ErrFieldTooLong that has the filename.
+	rtest.Assert(t, errors.Is(err, tar.ErrFieldTooLong), "wrong type %T", err)
+	rtest.Assert(t, strings.Contains(err.Error(), node.Path),
+		"no filename in %q", err)
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

When restic dump encounters a node with extended attributes that are too long, it now reports the name of that file.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Updates #4307. As @jtru said there, reporting the filename is the least we can do. The test is useful for further development.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
