### PR TITLE
Add JSON support for the restore progress bar

### DIFF
--- a/changelog/unreleased/issue-426
+++ b/changelog/unreleased/issue-426
@@ -4,6 +4,11 @@ The `restore` command now shows a progress report while restoring files.
 
 Example: [0:42]  5.76%  23 files 12.98 MiB, total 3456 files 23.54 GiB
 
+JSON output is now also supported.
+
+https://github.com/restic/restic/issues/426
+https://github.com/restic/restic/issues/3413
 https://github.com/restic/restic/issues/3627
 https://github.com/restic/restic/pull/3991
+https://github.com/restic/restic/pull/4314
 https://forum.restic.net/t/progress-bar-for-restore/5210

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -177,7 +177,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 
 	var progress *restoreui.Progress
 	if !gopts.Quiet && !gopts.JSON {
-		progress = restoreui.NewProgress(restoreui.NewProgressPrinter(term), calculateProgressInterval(!gopts.Quiet, gopts.JSON))
+		progress = restoreui.NewProgress(restoreui.NewTextPrinter(term), calculateProgressInterval(!gopts.Quiet, gopts.JSON))
 	}
 
 	res := restorer.NewRestorer(repo, sn, opts.Sparse, progress)

--- a/cmd/restic/cmd_restore_integration_test.go
+++ b/cmd/restic/cmd_restore_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/restic/restic/internal/filter"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/ui/termstatus"
 )
 
 func testRunRestore(t testing.TB, opts GlobalOptions, dir string, snapshotID restic.ID) {
@@ -26,11 +27,13 @@ func testRunRestoreExcludes(t testing.TB, gopts GlobalOptions, dir string, snaps
 		Exclude: excludes,
 	}
 
-	rtest.OK(t, runRestore(context.TODO(), opts, gopts, nil, []string{snapshotID.String()}))
+	rtest.OK(t, testRunRestoreAssumeFailure(snapshotID.String(), opts, gopts))
 }
 
 func testRunRestoreAssumeFailure(snapshotID string, opts RestoreOptions, gopts GlobalOptions) error {
-	return runRestore(context.TODO(), opts, gopts, nil, []string{snapshotID})
+	return withTermStatus(gopts, func(ctx context.Context, term *termstatus.Terminal) error {
+		return runRestore(ctx, opts, gopts, term, []string{snapshotID})
+	})
 }
 
 func testRunRestoreLatest(t testing.TB, gopts GlobalOptions, dir string, paths []string, hosts []string) {
@@ -42,7 +45,7 @@ func testRunRestoreLatest(t testing.TB, gopts GlobalOptions, dir string, paths [
 		},
 	}
 
-	rtest.OK(t, runRestore(context.TODO(), opts, gopts, nil, []string{"latest"}))
+	rtest.OK(t, testRunRestoreAssumeFailure("latest", opts, gopts))
 }
 
 func testRunRestoreIncludes(t testing.TB, gopts GlobalOptions, dir string, snapshotID restic.ID, includes []string) {
@@ -51,7 +54,7 @@ func testRunRestoreIncludes(t testing.TB, gopts GlobalOptions, dir string, snaps
 		Include: includes,
 	}
 
-	rtest.OK(t, runRestore(context.TODO(), opts, gopts, nil, []string{snapshotID.String()}))
+	rtest.OK(t, testRunRestoreAssumeFailure(snapshotID.String(), opts, gopts))
 }
 
 func TestRestoreFilter(t *testing.T) {

--- a/internal/ui/backup/json.go
+++ b/internal/ui/backup/json.go
@@ -1,8 +1,6 @@
 package backup
 
 import (
-	"bytes"
-	"encoding/json"
 	"sort"
 	"time"
 
@@ -32,21 +30,12 @@ func NewJSONProgress(term *termstatus.Terminal, verbosity uint) *JSONProgress {
 	}
 }
 
-func toJSONString(status interface{}) string {
-	buf := new(bytes.Buffer)
-	err := json.NewEncoder(buf).Encode(status)
-	if err != nil {
-		panic(err)
-	}
-	return buf.String()
-}
-
 func (b *JSONProgress) print(status interface{}) {
-	b.term.Print(toJSONString(status))
+	b.term.Print(ui.ToJSONString(status))
 }
 
 func (b *JSONProgress) error(status interface{}) {
-	b.term.Error(toJSONString(status))
+	b.term.Error(ui.ToJSONString(status))
 }
 
 // Update updates the status lines.

--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -1,6 +1,8 @@
 package ui
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -52,4 +54,13 @@ func FormatSeconds(sec uint64) string {
 		return fmt.Sprintf("%d:%02d:%02d", hours, min, sec)
 	}
 	return fmt.Sprintf("%d:%02d", min, sec)
+}
+
+func ToJSONString(status interface{}) string {
+	buf := new(bytes.Buffer)
+	err := json.NewEncoder(buf).Encode(status)
+	if err != nil {
+		panic(err)
+	}
+	return buf.String()
 }

