### PR TITLE
backend: Fix unreliable TestListCancel/Timeout test

### DIFF
--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -428,6 +428,11 @@ func (s *Suite[C]) TestListCancel(t *testing.T) {
 
 			// wait until the context is cancelled
 			<-ctxTimeout.Done()
+			// The cancellation of a context first closes the done channel of the context and
+			// _afterwards_ propagates the cancellation to child contexts. If the List
+			// implementation uses a child context, then it may take a moment until that context
+			// is also cancelled. Thus give the context cancellation a moment to propagate.
+			time.Sleep(time.Millisecond)
 			return nil
 		})
 


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

There have recently been several failures of the `TestListCancel/Timeout` test for several backend:

```
https://github.com/restic/restic/actions/runs/5159584841/job/13968878545
TestBackendGS/TestListCancel/Timeout
        tests.go:429: expected error not found, want context.deadlineExceededError{}, got <nil>

https://github.com/restic/restic/actions/runs/5204451274/job/14087070990?pr=4361
TestBackendMinio/TestListCancel/Timeout
        tests.go:429: expected error not found, want context.deadlineExceededError{}, got <nil>

https://github.com/restic/restic/actions/runs/5220093038/job/14130620348?pr=3261
TestBackendMinio/TestListCancel/Timeout
        tests.go:433: wrong number of files returned by List, want <= 2, got 3

https://github.com/restic/restic/actions/runs/5558466816/job/15058052706
TestBackendB2/TestListCancel/Timeout
        tests.go:429: expected error not found, want context.deadlineExceededError{}, got <nil>
```

The test uses `context.WithTimeout` to create a context that cancels the List operation after a given delay. Several backends internally use a derived child context created using `WithCancel`.

The cancellation of a context first closes the done channel of the context (here: the `WithTimeout` context) and _afterwards_ propagates the cancellation to child contexts (here: the `WithCancel` context). Therefor if the List implementation uses a child context, then it may take a moment until that context is also cancelled. Thus give the context cancellation a moment to propagate.


<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
