### PR TITLE
Remove additional `--update` for apk in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -11,7 +11,7 @@ RUN go run build.go
 
 FROM alpine:latest AS restic
 
-RUN apk add --update --no-cache ca-certificates fuse openssh-client tzdata jq
+RUN apk add --no-cache ca-certificates fuse openssh-client tzdata jq
 
 COPY --from=builder /go/src/github.com/restic/restic/restic /usr/bin
 

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -13,6 +13,6 @@ RUN mv /output/restic_${TARGETOS}_${TARGETARCH} /output/restic
 FROM alpine:latest
 
 COPY --from=helper /output/restic /usr/bin
-RUN apk add --update --no-cache ca-certificates fuse openssh-client tzdata jq
+RUN apk add --no-cache ca-certificates fuse openssh-client tzdata jq
 
 ENTRYPOINT ["/usr/bin/restic"]


### PR DESCRIPTION

What does this PR change? What problem does it solve?
-----------------------------------------------------

This commit removes the redundant `--update` flag from the `apk add` command in both `Dockerfile` and `Dockerfile.release`.

The `--update` flag is unnecessary and conflicts with the `--no-cache` option. While `--update` does update the package index, it also leaves a cache of the package index in the Docker image, which can increase the image size. On the other hand, `--no-cache` updates the package index and does not leave a cache, making it more suitable for the use case.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Nope

Checklist
---------

- [ ] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
