### PR TITLE
docs: fix malformed table

### DIFF
--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -485,7 +485,7 @@ Status
 +----------------------+------------------------------------------------------------+
 |``seconds_elapsed``   | Time since restore started                                 |
 +----------------------+------------------------------------------------------------+
-|``percent_done``      | Percentage of data restored (bytes_restored/total_bytes)  |
+|``percent_done``      | Percentage of data restored (bytes_restored/total_bytes)   |
 +----------------------+------------------------------------------------------------+
 |``total_files``       | Total number of files detected                             |
 +----------------------+------------------------------------------------------------+

--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -145,7 +145,7 @@ Verbose status provides details about the progress, including details about back
 Summary
 ^^^^^^^
 
-Summary is the last output line in a successful backup. 
+Summary is the last output line in a successful backup.
 
 +---------------------------+---------------------------------------------------------+
 | ``message_type``          | Always "summary"                                        |


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Follow-up for #4434, Sphinx complains about a malformed table when building the docs:

```
[..] restic/doc/075_scripting.rst:483: ERROR: Malformed table.
```

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
