### PR TITLE
cache: Restructure New to remove redundant operations

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,0 +1,46 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestNew(t *testing.T) {
+	parent := rtest.TempDir(t)
+	basedir := filepath.Join(parent, "cache")
+	id := restic.NewRandomID().String()
+	tagFile := filepath.Join(basedir, "CACHEDIR.TAG")
+	versionFile := filepath.Join(basedir, id, "version")
+
+	const (
+		stepCreate = iota
+		stepComplete
+		stepRmTag
+		stepRmVersion
+		stepEnd
+	)
+
+	for step := stepCreate; step < stepEnd; step++ {
+		switch step {
+		case stepRmTag:
+			rtest.OK(t, os.Remove(tagFile))
+		case stepRmVersion:
+			rtest.OK(t, os.Remove(versionFile))
+		}
+
+		c, err := New(id, basedir)
+		rtest.OK(t, err)
+		rtest.Equals(t, basedir, c.Base)
+		rtest.Equals(t, step == stepCreate, c.Created)
+
+		for _, name := range []string{tagFile, versionFile} {
+			info, err := os.Lstat(name)
+			rtest.OK(t, err)
+			rtest.Assert(t, info.Mode().IsRegular(), "")
+		}
+	}
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

cache.New and its helpers used to create the cache directories several times over. They now only do so once. The added test (probably the most valuable part of the PR) ensures that the cache is produced in a consistent state when parts are deleted.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
