### PR TITLE
feat: use http when specified for azure storage

### DIFF
--- a/changelog/unreleased/pull-4439
+++ b/changelog/unreleased/pull-4439
@@ -1,0 +1,10 @@
+Enhancement: Use http connections when explicitly specified for Azure Storage Services
+
+Restic only allowed HTTPs connections to Azure Storage Services when using
+the `azure` storage backend. It now permits users to provide an extended option
+`-o azure.usehttp=true` to explicitly specify to use HTTP connections. This will
+allow users who have disabled `Secure Transfer Required` on Azure Stoage accounts
+to backup and restore over HTTP connections. 
+
+https://github.com/restic/restic/issues/4438
+https://github.com/restic/restic/pull/4439

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -564,6 +564,9 @@ The number of concurrent connections to the Azure Blob Storage service can be se
 ``-o azure.connections=10`` switch. By default, at most five parallel connections are
 established.
 
+HTTP connections to Azure Blob Storage can be set with the ``-o azure.usehttp=true`` switch.
+By default, HTTPs connectiosn are established. 
+
 Google Cloud Storage
 ********************
 

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -60,7 +60,14 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 	} else {
 		endpointSuffix = "core.windows.net"
 	}
-	url := fmt.Sprintf("https://%s.blob.%s/%s", cfg.AccountName, endpointSuffix, cfg.Container)
+
+	var protocol string = "https"
+	if cfg.UseHTTP {
+		protocol = "http"
+		debug.Log("- using http")
+	}
+
+	url := fmt.Sprintf("%s://%s.blob.%s/%s", protocol, cfg.AccountName, endpointSuffix, cfg.Container)
 	opts := &azContainer.ClientOptions{
 		ClientOptions: azcore.ClientOptions{
 			Transport: &http.Client{Transport: rt},

--- a/internal/backend/azure/config.go
+++ b/internal/backend/azure/config.go
@@ -19,6 +19,7 @@ type Config struct {
 	EndpointSuffix string
 	Container      string
 	Prefix         string
+	UseHTTP        bool `option:"usehttp" help:"explicitly specify to use a HTTP connection (default: false)"`
 
 	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
----------------------------------------------------------------
- Add `UseHTTP` configuration and make it configurations to extended options
- Add support to make HTTP connections to Azure Storage Services, when it's explicitly specified using the `-o azure.usehttp=true` extended option.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
#4438 - add support for HTTP connections to Azure Storage Backend

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
