### PR TITLE
Add support for extended attributes on symlinks

### DIFF
--- a/changelog/unreleased/issue-4375
+++ b/changelog/unreleased/issue-4375
@@ -1,0 +1,8 @@
+Enhancement: Add support for extended attributes on symlinks
+
+Restic now supports extended attributes on symlinks when backing up,
+restoring, or FUSE-mounting snapshots. This includes, for example, the
+`security.selinux` xattr on Linux distributions that use SELinux.
+
+https://github.com/restic/restic/issues/4375
+https://github.com/restic/restic/pull/4379

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -222,19 +222,10 @@ func (d *dir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 }
 
 func (d *dir) Listxattr(_ context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
-	debug.Log("Listxattr(%v, %v)", d.node.Name, req.Size)
-	for _, attr := range d.node.ExtendedAttributes {
-		resp.Append(attr.Name)
-	}
+	nodeToXattrList(d.node, req, resp)
 	return nil
 }
 
 func (d *dir) Getxattr(_ context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
-	debug.Log("Getxattr(%v, %v, %v)", d.node.Name, req.Name, req.Size)
-	attrval := d.node.GetExtendedAttribute(req.Name)
-	if attrval != nil {
-		resp.Xattr = attrval
-		return nil
-	}
-	return fuse.ErrNoXattr
+	return nodeGetXattr(d.node, req, resp)
 }

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -167,19 +167,10 @@ func (f *openFile) Read(ctx context.Context, req *fuse.ReadRequest, resp *fuse.R
 }
 
 func (f *file) Listxattr(_ context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
-	debug.Log("Listxattr(%v, %v)", f.node.Name, req.Size)
-	for _, attr := range f.node.ExtendedAttributes {
-		resp.Append(attr.Name)
-	}
+	nodeToXattrList(f.node, req, resp)
 	return nil
 }
 
 func (f *file) Getxattr(_ context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
-	debug.Log("Getxattr(%v, %v, %v)", f.node.Name, req.Name, req.Size)
-	attrval := f.node.GetExtendedAttribute(req.Name)
-	if attrval != nil {
-		resp.Xattr = attrval
-		return nil
-	}
-	return fuse.ErrNoXattr
+	return nodeGetXattr(f.node, req, resp)
 }

