### PR TITLE
restore: Correctly account for hardlinks in progress bar

### DIFF
--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -257,19 +257,26 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 				return nil
 			}
 
-			if res.progress != nil {
-				res.progress.AddFile(node.Size)
-			}
-
 			if node.Size == 0 {
+				if res.progress != nil {
+					res.progress.AddFile(node.Size)
+				}
 				return nil // deal with empty files later
 			}
 
 			if node.Links > 1 {
 				if idx.Has(node.Inode, node.DeviceID) {
+					if res.progress != nil {
+						// a hardlinked file does not increase the restore size
+						res.progress.AddFile(0)
+					}
 					return nil
 				}
 				idx.Add(node.Inode, node.DeviceID, location)
+			}
+
+			if res.progress != nil {
+				res.progress.AddFile(node.Size)
 			}
 
 			filerestorer.addFile(location, node.Content, int64(node.Size))

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -9,10 +9,12 @@ import (
 	"path/filepath"
 	"syscall"
 	"testing"
+	"time"
 
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
+	restoreui "github.com/restic/restic/internal/ui/restore"
 )
 
 func TestRestorerRestoreEmptyHardlinkedFileds(t *testing.T) {
@@ -65,4 +67,57 @@ func getBlockCount(t *testing.T, filename string) int64 {
 		return -1
 	}
 	return st.Blocks
+}
+
+type printerMock struct {
+	filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64
+}
+
+func (p *printerMock) Update(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration) {
+}
+func (p *printerMock) Finish(filesFinished, filesTotal, allBytesWritten, allBytesTotal uint64, duration time.Duration) {
+	p.filesFinished = filesFinished
+	p.filesTotal = filesTotal
+	p.allBytesWritten = allBytesWritten
+	p.allBytesTotal = allBytesTotal
+}
+
+func TestRestorerProgressBar(t *testing.T) {
+	repo := repository.TestRepository(t)
+
+	sn, _ := saveSnapshot(t, repo, Snapshot{
+		Nodes: map[string]Node{
+			"dirtest": Dir{
+				Nodes: map[string]Node{
+					"file1": File{Links: 2, Inode: 1, Data: "foo"},
+					"file2": File{Links: 2, Inode: 1, Data: "foo"},
+				},
+			},
+			"file2": File{Links: 1, Inode: 2, Data: "example"},
+		},
+	})
+
+	mock := &printerMock{}
+	progress := restoreui.NewProgress(mock, 0)
+	res := NewRestorer(context.TODO(), repo, sn, false, progress)
+	res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
+		return true, true
+	}
+
+	tempdir := rtest.TempDir(t)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	err := res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
+	progress.Finish()
+
+	const filesFinished = 4
+	const filesTotal = filesFinished
+	const allBytesWritten = 10
+	const allBytesTotal = allBytesWritten
+	rtest.Assert(t, mock.filesFinished == filesFinished, "filesFinished: expected %v, got %v", filesFinished, mock.filesFinished)
+	rtest.Assert(t, mock.filesTotal == filesTotal, "filesTotal: expected %v, got %v", filesTotal, mock.filesTotal)
+	rtest.Assert(t, mock.allBytesWritten == allBytesWritten, "allBytesWritten: expected %v, got %v", allBytesWritten, mock.allBytesWritten)
+	rtest.Assert(t, mock.allBytesTotal == allBytesTotal, "allBytesTotal: expected %v, got %v", allBytesTotal, mock.allBytesTotal)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The file size of hardlinks should only be counted once. This PR corrects the current accounting in that regard. In addition, directories and other directory entries like symlinks are also counted. This ensures that the files count reported by the restore progress bar and the `stats` command matches.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #4303
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