--- a/internal/ui/restore/json.go
+++ b/internal/ui/restore/json.go
@@ -25,9 +25,9 @@ func (t *jsonPrinter) Update(filesFinished, filesTotal, allBytesWritten, allByte
 		MessageType:    "status",
 		SecondsElapsed: uint64(duration / time.Second),
 		TotalFiles:     filesTotal,
-		FilesDone:      filesFinished,
+		FilesRestored:  filesFinished,
 		TotalBytes:     allBytesTotal,
-		BytesDone:      allBytesWritten,
+		BytesRestored:  allBytesWritten,
 	}
 
 	if allBytesTotal > 0 {
@@ -42,9 +42,9 @@ func (t *jsonPrinter) Finish(filesFinished, filesTotal, allBytesWritten, allByte
 		MessageType:    "summary",
 		SecondsElapsed: uint64(duration / time.Second),
 		TotalFiles:     filesTotal,
-		FilesDone:      filesFinished,
+		FilesRestored:  filesFinished,
 		TotalBytes:     allBytesTotal,
-		BytesDone:      allBytesWritten,
+		BytesRestored:  allBytesWritten,
 	}
 	t.print(status)
 }
@@ -54,16 +54,16 @@ type statusUpdate struct {
 	SecondsElapsed uint64  `json:"seconds_elapsed,omitempty"`
 	PercentDone    float64 `json:"percent_done"`
 	TotalFiles     uint64  `json:"total_files,omitempty"`
-	FilesDone      uint64  `json:"files_done,omitempty"`
+	FilesRestored  uint64  `json:"files_restored,omitempty"`
 	TotalBytes     uint64  `json:"total_bytes,omitempty"`
-	BytesDone      uint64  `json:"bytes_done,omitempty"`
+	BytesRestored  uint64  `json:"bytes_restored,omitempty"`
 }
 
 type summaryOutput struct {
 	MessageType    string `json:"message_type"` // "summary"
 	SecondsElapsed uint64 `json:"seconds_elapsed,omitempty"`
 	TotalFiles     uint64 `json:"total_files,omitempty"`
-	FilesDone      uint64 `json:"files_done,omitempty"`
+	FilesRestored  uint64 `json:"files_restored,omitempty"`
 	TotalBytes     uint64 `json:"total_bytes,omitempty"`
-	BytesDone      uint64 `json:"bytes_done,omitempty"`
+	BytesRestored  uint64 `json:"bytes_restored,omitempty"`
 }

