### PR TITLE
backend, termstatus: fix ioctl calls for 64-bit big-endian platforms

### DIFF
--- a/internal/ui/termstatus/background_linux.go
+++ b/internal/ui/termstatus/background_linux.go
@@ -18,6 +18,10 @@ func IsProcessBackground(fd uintptr) bool {
 }
 
 func isProcessBackground(fd uintptr) (bool, error) {
-	pid, err := unix.IoctlGetInt(int(fd), unix.TIOCGPGRP)
-	return pid != unix.Getpgrp(), err
+	// We need to use IoctlGetUint32 here, because pid_t is 32-bit even on
+	// 64-bit Linux. IoctlGetInt doesn't work on big-endian platforms:
+	// https://github.com/golang/go/issues/45585
+	// https://github.com/golang/go/issues/60429
+	pid, err := unix.IoctlGetUint32(int(fd), unix.TIOCGPGRP)
+	return int(pid) != unix.Getpgrp(), err
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Changes the way we call ioctl to get and set terminal info. The old code didn't work on some 64-bit big-endian platforms, notably linux/s390x.

See commit messages for details. This code already has tests.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes #4223.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
