### PR TITLE
Add bitrot detection to "diff" command

### DIFF
--- a/changelog/unreleased/pull-4526
+++ b/changelog/unreleased/pull-4526
@@ -1,0 +1,11 @@
+Enhancement: Add bitrot detection to `diff` command
+
+The output of the `diff` command now includes the modifier `?` for files
+to indicate bitrot in backed up files. It will appear whenever there is a
+difference in content while the metadata is exactly the same. Since files with
+unchanged metadata are normally not read again when creating a backup, the
+detection is only effective if the right-hand side of the diff has been created
+with "backup --force".
+
+https://github.com/restic/restic/issues/805
+https://github.com/restic/restic/pull/4526

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -274,11 +274,13 @@ func (c *Comparer) diffTree(ctx context.Context, stats *DiffStatsContainer, pref
 				mod += "M"
 				stats.ChangedFiles++
 
-				node1NilContent := node1
-				node2NilContent := node2
+				node1NilContent := *node1
+				node2NilContent := *node2
 				node1NilContent.Content = nil
 				node2NilContent.Content = nil
-				if node1NilContent.Equals(*node2NilContent) {
+				// the bitrot detection may not work if `backup --ignore-inode` or `--ignore-ctime` were used
+				if node1NilContent.Equals(node2NilContent) {
+					// probable bitrot detected
 					mod += "?"
 				}
 			} else if c.opts.ShowMetadata && !node1.Equals(*node2) {

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -29,6 +29,9 @@ directory:
 * T  The type was changed, e.g. a file was made a symlink
 * ?  Bitrot detected: The file's content has changed but all metadata is the same
 
+Metadata comparison will likely not work if a backup was created using the
+'--ignore-inode' or '--ignore-ctime' option.
+
 To only compare files in specific subfolders, you can use the
 "<snapshotID>:<subfolder>" syntax, where "subfolder" is a path within the
 snapshot.

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -27,6 +27,7 @@ directory:
 * U  The metadata (access mode, timestamps, ...) for the item was updated
 * M  The file's content was modified
 * T  The type was changed, e.g. a file was made a symlink
+* ?  Bitrot detected: The file's content has changed but all metadata is the same
 
 To only compare files in specific subfolders, you can use the
 "<snapshotID>:<subfolder>" syntax, where "subfolder" is a path within the
@@ -272,6 +273,14 @@ func (c *Comparer) diffTree(ctx context.Context, stats *DiffStatsContainer, pref
 				!reflect.DeepEqual(node1.Content, node2.Content) {
 				mod += "M"
 				stats.ChangedFiles++
+
+				node1NilContent := node1
+				node2NilContent := node2
+				node1NilContent.Content = nil
+				node2NilContent.Content = nil
+				if node1NilContent.Equals(*node2NilContent) {
+					mod += "?"
+				}
 			} else if c.opts.ShowMetadata && !node1.Equals(*node2) {
 				mod += "U"
 			}

--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -201,7 +201,8 @@ change
 +------------------+--------------------------------------------------------------+
 | ``modifier``     | Type of change, a concatenation of the following characters: |
 |                  | "+" = added, "-" = removed, "T" = entry type changed,        |
-|                  | "M" = file content changed, "U" = metadata changed           |
+|                  | "M" = file content changed, "U" = metadata changed,          |
+|                  | "?" = bitrot detected                                        |
 +------------------+--------------------------------------------------------------+
 
 statistics


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This introduces a new modifier to the output of the diff command. It appears whenever two files being compared only differ in their content but not in their metadata. As far as we know, under normal circumstances, this should only ever happen if some kind of bitrot has happened in the source file. The prerequisite for this detection to work is that the right-side snapshot of the comparison has been created with "backup --force".

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

See #805 

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
