### PR TITLE
mount: enable debug logging for the flaky TestMount test

### DIFF
--- a/cmd/restic/integration_fuse_test.go
+++ b/cmd/restic/integration_fuse_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
@@ -157,6 +158,11 @@ func checkSnapshots(t testing.TB, global GlobalOptions, repo *repository.Reposit
 func TestMount(t *testing.T) {
 	if !rtest.RunFuseTest {
 		t.Skip("Skipping fuse tests")
+	}
+
+	debugEnabled := debug.TestLogToStderr(t)
+	if debugEnabled {
+		defer debug.TestDisableLog(t)
 	}
 
 	env, cleanup := withTestEnvironment(t)

--- a/internal/debug/testing.go
+++ b/internal/debug/testing.go
@@ -1,0 +1,23 @@
+package debug
+
+import (
+	"log"
+	"os"
+	"testing"
+)
+
+// TestLogToStderr configures debug to log to stderr if not the debug log is
+// not already configured and returns whether logging was enabled.
+func TestLogToStderr(t testing.TB) bool {
+	if opts.isEnabled {
+		return false
+	}
+	opts.logger = log.New(os.Stderr, "", log.LstdFlags)
+	opts.isEnabled = true
+	return true
+}
+
+func TestDisableLog(t testing.TB) {
+	opts.logger = nil
+	opts.isEnabled = false
+}


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The `TestMount` test case fails from time to time with an Input/Output error (see https://github.com/restic/restic/actions/runs/4852407213/jobs/8647353957?pr=4316) while trying to access the snapshots directory. The test failures only occur sporadically which complicates debugging. Enable debug logs for this test case to help with analyzing the problem.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
