### PR TITLE
README: add Mastodon link

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ release. Instructions on how to do that are contained in the
 News
 ----
 
-You can follow the restic project on Twitter [@resticbackup](https://twitter.com/resticbackup) or by subscribing to
+You can follow the restic project on Mastodon [@resticbackup](https://fosstodon.org/@restic) or by subscribing to
 the [project blog](https://restic.net/blog/).
 
 License


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR accompanies https://github.com/restic/restic.net/commit/6b037c7ba42afa2fa0d08f5a4c27a113128b4cc7 and replaces the link to Twitter in the README accordingly.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
