### PR TITLE
retry: Do not retry Load() if file does not exist

### DIFF
--- a/changelog/unreleased/issue-4515
+++ b/changelog/unreleased/issue-4515
@@ -1,0 +1,8 @@
+Change: Don't retry to load files that don't exist
+
+Restic used to always retry to load files. It now only retries to load
+files if they exist.
+
+https://github.com/restic/restic/issues/4515
+https://github.com/restic/restic/issues/1523
+https://github.com/restic/restic/pull/4520

--- a/internal/backend/retry/backend_retry.go
+++ b/internal/backend/retry/backend_retry.go
@@ -128,7 +128,11 @@ func (be *Backend) Save(ctx context.Context, h restic.Handle, rd restic.RewindRe
 func (be *Backend) Load(ctx context.Context, h restic.Handle, length int, offset int64, consumer func(rd io.Reader) error) (err error) {
 	return be.retry(ctx, fmt.Sprintf("Load(%v, %v, %v)", h, length, offset),
 		func() error {
-			return be.Backend.Load(ctx, h, length, offset, consumer)
+			err := be.Backend.Load(ctx, h, length, offset, consumer)
+			if be.Backend.IsNotExist(err) {
+				return backoff.Permanent(err)
+			}
+			return err
 		})
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
It changes the behavior of retry for Load by not retrying if file does not exist.
This will prevent retrying Load in a situation where no matter the number of retries, Load will not succeed. 
ex: loading the lock file placed in repo by another host that has since been deleted.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
fixes #4515
fixes #1523
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- <s>[ ] I have added documentation for relevant changes (in the manual).</s>
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
