### PR TITLE
Fix flaky TestCheckerModifiedData test

### DIFF
--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -331,10 +331,6 @@ func (erd errorReadCloser) Read(p []byte) (int, error) {
 
 // induceError flips a bit in the slice.
 func induceError(data []byte) {
-	if rand.Float32() < 0.2 {
-		return
-	}
-
 	pos := rand.Intn(len(data))
 	data[pos] ^= 1
 }

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -61,7 +61,7 @@ func LoadSnapshot(ctx context.Context, loader LoaderUnpacked, id ID) (*Snapshot,
 	sn := &Snapshot{id: &id}
 	err := LoadJSONUnpacked(ctx, loader, SnapshotFile, id, sn)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to load snapshot %v: %w", id.Str(), err)
 	}
 
 	return sn, nil


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The `TestCheckerModifiedData` test has recently started to fail far too often when run by the `Linux (race) Go 1.20.x` CI job.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See e.g. https://github.com/restic/restic/pull/4308
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