--- a/internal/ui/restore/json.go
+++ b/internal/ui/restore/json.go
@@ -1,0 +1,69 @@
+package restore
+
+import (
+	"time"
+
+	"github.com/restic/restic/internal/ui"
+)
+
+type jsonPrinter struct {
+	terminal term
+}
+
+func NewJSONProgress(terminal term) ProgressPrinter {
+	return &jsonPrinter{
+		terminal: terminal,
+	}
+}
+
+func (t *jsonPrinter) print(status interface{}) {
+	t.terminal.Print(ui.ToJSONString(status))
+}
+
+func (t *jsonPrinter) Update(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration) {
+	status := statusUpdate{
+		MessageType:    "status",
+		SecondsElapsed: uint64(duration / time.Second),
+		TotalFiles:     filesTotal,
+		FilesDone:      filesFinished,
+		TotalBytes:     allBytesTotal,
+		BytesDone:      allBytesWritten,
+	}
+
+	if allBytesTotal > 0 {
+		status.PercentDone = float64(allBytesWritten) / float64(allBytesTotal)
+	}
+
+	t.print(status)
+}
+
+func (t *jsonPrinter) Finish(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration) {
+	status := summaryOutput{
+		MessageType:    "summary",
+		SecondsElapsed: uint64(duration / time.Second),
+		TotalFiles:     filesTotal,
+		FilesDone:      filesFinished,
+		TotalBytes:     allBytesTotal,
+		BytesDone:      allBytesWritten,
+	}
+	t.print(status)
+}
+
+type statusUpdate struct {
+	MessageType    string  `json:"message_type"` // "status"
+	SecondsElapsed uint64  `json:"seconds_elapsed,omitempty"`
+	PercentDone    float64 `json:"percent_done"`
+	TotalFiles     uint64  `json:"total_files,omitempty"`
+	FilesDone      uint64  `json:"files_done,omitempty"`
+	TotalBytes     uint64  `json:"total_bytes,omitempty"`
+	BytesDone      uint64  `json:"bytes_done,omitempty"`
+}
+
+type summaryOutput struct {
+	MessageType    string `json:"message_type"` // "summary"
+	SecondsElapsed uint64 `json:"seconds_elapsed,omitempty"`
+	TotalFiles     uint64 `json:"total_files,omitempty"`
+	FilesDone      uint64 `json:"files_done,omitempty"`
+	TotalBytes     uint64 `json:"total_bytes,omitempty"`
+	BytesDone      uint64 `json:"bytes_done,omitempty"`
+}

--- a/internal/ui/restore/json_test.go
+++ b/internal/ui/restore/json_test.go
@@ -1,0 +1,29 @@
+package restore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/test"
+)
+
+func TestJSONPrintUpdate(t *testing.T) {
+	term := &mockTerm{}
+	printer := NewJSONProgress(term)
+	printer.Update(3, 11, 29, 47, 5*time.Second)
+	test.Equals(t, []string{"{\"message_type\":\"status\",\"seconds_elapsed\":5,\"percent_done\":0.6170212765957447,\"total_files\":11,\"files_done\":3,\"total_bytes\":47,\"bytes_done\":29}\n"}, term.output)
+}
+
+func TestJSONPrintSummaryOnSuccess(t *testing.T) {
+	term := &mockTerm{}
+	printer := NewJSONProgress(term)
+	printer.Finish(11, 11, 47, 47, 5*time.Second)
+	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_done\":11,\"total_bytes\":47,\"bytes_done\":47}\n"}, term.output)
+}
+
+func TestJSONPrintSummaryOnErrors(t *testing.T) {
+	term := &mockTerm{}
+	printer := NewJSONProgress(term)
+	printer.Finish(3, 11, 29, 47, 5*time.Second)
+	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_done\":3,\"total_bytes\":47,\"bytes_done\":29}\n"}, term.output)
+}

