### PR TITLE
Add script to verify release binaries

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -47,6 +47,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@f95db51fddba0c2d1ec667646a06c2ce06100226
 
+      - name: Ensure consistent binaries
+        run: |
+          echo "removing git directory for consistency with release binaries"
+          rm -rf .git
+        # remove VCS information from release builds, keep VCS for nightly builds on master
+        if: github.ref != 'refs/heads/master'
+
       - name: Build and push Docker image
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:

--- a/helpers/verify-release-binaries.sh
+++ b/helpers/verify-release-binaries.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+    echo "Usage: $0 restic_version go_version"
+    exit 1
+fi
+
+restic_version="$1"
+go_version="$2"
+
+# invalid if zero
+is_valid=1
+
+tmpdir="$(mktemp -d -p .)"
+cd "${tmpdir}"
+echo -e "Running checks in ${tmpdir}\n"
+
+highlight() {
+    echo "@@${1//?/@}@@"
+    echo "@ ${1} @"
+    echo "@@${1//?/@}@@"
+}
+
+
+highlight "Verifying release self-consistency"
+
+curl -OLSs https://github.com/restic/restic/releases/download/v${restic_version}/restic-${restic_version}.tar.gz.asc
+# tarball is downloaded while processing the SHA256SUMS
+curl -OLSs https://github.com/restic/restic/releases/download/v${restic_version}/SHA256SUMS.asc
+curl -OLSs https://github.com/restic/restic/releases/download/v${restic_version}/SHA256SUMS
+
+export GNUPGHOME=$PWD/gnupg
+mkdir -p 700 $GNUPGHOME
+curl -OLSs https://restic.net/gpg-key-alex.asc
+gpg --import gpg-key-alex.asc
+gpg --verify SHA256SUMS.asc SHA256SUMS
+
+for i in $(cat SHA256SUMS | cut -d " "  -f 3 ) ; do
+    echo "Downloading $i"
+    curl -OLSs https://github.com/restic/restic/releases/download/v${restic_version}/"$i"
+done
+shasum -a256 -c SHA256SUMS || echo "WARNING: RELEASE BINARIES DO NOT MATCH SHA256SUMS!" && is_valid=0
+gpg --verify restic-${restic_version}.tar.gz.asc restic-${restic_version}.tar.gz
+# TODO verify that the release does not contain any unexpected files
+
+
+highlight "Verifying tarball matches tagged commit"
+
+tar xzf "restic-${restic_version}.tar.gz"
+git clone -b "v${restic_version}" https://github.com/restic/restic.git
+rm -rf restic/.git
+diff -r restic restic-${restic_version}
+
+
+highlight "Regenerating builder container"
+
+git clone https://github.com/restic/builder.git
+docker pull debian:stable
+docker build --no-cache -t restic/builder:tmp --build-arg GO_VERSION=${go_version} builder
+
+
+highlight "Reproducing release binaries"
+
+mkdir output
+docker run --rm \
+    --volume "$PWD/restic-${restic_version}:/restic" \
+    --volume "$PWD/output:/output" \
+    restic/builder:tmp \
+    go run helpers/build-release-binaries/main.go --version "${restic_version}"
+
+cp "restic-${restic_version}.tar.gz" output
+cp SHA256SUMS output
+
+# check that all release binaries have been reproduced successfully
+(cd output && shasum -a256 -c SHA256SUMS) || echo "WARNING: REPRODUCED BINARIES DO NOT MATCH RELEASE BINARIES!" && is_valid=0
+# and that the SHA256SUMS files does not miss binaries
+for i in output/restic* ; do grep "$(basename "$i")" SHA256SUMS > /dev/null || echo "WARNING: $i MISSING FROM RELEASE SHA256SUMS FILE!" && is_valid=0 ; done
+
+
+extract_docker() {
+    image=$1
+    docker_platform=$2
+    restic_platform=$3
+    out=restic_${restic_version}_linux_${restic_platform}.bz2
+
+    docker image pull --platform "linux/${docker_platform}" ${image}:${restic_version} > /dev/null
+    docker image save ${image}:${restic_version} -o docker.tar
+
+    mkdir img
+    tar xvf docker.tar -C img --wildcards \*/layer.tar > /dev/null
+    rm docker.tar
+    for i in img/*/layer.tar; do
+        tar -xvf "$i" -C img usr/bin/restic 2> /dev/null 1>&2 || true
+        if [[ -f img/usr/bin/restic ]]; then
+            if [[ -f restic-docker ]]; then
+                echo "WARNING: CONTAINER CONTAINS MULTIPLE RESTIC BINARIES"
+                is_valid=0
+            fi
+            mv img/usr/bin/restic restic-docker
+        fi
+    done
+    
+    rm -rf img
+    bzip2 restic-docker
+    mv restic-docker.bz2 docker/${out}
+    grep ${out} SHA256SUMS >> docker/SHA256SUMS
+}
+
+ctr=0
+for img in restic/restic ghcr.io/restic/restic; do
+    highlight "Verifying binaries in docker containers from $img"
+    mkdir docker
+
+    extract_docker "$img" arm/v7 arm
+    extract_docker "$img" arm64 arm64
+    extract_docker "$img" 386 386
+    extract_docker "$img" amd64 amd64
+
+    (cd docker && shasum -a256 -c SHA256SUMS) || echo "WARNING: DOCKER CONTAINER DOES NOT CONTAIN RELEASE BINARIES!" && is_valid=0
+
+    mv docker docker-$(( ctr++ ))
+done
+
+
+if [[ $is_valid -ne 1 ]]; then
+    highlight "Failed to reproduce some binaries, check the script output for details"
+    exit 1
+else
+    cd ..
+    rm -rf "${tmpdir}"
+fi


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Verifying the official release binaries is currently quite a bit of work. This PR adds a script to automate the process such that only the restic version and the used go compiler version has to be supplied. 

The script then downloads all release binaries, checks the GPG signatures and that the binaries match the provided SHA256SUMS. Afterwards the script reproduces all binaries and compares them with the released binaries. In addition, the restic binary included in the provided containers is verified to match the official released binaries.

This led to two discoveries:
- `restic_0.16.0_aix_ppc64.bz2` cannot be rebuilt exactly. A closer inspection showed that the buildID is different each time the binary is built. This seems to be a bug in the go compiler, which fortunately has been fixed for Go 1.21 (restic 0.16.0 is built using Go 1.20.6).
- The binaries in the containers from `ghcr.io/restic/restic` are slightly different: these are built separately and in contrast to the official release binaries, they included VCS information. This PR includes a commit to remove that information, such that the binaries match.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [ ] I have added documentation for relevant changes (in the manual).
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
