### PR TITLE
Allow AWS Assume Role

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.idea
 /restic
 /restic.exe
 /.vagrant

--- a/changelog/unreleased/issue-4472
+++ b/changelog/unreleased/issue-4472
@@ -1,14 +1,18 @@
 Enhancement: Allow AWS Assume Role to be used for S3 backend
 
-Previously only credentials discovered via the Minio Click discovery methods
-would be used to authenticate. However there are many circumstances where the
-discovered credentials have lower permissions and need to assume a specific role.
+Previously only credentials discovered via the Minio discovery methods
+were used to authenticate.
 
-New Environment Variables:
+However, there are many circumstances where the discovered credentials have
+lower permissions and need to assume a specific role. This is now possible
+using the following new environment variables.
 
 - RESTIC_AWS_ASSUME_ROLE_ARN
 - RESTIC_AWS_ASSUME_ROLE_SESSION_NAME
 - RESTIC_AWS_ASSUME_ROLE_EXTERNAL_ID
-- RESTIC_AWS_ASSUME_ROLE_REGION (if need to override from us-east-1)
+- RESTIC_AWS_ASSUME_ROLE_REGION (defaults to us-east-1)
 - RESTIC_AWS_ASSUME_ROLE_POLICY
 - RESTIC_AWS_ASSUME_ROLE_STS_ENDPOINT
+
+https://github.com/restic/restic/issues/4472
+https://github.com/restic/restic/pull/4474

--- a/changelog/unreleased/issue-4472
+++ b/changelog/unreleased/issue-4472
@@ -1,0 +1,14 @@
+Enhancement: Allow AWS Assume Role to be used for S3 backend
+
+Previously only credentials discovered via the Minio Click discovery methods
+would be used to authenticate. However there are many circumstances where the
+discovered credentials have lower permissions and need to assume a specific role.
+
+New Environment Variables:
+
+- RESTIC_AWS_ASSUME_ROLE_ARN
+- RESTIC_AWS_ASSUME_ROLE_SESSION_NAME
+- RESTIC_AWS_ASSUME_ROLE_EXTERNAL_ID
+- RESTIC_AWS_ASSUME_ROLE_REGION (if need to override from us-east-1)
+- RESTIC_AWS_ASSUME_ROLE_POLICY
+- RESTIC_AWS_ASSUME_ROLE_STS_ENDPOINT

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -631,7 +631,9 @@ environment variables. The following lists these environment variables:
     RESTIC_AWS_ASSUME_ROLE_ARN          Amazon IAM Role ARN to assume using discovered credentials
     RESTIC_AWS_ASSUME_ROLE_SESSION_NAME Session Name to use with the role assumption
     RESTIC_AWS_ASSUME_ROLE_EXTERNAL_ID  External ID to use with the role assumption
-    RESTIC_AWS_ASSUME_ROLE_REGION       Region to use for IAM calls for the role assumption
+    RESTIC_AWS_ASSUME_ROLE_POLICY       Inline Amazion IAM session policy
+    RESTIC_AWS_ASSUME_ROLE_REGION       Region to use for IAM calls for the role assumption (default: us-east-1)
+    RESTIC_AWS_ASSUME_ROLE_STS_ENDPOINT URL to the STS endpoint (default is determined based on RESTIC_AWS_ASSUME_ROLE_REGION). You generally do not need to set this, advanced use only.
 
     AZURE_ACCOUNT_NAME                  Account name for Azure
     AZURE_ACCOUNT_KEY                   Account key for Azure

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -628,6 +628,10 @@ environment variables. The following lists these environment variables:
     AWS_DEFAULT_REGION                  Amazon S3 default region
     AWS_PROFILE                         Amazon credentials profile (alternative to specifying key and region)
     AWS_SHARED_CREDENTIALS_FILE         Location of the AWS CLI shared credentials file (default: ~/.aws/credentials)
