### PR TITLE
forget: replace `--keep-* -1` with `--keep-* unlimited`

### DIFF
--- a/changelog/unreleased/issue-2565
+++ b/changelog/unreleased/issue-2565
@@ -1,8 +1,9 @@
-Bugfix: Restic forget --keep-* options now interpret "-1" as "forever"
+Bugfix: Support "unlimited" in `forget --keep-*` options
 
-Restic would forget snapshots that should have been kept when "-1" was
-used as a value for --keep-* options. It now interprets "-1" as forever,
-e.g. an option like --keep-monthly -1 will keep all monthly snapshots.
+Restic would forget snapshots that should have been kept when a negative value
+was passed to the `--keep-*` options. Negative values are now forbidden. To
+keep all snapshots, the special value `unlimited` is now supported. For
+example, `--keep-monthly unlimited` will keep all monthly snapshots.
 
 https://github.com/restic/restic/issues/2565
 https://github.com/restic/restic/pull/4234

--- a/cmd/restic/cmd_forget_test.go
+++ b/cmd/restic/cmd_forget_test.go
@@ -7,6 +7,36 @@ import (
 	rtest "github.com/restic/restic/internal/test"
 )
 
+func TestForgetPolicyValues(t *testing.T) {
+	testCases := []struct {
+		input string
+		value ForgetPolicyCount
+		err   string
+	}{
+		{"0", ForgetPolicyCount(0), ""},
+		{"1", ForgetPolicyCount(1), ""},
+		{"unlimited", ForgetPolicyCount(-1), ""},
+		{"", ForgetPolicyCount(0), "strconv.ParseInt: parsing \"\": invalid syntax"},
+		{"-1", ForgetPolicyCount(0), ErrNegativePolicyCount.Error()},
+		{"abc", ForgetPolicyCount(0), "strconv.ParseInt: parsing \"abc\": invalid syntax"},
+	}
+	for _, testCase := range testCases {
+		t.Run("", func(t *testing.T) {
+			var count ForgetPolicyCount
+			err := count.Set(testCase.input)
+
+			if testCase.err != "" {
+				rtest.Assert(t, err != nil, "should have returned error for input %+v", testCase.input)
+				rtest.Equals(t, testCase.err, err.Error())
+			} else {
+				rtest.Assert(t, err == nil, "expected no error for input %+v, got %v", testCase.input, err)
+				rtest.Equals(t, testCase.value, count)
+				rtest.Equals(t, testCase.input, count.String())
+			}
+		})
+	}
+}
+
 func TestForgetOptionValues(t *testing.T) {
 	const negValErrorMsg = "Fatal: negative values other than -1 are not allowed for --keep-*"
 	const negDurationValErrorMsg = "Fatal: durations containing negative values are not allowed for --keep-within*"

--- a/cmd/restic/cmd_forget_test.go
+++ b/cmd/restic/cmd_forget_test.go
@@ -41,51 +41,50 @@ func TestForgetOptionValues(t *testing.T) {
 	const negValErrorMsg = "Fatal: negative values other than -1 are not allowed for --keep-*"
 	const negDurationValErrorMsg = "Fatal: durations containing negative values are not allowed for --keep-within*"
 	testCases := []struct {
-		input        ForgetOptions
-		expectsError bool
-		errorMsg     string
+		input    ForgetOptions
+		errorMsg string
 	}{
-		{ForgetOptions{Last: 1}, false, ""},
-		{ForgetOptions{Hourly: 1}, false, ""},
-		{ForgetOptions{Daily: 1}, false, ""},
-		{ForgetOptions{Weekly: 1}, false, ""},
-		{ForgetOptions{Monthly: 1}, false, ""},
-		{ForgetOptions{Yearly: 1}, false, ""},
-		{ForgetOptions{Last: 0}, false, ""},
-		{ForgetOptions{Hourly: 0}, false, ""},
-		{ForgetOptions{Daily: 0}, false, ""},
-		{ForgetOptions{Weekly: 0}, false, ""},
-		{ForgetOptions{Monthly: 0}, false, ""},
-		{ForgetOptions{Yearly: 0}, false, ""},
-		{ForgetOptions{Last: -1}, false, ""},
-		{ForgetOptions{Hourly: -1}, false, ""},
-		{ForgetOptions{Daily: -1}, false, ""},
-		{ForgetOptions{Weekly: -1}, false, ""},
-		{ForgetOptions{Monthly: -1}, false, ""},
-		{ForgetOptions{Yearly: -1}, false, ""},
-		{ForgetOptions{Last: -2}, true, negValErrorMsg},
-		{ForgetOptions{Hourly: -2}, true, negValErrorMsg},
-		{ForgetOptions{Daily: -2}, true, negValErrorMsg},
-		{ForgetOptions{Weekly: -2}, true, negValErrorMsg},
-		{ForgetOptions{Monthly: -2}, true, negValErrorMsg},
-		{ForgetOptions{Yearly: -2}, true, negValErrorMsg},
-		{ForgetOptions{Within: restic.ParseDurationOrPanic("1y2m3d3h")}, false, ""},
-		{ForgetOptions{WithinHourly: restic.ParseDurationOrPanic("1y2m3d3h")}, false, ""},
-		{ForgetOptions{WithinDaily: restic.ParseDurationOrPanic("1y2m3d3h")}, false, ""},
-		{ForgetOptions{WithinWeekly: restic.ParseDurationOrPanic("1y2m3d3h")}, false, ""},
-		{ForgetOptions{WithinMonthly: restic.ParseDurationOrPanic("2y4m6d8h")}, false, ""},
-		{ForgetOptions{WithinYearly: restic.ParseDurationOrPanic("2y4m6d8h")}, false, ""},
-		{ForgetOptions{Within: restic.ParseDurationOrPanic("-1y2m3d3h")}, true, negDurationValErrorMsg},
-		{ForgetOptions{WithinHourly: restic.ParseDurationOrPanic("1y-2m3d3h")}, true, negDurationValErrorMsg},
-		{ForgetOptions{WithinDaily: restic.ParseDurationOrPanic("1y2m-3d3h")}, true, negDurationValErrorMsg},
-		{ForgetOptions{WithinWeekly: restic.ParseDurationOrPanic("1y2m3d-3h")}, true, negDurationValErrorMsg},
-		{ForgetOptions{WithinMonthly: restic.ParseDurationOrPanic("-2y4m6d8h")}, true, negDurationValErrorMsg},
-		{ForgetOptions{WithinYearly: restic.ParseDurationOrPanic("2y-4m6d8h")}, true, negDurationValErrorMsg},
+		{ForgetOptions{Last: 1}, ""},
+		{ForgetOptions{Hourly: 1}, ""},
+		{ForgetOptions{Daily: 1}, ""},
+		{ForgetOptions{Weekly: 1}, ""},
+		{ForgetOptions{Monthly: 1}, ""},
+		{ForgetOptions{Yearly: 1}, ""},
+		{ForgetOptions{Last: 0}, ""},
+		{ForgetOptions{Hourly: 0}, ""},
+		{ForgetOptions{Daily: 0}, ""},
+		{ForgetOptions{Weekly: 0}, ""},
+		{ForgetOptions{Monthly: 0}, ""},
+		{ForgetOptions{Yearly: 0}, ""},
+		{ForgetOptions{Last: -1}, ""},
+		{ForgetOptions{Hourly: -1}, ""},
+		{ForgetOptions{Daily: -1}, ""},
+		{ForgetOptions{Weekly: -1}, ""},
+		{ForgetOptions{Monthly: -1}, ""},
+		{ForgetOptions{Yearly: -1}, ""},
+		{ForgetOptions{Last: -2}, negValErrorMsg},
+		{ForgetOptions{Hourly: -2}, negValErrorMsg},
+		{ForgetOptions{Daily: -2}, negValErrorMsg},
+		{ForgetOptions{Weekly: -2}, negValErrorMsg},
+		{ForgetOptions{Monthly: -2}, negValErrorMsg},
+		{ForgetOptions{Yearly: -2}, negValErrorMsg},
+		{ForgetOptions{Within: restic.ParseDurationOrPanic("1y2m3d3h")}, ""},
+		{ForgetOptions{WithinHourly: restic.ParseDurationOrPanic("1y2m3d3h")}, ""},
+		{ForgetOptions{WithinDaily: restic.ParseDurationOrPanic("1y2m3d3h")}, ""},
+		{ForgetOptions{WithinWeekly: restic.ParseDurationOrPanic("1y2m3d3h")}, ""},
+		{ForgetOptions{WithinMonthly: restic.ParseDurationOrPanic("2y4m6d8h")}, ""},
+		{ForgetOptions{WithinYearly: restic.ParseDurationOrPanic("2y4m6d8h")}, ""},
+		{ForgetOptions{Within: restic.ParseDurationOrPanic("-1y2m3d3h")}, negDurationValErrorMsg},
+		{ForgetOptions{WithinHourly: restic.ParseDurationOrPanic("1y-2m3d3h")}, negDurationValErrorMsg},
+		{ForgetOptions{WithinDaily: restic.ParseDurationOrPanic("1y2m-3d3h")}, negDurationValErrorMsg},
+		{ForgetOptions{WithinWeekly: restic.ParseDurationOrPanic("1y2m3d-3h")}, negDurationValErrorMsg},
+		{ForgetOptions{WithinMonthly: restic.ParseDurationOrPanic("-2y4m6d8h")}, negDurationValErrorMsg},
+		{ForgetOptions{WithinYearly: restic.ParseDurationOrPanic("2y-4m6d8h")}, negDurationValErrorMsg},
 	}
 
 	for _, testCase := range testCases {
 		err := verifyForgetOptions(&testCase.input)
-		if testCase.expectsError {
+		if testCase.errorMsg != "" {
 			rtest.Assert(t, err != nil, "should have returned error for input %+v", testCase.input)
 			rtest.Equals(t, testCase.errorMsg, err.Error())
 		} else {


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This ensures consistency with the `prune --max-unused unlimited` option.

Now all negative values for `forget --keep-* n` are forbidden. To keep all snapshots the special value `unlimited` can be used.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Follow-up to https://github.com/restic/restic/pull/4234 
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
