### PR TITLE
Add hostname flag to Docker docs

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -265,6 +265,10 @@ binary, you can get it with `docker pull` like this:
 
     $ docker pull restic/restic
 
+Restic relies on the hostname for various operations. Make sure to set a static
+hostname using `--hostname` when creating a Docker container, otherwise Docker
+will assign a random hostname each time.
+
 From Source
 ***********
 

--- a/docker/README.md
+++ b/docker/README.md
@@ -16,9 +16,13 @@ Set environment variable `RESTIC_REPOSITORY` and map volume to directories and
 files like:
 
 ```
-docker run --rm -ti \
+docker run --rm --hostname my-host -ti \
     -v $HOME/.restic/passfile:/pass \
     -v $HOME/importantdirectory:/data \
     -e RESTIC_REPOSITORY=rest:https://user:pass@hostname/ \
     restic/restic -p /pass backup /data
 ```
+
+Restic relies on the hostname for various operations. Make sure to set a static
+hostname using `--hostname` when creating a Docker container, otherwise Docker
+will assign a random hostname each time.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It updates the docs to make Docker users aware of random hostnames in Docker.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #4380.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
