### PR TITLE
Don't load password when autocompleting CLI commands

### DIFF
--- a/changelog/unreleased/issue-4516
+++ b/changelog/unreleased/issue-4516
@@ -1,0 +1,8 @@
+Bugfix: Do not try to load password on command line autocomplete
+
+The command line autocompletion previously tried to load the repository
+password. This could cause the autocompletion not to work. Now, this step gets
+skipped.
+
+https://github.com/restic/restic/issues/4516
+https://github.com/restic/restic/pull/4526

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -80,7 +80,7 @@ The full documentation can be found at https://restic.readthedocs.io/ .
 // user for authentication).
 func needsPassword(cmd string) bool {
 	switch cmd {
-	case "cache", "generate", "help", "options", "self-update", "version":
+	case "cache", "generate", "help", "options", "self-update", "version", "__complete":
 		return false
 	default:
 		return true


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Don't load the repository password when autocompleting CLI commands. This can break autocompletion if for example `RESTIC_PASSWORD_FILE` is set to an invalid path.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #4516
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~ Manually tested.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