+    RESTIC_AWS_ASSUME_ROLE_ARN          Amazon IAM Role ARN to assume using discovered credentials
+    RESTIC_AWS_ASSUME_ROLE_SESSION_NAME Session Name to use with the role assumption
+    RESTIC_AWS_ASSUME_ROLE_EXTERNAL_ID  External ID to use with the role assumption
+    RESTIC_AWS_ASSUME_ROLE_REGION       Region to use for IAM calls for the role assumption
 
     AZURE_ACCOUNT_NAME                  Account name for Azure
     AZURE_ACCOUNT_KEY                   Account key for Azure

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -138,7 +138,7 @@ func getCredentials(cfg Config) (*credentials.Credentials, error) {
 		// use the region provided by the configuration by default
 		awsRegion := cfg.Region
 		// allow the region to be overridden if for some reason it is required
-		if len(os.Getenv("RESTIC_AWS_ASSUME_ROLE_REGION")) > 0 {
+		if os.Getenv("RESTIC_AWS_ASSUME_ROLE_REGION") != "" {
 			awsRegion = os.Getenv("RESTIC_AWS_ASSUME_ROLE_REGION")
 		}
 
@@ -148,7 +148,7 @@ func getCredentials(cfg Config) (*credentials.Credentials, error) {
 		stsEndpoint := os.Getenv("RESTIC_AWS_ASSUME_ROLE_STS_ENDPOINT")
 
 		if stsEndpoint == "" {
-			if len(awsRegion) > 0 {
+			if awsRegion != "" {
 				if strings.HasPrefix(awsRegion, "cn-") {
 					stsEndpoint = "https://sts." + awsRegion + ".amazonaws.com.cn"
 				} else {
@@ -167,9 +167,7 @@ func getCredentials(cfg Config) (*credentials.Credentials, error) {
 			RoleSessionName: sessionName,
 			ExternalID:      externalID,
 			Policy:          policy,
-		}
-		if len(awsRegion) > 0 {
-			opts.Location = awsRegion
+			Location:        awsRegion,
 		}
 
 		creds, err = credentials.NewSTSAssumeRole(stsEndpoint, opts)

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -107,13 +107,13 @@ func getCredentials(cfg Config) (*credentials.Credentials, error) {
 	//    call to a pre-defined endpoint, only valid inside
 	//    configured ec2 instances)
 	creds := credentials.NewChainCredentials([]credentials.Provider{
+		&credentials.EnvAWS{},
 		&credentials.Static{
 			Value: credentials.Value{
 				AccessKeyID:     cfg.KeyID,
 				SecretAccessKey: cfg.Secret.Unwrap(),
 			},
 		},
-		&credentials.EnvAWS{},
 		&credentials.EnvMinio{},
 		&credentials.FileAWSCredentials{},
 		&credentials.FileMinioClient{},


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

- Adds support for Assuming a Role in AWS

Resolves #4472 

It adds the ability to allow the discovered credentials for AWS to assume another role and use those credentials for the actual run of restic.

Example: Personal IAM user (ekristen) has access to ec2 console but not s3 backup location but has the right to assume the role, backup, backup has full access to the s3 bucket, so this allows restic to assume a role.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Not really, opened #4472

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Testing this Pull Request
-------------------------
Using the files from this gist create the folllowing, a test iam user, test iam role, and test s3 bucket. https://gist.github.com/ekristen/e20a976653d0624957add5b4d2ef64ba

1. Create a set of IAM creds for the test user and export them using AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY
2. Export AWS_ASSUME_ROLE_ARN with the value of your test iam role arn
3. Run restic against your newly created s3 bucket. 

*Note:** for more advanced use cases you can pass AWS_ASSUME_ROLE_SESSION_NAME and AWS_ASSUME_ROLE_EXTERNAL_ID and use conditions to trust based on values.  Additionally you can pass AWS_ASSUME_ROLE_POLICY which is a JSON document for an IAM policy, this can be used to set a STS policy to restrict the STS credentials to a specific path as an example.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

Note: tests -- there aren't extensive existing tests on authentication methods, there's not a framework to build off of that I could see to add tests.

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
