### PR TITLE
Check for arguments before opening remote connection in cat command

### DIFF
--- a/cmd/restic/cmd_cat_test.go
+++ b/cmd/restic/cmd_cat_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"strings"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestCatArgsValidation(t *testing.T) {
+	for _, test := range []struct {
+		args []string
+		err  string
+	}{
+		{[]string{}, "Fatal: type not specified"},
+		{[]string{"masterkey"}, ""},
+		{[]string{"invalid"}, `Fatal: invalid type "invalid"`},
+		{[]string{"snapshot"}, "Fatal: ID not specified"},
+		{[]string{"snapshot", "12345678"}, ""},
+	} {
+		t.Run("", func(t *testing.T) {
+			err := validateCatArgs(test.args)
+			if test.err == "" {
+				rtest.Assert(t, err == nil, "unexpected error %q", err)
+			} else {
+				rtest.Assert(t, strings.Contains(err.Error(), test.err), "unexpected error expected %q to contain %q", err, test.err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Check for arguments to `cat` command befire opening the remote connection
<!--
Describe the changes and their purpose here, as detailed as needed.
-->
Checking the allowed arguments from an array

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
#4416

<!--
Link issues and relevant forum posts here.
#4416 

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
Closes #4416 

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [ ] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [ ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
