### PR TITLE
Flush pack to avoid oversized

### DIFF
--- a/changelog/unreleased/issue-4412
+++ b/changelog/unreleased/issue-4412
@@ -1,0 +1,9 @@
+Change: Keep packs size closer to target size
+
+Restic treated the target pack size value (--pack-size or the environment variable RESTIC_PACK_SIZE)
+as rather a minimum value for pack sizes. Sometimes a pack size was more than twice the target size.
+Restic now makes an effort to ensure that packs do not exceed the target size,
+although in some cases packs may still exceed it.
+
+https://github.com/restic/restic/issues/4412
+https://github.com/restic/restic/pull/4413

--- a/internal/backend/retry/backend_retry.go
+++ b/internal/backend/retry/backend_retry.go
@@ -112,7 +112,7 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 			debug.Log("Save(%v) failed with error, removing file: %v", h, err)
 			rerr := be.Backend.Remove(ctx, h)
 			if rerr != nil {
-				debug.Log("Remove(%v) returned error: %v", h, err)
+				debug.Log("Remove(%v) returned error: %v", h, rerr)
 			}
 		}
 

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -18,7 +18,7 @@ import (
 type Packer struct {
 	blobs []restic.Blob
 
-	bytes uint
+	bytes int
 	k     *crypto.Key
 	wr    io.Writer
 
@@ -40,9 +40,9 @@ func (p *Packer) Add(t restic.BlobType, id restic.ID, data []byte, uncompressedL
 
 	n, err := p.wr.Write(data)
 	c.Length = uint(n)
-	c.Offset = p.bytes
+	c.Offset = uint(p.bytes)
 	c.UncompressedLength = uint(uncompressedLength)
-	p.bytes += uint(n)
+	p.bytes += n
 	p.blobs = append(p.blobs, c)
 	n += CalculateEntrySize(c)
 
@@ -100,7 +100,7 @@ func (p *Packer) Finalize() error {
 	if err != nil {
 		return errors.Wrap(err, "binary.Write")
 	}
-	p.bytes += uint(hdrBytes + binary.Size(uint32(0)))
+	p.bytes += hdrBytes + binary.Size(uint32(0))
 
 	return nil
 }
@@ -142,7 +142,7 @@ func (p *Packer) makeHeader() ([]byte, error) {
 }
 
 // Size returns the number of bytes written so far.
-func (p *Packer) Size() uint {
+func (p *Packer) Size() int {
 	p.m.Lock()
 	defer p.m.Unlock()
 

--- a/internal/pack/pack_test.go
+++ b/internal/pack/pack_test.go
@@ -24,7 +24,7 @@ type Buf struct {
 	id   restic.ID
 }
 
-func newPack(t testing.TB, k *crypto.Key, lengths []int) ([]Buf, []byte, uint) {
+func newPack(t testing.TB, k *crypto.Key, lengths []int) ([]Buf, []byte, int) {
 	bufs := []Buf{}
 
 	for _, l := range lengths {
@@ -49,7 +49,7 @@ func newPack(t testing.TB, k *crypto.Key, lengths []int) ([]Buf, []byte, uint) {
 	return bufs, buf.Bytes(), p.Size()
 }
 
-func verifyBlobs(t testing.TB, bufs []Buf, k *crypto.Key, rd io.ReaderAt, packSize uint) {
+func verifyBlobs(t testing.TB, bufs []Buf, k *crypto.Key, rd io.ReaderAt, packSize int) {
 	written := 0
 	for _, buf := range bufs {
 		written += len(buf.data)
@@ -65,7 +65,7 @@ func verifyBlobs(t testing.TB, bufs []Buf, k *crypto.Key, rd io.ReaderAt, packSi
 	written += headerSize
 
 	// check length
-	rtest.Equals(t, uint(written), packSize)
+	rtest.Equals(t, written, packSize)
 	rtest.Equals(t, headerSize, int(hdrSize))
 
 	var buf []byte
@@ -91,7 +91,7 @@ func TestCreatePack(t *testing.T) {
 	k := crypto.NewRandomKey()
 
 	bufs, packData, packSize := newPack(t, k, testLens)
-	rtest.Equals(t, uint(len(packData)), packSize)
+	rtest.Equals(t, len(packData), packSize)
 	verifyBlobs(t, bufs, k, bytes.NewReader(packData), packSize)
 }
 


### PR DESCRIPTION
Closes https://github.com/restic/restic/issues/4412

What does this PR change? What problem does it solve?
-----------------------------------------------------
Reduces the possibility of packs to be larger than --pack-size

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://github.com/restic/restic/issues/4412

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