--- a/internal/fuse/link.go
+++ b/internal/fuse/link.go
@@ -6,8 +6,6 @@ package fuse
 import (
 	"context"
 
-	"github.com/restic/restic/internal/debug"
-
 	"github.com/anacrolix/fuse"
 	"github.com/anacrolix/fuse/fs"
 	"github.com/restic/restic/internal/restic"
@@ -50,19 +48,10 @@ func (l *link) Attr(_ context.Context, a *fuse.Attr) error {
 }
 
 func (l *link) Listxattr(_ context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
-	debug.Log("Listxattr(%v, %v)", l.node.Name, req.Size)
-	for _, attr := range l.node.ExtendedAttributes {
-		resp.Append(attr.Name)
-	}
+	nodeToXattrList(l.node, req, resp)
 	return nil
 }
 
 func (l *link) Getxattr(_ context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
-	debug.Log("Getxattr(%v, %v, %v)", l.node.Name, req.Name, req.Size)
-	attrval := l.node.GetExtendedAttribute(req.Name)
-	if attrval != nil {
-		resp.Xattr = attrval
-		return nil
-	}
-	return fuse.ErrNoXattr
+	return nodeGetXattr(l.node, req, resp)
 }

--- a/internal/fuse/link.go
+++ b/internal/fuse/link.go
@@ -6,6 +6,8 @@ package fuse
 import (
 	"context"
 
+	"github.com/restic/restic/internal/debug"
+
 	"github.com/anacrolix/fuse"
 	"github.com/anacrolix/fuse/fs"
 	"github.com/restic/restic/internal/restic"
@@ -45,4 +47,22 @@ func (l *link) Attr(_ context.Context, a *fuse.Attr) error {
 	a.Blocks = (a.Size + blockSize - 1) / blockSize
 
 	return nil
+}
+
+func (l *link) Listxattr(_ context.Context, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) error {
+	debug.Log("Listxattr(%v, %v)", l.node.Name, req.Size)
+	for _, attr := range l.node.ExtendedAttributes {
+		resp.Append(attr.Name)
+	}
+	return nil
+}
+
+func (l *link) Getxattr(_ context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
+	debug.Log("Getxattr(%v, %v, %v)", l.node.Name, req.Name, req.Size)
+	attrval := l.node.GetExtendedAttribute(req.Name)
+	if attrval != nil {
+		resp.Xattr = attrval
+		return nil
+	}
+	return fuse.ErrNoXattr
 }

--- a/internal/fuse/xattr.go
+++ b/internal/fuse/xattr.go
@@ -1,0 +1,24 @@
+package fuse
+
+import (
+	"github.com/anacrolix/fuse"
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/restic"
+)
+
+func nodeToXattrList(node *restic.Node, req *fuse.ListxattrRequest, resp *fuse.ListxattrResponse) {
+	debug.Log("Listxattr(%v, %v)", node.Name, req.Size)
+	for _, attr := range node.ExtendedAttributes {
+		resp.Append(attr.Name)
+	}
+}
+
+func nodeGetXattr(node *restic.Node, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
+	debug.Log("Getxattr(%v, %v, %v)", node.Name, req.Name, req.Size)
+	attrval := node.GetExtendedAttribute(req.Name)
+	if attrval != nil {
+		resp.Xattr = attrval
+		return nil
+	}
+	return fuse.ErrNoXattr
+}

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -609,10 +609,6 @@ func (node *Node) fillExtra(path string, fi os.FileInfo) error {
 }
 
 func (node *Node) fillExtendedAttributes(path string) error {
-	if node.Type == "symlink" {
-		return nil
-	}
-
 	xattrs, err := Listxattr(path)
 	debug.Log("fillExtendedAttributes(%v) %v %v", path, xattrs, err)
 	if err != nil {

--- a/internal/restic/node_test.go
+++ b/internal/restic/node_test.go
@@ -198,63 +198,65 @@ func TestNodeRestoreAt(t *testing.T) {
 	tempdir := t.TempDir()
 
 	for _, test := range nodeTests {
-		var nodePath string
-		if test.ExtendedAttributes != nil {
-			if runtime.GOOS == "windows" {
-				// restic does not support xattrs on windows
-				return
+		t.Run("", func(t *testing.T) {
+			var nodePath string
+			if test.ExtendedAttributes != nil {
+				if runtime.GOOS == "windows" {
+					// restic does not support xattrs on windows
+					return
+				}
+
+				// tempdir might be backed by a filesystem that does not support
+				// extended attributes
+				nodePath = test.Name
+				defer func() {
+					_ = os.Remove(nodePath)
+				}()
+			} else {
+				nodePath = filepath.Join(tempdir, test.Name)
+			}
+			rtest.OK(t, test.CreateAt(context.TODO(), nodePath, nil))
+			rtest.OK(t, test.RestoreMetadata(nodePath))
+
+			if test.Type == "dir" {
+				rtest.OK(t, test.RestoreTimestamps(nodePath))
 			}
 
-			// tempdir might be backed by a filesystem that does not support
-			// extended attributes
-			nodePath = test.Name
-			defer func() {
-				_ = os.Remove(nodePath)
-			}()
-		} else {
-			nodePath = filepath.Join(tempdir, test.Name)
-		}
-		rtest.OK(t, test.CreateAt(context.TODO(), nodePath, nil))
-		rtest.OK(t, test.RestoreMetadata(nodePath))
+			fi, err := os.Lstat(nodePath)
+			rtest.OK(t, err)
 
-		if test.Type == "dir" {
-			rtest.OK(t, test.RestoreTimestamps(nodePath))
-		}
+			n2, err := restic.NodeFromFileInfo(nodePath, fi)
+			rtest.OK(t, err)
 
-		fi, err := os.Lstat(nodePath)
-		rtest.OK(t, err)
+			rtest.Assert(t, test.Name == n2.Name,
+				"%v: name doesn't match (%v != %v)", test.Type, test.Name, n2.Name)
+			rtest.Assert(t, test.Type == n2.Type,
+				"%v: type doesn't match (%v != %v)", test.Type, test.Type, n2.Type)
+			rtest.Assert(t, test.Size == n2.Size,
+				"%v: size doesn't match (%v != %v)", test.Size, test.Size, n2.Size)
 
-		n2, err := restic.NodeFromFileInfo(nodePath, fi)
-		rtest.OK(t, err)
-
-		rtest.Assert(t, test.Name == n2.Name,
-			"%v: name doesn't match (%v != %v)", test.Type, test.Name, n2.Name)
-		rtest.Assert(t, test.Type == n2.Type,
-			"%v: type doesn't match (%v != %v)", test.Type, test.Type, n2.Type)
-		rtest.Assert(t, test.Size == n2.Size,
-			"%v: size doesn't match (%v != %v)", test.Size, test.Size, n2.Size)
-
-		if runtime.GOOS != "windows" {
-			rtest.Assert(t, test.UID == n2.UID,
-				"%v: UID doesn't match (%v != %v)", test.Type, test.UID, n2.UID)
-			rtest.Assert(t, test.GID == n2.GID,
-				"%v: GID doesn't match (%v != %v)", test.Type, test.GID, n2.GID)
-			if test.Type != "symlink" {
-				// On OpenBSD only root can set sticky bit (see sticky(8)).
-				if runtime.GOOS != "openbsd" && runtime.GOOS != "netbsd" && runtime.GOOS != "solaris" && test.Name == "testSticky" {
-					rtest.Assert(t, test.Mode == n2.Mode,
-						"%v: mode doesn't match (0%o != 0%o)", test.Type, test.Mode, n2.Mode)
+			if runtime.GOOS != "windows" {
+				rtest.Assert(t, test.UID == n2.UID,
+					"%v: UID doesn't match (%v != %v)", test.Type, test.UID, n2.UID)
+				rtest.Assert(t, test.GID == n2.GID,
+					"%v: GID doesn't match (%v != %v)", test.Type, test.GID, n2.GID)
+				if test.Type != "symlink" {
+					// On OpenBSD only root can set sticky bit (see sticky(8)).
+					if runtime.GOOS != "openbsd" && runtime.GOOS != "netbsd" && runtime.GOOS != "solaris" && test.Name == "testSticky" {
+						rtest.Assert(t, test.Mode == n2.Mode,
+							"%v: mode doesn't match (0%o != 0%o)", test.Type, test.Mode, n2.Mode)
+					}
 				}
 			}
-		}
 
-		AssertFsTimeEqual(t, "AccessTime", test.Type, test.AccessTime, n2.AccessTime)
-		AssertFsTimeEqual(t, "ModTime", test.Type, test.ModTime, n2.ModTime)
-		if len(n2.ExtendedAttributes) == 0 {
-			n2.ExtendedAttributes = nil
-		}
-		rtest.Assert(t, reflect.DeepEqual(test.ExtendedAttributes, n2.ExtendedAttributes),
-			"%v: xattrs don't match (%v != %v)", test.Name, test.ExtendedAttributes, n2.ExtendedAttributes)
+			AssertFsTimeEqual(t, "AccessTime", test.Type, test.AccessTime, n2.AccessTime)
+			AssertFsTimeEqual(t, "ModTime", test.Type, test.ModTime, n2.ModTime)
+			if len(n2.ExtendedAttributes) == 0 {
+				n2.ExtendedAttributes = nil
+			}
+			rtest.Assert(t, reflect.DeepEqual(test.ExtendedAttributes, n2.ExtendedAttributes),
+				"%v: xattrs don't match (%v != %v)", test.Name, test.ExtendedAttributes, n2.ExtendedAttributes)
+		})
 	}
 }
 

--- a/internal/restic/node_xattr.go
+++ b/internal/restic/node_xattr.go
@@ -13,20 +13,20 @@ import (
 
 // Getxattr retrieves extended attribute data associated with path.
 func Getxattr(path, name string) ([]byte, error) {
-	b, err := xattr.Get(path, name)
+	b, err := xattr.LGet(path, name)
 	return b, handleXattrErr(err)
 }
 
 // Listxattr retrieves a list of names of extended attributes associated with the
 // given path in the file system.
 func Listxattr(path string) ([]string, error) {
-	l, err := xattr.List(path)
+	l, err := xattr.LList(path)
 	return l, handleXattrErr(err)
 }
 
 // Setxattr associates name and data together as an attribute of path.
 func Setxattr(path, name string, data []byte) error {
-	return handleXattrErr(xattr.Set(path, name, data))
+	return handleXattrErr(xattr.LSet(path, name, data))
 }
 
 func handleXattrErr(err error) error {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Linux allows the use of non-`user.` extended attributes on symlinks. One of the main users of this functionality is SELinux's `security.selinux` xattr for storing a path's label. By storing symlink xattrs, restic is now suitable for backing up the root filesystem on Linux distributions that use SELinux.

This commit adds support for symlink xattrs when backing up data, restoring data, and mounting snapshots via a fuse mount. All calls to the xattr library have been updated to the use `L` variants of the various functions, which always operate on the path given, without following symlinks.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes: #4375

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
