### PR TITLE
internal/restic: Return summary from BlobSet.String

### DIFF
--- a/internal/restic/blob_set.go
+++ b/internal/restic/blob_set.go
@@ -1,6 +1,10 @@
 package restic
 
-import "sort"
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
 
 // BlobSet is a set of blobs.
 type BlobSet map[BlobHandle]struct{}
@@ -103,11 +107,27 @@ func (s BlobSet) List() BlobHandles {
 	return list
 }
 
+// String produces a human-readable representation of ids.
+// It is meant for producing error messages,
+// so it only returns a summary if ids is long.
 func (s BlobSet) String() string {
-	str := s.List().String()
-	if len(str) < 2 {
-		return "{}"
-	}
+	const maxelems = 10
 
-	return "{" + str[1:len(str)-1] + "}"
+	sb := new(strings.Builder)
+	sb.WriteByte('{')
+	n := 0
+	for k := range s {
+		if n != 0 {
+			sb.WriteByte(' ')
+		}
+		sb.WriteString(k.String())
+
+		if n++; n == maxelems {
+			fmt.Fprintf(sb, " (%d more)", len(s)-n-1)
+			break
+		}
+	}
+	sb.WriteByte('}')
+
+	return sb.String()
 }

--- a/internal/restic/blob_set_test.go
+++ b/internal/restic/blob_set_test.go
@@ -1,0 +1,32 @@
+package restic
+
+import (
+	"math/rand"
+	"regexp"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestBlobSetString(t *testing.T) {
+	s := NewBlobSet()
+
+	rtest.Equals(t, "{}", s.String())
+
+	id, _ := ParseID(
+		"1111111111111111111111111111111111111111111111111111111111111111")
+	s.Insert(BlobHandle{ID: id, Type: TreeBlob})
+	rtest.Equals(t, "{<tree/11111111>}", s.String())
+
+	var h BlobHandle
+	for i := 0; i < 100; i++ {
+		h.Type = DataBlob
+		_, _ = rand.Read(h.ID[:])
+		s.Insert(h)
+	}
+
+	r := regexp.MustCompile(
+		`^{(?:<(?:data|tree)/[0-9a-f]{8}> ){10}\(90 more\)}$`)
+	str := s.String()
+	rtest.Assert(t, r.MatchString(str), "%q doesn't match pattern", str)
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Makes BlobSet.String return a summary when the number of blobs in the set is large (defined as >10).

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes #4449.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
