### PR TITLE
Support reading basic auth credentials for REST server from environment variables

### DIFF
--- a/changelog/unreleased/pull-4480
+++ b/changelog/unreleased/pull-4480
@@ -1,0 +1,10 @@
+Enhancement: Allow setting REST password and username via environment variables
+
+Previously, it was only possible to specify the REST server username and
+password in the repository URL, or using the `--repository-file` option. This
+meant it was not possible to use authentication in contexts where the repository
+URL is public and parts of it are templated by other software. Restic now
+allows setting the username and password using the `RESTIC_REST_USERNAME` and
+`RESTIC_REST_PASSWORD` variables.
+
+https://github.com/restic/restic/pull/4480

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -209,6 +209,14 @@ are some more examples:
     $ restic -r rest:https://user:pass@host:8000/ init
     $ restic -r rest:https://user:pass@host:8000/my_backup_repo/ init
 
+The server username and password can be specified using environment
+variables as well:
+
+.. code-block:: console
+
+    $ export RESTIC_REST_USERNAME=<MY_REST_SERVER_USERNAME>
+    $ export RESTIC_REST_PASSWORD=<MY_REST_SERVER_PASSWORD>
+
 If you use TLS, restic will use the system's CA certificates to verify the
 server certificate. When the verification fails, restic refuses to proceed and
 exits with an error. If you have your own self-signed certificate, or a custom

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -593,9 +593,16 @@ environment variables. The following lists these environment variables:
     AWS_PROFILE                         Amazon credentials profile (alternative to specifying key and region)
     AWS_SHARED_CREDENTIALS_FILE         Location of the AWS CLI shared credentials file (default: ~/.aws/credentials)
 
-    ST_AUTH                             Auth URL for keystone v1 authentication
-    ST_USER                             Username for keystone v1 authentication
-    ST_KEY                              Password for keystone v1 authentication
+    AZURE_ACCOUNT_NAME                  Account name for Azure
+    AZURE_ACCOUNT_KEY                   Account key for Azure
+    AZURE_ACCOUNT_SAS                   Shared access signatures (SAS) for Azure
+    AZURE_ENDPOINT_SUFFIX               Endpoint suffix for Azure Storage (default: core.windows.net)
+
+    B2_ACCOUNT_ID                       Account ID or applicationKeyId for Backblaze B2
+    B2_ACCOUNT_KEY                      Account Key or applicationKey for Backblaze B2
+
+    GOOGLE_PROJECT_ID                   Project ID for Google Cloud Storage
+    GOOGLE_APPLICATION_CREDENTIALS      Application Credentials for Google Cloud Storage (e.g. $HOME/.config/gs-secret-restic-key.json)
 
     OS_AUTH_URL                         Auth URL for keystone authentication
     OS_REGION_NAME                      Region name for keystone authentication
@@ -619,18 +626,14 @@ environment variables. The following lists these environment variables:
     OS_STORAGE_URL                      Storage URL for token authentication
     OS_AUTH_TOKEN                       Auth token for token authentication
 
-    B2_ACCOUNT_ID                       Account ID or applicationKeyId for Backblaze B2
-    B2_ACCOUNT_KEY                      Account Key or applicationKey for Backblaze B2
-
-    AZURE_ACCOUNT_NAME                  Account name for Azure
-    AZURE_ACCOUNT_KEY                   Account key for Azure
-    AZURE_ACCOUNT_SAS                   Shared access signatures (SAS) for Azure
-    AZURE_ENDPOINT_SUFFIX               Endpoint suffix for Azure Storage (default: core.windows.net)
-
-    GOOGLE_PROJECT_ID                   Project ID for Google Cloud Storage
-    GOOGLE_APPLICATION_CREDENTIALS      Application Credentials for Google Cloud Storage (e.g. $HOME/.config/gs-secret-restic-key.json)
-
     RCLONE_BWLIMIT                      rclone bandwidth limit
+
+    RESTIC_REST_USERNAME                Restic REST Server username
+    RESTIC_REST_PASSWORD                Restic REST Server password
+
+    ST_AUTH                             Auth URL for keystone v1 authentication
+    ST_USER                             Username for keystone v1 authentication
+    ST_KEY                              Password for keystone v1 authentication
 
 See :ref:`caching` for the rules concerning cache locations when
 ``RESTIC_CACHE_DIR`` is not set.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR adds an `ApplyEnvironment` function to the REST backend, similar to other backends, that reads `REST_USERNAME` and `REST_PASSWORD` variables if the repository URL does not already contain the username or password. This makes it possible to pass secrets to restic without including them in the repository string or repository file. 

I and several other people have run into this problem when configuring restic in NixOS configurations that apply to more than one system. In such cases, the secrets cannot be provided in the repository file, since the repository string is templated at build time to include the target system's hostname (for example: `repository = "rest:http://10.20.1.2:8000/${config.networking.hostName}/";`). The secrets also can't be written in the repository string itself, because the repository string appears in world-readable files in `/nix/store`, and would be publically accessible from the git repository that contains the configuration files.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes. (note: I looked into adding tests, but none of the other backends test `ApplyEnvironment`, so I'm unsure if I should)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
