### PR TITLE
restic restore docs: Mention that restic restore is fastest

### DIFF
--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -96,6 +96,11 @@ hard links from a fuse mount should be done by a program that preserves
 hard links. A program that does so is ``rsync``, used with the option
 --hard-links.
 
+.. note:: ``restic mount`` is mostly useful if you want to restore just a few
+   files out of a snapshot, or to check which files are contained in a snapshot.
+   To restore many files or a whole snapshot, ``restic restore`` is the best
+   alternative, often it is *significantly* faster.
+
 Printing files to stdout
 ========================
 


### PR DESCRIPTION
Especially with lots of files (like when backing up git repos), restic mount + cp -r can be really slow.

The documentation should mention that restic restore can be a lot faster.

What does this PR change? What problem does it solve?
-----------------------------------------------------

it updates the documentation accordingly

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

as requested in https://github.com/restic/restic/issues/3828#issuecomment-1570880245

Checklist

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
