### PR TITLE
Tune Go garbage collector

### DIFF
--- a/changelog/unreleased/issue-3328
+++ b/changelog/unreleased/issue-3328
@@ -1,0 +1,5 @@
+Enhancement: Reduce memory usage by up to 25%
+
+https://github.com/restic/restic/issues/3328
+https://github.com/restic/restic/pull/4352
+https://github.com/restic/restic/pull/4353

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"math"
+	"runtime"
 	"sort"
 	"strconv"
 	"strings"
@@ -204,6 +205,9 @@ func runPruneWithRepo(ctx context.Context, opts PruneOptions, gopts GlobalOption
 	if err != nil {
 		return err
 	}
+
+	// Trigger GC to reset garbage collection threshold
+	runtime.GC()
 
 	return doPrune(ctx, opts, gopts, repo, plan)
 }

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"runtime"
+	godebug "runtime/debug"
 
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/options"
@@ -81,7 +82,16 @@ func needsPassword(cmd string) bool {
 
 var logBuffer = bytes.NewBuffer(nil)
 
+func tweakGoGC() {
+	// lower GOGC from 100 to 50, unless it was manually overwritten by the user
+	oldValue := godebug.SetGCPercent(50)
+	if oldValue != 100 {
+		godebug.SetGCPercent(oldValue)
+	}
+}
+
 func main() {
+	tweakGoGC()
 	// install custom global logger into a buffer, if an error occurs
 	// we can show the logs
 	log.SetOutput(logBuffer)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"sort"
 	"sync"
 
@@ -600,6 +601,9 @@ func (r *Repository) LoadIndex(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+
+	// Trigger GC to reset garbage collection threshold
+	runtime.GC()
 
 	if r.cfg.Version < 2 {
 		// sanity check


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Reduce GOGC to 50. This leads to a decrease in memory usage by 25%.

The index used by restic consumes a major part of the total memory usage. This leads to an unnecessarily large amount of memory that contains ephemeral objects that are only used for a short time.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #3328
Depends on https://github.com/restic/restic/pull/4352 for reasonable GC performance.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
