### PR TITLE
Make `key list` command honor `--no-lock`

### DIFF
--- a/changelog/unreleased/issue-4513
+++ b/changelog/unreleased/issue-4513
@@ -1,0 +1,8 @@
+Bugfix: Make `key list` command honor `--no-lock`
+
+This allows to determine which keys a repo can be accessed by without the
+need for having write access (e.g., read-only sftp access, filesystem
+snapshot).
+
+https://github.com/restic/restic/issues/4513
+https://github.com/restic/restic/pull/4514

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -212,10 +212,13 @@ func runKey(ctx context.Context, gopts GlobalOptions, args []string) error {
 
 	switch args[0] {
 	case "list":
-		lock, ctx, err := lockRepo(ctx, repo, gopts.RetryLock, gopts.JSON)
-		defer unlockRepo(lock)
-		if err != nil {
-			return err
+		if !gopts.NoLock {
+			var lock *restic.Lock
+			lock, ctx, err = lockRepo(ctx, repo, gopts.RetryLock, gopts.JSON)
+			defer unlockRepo(lock)
+			if err != nil {
+				return err
+			}
 		}
 
 		return listKeys(ctx, repo, gopts)


### PR DESCRIPTION
Fixes #4513

What does this PR change? What problem does it solve?
-----------------------------------------------------

Don't lock repo if `--no-lock` flag was used as in `restic key list --no-list`

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

#4513

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] ~~I have added tests for all code changes.~~

It seems like there are no unit tests for --no-lock besides TestCheckRestoreNoLock anywhere, so I think this should be part of a bigger effort to add such tests.

- [ ] ~~I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
