### PR TITLE
Only support ARMv6 on ARM platforms

### DIFF
--- a/changelog/unreleased/issue-4540
+++ b/changelog/unreleased/issue-4540
@@ -1,0 +1,6 @@
+Change: Require at least ARMv6 for ARM binaries
+
+The official release binaries of restic now require at least ARMv6 support for ARM platforms.
+
+https://github.com/restic/restic/issues/4540
+https://github.com/restic/restic/pull/4542

--- a/helpers/build-release-binaries/main.go
+++ b/helpers/build-release-binaries/main.go
@@ -125,6 +125,10 @@ func build(sourceDir, outputDir, goos, goarch string) (filename string) {
 		"GOOS="+goos,
 		"GOARCH="+goarch,
 	)
+	if goarch == "arm" {
+		// the raspberry pi 1 only supports the ARMv6 instruction set
+		c.Env = append(c.Env, "GOARM=6")
+	}
 	verbose("run %v %v in %v", "go", c.Args, c.Dir)
 
 	err := c.Run()


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Go 1.21 has switched the default from GOARM=5 to GOARM=7. So far there have been complaints from Raspberry Pi 1 users, as the first raspberry pi version only supports ARMv6. Exclude older ARM versions as these are likely not relevant (rest-server also only supports ARMv6/7) and enforce the use of software floating point emulation.

This also fixes the mislabeling of our docker containers as linux/arm/v7 when the contained binary actually only required linux/arm/v5

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #4540
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