--- a/internal/ui/restore/json_test.go
+++ b/internal/ui/restore/json_test.go
@@ -11,19 +11,19 @@ func TestJSONPrintUpdate(t *testing.T) {
 	term := &mockTerm{}
 	printer := NewJSONProgress(term)
 	printer.Update(3, 11, 29, 47, 5*time.Second)
-	test.Equals(t, []string{"{\"message_type\":\"status\",\"seconds_elapsed\":5,\"percent_done\":0.6170212765957447,\"total_files\":11,\"files_done\":3,\"total_bytes\":47,\"bytes_done\":29}\n"}, term.output)
+	test.Equals(t, []string{"{\"message_type\":\"status\",\"seconds_elapsed\":5,\"percent_done\":0.6170212765957447,\"total_files\":11,\"files_restored\":3,\"total_bytes\":47,\"bytes_restored\":29}\n"}, term.output)
 }
 
 func TestJSONPrintSummaryOnSuccess(t *testing.T) {
 	term := &mockTerm{}
 	printer := NewJSONProgress(term)
 	printer.Finish(11, 11, 47, 47, 5*time.Second)
-	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_done\":11,\"total_bytes\":47,\"bytes_done\":47}\n"}, term.output)
+	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_restored\":11,\"total_bytes\":47,\"bytes_restored\":47}\n"}, term.output)
 }
 
 func TestJSONPrintSummaryOnErrors(t *testing.T) {
 	term := &mockTerm{}
 	printer := NewJSONProgress(term)
 	printer.Finish(3, 11, 29, 47, 5*time.Second)
-	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_done\":3,\"total_bytes\":47,\"bytes_done\":29}\n"}, term.output)
+	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_restored\":3,\"total_bytes\":47,\"bytes_restored\":29}\n"}, term.output)
 }

--- a/internal/ui/restore/progress_test.go
+++ b/internal/ui/restore/progress_test.go
@@ -135,36 +135,3 @@ func TestSummaryOnErrors(t *testing.T) {
 		printerTraceEntry{1, 2, 50 + fileSize/2, 50 + fileSize, mockFinishDuration, true},
 	}, result)
 }
-
-type mockTerm struct {
-	output []string
-}
-
-func (m *mockTerm) Print(line string) {
-	m.output = append(m.output, line)
-}
-
-func (m *mockTerm) SetStatus(lines []string) {
-	m.output = append([]string{}, lines...)
-}
-
-func TestPrintUpdate(t *testing.T) {
-	term := &mockTerm{}
-	printer := NewProgressPrinter(term)
-	printer.Update(3, 11, 29, 47, 5*time.Second)
-	test.Equals(t, []string{"[0:05] 61.70%  3 files 29 B, total 11 files 47 B"}, term.output)
-}
-
-func TestPrintSummaryOnSuccess(t *testing.T) {
-	term := &mockTerm{}
-	printer := NewProgressPrinter(term)
-	printer.Finish(11, 11, 47, 47, 5*time.Second)
-	test.Equals(t, []string{"Summary: Restored 11 Files (47 B) in 0:05"}, term.output)
-}
-
-func TestPrintSummaryOnErrors(t *testing.T) {
-	term := &mockTerm{}
-	printer := NewProgressPrinter(term)
-	printer.Finish(3, 11, 29, 47, 5*time.Second)
-	test.Equals(t, []string{"Summary: Restored 3 / 11 Files (29 B / 47 B) in 0:05"}, term.output)
-}

--- a/internal/ui/restore/text.go
+++ b/internal/ui/restore/text.go
@@ -11,7 +11,7 @@ type textPrinter struct {
 	terminal term
 }
 
