### PR TITLE
cmd, ui: Move size parsing code and make it more robust

### DIFF
--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -16,6 +16,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/ui"
 )
 
 var cmdCheck = &cobra.Command{
@@ -97,7 +98,7 @@ func checkFlags(opts CheckOptions) error {
 			}
 
 		} else {
-			fileSize, err := parseSizeStr(opts.ReadDataSubset)
+			fileSize, err := ui.ParseBytes(opts.ReadDataSubset)
 			if err != nil {
 				return argumentError
 			}
@@ -363,7 +364,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 			if repoSize == 0 {
 				return errors.Fatal("Cannot read from a repository having size 0")
 			}
-			subsetSize, _ := parseSizeStr(opts.ReadDataSubset)
+			subsetSize, _ := ui.ParseBytes(opts.ReadDataSubset)
 			if subsetSize > repoSize {
 				subsetSize = repoSize
 			}

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -81,7 +81,7 @@ func addPruneOptions(c *cobra.Command) {
 func verifyPruneOptions(opts *PruneOptions) error {
 	opts.MaxRepackBytes = math.MaxUint64
 	if len(opts.MaxRepackSize) > 0 {
-		size, err := parseSizeStr(opts.MaxRepackSize)
+		size, err := ui.ParseBytes(opts.MaxRepackSize)
 		if err != nil {
 			return err
 		}
@@ -124,7 +124,7 @@ func verifyPruneOptions(opts *PruneOptions) error {
 		}
 
 	default:
-		size, err := parseSizeStr(maxUnused)
+		size, err := ui.ParseBytes(maxUnused)
 		if err != nil {
 			return errors.Fatalf("invalid number of bytes %q for --max-unused: %v", opts.MaxUnused, err)
 		}

--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 
@@ -17,6 +16,7 @@ import (
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/textfile"
+	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/pflag"
 )
 
@@ -364,7 +364,7 @@ func rejectResticCache(repo *repository.Repository) (RejectByNameFunc, error) {
 }
 
 func rejectBySize(maxSizeStr string) (RejectFunc, error) {
-	maxSize, err := parseSizeStr(maxSizeStr)
+	maxSize, err := ui.ParseBytes(maxSizeStr)
 	if err != nil {
 		return nil, err
 	}
@@ -383,35 +383,6 @@ func rejectBySize(maxSizeStr string) (RejectFunc, error) {
 
 		return false
 	}, nil
-}
-
-func parseSizeStr(sizeStr string) (int64, error) {
-	if sizeStr == "" {
-		return 0, errors.New("expected size, got empty string")
-	}
-
-	numStr := sizeStr[:len(sizeStr)-1]
-	var unit int64 = 1
-
-	switch sizeStr[len(sizeStr)-1] {
-	case 'b', 'B':
-		// use initialized values, do nothing here
-	case 'k', 'K':
-		unit = 1024
-	case 'm', 'M':
-		unit = 1024 * 1024
-	case 'g', 'G':
-		unit = 1024 * 1024 * 1024
-	case 't', 'T':
-		unit = 1024 * 1024 * 1024 * 1024
-	default:
-		numStr = sizeStr
-	}
-	value, err := strconv.ParseInt(numStr, 10, 64)
-	if err != nil {
-		return 0, err
-	}
-	return value * unit, nil
 }
 
 // readExcludePatternsFromFiles reads all exclude files and returns the list of

--- a/cmd/restic/exclude_test.go
+++ b/cmd/restic/exclude_test.go
@@ -187,54 +187,6 @@ func TestMultipleIsExcludedByFile(t *testing.T) {
 	}
 }
 
-func TestParseSizeStr(t *testing.T) {
-	sizeStrTests := []struct {
-		in       string
-		expected int64
-	}{
-		{"1024", 1024},
-		{"1024b", 1024},
-		{"1024B", 1024},
-		{"1k", 1024},
-		{"100k", 102400},
-		{"100K", 102400},
-		{"10M", 10485760},
-		{"100m", 104857600},
-		{"20G", 21474836480},
-		{"10g", 10737418240},
-		{"2T", 2199023255552},
-		{"2t", 2199023255552},
-	}
-
-	for _, tt := range sizeStrTests {
-		actual, err := parseSizeStr(tt.in)
-		test.OK(t, err)
-
-		if actual != tt.expected {
-			t.Errorf("parseSizeStr(%s) = %d; expected %d", tt.in, actual, tt.expected)
-		}
-	}
-}
-
-func TestParseInvalidSizeStr(t *testing.T) {
-	invalidSizes := []string{
-		"",
-		" ",
-		"foobar",
-		"zzz",
-	}
-
-	for _, s := range invalidSizes {
-		v, err := parseSizeStr(s)
-		if err == nil {
-			t.Errorf("wanted error for invalid value %q, got nil", s)
-		}
-		if v != 0 {
-			t.Errorf("wanted zero for invalid value %q, got: %v", s, v)
-		}
-	}
-}
-
 // TestIsExcludedByFileSize is for testing the instance of
 // --exclude-larger-than parameters
 func TestIsExcludedByFileSize(t *testing.T) {

--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -3,7 +3,10 @@ package ui
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"math/bits"
+	"strconv"
 	"time"
 )
 
@@ -54,6 +57,44 @@ func FormatSeconds(sec uint64) string {
 		return fmt.Sprintf("%d:%02d:%02d", hours, min, sec)
 	}
 	return fmt.Sprintf("%d:%02d", min, sec)
+}
+
+// ParseBytes parses a size in bytes from s. It understands the suffixes
+// B, K, M, G and T for powers of 1024.
+func ParseBytes(s string) (int64, error) {
+	if s == "" {
+		return 0, errors.New("expected size, got empty string")
+	}
+
+	numStr := s[:len(s)-1]
+	var unit uint64 = 1
+
+	switch s[len(s)-1] {
+	case 'b', 'B':
+		// use initialized values, do nothing here
+	case 'k', 'K':
+		unit = 1024
+	case 'm', 'M':
+		unit = 1024 * 1024
+	case 'g', 'G':
+		unit = 1024 * 1024 * 1024
+	case 't', 'T':
+		unit = 1024 * 1024 * 1024 * 1024
+	default:
+		numStr = s
+	}
+	value, err := strconv.ParseInt(numStr, 10, 64)
+	if err != nil {
+		return 0, err
+	}
+
+	hi, lo := bits.Mul64(uint64(value), unit)
+	value = int64(lo)
+	if hi != 0 || value < 0 {
+		return 0, fmt.Errorf("ParseSize: %q: %w", numStr, strconv.ErrRange)
+	}
+
+	return value, nil
 }
 
 func ToJSONString(status interface{}) string {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Moves the function parseSizeStr from cmd/restic to internal/ui. Also makes it more robust against overflow.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No. But I've been doing some preliminary work on #4325 and I need a parser for the maximum size of the cache.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
