### PR TITLE
stats: Add `debug` mode to collect repository statistics

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,9 @@ it might be necessary to manually clean up stale lock files using
 On Windows, please set the environment variable `RESTIC_DEBUG_STACKTRACE_SIGINT`
 to `true` and press `Ctrl-C` to create a stacktrace.
 
+If you think restic uses too much memory or a too large cache directory, then
+please include the output of `restic stats --mode debug`.
+
 
 Development Environment
 =======================

--- a/cmd/restic/cmd_stats_test.go
+++ b/cmd/restic/cmd_stats_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestSizeHistogramNew(t *testing.T) {
+	h := newSizeHistogram(42)
+
+	exp := &sizeHistogram{
+		count:     0,
+		totalSize: 0,
+		buckets: []sizeClass{
+			{0, 0, 0},
+			{1, 9, 0},
+			{10, 42, 0},
+		},
+	}
+
+	rtest.Equals(t, exp, h)
+}
+
+func TestSizeHistogramAdd(t *testing.T) {
+	h := newSizeHistogram(42)
+	for i := uint64(0); i < 45; i++ {
+		h.Add(i)
+	}
+
+	exp := &sizeHistogram{
+		count:     45,
+		totalSize: 990,
+		buckets: []sizeClass{
+			{0, 0, 1},
+			{1, 9, 9},
+			{10, 42, 33},
+		},
+		oversized: []uint64{43, 44},
+	}
+
+	rtest.Equals(t, exp, h)
+}
+
+func TestSizeHistogramString(t *testing.T) {
+	t.Run("overflow", func(t *testing.T) {
+		h := newSizeHistogram(42)
+		h.Add(8)
+		h.Add(50)
+
+		rtest.Equals(t, "Count: 2\nTotal Size: 58 B\nSize        Count\n-----------------\n1 - 9 Byte  1\n-----------------\nOversized: [50]\n", h.String())
+	})
+
+	t.Run("withZero", func(t *testing.T) {
+		h := newSizeHistogram(42)
+		h.Add(0)
+		h.Add(1)
+		h.Add(10)
+
+		rtest.Equals(t, "Count: 3\nTotal Size: 11 B\nSize          Count\n-------------------\n  0 - 0 Byte  1\n  1 - 9 Byte  1\n10 - 42 Byte  1\n-------------------\n", h.String())
+	})
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
`restic stats --mode debug` now prints statistics about the size of the individual blob / files types in a repository. The idea is to help with debugging issues related to unexpectedly high memory / cache usage.

So far the command is not shown in the help output of the stats command, as I'm not sure what use cases besides debugging would be.

Sample output:
```
Collecting size statistics

File Type: key
Count: 1
Total Size: 451 B
Size            Count
---------------------
100 - 999 Byte  1
---------------------

File Type: lock
Count: 2
Total Size: 302 B
Size            Count
---------------------
100 - 999 Byte  2
---------------------

File Type: index
Count: 106
Total Size: 230.657 MiB
Size                    Count
-----------------------------
    10000 - 99999 Byte  8
  100000 - 999999 Byte  3
1000000 - 9999999 Byte  95
-----------------------------

File Type: data
Count: 15428
Total Size: 246.514 GiB
Size                      Count
-------------------------------
      10000 - 99999 Byte  1
    100000 - 999999 Byte  16
  1000000 - 9999999 Byte  286
10000000 - 99999999 Byte  15125
-------------------------------

Blob Type: data
Count: 3753205
Total Size: 241.391 GiB
Size                    Count
-------------------------------
          10 - 99 Byte  46443
        100 - 999 Byte  1129200
      1000 - 9999 Byte  1569321
    10000 - 99999 Byte  628942
  100000 - 999999 Byte  311586
1000000 - 9999999 Byte  67713
-------------------------------


Blob Type: tree
Count: 1313735
Total Size: 1.178 GiB
Size                    Count
-------------------------------
          10 - 99 Byte  1
        100 - 999 Byte  1127061
      1000 - 9999 Byte  173620
    10000 - 99999 Byte  12481
  100000 - 999999 Byte  570
1000000 - 9999999 Byte  2
-------------------------------
```
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Alternative to #2543 
Fixes #1047

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