-func NewTextPrinter(terminal term) ProgressPrinter {
+func NewTextProgress(terminal term) ProgressPrinter {
 	return &textPrinter{
 		terminal: terminal,
 	}

--- a/internal/ui/restore/text.go
+++ b/internal/ui/restore/text.go
@@ -1,0 +1,47 @@
+package restore
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/restic/restic/internal/ui"
+)
+
+type textPrinter struct {
+	terminal term
+}
+
+func NewTextPrinter(terminal term) ProgressPrinter {
+	return &textPrinter{
+		terminal: terminal,
+	}
+}
+
+func (t *textPrinter) Update(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration) {
+	timeLeft := ui.FormatDuration(duration)
+	formattedAllBytesWritten := ui.FormatBytes(allBytesWritten)
+	formattedAllBytesTotal := ui.FormatBytes(allBytesTotal)
+	allPercent := ui.FormatPercent(allBytesWritten, allBytesTotal)
+	progress := fmt.Sprintf("[%s] %s  %v files %s, total %v files %v",
+		timeLeft, allPercent, filesFinished, formattedAllBytesWritten, filesTotal, formattedAllBytesTotal)
+
+	t.terminal.SetStatus([]string{progress})
+}
+
+func (t *textPrinter) Finish(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration) {
+	t.terminal.SetStatus([]string{})
+
+	timeLeft := ui.FormatDuration(duration)
+	formattedAllBytesTotal := ui.FormatBytes(allBytesTotal)
+
+	var summary string
+	if filesFinished == filesTotal && allBytesWritten == allBytesTotal {
+		summary = fmt.Sprintf("Summary: Restored %d Files (%s) in %s", filesTotal, formattedAllBytesTotal, timeLeft)
+	} else {
+		formattedAllBytesWritten := ui.FormatBytes(allBytesWritten)
+		summary = fmt.Sprintf("Summary: Restored %d / %d Files (%s / %s) in %s",
+			filesFinished, filesTotal, formattedAllBytesWritten, formattedAllBytesTotal, timeLeft)
+	}
+
+	t.terminal.Print(summary)
+}

--- a/internal/ui/restore/text_test.go
+++ b/internal/ui/restore/text_test.go
@@ -1,0 +1,41 @@
+package restore
+
+import (
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/test"
+)
+
+type mockTerm struct {
+	output []string
+}
+
+func (m *mockTerm) Print(line string) {
+	m.output = append(m.output, line)
+}
+
+func (m *mockTerm) SetStatus(lines []string) {
+	m.output = append([]string{}, lines...)
+}
+
+func TestPrintUpdate(t *testing.T) {
+	term := &mockTerm{}
+	printer := NewTextPrinter(term)
+	printer.Update(3, 11, 29, 47, 5*time.Second)
+	test.Equals(t, []string{"[0:05] 61.70%  3 files 29 B, total 11 files 47 B"}, term.output)
+}
+
+func TestPrintSummaryOnSuccess(t *testing.T) {
+	term := &mockTerm{}
+	printer := NewTextPrinter(term)
+	printer.Finish(11, 11, 47, 47, 5*time.Second)
+	test.Equals(t, []string{"Summary: Restored 11 Files (47 B) in 0:05"}, term.output)
+}
+
+func TestPrintSummaryOnErrors(t *testing.T) {
+	term := &mockTerm{}
+	printer := NewTextPrinter(term)
+	printer.Finish(3, 11, 29, 47, 5*time.Second)
+	test.Equals(t, []string{"Summary: Restored 3 / 11 Files (29 B / 47 B) in 0:05"}, term.output)
+}

--- a/internal/ui/restore/text_test.go
+++ b/internal/ui/restore/text_test.go
@@ -21,21 +21,21 @@ func (m *mockTerm) SetStatus(lines []string) {
 
 func TestPrintUpdate(t *testing.T) {
 	term := &mockTerm{}
-	printer := NewTextPrinter(term)
+	printer := NewTextProgress(term)
 	printer.Update(3, 11, 29, 47, 5*time.Second)
 	test.Equals(t, []string{"[0:05] 61.70%  3 files 29 B, total 11 files 47 B"}, term.output)
 }
 
 func TestPrintSummaryOnSuccess(t *testing.T) {
 	term := &mockTerm{}
-	printer := NewTextPrinter(term)
+	printer := NewTextProgress(term)
 	printer.Finish(11, 11, 47, 47, 5*time.Second)
 	test.Equals(t, []string{"Summary: Restored 11 Files (47 B) in 0:05"}, term.output)
 }
 
 func TestPrintSummaryOnErrors(t *testing.T) {
 	term := &mockTerm{}
-	printer := NewTextPrinter(term)
+	printer := NewTextProgress(term)
 	printer.Finish(3, 11, 29, 47, 5*time.Second)
 	test.Equals(t, []string{"Summary: Restored 3 / 11 Files (29 B / 47 B) in 0:05"}, term.output)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Add rudimentary JSON output for restore command. There is no progress for the `restore --verify` option so far (but also progress bar in the normal text output).

The JSON format is in parts copied from that used by the backup command.

TODOs:
- [x] The error output is still plain text and is not synchronized with the progress bar updates
- [x] Finalize format of JSON output

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3413
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
