### PR TITLE
Add snapshot subfolder syntax in help output of diff/dump/restore

### DIFF
--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -29,6 +29,10 @@ directory:
 * M  The file's content was modified
 * T  The type was changed, e.g. a file was made a symlink
 
+To only compare files in specific subfolders, you can use the
+"<snapshotID>:<subfolder>" syntax, where "subfolder" is a path within the
+snapshot.
+
 EXIT STATUS
 ===========
 

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -16,7 +16,7 @@ import (
 )
 
 var cmdDiff = &cobra.Command{
-	Use:   "diff [flags] snapshot-ID snapshot-ID",
+	Use:   "diff [flags] snapshotID snapshotID",
 	Short: "Show differences between two snapshots",
 	Long: `
 The "diff" command shows differences from the first to the second snapshot. The

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -27,6 +27,10 @@ Pass "/" as file name to dump the whole snapshot as an archive file.
 The special snapshot "latest" can be used to use the latest snapshot in the
 repository.
 
+To include the folder content at the root of the archive, you can use the
+"<snapshotID>:<subfolder>" syntax, where "subfolder" is a path within the
+snapshot.
+
 EXIT STATUS
 ===========
 

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -24,7 +24,7 @@ single file is selected, it prints its contents to stdout. Folders are output
 as a tar (default) or zip file containing the contents of the specified folder.
 Pass "/" as file name to dump the whole snapshot as an archive file.
 
-The special snapshot "latest" can be used to use the latest snapshot in the
+The special snapshotID "latest" can be used to use the latest snapshot in the
 repository.
 
 To include the folder content at the root of the archive, you can use the

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -28,6 +28,9 @@ a directory.
 The special snapshot "latest" can be used to restore the latest snapshot in the
 repository.
 
+To only restore a specific subfolder, you can use the "<snapshotID>:<subfolder>"
+syntax, where "subfolder" is a path within the snapshot.
+
 EXIT STATUS
 ===========
 

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -25,7 +25,7 @@ var cmdRestore = &cobra.Command{
 The "restore" command extracts the data from a snapshot from the repository to
 a directory.
 
-The special snapshot "latest" can be used to restore the latest snapshot in the
+The special snapshotID "latest" can be used to restore the latest snapshot in the
 repository.
 
 To only restore a specific subfolder, you can use the "<snapshotID>:<subfolder>"

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -12,7 +12,7 @@ import (
 )
 
 var cmdTag = &cobra.Command{
-	Use:   "tag [flags] [snapshot-ID ...]",
+	Use:   "tag [flags] [snapshotID ...]",
 	Short: "Modify tags on snapshots",
 	Long: `
 The "tag" command allows you to modify tags on exiting snapshots.
@@ -20,7 +20,7 @@ The "tag" command allows you to modify tags on exiting snapshots.
 You can either set/replace the entire set of tags on a snapshot, or
 add tags to/remove tags from the existing set.
 
-When no snapshot-ID is given, all snapshots matching the host, tag and path filter criteria are modified.
+When no snapshotID is given, all snapshots matching the host, tag and path filter criteria are modified.
 
 EXIT STATUS
 ===========


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Add snapshot subfolder syntax in help output of diff/dump/restore
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See https://forum.restic.net/t/restic-0-16-0-released/6525/2
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
