### PR TITLE
Issue #3624: Preserve oldest snapshot when keep-* values are not sati…

### DIFF
--- a/changelog/unreleased/issue-3624
+++ b/changelog/unreleased/issue-3624
@@ -1,11 +1,8 @@
-Enhancement: Keep oldest snapshot when there aren't enough snapshots
+Enhancement: Keep oldest snapshot when there are not enough snapshots
 
-The `forget` command does not preserve the oldest snapshot incase the 
-keep-* parameters are not satisfied, which led to users not being able to
-preserve old data. Now, restic will always preserve the oldest snapshot 
-whenever any of the keep-* options to the `forget` command are not 
-satisfied.
-
+The `forget` command now additionally preserves the oldest snapshot if fewer
+snapshots are kept than allowed by the `--keep-*` parameters. This maximizes
+amount of history kept while the specified limits are not yet reached.
 
 https://github.com/restic/restic/issues/3624
 https://github.com/restic/restic/pull/4366

--- a/changelog/unreleased/issue-3624
+++ b/changelog/unreleased/issue-3624
@@ -1,0 +1,12 @@
+Enhancement: Keep oldest snapshot when there aren't enough snapshots
+
+The `forget` command does not preserve the oldest snapshot incase the 
+keep-* parameters are not satisfied, which led to users not being able to
+preserve old data. Now, restic will always preserve the oldest snapshot 
+whenever any of the keep-* options to the `forget` command are not 
+satisfied.
+
+
+https://github.com/restic/restic/issues/3624
+https://github.com/restic/restic/pull/4366
+https://forum.restic.net/t/keeping-yearly-snapshots-policy-when-backup-began-during-the-year/4670/2

