### PR TITLE
master_index: fix inconsistent length blob length in test

### DIFF
--- a/internal/index/master_index_test.go
+++ b/internal/index/master_index_test.go
@@ -43,9 +43,10 @@ func TestMasterIndex(t *testing.T) {
 	blob12a := restic.PackedBlob{
 		PackID: restic.NewRandomID(),
 		Blob: restic.Blob{
-			BlobHandle: bhInIdx12,
-			Length:     uint(crypto.CiphertextLength(123)),
-			Offset:     110,
+			BlobHandle:         bhInIdx12,
+			Length:             uint(crypto.CiphertextLength(123)),
+			Offset:             110,
+			UncompressedLength: 80,
 		},
 	}
 
@@ -116,7 +117,7 @@ func TestMasterIndex(t *testing.T) {
 
 	size, found = mIdx.LookupSize(bhInIdx12)
 	rtest.Equals(t, true, found)
-	rtest.Equals(t, uint(123), size)
+	rtest.Equals(t, uint(80), size)
 
 	// test not in index
 	found = mIdx.Has(restic.BlobHandle{ID: restic.NewRandomID(), Type: restic.TreeBlob})


### PR DESCRIPTION
Two blobs with the same hash must always have the same content length.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Fixes https://github.com/restic/restic/issues/4448.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
