### PR TITLE
azure domain can be overridden with env variable

### DIFF
--- a/changelog/unreleased/issue-2468
+++ b/changelog/unreleased/issue-2468
@@ -1,6 +1,10 @@
 Enhancement: Add support for non-global Azure clouds
 
-Restic backups on azure only worked for storages on the global domain `core.windows.net`. This meant that backups to other domains such as Azure China (`core.chinacloudapi.cn') were not supported. Restic now allows overriding the global domain using the environment variable `AZURE_ENDPOINT_SUFFIX'.
+Restic backups on Azure only supported storages using the global domain
+`core.windows.net`. This meant that backups to other domains such as Azure
+China (`core.chinacloudapi.cn') or Azure Germany (`core.cloudapi.de`) were
+not supported. Restic now allows overriding the global domain using the 
+environment variable `AZURE_ENDPOINT_SUFFIX'.
 
 https://github.com/restic/restic/issues/2468
 https://github.com/restic/restic/pull/4387

--- a/changelog/unreleased/issue-2468
+++ b/changelog/unreleased/issue-2468
@@ -1,0 +1,6 @@
+Enhancement: Add support for non-global Azure clouds
+
+Restic backups on azure only worked for storages on the global domain `core.windows.net`. This meant that backups to other domains such as Azure China (`core.chinacloudapi.cn') were not supported. Restic now allows overriding the global domain using the environment variable `AZURE_ENDPOINT_SUFFIX'.
+
+https://github.com/restic/restic/issues/2468
+https://github.com/restic/restic/pull/4387

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -537,12 +537,12 @@ or
     $ export AZURE_ACCOUNT_NAME=<ACCOUNT_NAME>
     $ export AZURE_ACCOUNT_SAS=<SAS_TOKEN>
 
-Restic will use Azure's global domain ``core.windows.net`` by default. You can specify other
-domains to be used like so:
+Restic will by default use Azure's global domain ``core.windows.net`` as endpoint suffix.
+You can specify other suffixes as follows:
 
 .. code-block:: console
 
-    $export AZURE_ENDPOINT_SUFFIX=<ENDPOINT_SUFFIX>
+    $ export AZURE_ENDPOINT_SUFFIX=<ENDPOINT_SUFFIX>
 
 Afterwards you can initialize a repository in a container called ``foo`` in the
 root path like this:

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -537,6 +537,13 @@ or
     $ export AZURE_ACCOUNT_NAME=<ACCOUNT_NAME>
     $ export AZURE_ACCOUNT_SAS=<SAS_TOKEN>
 
+Restic will use Azure's global domain ``core.windows.net`` by default. You can specify other
+domains to be used like so:
+
+.. code-block:: console
+
+    $export AZURE_ENDPOINT_SUFFIX=<ENDPOINT_SUFFIX>
+
 Afterwards you can initialize a repository in a container called ``foo`` in the
 root path like this:
 

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -614,7 +614,7 @@ environment variables. The following lists these environment variables:
     AZURE_ACCOUNT_NAME                  Account name for Azure
     AZURE_ACCOUNT_KEY                   Account key for Azure
     AZURE_ACCOUNT_SAS                   Shared access signatures (SAS) for Azure
-    AZURE_ENDPOINT_SUFFIX               Domain of Azure Storage (default: core.windows.net)
+    AZURE_ENDPOINT_SUFFIX               Endpoint suffix for Azure Storage (default: core.windows.net)
 
     GOOGLE_PROJECT_ID                   Project ID for Google Cloud Storage
     GOOGLE_APPLICATION_CREDENTIALS      Application Credentials for Google Cloud Storage (e.g. $HOME/.config/gs-secret-restic-key.json)

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -614,6 +614,7 @@ environment variables. The following lists these environment variables:
     AZURE_ACCOUNT_NAME                  Account name for Azure
     AZURE_ACCOUNT_KEY                   Account key for Azure
     AZURE_ACCOUNT_SAS                   Shared access signatures (SAS) for Azure
+    AZURE_ENDPOINT_SUFFIX               Domain of Azure Storage (default: core.windows.net)
 
     GOOGLE_PROJECT_ID                   Project ID for Google Cloud Storage
     GOOGLE_APPLICATION_CREDENTIALS      Application Credentials for Google Cloud Storage (e.g. $HOME/.config/gs-secret-restic-key.json)

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -53,7 +53,13 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 	var client *azContainer.Client
 	var err error
 
-	url := fmt.Sprintf("https://%s.blob.core.windows.net/%s", cfg.AccountName, cfg.Container)
+	var endpointSuffix string
+	if cfg.EndpointSuffix != "" {
+		endpointSuffix = cfg.EndpointSuffix
+	} else {
+		endpointSuffix = "core.windows.net"
+	}
+	url := fmt.Sprintf("https://%s.blob.%s/%s", cfg.AccountName, endpointSuffix, cfg.Container)
 	opts := &azContainer.ClientOptions{
 		ClientOptions: azcore.ClientOptions{
 			Transport: &http.Client{Transport: rt},

--- a/internal/backend/azure/config.go
+++ b/internal/backend/azure/config.go
@@ -72,7 +72,8 @@ func (cfg *Config) ApplyEnvironment(prefix string) {
 	if cfg.AccountSAS.String() == "" {
 		cfg.AccountSAS = options.NewSecretString(os.Getenv(prefix + "AZURE_ACCOUNT_SAS"))
 	}
+
 	if cfg.EndpointSuffix == "" {
-		cfg.EndpointSuffix = os.Getenv("AZURE_ENDPOINT_SUFFIX")
+		cfg.EndpointSuffix = os.Getenv(prefix + "AZURE_ENDPOINT_SUFFIX")
 	}
 }

--- a/internal/backend/azure/config.go
+++ b/internal/backend/azure/config.go
@@ -13,11 +13,12 @@ import (
 // Config contains all configuration necessary to connect to an azure compatible
 // server.
 type Config struct {
-	AccountName string
-	AccountSAS  options.SecretString
-	AccountKey  options.SecretString
-	Container   string
-	Prefix      string
+	AccountName    string
+	AccountSAS     options.SecretString
+	AccountKey     options.SecretString
+	EndpointSuffix string
+	Container      string
+	Prefix         string
 
 	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
 }
@@ -70,5 +71,8 @@ func (cfg *Config) ApplyEnvironment(prefix string) {
 
 	if cfg.AccountSAS.String() == "" {
 		cfg.AccountSAS = options.NewSecretString(os.Getenv(prefix + "AZURE_ACCOUNT_SAS"))
+	}
+	if cfg.EndpointSuffix == "" {
+		cfg.EndpointSuffix = os.Getenv("AZURE_ENDPOINT_SUFFIX")
 	}
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Restic backups on azure only worked for storages on the global domain `core.windows.net`. This meant that backups to other domains such as Azure China (`core.chinacloudapi.cn') were not supported. Restic now allows overriding the global domain using the environment variable `AZURE_DOMAIN'.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #2468 
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
