### PR TITLE
Tweak restore summary

### DIFF
--- a/internal/ui/restore/text.go
+++ b/internal/ui/restore/text.go
@@ -22,7 +22,7 @@ func (t *textPrinter) Update(filesFinished, filesTotal, allBytesWritten, allByte
 	formattedAllBytesWritten := ui.FormatBytes(allBytesWritten)
 	formattedAllBytesTotal := ui.FormatBytes(allBytesTotal)
 	allPercent := ui.FormatPercent(allBytesWritten, allBytesTotal)
-	progress := fmt.Sprintf("[%s] %s  %v files %s, total %v files %v",
+	progress := fmt.Sprintf("[%s] %s  %v files/dirs %s, total %v files/dirs %v",
 		timeLeft, allPercent, filesFinished, formattedAllBytesWritten, filesTotal, formattedAllBytesTotal)
 
 	t.terminal.SetStatus([]string{progress})
@@ -36,10 +36,10 @@ func (t *textPrinter) Finish(filesFinished, filesTotal, allBytesWritten, allByte
 
 	var summary string
 	if filesFinished == filesTotal && allBytesWritten == allBytesTotal {
-		summary = fmt.Sprintf("Summary: Restored %d Files (%s) in %s", filesTotal, formattedAllBytesTotal, timeLeft)
+		summary = fmt.Sprintf("Summary: Restored %d files/dirs (%s) in %s", filesTotal, formattedAllBytesTotal, timeLeft)
 	} else {
 		formattedAllBytesWritten := ui.FormatBytes(allBytesWritten)
-		summary = fmt.Sprintf("Summary: Restored %d / %d Files (%s / %s) in %s",
+		summary = fmt.Sprintf("Summary: Restored %d / %d files/dirs (%s / %s) in %s",
 			filesFinished, filesTotal, formattedAllBytesWritten, formattedAllBytesTotal, timeLeft)
 	}
 

--- a/internal/ui/restore/text_test.go
+++ b/internal/ui/restore/text_test.go
@@ -23,19 +23,19 @@ func TestPrintUpdate(t *testing.T) {
 	term := &mockTerm{}
 	printer := NewTextProgress(term)
 	printer.Update(3, 11, 29, 47, 5*time.Second)
-	test.Equals(t, []string{"[0:05] 61.70%  3 files 29 B, total 11 files 47 B"}, term.output)
+	test.Equals(t, []string{"[0:05] 61.70%  3 files/dirs 29 B, total 11 files/dirs 47 B"}, term.output)
 }
 
 func TestPrintSummaryOnSuccess(t *testing.T) {
 	term := &mockTerm{}
 	printer := NewTextProgress(term)
 	printer.Finish(11, 11, 47, 47, 5*time.Second)
-	test.Equals(t, []string{"Summary: Restored 11 Files (47 B) in 0:05"}, term.output)
+	test.Equals(t, []string{"Summary: Restored 11 files/dirs (47 B) in 0:05"}, term.output)
 }
 
 func TestPrintSummaryOnErrors(t *testing.T) {
 	term := &mockTerm{}
 	printer := NewTextProgress(term)
 	printer.Finish(3, 11, 29, 47, 5*time.Second)
-	test.Equals(t, []string{"Summary: Restored 3 / 11 Files (29 B / 47 B) in 0:05"}, term.output)
+	test.Equals(t, []string{"Summary: Restored 3 / 11 files/dirs (29 B / 47 B) in 0:05"}, term.output)
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Use `files/dirs` when displaying progress during restore.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

https://forum.restic.net/t/restic-restore-incorrect-different-files-count/6536

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
