### PR TITLE
docs: explain meaning of asterisk when managing repository keys

### DIFF
--- a/doc/070_encryption.rst
+++ b/doc/070_encryption.rst
@@ -49,3 +49,5 @@ per repository. In fact, you can use the ``list``, ``add``, ``remove``, and
     ----------------------------------------------------------------------
      5c657874    username    kasimir   2015-08-12 13:35:05
     *eb78040b    username    kasimir   2015-08-12 13:29:57
+
+Note that the currently used key is indicated by an asterisk (``*``).


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

In the docs for [managing repository keys](https://restic.readthedocs.io/en/latest/070_encryption.html#manage-repository-keys) there's currently no explanation what the asterisk means.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

I don't think so.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
