### PR TITLE
dump requires absolute path from within the repo

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -45,6 +45,17 @@ size of the files and directories in ``~/work`` on the local file system. It
 also tells us that only 1.200 GiB was added to the repository. This means that
 some of the data was duplicate and restic was able to efficiently reduce it.
 
+We just attached the absolute path ``~/work`` to the backup, so the path
+within the repository is ``/home/user/work``, depending on your user name.
+
+If we attach a relative path ``work``, the path within the repository is ``/work``.
+
+For example ``restic backup work`` run from ``/home/user`` crates a snapshot
+with a attached path ``/home/user/work`` that contains the path ``/work``
+within the repository. This path-related discrepancy applies to each command
+that tries to access data within a snapshot. You can lookup the paths within
+a repository using the ``ls latest /`` command.
+
 If you don't pass the ``--verbose`` option, restic will print less data. You'll
 still get a nice live status display. Be aware that the live status shows the
 processed files and not the transferred data. Transferred volume might be lower

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -46,13 +46,13 @@ also tells us that only 1.200 GiB was added to the repository. This means that
 some of the data was duplicate and restic was able to efficiently reduce it.
 
 We just attached the absolute path ``~/work`` to the backup, so the path
-within the repository is ``/home/user/work``, depending on your user name.
+within the snapshot is ``/home/user/work``.
 
-If we attach a relative path ``work``, the path within the repository is ``/work``.
+If we attach a relative path ``work``, the path within the snaphot is ``/work``.
 
-For example ``restic backup work`` run from ``/home/user`` crates a snapshot
-with a attached path ``/home/user/work`` that contains the path ``/work``
-within the repository. This path-related discrepancy applies to each command
+For example ``restic backup work`` run from ``/home/user`` creates a snapshot
+with a directory ``/home/user/work`` that contains the path ``/work``
+within the snapshot. This path-related discrepancy applies to each command
 that tries to access data within a snapshot. You can lookup the paths within
 a repository using the ``ls latest /`` command.
 

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -32,6 +32,9 @@ Now, you can list all the snapshots stored in the repository:
     590c8fc8  2015-05-08 21:47:38  kazik          /srv
     9f0bc19e  2015-05-08 21:46:11  luigi          /srv
 
+The Directory column shows the attached path, which may differ
+from the path within the repository, see https://restic.readthedocs.io/en/stable/040_backup.html#backing-up for details of this discrepancy.
+
 You can filter the listing by directory path:
 
 .. code-block:: console

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -156,12 +156,12 @@ e.g.:
 
     $ restic -r /srv/restic-repo dump --path /production.sql latest production.sql | mysql
 
-This example assumes you attached an absolute path, which means it coincides with the
-path within the repository.
+This example assumes you ran a backup using an absolute path, which coincides with the
+path within the snaphots.
 See https://restic.readthedocs.io/en/stable/040_backup.html#backing-up for the difference
-between attached path and path within the repository.
+between the path used to create the repository and the paths within the snaphots.
 
-If you attached a relative path, the ``dump`` command would look like:
+If you ran a backup using the relative path ``work/``, the ``dump`` command would look like:
 
 .. code-block:: console
 
@@ -169,7 +169,7 @@ If you attached a relative path, the ``dump`` command would look like:
 
 
 If dump results in the error message ``cannot dump file: path "/home" not found in snapshot``
-first double check you used the path within the repository, using the ``ls latest /`` command,
+first double check you used the path within the snaphot, using the ``ls latest /`` command,
 which for the repository above results in:
 
 .. code-block:: console

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -156,6 +156,24 @@ e.g.:
 
     $ restic -r /srv/restic-repo dump --path /production.sql latest production.sql | mysql
 
+For a local repository, the "Directory" path can result in the error message ``cannot dump file: path "/home" not found in snapshot``
+In this case, you can query the absolute path within the repository using the ```ls`` command:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo ls latest /
+    enter password for repository:
+    snapshot 1541acae of [/home/other/work] filtered by [/] at 2023-08-09 04:00:03.533117139 +0200 CEST):
+    /work
+
+
+and use the latter absolute path for the ``dump`` command:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo dump latest /work/README.md
+
+
 It is also possible to ``dump`` the contents of a whole folder structure to
 stdout. To retain the information about the files and folders Restic will
 output the contents in the tar (default) or zip format:

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -156,8 +156,21 @@ e.g.:
 
     $ restic -r /srv/restic-repo dump --path /production.sql latest production.sql | mysql
 
-For a local repository, the "Directory" path can result in the error message ``cannot dump file: path "/home" not found in snapshot``
-In this case, you can query the absolute path within the repository using the ```ls`` command:
+This example assumes you attached an absolute path, which means it coincides with the
+path within the repository.
+See https://restic.readthedocs.io/en/stable/040_backup.html#backing-up for the difference
+between attached path and path within the repository.
+
+If you attached a relative path, the ``dump`` command would look like:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo dump latest /work/README.md
+
+
+If dump results in the error message ``cannot dump file: path "/home" not found in snapshot``
+first double check you used the path within the repository, using the ``ls latest /`` command,
+which for the repository above results in:
 
 .. code-block:: console
 
@@ -166,12 +179,6 @@ In this case, you can query the absolute path within the repository using the ``
     snapshot 1541acae of [/home/other/work] filtered by [/] at 2023-08-09 04:00:03.533117139 +0200 CEST):
     /work
 
-
-and use the latter absolute path for the ``dump`` command:
-
-.. code-block:: console
-
-    $ restic -r /srv/restic-repo dump latest /work/README.md
 
 
 It is also possible to ``dump`` the contents of a whole folder structure to


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Dumping a file following the present documentation resulted in the error message given below.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
I found other discussions where dumping failed, but not sure if they are related.


To be discussed:
- [x] Under which conditions the "Directory" (attached) path and the "repository" path differ?
- [x] Under which conditions `dump` requires the "Directory" path?  
- [ ] How to refer to chapters from the documentation? (currently plain hyperlinks)
