### PR TITLE
add --stdin-from-command flag to backup command

### DIFF
--- a/changelog/unreleased/issue-4251
+++ b/changelog/unreleased/issue-4251
@@ -1,8 +1,12 @@
-Enhancement: Add flag to source the backup from a program's standard output
+Enhancement: Support reading backup from a program's standard output
 
-The `backup` command now supports sourcing the backup content from the standard
-output of an arbitrary command, ensuring that the exit code is zero for a
-successful backup.
+When reading data from stdin, the `backup` command could not verify whether the
+corresponding command completed successfully.
+
+The `backup` command now supports starting an arbitrary command and sourcing
+the backup content from its standard output. This enables restic to verify that
+the command completes with exit code zero. A non-zero exit code causes the
+backup to fail.
 
 Example: `restic backup --stdin-from-command mysqldump [...]`
 

--- a/changelog/unreleased/issue-4251
+++ b/changelog/unreleased/issue-4251
@@ -1,0 +1,10 @@
+Enhancement: Add flag to source the backup from a program's standard output
+
+The `backup` command now supports sourcing the backup content from the standard
+output of an arbitrary command, ensuring that the exit code is zero for a
+successful backup.
+
+Example: `restic backup --stdin-from-command mysqldump [...]`
+
+https://github.com/restic/restic/issues/4251
+https://github.com/restic/restic/pull/4410

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -97,6 +97,7 @@ type BackupOptions struct {
 	ExcludeLargerThan string
 	Stdin             bool
 	StdinFilename     string
+	StdinCommand      bool
 	Tags              restic.TagLists
 	Host              string
 	FilesFrom         []string
@@ -134,6 +135,7 @@ func init() {
 	f.StringVar(&backupOptions.ExcludeLargerThan, "exclude-larger-than", "", "max `size` of the files to be backed up (allowed suffixes: k/K, m/M, g/G, t/T)")
 	f.BoolVar(&backupOptions.Stdin, "stdin", false, "read backup from stdin")
 	f.StringVar(&backupOptions.StdinFilename, "stdin-filename", "stdin", "`filename` to use when reading from stdin")
+	f.BoolVar(&backupOptions.StdinCommand, "stdin-from-command", false, "execute command and store its stdout")
 	f.Var(&backupOptions.Tags, "tag", "add `tags` for the new snapshot in the format `tag[,tag,...]` (can be specified multiple times)")
 	f.UintVar(&backupOptions.ReadConcurrency, "read-concurrency", 0, "read `n` files concurrently (default: $RESTIC_READ_CONCURRENCY or 2)")
 	f.StringVarP(&backupOptions.Host, "host", "H", "", "set the `hostname` for the snapshot manually. To prevent an expensive rescan use the \"parent\" flag")

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -289,7 +289,7 @@ func (opts BackupOptions) Check(gopts GlobalOptions, args []string) error {
 		}
 	}
 
-	if opts.Stdin {
+	if opts.Stdin || opts.StdinCommand {
 		if len(opts.FilesFrom) > 0 {
 			return errors.Fatal("--stdin and --files-from cannot be used together")
 		}
@@ -300,7 +300,7 @@ func (opts BackupOptions) Check(gopts GlobalOptions, args []string) error {
 			return errors.Fatal("--stdin and --files-from-raw cannot be used together")
 		}
 
-		if len(args) > 0 {
+		if len(args) > 0 && opts.StdinCommand == false {
 			return errors.Fatal("--stdin was specified and files/dirs were listed as arguments")
 		}
 	}
@@ -368,7 +368,7 @@ func collectRejectFuncs(opts BackupOptions, targets []string) (fs []RejectFunc, 
 
 // collectTargets returns a list of target files/dirs from several sources.
 func collectTargets(opts BackupOptions, args []string) (targets []string, err error) {
-	if opts.Stdin {
+	if opts.Stdin || opts.StdinCommand {
 		return nil, nil
 	}
 

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -676,6 +676,8 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 		Hostname:       opts.Host,
 		ParentSnapshot: parentSnapshot,
 		ProgramVersion: "restic " + version,
+		Command:        command,
+		CommandStderr:  stderr,
 	}
 
 	if !gopts.JSON {

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -728,5 +728,5 @@ func prepareStdinCommand(ctx context.Context, args []string) (io.ReadCloser, err
 	if err := command.Start(); err != nil {
 		return nil, errors.Wrap(err, "command.Start")
 	}
-	return &fs.ReadCloserCommand{Cmd: command, Stdout: stdout}, nil
+	return fs.NewCommandReader(command, stdout), nil
 }

--- a/cmd/restic/cmd_backup_integration_test.go
+++ b/cmd/restic/cmd_backup_integration_test.go
@@ -568,3 +568,55 @@ func linkEqual(source, dest []string) bool {
 
 	return true
 }
+
+func TestStdinFromCommand(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{
+		StdinCommand:  true,
+		StdinFilename: "stdin",
+	}
+
+	testRunBackup(t, filepath.Dir(env.testdata), []string{"ls"}, opts, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+
+	testRunCheck(t, env.gopts)
+}
+
+func TestStdinFromCommandFailNoOutput(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{
+		StdinCommand:  true,
+		StdinFilename: "stdin",
+	}
+
+	err := testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"python", "-c", "import sys; sys.exit(1)"}, opts, env.gopts)
+	rtest.Assert(t, err != nil, "Expected error while backing up")
+
+	testListSnapshots(t, env.gopts, 0)
+
+	testRunCheck(t, env.gopts)
+}
+
+func TestStdinFromCommandFailExitCode(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{
+		StdinCommand:  true,
+		StdinFilename: "stdin",
+	}
+
+	err := testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"python", "-c", "import sys; print('test'); sys.exit(1)"}, opts, env.gopts)
+	rtest.Assert(t, err != nil, "Expected error while backing up")
+
+	testListSnapshots(t, env.gopts, 0)
+
+	testRunCheck(t, env.gopts)
+}

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -2,7 +2,9 @@ package archiver
 
 import (
 	"context"
+	"io"
 	"os"
+	"os/exec"
 	"path"
 	"runtime"
 	"sort"
@@ -681,6 +683,8 @@ type SnapshotOptions struct {
 	Time           time.Time
 	ParentSnapshot *restic.Snapshot
 	ProgramVersion string
+	Command        *exec.Cmd
+	CommandStderr  io.ReadCloser
 }
 
 // loadParentTree loads a tree referenced by snapshot id. If id is null, nil is returned.

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -2,9 +2,7 @@ package archiver
 
 import (
 	"context"
-	"io"
 	"os"
-	"os/exec"
 	"path"
 	"runtime"
 	"sort"
@@ -683,8 +681,6 @@ type SnapshotOptions struct {
 	Time           time.Time
 	ParentSnapshot *restic.Snapshot
 	ProgramVersion string
-	Command        *exec.Cmd
-	CommandStderr  io.ReadCloser
 }
 
 // loadParentTree loads a tree referenced by snapshot id. If id is null, nil is returned.
@@ -794,15 +790,6 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 	err = wgUp.Wait()
 	if err != nil {
 		return nil, restic.ID{}, err
-	}
-
-	if opts.Command != nil {
-		errBytes, _ := io.ReadAll(opts.CommandStderr)
-		cmdErr := opts.Command.Wait()
-		if cmdErr != nil {
-			debug.Log("error while executing command: %v", cmdErr)
-			return nil, restic.ID{}, errors.New(string(errBytes))
-		}
 	}
 
 	sn, err := restic.NewSnapshot(targets, opts.Tags, opts.Hostname, opts.Time)

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -796,6 +796,15 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 		return nil, restic.ID{}, err
 	}
 
+	if opts.Command != nil {
+		errBytes, _ := io.ReadAll(opts.CommandStderr)
+		cmdErr := opts.Command.Wait()
+		if cmdErr != nil {
+			debug.Log("error while executing command: %v", cmdErr)
+			return nil, restic.ID{}, errors.New(string(errBytes))
+		}
+	}
+
 	sn, err := restic.NewSnapshot(targets, opts.Tags, opts.Hostname, opts.Time)
 	if err != nil {
 		return nil, restic.ID{}, err

--- a/internal/archiver/file_saver.go
+++ b/internal/archiver/file_saver.go
@@ -2,6 +2,7 @@ package archiver
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"sync"
@@ -146,7 +147,7 @@ func (s *FileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 				panic("completed twice")
 			}
 			isCompleted = true
-			fnr.err = err
+			fnr.err = fmt.Errorf("failed to save %v: %w", target, err)
 			fnr.node = nil
 			fnr.stats = ItemStats{}
 			finish(fnr)

--- a/internal/fs/fs_reader_command.go
+++ b/internal/fs/fs_reader_command.go
@@ -1,17 +1,18 @@
 package fs
 
 import (
-	"github.com/restic/restic/internal/errors"
 	"io"
 	"os/exec"
+
+	"github.com/restic/restic/internal/errors"
 )
 
-// ReadCloserCommand wraps an exec.Cmd and its standard output to provide an
+// CommandReader wraps an exec.Cmd and its standard output to provide an
 // io.ReadCloser that waits for the command to terminate on Close(), reporting
 // any error in the command.Wait() function back to the Close() caller.
-type ReadCloserCommand struct {
-	Cmd    *exec.Cmd
-	Stdout io.ReadCloser
+type CommandReader struct {
+	cmd    *exec.Cmd
+	stdout io.ReadCloser
 
 	// We should call exec.Wait() once. waitHandled is taking care of storing
 	// whether we already called that function in Read() to avoid calling it
@@ -25,44 +26,36 @@ type ReadCloserCommand struct {
 	alreadyClosedReadErr error
 }
 
+func NewCommandReader(cmd *exec.Cmd, stdout io.ReadCloser) *CommandReader {
+	return &CommandReader{
+		cmd:    cmd,
+		stdout: stdout,
+	}
+}
+
 // Read populate the array with data from the process stdout.
-func (fp *ReadCloserCommand) Read(p []byte) (int, error) {
+func (fp *CommandReader) Read(p []byte) (int, error) {
 	if fp.alreadyClosedReadErr != nil {
 		return 0, fp.alreadyClosedReadErr
 	}
-	b, err := fp.Stdout.Read(p)
+	b, err := fp.stdout.Read(p)
 
 	// If the error is io.EOF, the program terminated. We need to check the
 	// exit code here because, if the program terminated with no output, the
 	// error in `Close()` is ignored.
 	if errors.Is(err, io.EOF) {
-		// Check if the command terminated successfully. If not, return the
-		// error.
 		fp.waitHandled = true
-		errw := fp.Cmd.Wait()
-		if errw != nil {
-			// If we have information about the exit code, let's use it in the
-			// error message. Otherwise, send the error message along.
-			// In any case, use a fatal error to abort the snapshot.
-			var err2 *exec.ExitError
-			if errors.As(errw, &err2) {
-				err = errors.Fatalf("command terminated with exit code %d", err2.ExitCode())
-			} else {
-				err = errors.Fatal(errw.Error())
-			}
+		// check if the command terminated successfully, If not return the error.
+		if errw := fp.wait(); errw != nil {
+			err = errw
 		}
 	}
 	fp.alreadyClosedReadErr = err
 	return b, err
 }
 
-func (fp *ReadCloserCommand) Close() error {
-	if fp.waitHandled {
-		return nil
-	}
-
-	// No need to close fp.Stdout as Wait() closes all pipes.
-	err := fp.Cmd.Wait()
+func (fp *CommandReader) wait() error {
+	err := fp.cmd.Wait()
 	if err != nil {
 		// If we have information about the exit code, let's use it in the
 		// error message. Otherwise, send the error message along.
@@ -74,4 +67,12 @@ func (fp *ReadCloserCommand) Close() error {
 		return errors.Fatal(err.Error())
 	}
 	return nil
+}
+
+func (fp *CommandReader) Close() error {
+	if fp.waitHandled {
+		return nil
+	}
+
+	return fp.wait()
 }

--- a/internal/fs/fs_reader_command.go
+++ b/internal/fs/fs_reader_command.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"github.com/restic/restic/internal/errors"
 	"io"
 	"os/exec"
 )
@@ -11,13 +12,43 @@ import (
 type ReadCloserCommand struct {
 	Cmd    *exec.Cmd
 	Stdout io.ReadCloser
+
+	bytesRead bool
 }
 
-func (fp *ReadCloserCommand) Read(p []byte) (n int, err error) {
-	return fp.Stdout.Read(p)
+// Read populate the array with data from the process stdout.
+func (fp *ReadCloserCommand) Read(p []byte) (int, error) {
+	// We may encounter two different error conditions here:
+	// - EOF with no bytes read: the program terminated prematurely, so we send
+	//   a fatal error to cancel the snapshot;
+	// - an error that is not EOF: something bad happened, we need to abort the
+	//   snapshot.
+	b, err := fp.Stdout.Read(p)
+	if b == 0 && errors.Is(err, io.EOF) && !fp.bytesRead {
+		// The command terminated with no output at all. Raise a fatal error.
+		return 0, errors.Fatalf("command terminated with no output")
+	} else if err != nil && !errors.Is(err, io.EOF) {
+		// The command terminated with an error that is not EOF. Raise a fatal
+		// error.
+		return 0, errors.Fatal(err.Error())
+	} else if b > 0 {
+		fp.bytesRead = true
+	}
+	return b, err
 }
 
 func (fp *ReadCloserCommand) Close() error {
 	// No need to close fp.Stdout as Wait() closes all pipes.
-	return fp.Cmd.Wait()
+	err := fp.Cmd.Wait()
+	if err != nil {
+		// If we have information about the exit code, let's use it in the
+		// error message. Otherwise, send the error message along.
+		// In any case, use a fatal error to abort the snapshot.
+		var err2 *exec.ExitError
+		if errors.As(err, &err2) {
+			return errors.Fatalf("command terminated with exit code %d", err2.ExitCode())
+		}
+		return errors.Fatal(err.Error())
+	}
+	return nil
 }

--- a/internal/fs/fs_reader_command.go
+++ b/internal/fs/fs_reader_command.go
@@ -1,0 +1,23 @@
+package fs
+
+import (
+	"io"
+	"os/exec"
+)
+
+// ReadCloserCommand wraps an exec.Cmd and its standard output to provide an
+// io.ReadCloser that waits for the command to terminate on Close(), reporting
+// any error in the command.Wait() function back to the Close() caller.
+type ReadCloserCommand struct {
+	Cmd    *exec.Cmd
+	Stdout io.ReadCloser
+}
+
+func (fp *ReadCloserCommand) Read(p []byte) (n int, err error) {
+	return fp.Stdout.Read(p)
+}
+
+func (fp *ReadCloserCommand) Close() error {
+	// No need to close fp.Stdout as Wait() closes all pipes.
+	return fp.Cmd.Wait()
+}

--- a/internal/fs/fs_reader_command.go
+++ b/internal/fs/fs_reader_command.go
@@ -83,7 +83,7 @@ func (fp *CommandReader) wait() error {
 	err := fp.cmd.Wait()
 	if err != nil {
 		// Use a fatal error to abort the snapshot.
-		return errors.Fatal(err.Error())
+		return errors.Fatal(fmt.Errorf("command failed: %w", err).Error())
 	}
 	return nil
 }

--- a/internal/fs/fs_reader_command.go
+++ b/internal/fs/fs_reader_command.go
@@ -13,31 +13,54 @@ type ReadCloserCommand struct {
 	Cmd    *exec.Cmd
 	Stdout io.ReadCloser
 
-	bytesRead bool
+	// We should call exec.Wait() once. waitHandled is taking care of storing
+	// whether we already called that function in Read() to avoid calling it
+	// again in Close().
+	waitHandled bool
+
+	// alreadyClosedReadErr is the error that we should return if we try to
+	// read the pipe again after closing. This works around a Read() call that
+	// is issued after a previous Read() with `io.EOF` (but some bytes were
+	// read in the past).
+	alreadyClosedReadErr error
 }
 
 // Read populate the array with data from the process stdout.
 func (fp *ReadCloserCommand) Read(p []byte) (int, error) {
-	// We may encounter two different error conditions here:
-	// - EOF with no bytes read: the program terminated prematurely, so we send
-	//   a fatal error to cancel the snapshot;
-	// - an error that is not EOF: something bad happened, we need to abort the
-	//   snapshot.
-	b, err := fp.Stdout.Read(p)
-	if b == 0 && errors.Is(err, io.EOF) && !fp.bytesRead {
-		// The command terminated with no output at all. Raise a fatal error.
-		return 0, errors.Fatalf("command terminated with no output")
-	} else if err != nil && !errors.Is(err, io.EOF) {
-		// The command terminated with an error that is not EOF. Raise a fatal
-		// error.
-		return 0, errors.Fatal(err.Error())
-	} else if b > 0 {
-		fp.bytesRead = true
+	if fp.alreadyClosedReadErr != nil {
+		return 0, fp.alreadyClosedReadErr
 	}
+	b, err := fp.Stdout.Read(p)
+
+	// If the error is io.EOF, the program terminated. We need to check the
+	// exit code here because, if the program terminated with no output, the
+	// error in `Close()` is ignored.
+	if errors.Is(err, io.EOF) {
+		// Check if the command terminated successfully. If not, return the
+		// error.
+		fp.waitHandled = true
+		errw := fp.Cmd.Wait()
+		if errw != nil {
+			// If we have information about the exit code, let's use it in the
+			// error message. Otherwise, send the error message along.
+			// In any case, use a fatal error to abort the snapshot.
+			var err2 *exec.ExitError
+			if errors.As(errw, &err2) {
+				err = errors.Fatalf("command terminated with exit code %d", err2.ExitCode())
+			} else {
+				err = errors.Fatal(errw.Error())
+			}
+		}
+	}
+	fp.alreadyClosedReadErr = err
 	return b, err
 }
 
 func (fp *ReadCloserCommand) Close() error {
+	if fp.waitHandled {
+		return nil
+	}
+
 	// No need to close fp.Stdout as Wait() closes all pipes.
 	err := fp.Cmd.Wait()
 	if err != nil {

--- a/internal/fs/fs_reader_command_test.go
+++ b/internal/fs/fs_reader_command_test.go
@@ -1,0 +1,48 @@
+package fs_test
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/test"
+)
+
+func TestCommandReaderSuccess(t *testing.T) {
+	reader, err := fs.NewCommandReader(context.TODO(), []string{"true"}, io.Discard)
+	test.OK(t, err)
+
+	_, err = io.Copy(io.Discard, reader)
+	test.OK(t, err)
+
+	test.OK(t, reader.Close())
+}
+
+func TestCommandReaderFail(t *testing.T) {
+	reader, err := fs.NewCommandReader(context.TODO(), []string{"false"}, io.Discard)
+	test.OK(t, err)
+
+	_, err = io.Copy(io.Discard, reader)
+	test.Assert(t, err != nil, "missing error")
+}
+
+func TestCommandReaderInvalid(t *testing.T) {
+	_, err := fs.NewCommandReader(context.TODO(), []string{"w54fy098hj7fy5twijouytfrj098y645wr"}, io.Discard)
+	test.Assert(t, err != nil, "missing error")
+}
+
+func TestCommandReaderOutput(t *testing.T) {
+	reader, err := fs.NewCommandReader(context.TODO(), []string{"echo", "hello world"}, io.Discard)
+	test.OK(t, err)
+
+	var buf bytes.Buffer
+
+	_, err = io.Copy(&buf, reader)
+	test.OK(t, err)
+	test.OK(t, reader.Close())
+
+	test.Equals(t, "hello world", strings.TrimSpace(buf.String()))
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This pull request is a continuation of #4254.

This fixes [#4251](https://github.com/restic/restic/issues/4251) by providing the requested `--stdin-from-command` flag to the `restic backup` command. It skips snapshot creation in case the given commands fails as determined by `exec.Cmd.Wait()` and returns the stderr of the given command as an error message back to the user.

I have not written any tests, nor documentation because I wanted to get some feedback about the path taken here wrt. upstream inclusion first. I am seeing various test failures in existing tests but these seem to be unrelated and might just occur because I'm building/testing the project within a container. Using these changes locally does look promising though:

```
$ ./restic backup --stdin-from-command --repo ./backup -- pg_dump -h foobar
enter password for repository:
repository 55e7d5a0 opened (version 2, compression level auto)
using parent snapshot cc6e1dec
error: read /stdin: no data read
Fatal: unable to save snapshot: pg_dump: error: connection to database "root" failed: could not translate host name "foobar" to address: No address associated with hostname
```

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes [#4251](https://github.com/restic/restic/issues/4251)

Checklist
---------

-   [x]  I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
-   [x]  I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
-   [x]  I have added tests for all code changes.
-   [x]  I have added documentation for relevant changes (in the manual).
-   [x]  There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
-   [x]  I have run `gofmt` on the code in all commits.
-   [x]  All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
