### PR TITLE
cmd: Don't check for errno == 0

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -10,7 +10,6 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/restic/restic/internal/backend"
@@ -146,21 +145,6 @@ func init() {
 	restoreTerminal()
 }
 
-// checkErrno returns nil when err is set to syscall.Errno(0), since this is no
-// error condition.
-func checkErrno(err error) error {
-	e, ok := err.(syscall.Errno)
-	if !ok {
-		return err
-	}
-
-	if e == 0 {
-		return nil
-	}
-
-	return err
-}
-
 func stdinIsTerminal() bool {
 	return term.IsTerminal(int(os.Stdin.Fd()))
 }
@@ -209,7 +193,7 @@ func restoreTerminal() {
 		if !isReadingPassword {
 			return code, nil
 		}
-		err := checkErrno(term.Restore(fd, state))
+		err := term.Restore(fd, state)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "unable to restore terminal state: %v\n", err)
 		}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Removes an unnecessary check from cmd/restic/global.go.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