--- a/internal/restic/snapshot_policy.go
+++ b/internal/restic/snapshot_policy.go
@@ -278,7 +278,7 @@ func ApplyPolicy(list Snapshots, p ExpirePolicy) (keep, remove Snapshots, reason
 
 				if cur.Time.After(t) {
 					val := b.bucker(cur.Time, nr)
-					if val != b.Last {
+					if val != b.Last || nr == len(list)-1 {
 						debug.Log("keep %v, time %v, ID %v, bucker %v, val %v %v\n", b.reason, cur.Time, cur.id.Str(), i, val, b.Last)
 						keepSnap = true
 						bucketsWithin[i].Last = val

--- a/internal/restic/snapshot_policy.go
+++ b/internal/restic/snapshot_policy.go
@@ -183,6 +183,7 @@ type KeepReason struct {
 // according to the policy p. list is sorted in the process. reasons contains
 // the reasons to keep each snapshot, it is in the same order as keep.
 func ApplyPolicy(list Snapshots, p ExpirePolicy) (keep, remove Snapshots, reasons []KeepReason) {
+	// sort newest snapshots first
 	sort.Stable(list)
 
 	if p.Empty() {
@@ -256,6 +257,8 @@ func ApplyPolicy(list Snapshots, p ExpirePolicy) (keep, remove Snapshots, reason
 			// -1 means "keep all"
 			if b.Count > 0 || b.Count == -1 {
 				val := b.bucker(cur.Time, nr)
+				// also keep the oldest snapshot if the bucket has some counts left. This maximizes the
+				// the history length kept while some counts are left.
 				if val != b.Last || nr == len(list)-1 {
 					debug.Log("keep %v %v, bucker %v, val %v\n", cur.Time, cur.id.Str(), i, val)
 					keepSnap = true

--- a/internal/restic/snapshot_policy.go
+++ b/internal/restic/snapshot_policy.go
@@ -256,7 +256,7 @@ func ApplyPolicy(list Snapshots, p ExpirePolicy) (keep, remove Snapshots, reason
 			// -1 means "keep all"
 			if b.Count > 0 || b.Count == -1 {
 				val := b.bucker(cur.Time, nr)
-				if val != b.Last {
+				if val != b.Last || nr == len(list)-1 {
 					debug.Log("keep %v %v, bucker %v, val %v\n", cur.Time, cur.id.Str(), i, val)
 					keepSnap = true
 					buckets[i].Last = val

--- a/internal/restic/testdata/policy_keep_snapshots_16
+++ b/internal/restic/testdata/policy_keep_snapshots_16
@@ -14,6 +14,11 @@
       "time": "2014-11-22T10:20:30Z",
       "tree": null,
       "paths": null
+    },
+    {
+      "time": "2014-08-08T10:20:30Z",
+      "tree": null,
+      "paths": null
     }
   ],
   "reasons": [
@@ -54,6 +59,19 @@
       ],
       "counters": {
         "yearly": 7
+      }
+    },
+    {
+      "snapshot": {
+        "time": "2014-08-08T10:20:30Z",
+        "tree": null,
+        "paths": null
+      },
+      "matches": [
+        "yearly snapshot"
+      ],
+      "counters": {
+        "yearly": 6
       }
     }
   ]

--- a/internal/restic/testdata/policy_keep_snapshots_17
+++ b/internal/restic/testdata/policy_keep_snapshots_17
@@ -49,6 +49,11 @@
       "time": "2014-11-22T10:20:30Z",
       "tree": null,
       "paths": null
+    },
+    {
+      "time": "2014-08-08T10:20:30Z",
+      "tree": null,
+      "paths": null
     }
   ],
   "reasons": [
@@ -200,6 +205,19 @@
       ],
       "counters": {
         "yearly": 7
+      }
+    },
+    {
+      "snapshot": {
+        "time": "2014-08-08T10:20:30Z",
+        "tree": null,
+        "paths": null
+      },
+      "matches": [
+        "yearly snapshot"
+      ],
+      "counters": {
+        "yearly": 6
       }
     }
   ]

--- a/internal/restic/testdata/policy_keep_snapshots_35
+++ b/internal/restic/testdata/policy_keep_snapshots_35
@@ -44,6 +44,11 @@
       "time": "2014-11-22T10:20:30Z",
       "tree": null,
       "paths": null
+    },
+    {
+      "time": "2014-08-08T10:20:30Z",
+      "tree": null,
+      "paths": null
     }
   ],
   "reasons": [
@@ -145,6 +150,17 @@
     {
       "snapshot": {
         "time": "2014-11-22T10:20:30Z",
+        "tree": null,
+        "paths": null
+      },
+      "matches": [
+        "yearly within 9999y"
+      ],
+      "counters": {}
+    },
+    {
+      "snapshot": {
+        "time": "2014-08-08T10:20:30Z",
         "tree": null,
         "paths": null
       },

--- a/internal/restic/testdata/policy_keep_snapshots_39
+++ b/internal/restic/testdata/policy_keep_snapshots_39
@@ -57,6 +57,11 @@
       "time": "2014-08-22T10:20:30Z",
       "tree": null,
       "paths": null
+    },
+    {
+      "time": "2014-08-08T10:20:30Z",
+      "tree": null,
+      "paths": null
     }
   ],
   "reasons": [
@@ -187,6 +192,18 @@
       },
       "matches": [
         "monthly snapshot"
+      ],
+      "counters": {"Monthly": -1, "Yearly": -1}
+    },
+    {
+      "snapshot": {
+        "time": "2014-08-08T10:20:30Z",
+        "tree": null,
+        "paths": null
+      },
+      "matches": [
+        "monthly snapshot",
+        "yearly snapshot"
       ],
       "counters": {"Monthly": -1, "Yearly": -1}
     }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Currently, restic 'forget' command does not preserve the oldest snapshot if 'keep-\*' options are not satisfied. Due to this, users sometimes cannot preserve their oldest snapshots depending on the 'keep-\*' options they have specified.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->
When applying the snapshot policy, there is an additional check which checks if we are currently looking at the oldest snapshot and the count for that particular bucket is > 0, we mark it for preservation.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Yes. Please see #3624 

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Closes #3624 

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [X] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [X] I have added tests for all code changes.
- [X] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I have run `gofmt` on the code in all commits.
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [X] I'm done! This pull request is ready for review.
