### PR TITLE
sftp: allow customizing MaxConcurrentRequestsPerFile and MaxPacket

### DIFF
--- a/changelog/unreleased/pull-4445
+++ b/changelog/unreleased/pull-4445
@@ -1,0 +1,9 @@
+Enhancement: allow customizing MaxConcurrentRequestsPerFile and MaxPacket parameters in the sftp backend
+
+SFTP over long fat links suffers from poor performance due to its by default
+overly small max payload size. But implementations such as OpenSSH tend to
+accept vastly bigger packets, which improves backup performance for this
+kind of situation. Restic now allows customizing the max packet size and
+max concurrent requests per file parameters in the sftp backend.
+
+https://github.com/restic/restic/pull/4445

--- a/internal/backend/sftp/config.go
+++ b/internal/backend/sftp/config.go
@@ -16,13 +16,17 @@ type Config struct {
 	Layout  string `option:"layout" help:"use this backend directory layout (default: auto-detect)"`
 	Command string `option:"command" help:"specify command to create sftp connection"`
 
-	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	Connections                  uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	MaxConcurrentRequestsPerFile int  `option:"max_concurrent_requests_per_file" help:"sets the maximum concurrent requests allowed for a single file (default: 64)"`
+	MaxPacket                    int  `option:"max_packet" help:"sets the maximum size of the payload, measured in bytes (default: 32768)"`
 }
 
 // NewConfig returns a new config with default options applied.
 func NewConfig() Config {
 	return Config{
-		Connections: 5,
+		Connections:                  5,
+		MaxConcurrentRequestsPerFile: 64,
+		MaxPacket:                    32768,
 	}
 }
 

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -102,7 +102,10 @@ func startClient(cfg Config) (*SFTP, error) {
 	}()
 
 	// open the SFTP session
-	client, err := sftp.NewClientPipe(rd, wr)
+	client, err := sftp.NewClientPipe(rd, wr,
+		sftp.MaxConcurrentRequestsPerFile(cfg.MaxConcurrentRequestsPerFile),
+		sftp.MaxPacketUnchecked(cfg.MaxPacket),
+	)
 	if err != nil {
 		return nil, errors.Errorf("unable to start the sftp session, error: %v", err)
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
It allows customizing connection parameters in the underlying sftp library, which should help with the currently poor sftp performance to some extent.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See https://github.com/restic/restic/issues/4209
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
