### PR TITLE
Fix status output truncation

### DIFF
--- a/changelog/unreleased/pull-4318
+++ b/changelog/unreleased/pull-4318
@@ -1,0 +1,8 @@
+Bugfix: Correctly clean up status bar output of the `backup` command
+
+Due to a regression in restic 0.15.2, the status bar of the `backup` command
+could leave some output behind. This happened if filenames were printed that
+are wider than the current terminal width. This has been fixed.
+
+https://github.com/restic/restic/issues/4319
+https://github.com/restic/restic/pull/4318

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -334,6 +334,21 @@ func wideRune(s string) (wide bool, utfsize uint) {
 	return wide, uint(size)
 }
 
+func sanitizeLines(lines []string, width int) []string {
+	// Sanitize lines and truncate them if they're too long.
+	for i, line := range lines {
+		line = Quote(line)
+		if width > 0 {
+			line = Truncate(line, width-2)
+		}
+		if i < len(lines)-1 { // Last line gets no line break.
+			line += "\n"
+		}
+		lines[i] = line
+	}
+	return lines
+}
+
 // SetStatus updates the status lines.
 // The lines should not contain newlines; this method adds them.
 func (t *Terminal) SetStatus(lines []string) {
@@ -352,17 +367,7 @@ func (t *Terminal) SetStatus(lines []string) {
 		}
 	}
 
-	// Sanitize lines and truncate them if they're too long.
-	for i, line := range lines {
-		line = Quote(line)
-		if width > 0 {
-			line = Truncate(line, width-2)
-		}
-		if i < len(lines)-1 { // Last line gets no line break.
-			line += "\n"
-		}
-		lines[i] = line
-	}
+	sanitizeLines(lines, width)
 
 	select {
 	case t.status <- status{lines: lines}:

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -359,8 +359,9 @@ func (t *Terminal) SetStatus(lines []string) {
 			line = Truncate(line, width-2)
 		}
 		if i < len(lines)-1 { // Last line gets no line break.
-			lines[i] = line + "\n"
+			line += "\n"
 		}
+		lines[i] = line
 	}
 
 	select {

--- a/internal/ui/termstatus/status_test.go
+++ b/internal/ui/termstatus/status_test.go
@@ -1,12 +1,53 @@
 package termstatus
 
 import (
-	"reflect"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
 	"strconv"
 	"testing"
 
 	rtest "github.com/restic/restic/internal/test"
 )
+
+func TestSetStatus(t *testing.T) {
+	var buf bytes.Buffer
+	term := New(&buf, io.Discard, false)
+
+	term.canUpdateStatus = true
+	term.fd = ^uintptr(0)
+	term.clearCurrentLine = posixClearCurrentLine
+	term.moveCursorUp = posixMoveCursorUp
+
+	ctx, cancel := context.WithCancel(context.Background())
+	go term.Run(ctx)
+
+	const (
+		clear = posixControlClearLine
+		home  = posixControlMoveCursorHome
+		up    = posixControlMoveCursorUp
+	)
+
+	term.SetStatus([]string{"first"})
+	exp := home + clear + "first" + home
+
+	term.SetStatus([]string{"foo", "bar", "baz"})
+	exp += home + clear + "foo\n" + home + clear + "bar\n" +
+		home + clear + "baz" + home + up + up
+
+	term.SetStatus([]string{"quux", "needs\nquote"})
+	exp += home + clear + "quux\n" +
+		home + clear + "\"needs\\nquote\"\n" +
+		home + clear + home + up + up // Third line implicit.
+
+	cancel()
+	exp += home + clear + "\n" + home + clear + "\n" +
+		home + up + up // Status cleared.
+
+	<-term.closed
+	rtest.Equals(t, exp, buf.String())
+}
 
 func TestQuote(t *testing.T) {
 	for _, c := range []struct {
@@ -106,12 +147,9 @@ func TestSanitizeLines(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
+		t.Run(fmt.Sprintf("%s %d", test.input, test.width), func(t *testing.T) {
 			out := sanitizeLines(test.input, test.width)
-			if !reflect.DeepEqual(out, test.output) {
-				t.Fatalf("wrong output for input %v, width %d: want %q, got %q",
-					test.input, test.width, test.output, out)
-			}
+			rtest.Equals(t, test.output, out)
 		})
 	}
 }

--- a/internal/ui/termstatus/status_test.go
+++ b/internal/ui/termstatus/status_test.go
@@ -1,6 +1,7 @@
 package termstatus
 
 import (
+	"reflect"
 	"strconv"
 	"testing"
 
@@ -90,4 +91,27 @@ func BenchmarkTruncateUnicode(b *testing.B) {
 	b.ResetTimer()
 
 	benchmarkTruncate(b, s, w-1)
+}
+
+func TestSanitizeLines(t *testing.T) {
+	var tests = []struct {
+		input  []string
+		width  int
+		output []string
+	}{
+		{[]string{""}, 80, []string{""}},
+		{[]string{"too long test line"}, 10, []string{"too long"}},
+		{[]string{"too long test line", "text"}, 10, []string{"too long\n", "text"}},
+		{[]string{"too long test line", "second long test line"}, 10, []string{"too long\n", "second l"}},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			out := sanitizeLines(test.input, test.width)
+			if !reflect.DeepEqual(out, test.output) {
+				t.Fatalf("wrong output for input %v, width %d: want %q, got %q",
+					test.input, test.width, test.output, out)
+			}
+		})
+	}
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
PR #4192, which quotes problematic filenames, accidentally did not store the sanitized version of the last line in the status output.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Reported on IRC in `#restic`
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
