### PR TITLE
Hopefully fix `TestMount` failures

### DIFF
--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"golang.org/x/sync/errgroup"
@@ -236,5 +237,8 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 	bar := newProgressMax(!quiet, uint64(len(packList)), "packs copied")
 	_, err = repository.Repack(ctx, srcRepo, dstRepo, packList, copyBlobs, bar)
 	bar.Done()
-	return err
+	if err != nil {
+		return errors.Fatal(err.Error())
+	}
+	return nil
 }

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -93,7 +93,7 @@ func runInit(ctx context.Context, opts InitOptions, gopts GlobalOptions, args []
 		PackSize:    gopts.PackSize * 1024 * 1024,
 	})
 	if err != nil {
-		return err
+		return errors.Fatal(err.Error())
 	}
 
 	err = s.Init(ctx, version, gopts.password, chunkerPolynomial)

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -729,7 +729,7 @@ func doPrune(ctx context.Context, opts PruneOptions, gopts GlobalOptions, repo r
 		_, err := repository.Repack(ctx, repo, repo, plan.repackPacks, plan.keepBlobs, bar)
 		bar.Done()
 		if err != nil {
-			return errors.Fatalf("%s", err)
+			return errors.Fatal(err.Error())
 		}
 
 		// Also remove repacked packs

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -456,7 +456,7 @@ func OpenRepository(ctx context.Context, opts GlobalOptions) (*repository.Reposi
 		PackSize:    opts.PackSize * 1024 * 1024,
 	})
 	if err != nil {
-		return nil, err
+		return nil, errors.Fatal(err.Error())
 	}
 
 	passwordTriesLeft := 1

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -62,7 +62,7 @@ func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (*Backend, er
 
 	_, err = be.Stat(ctx, restic.Handle{Type: restic.ConfigFile})
 	if err == nil {
-		return nil, errors.Fatal("config file already exists")
+		return nil, errors.New("config file already exists")
 	}
 
 	url := *cfg.URL
@@ -76,7 +76,7 @@ func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (*Backend, er
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, errors.Fatalf("server response unexpected: %v (%v)", resp.Status, resp.StatusCode)
+		return nil, fmt.Errorf("server response unexpected: %v (%v)", resp.Status, resp.StatusCode)
 	}
 
 	_, err = io.Copy(io.Discard, resp.Body)

--- a/internal/backend/sftp/config.go
+++ b/internal/backend/sftp/config.go
@@ -80,7 +80,7 @@ func ParseConfig(s string) (interface{}, error) {
 
 	p := path.Clean(dir)
 	if strings.HasPrefix(p, "~") {
-		return nil, errors.Fatal("sftp path starts with the tilde (~) character, that fails for most sftp servers.\nUse a relative directory, most servers interpret this as relative to the user's home directory.")
+		return nil, errors.New("sftp path starts with the tilde (~) character, that fails for most sftp servers.\nUse a relative directory, most servers interpret this as relative to the user's home directory")
 	}
 
 	cfg := NewConfig()

--- a/internal/repository/key.go
+++ b/internal/repository/key.go
@@ -21,7 +21,7 @@ var (
 	ErrNoKeyFound = errors.New("wrong password or no key found")
 
 	// ErrMaxKeysReached is returned when the maximum number of keys was checked and no key could be found.
-	ErrMaxKeysReached = errors.Fatal("maximum number of keys reached")
+	ErrMaxKeysReached = errors.New("maximum number of keys reached")
 )
 
 // Key represents an encrypted master key for a repository.

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -29,7 +29,7 @@ func Repack(ctx context.Context, repo restic.Repository, dstRepo restic.Reposito
 	debug.Log("repacking %d packs while keeping %d blobs", len(packs), keepBlobs.Len())
 
 	if repo == dstRepo && dstRepo.Connections() < 2 {
-		return nil, errors.Fatal("repack step requires a backend connection limit of at least two")
+		return nil, errors.New("repack step requires a backend connection limit of at least two")
 	}
 
 	wg, wgCtx := errgroup.WithContext(ctx)

--- a/internal/restic/snapshot_group.go
+++ b/internal/restic/snapshot_group.go
@@ -2,10 +2,9 @@ package restic
 
 import (
 	"encoding/json"
+	"fmt"
 	"sort"
 	"strings"
-
-	"github.com/restic/restic/internal/errors"
 )
 
 type SnapshotGroupByOptions struct {
@@ -26,7 +25,7 @@ func splitSnapshotGroupBy(s string) (SnapshotGroupByOptions, error) {
 			l.Tag = true
 		case "":
 		default:
-			return SnapshotGroupByOptions{}, errors.Fatal("unknown grouping option: '" + option + "'")
+			return SnapshotGroupByOptions{}, fmt.Errorf("unknown grouping option: %q", option)
 		}
 	}
 	return l, nil


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The `TestMount` test fails from time to time. One instance of this is shown in https://github.com/restic/restic/actions/runs/4968574603/jobs/8891251180:
```
2023/05/13 19:42:24 restic/cmd_mount.go:178	restic.runMount.func2	163	fuse: <- Lookup [ID=0x4 Node=0x1 Uid=1001 Gid=123 Pid=10047] "snapshots"
2023/05/13 19:42:24 fuse/snapshots_dir.go:96	fuse.(*SnapshotsDir).Lookup	163	Lookup(snapshots)
2023/05/13 19:42:24 restic/cmd_mount.go:178	restic.runMount.func2	164	fuse: <- Interrupt [ID=0x5 Node=0x0 Uid=0 Gid=0 Pid=0] ID 0x4
2023/05/13 19:42:24 logger/log.go:59	logger.(*Backend).List	159	List(snapshot)
2023/05/13 19:42:24 restic/cmd_mount.go:178	restic.runMount.func2	164	fuse: -> [ID=0x5] Interrupt
2023/05/13 19:42:24 logger/log.go:61	logger.(*Backend).List	159	  list err <nil>
2023/05/13 19:42:24 repository/repository.go:585	repository.(*Repository).LoadIndex	163	Loading index
2023/05/13 19:42:24 restic/cmd_mount.go:178	restic.runMount.func2	163	fuse: -> [ID=0x4] Lookup error=EIO: Fatal: context canceled
2023/05/13 19:42:24 restic/cmd_mount.go:178	restic.runMount.func2	165	fuse: <- Lookup [ID=0x6 Node=0x1 Uid=1001 Gid=123 Pid=10047] "snapshots"
2023/05/13 19:42:24 fuse/snapshots_dir.go:96	fuse.(*SnapshotsDir).Lookup	165	Lookup(snapshots)
```

There `repository.LoadIndex` in canceled while it is in progress, which results in a `Fatal: context canceled` error. The problem there is that the `Fatal` error type only contains a string which makes it impossible to properly check for the contained `Context canceled` error.

Thus, this PR removes most usages of the `Fatal` error type from the `internal` packages. This also fixes a few cases of Fatal errors within another Fatal error.



<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Follow up to #4317.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
