### PR TITLE
Add --json option to version command

### DIFF
--- a/changelog/unreleased/issue-4547
+++ b/changelog/unreleased/issue-4547
@@ -1,0 +1,6 @@
+Enhancement: add --json option to version command.
+
+Restic now supports outputting restic version and used go version and platform
+target via json when using the version command
+
+https://github.com/restic/restic/issues/4547

--- a/changelog/unreleased/issue-4547
+++ b/changelog/unreleased/issue-4547
@@ -1,7 +1,7 @@
 Enhancement: Add support for `--json` option to `version` command
 
-Restic now supports outputting restic version and used go version and platform
-target via json when using the version command.
+Restic now supports outputting restic version and used go version, OS and
+architecture via JSON when using the version command.
 
 https://github.com/restic/restic/issues/4547
 https://github.com/restic/restic/pull/4553

--- a/changelog/unreleased/issue-4547
+++ b/changelog/unreleased/issue-4547
@@ -1,6 +1,7 @@
-Enhancement: add --json option to version command.
+Enhancement: Add support for `--json` option to `version` command
 
 Restic now supports outputting restic version and used go version and platform
-target via json when using the version command
+target via json when using the version command.
 
 https://github.com/restic/restic/issues/4547
+https://github.com/restic/restic/pull/4553

--- a/cmd/restic/cmd_version.go
+++ b/cmd/restic/cmd_version.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"fmt"
 	"runtime"
 
@@ -21,8 +22,31 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 `,
 	DisableAutoGenTag: true,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Printf("restic %s compiled with %v on %v/%v\n",
-			version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		if globalOptions.JSON {
+			type jsonVersion struct {
+				Version   string `json:"version"`
+				GoVersion string `json:"go_version"`
+				GoTarget  string `json:"go_target"`
+			}
+
+			jsonS := jsonVersion{
+				Version:   version,
+				GoVersion: runtime.Version(),
+				GoTarget:  runtime.GOOS + "/" + runtime.GOARCH,
+			}
+
+			jsonB, err := json.Marshal(jsonS)
+			if err != nil {
+				Warnf("Marshall failed: %v\n", err)
+				return
+			}
+
+			fmt.Println(string(jsonB))
+		} else {
+			fmt.Printf("restic %s compiled with %v on %v/%v\n",
+				version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		}
+
 	},
 }
 

--- a/cmd/restic/cmd_version.go
+++ b/cmd/restic/cmd_version.go
@@ -35,13 +35,11 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 				GoTarget:  runtime.GOOS + "/" + runtime.GOARCH,
 			}
 
-			jsonB, err := json.Marshal(jsonS)
+			err := json.NewEncoder(globalOptions.stdout).Encode(jsonS)
 			if err != nil {
-				Warnf("Marshall failed: %v\n", err)
+				Warnf("Encode failed: %v\n", err)
 				return
 			}
-
-			fmt.Println(string(jsonB))
 		} else {
 			fmt.Printf("restic %s compiled with %v on %v/%v\n",
 				version, runtime.Version(), runtime.GOOS, runtime.GOARCH)

--- a/cmd/restic/cmd_version.go
+++ b/cmd/restic/cmd_version.go
@@ -26,18 +26,20 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 			type jsonVersion struct {
 				Version   string `json:"version"`
 				GoVersion string `json:"go_version"`
-				GoTarget  string `json:"go_target"`
+				GoOS      string `json:"go_os"`
+				GoArch    string `json:"go_arch"`
 			}
 
 			jsonS := jsonVersion{
 				Version:   version,
 				GoVersion: runtime.Version(),
-				GoTarget:  runtime.GOOS + "/" + runtime.GOARCH,
+				GoOS:      runtime.GOOS,
+				GoArch:    runtime.GOARCH,
 			}
 
 			err := json.NewEncoder(globalOptions.stdout).Encode(jsonS)
 			if err != nil {
-				Warnf("Encode failed: %v\n", err)
+				Warnf("JSON encode failed: %v\n", err)
 				return
 			}
 		} else {

--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -588,5 +588,7 @@ The version command returns a single JSON object.
 +----------------+--------------------+
 | ``go_version`` | Go compile version |
 +----------------+--------------------+
-| ``go_target``  | Go target platform |
+| ``go_os``      | Go OS              |
++----------------+--------------------+
+| ``go_arch``    | Go architecture    |
 +----------------+--------------------+

--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -576,3 +576,17 @@ The snapshots command returns a single JSON object.
 +------------------------------+-----------------------------------------------------+
 | ``compression_space_saving`` | Overall space saving due to compression             |
 +------------------------------+-----------------------------------------------------+
+
+
+version
+-------
+
+The version command returns a single JSON object.
+
++----------------+--------------------+
+| ``version``    | restic version     |
++----------------+--------------------+
+| ``go_version`` | Go compile version |
++----------------+--------------------+
+| ``go_target``  | Go target platform |
++----------------+--------------------+


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Add --json option to version command

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

#4547 raised the issue of not having the option to output version information as json

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
