### PR TITLE
Restore generation of `HTMLZip` files on `readthedocs.com`.

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,6 +8,10 @@ build:
   tools:
     python: "3.11"
 
+# Build HTMLZip
+formats:
+  - htmlzip
+
 # Build documentation in the docs/ directory with Sphinx
 sphinx:
   configuration: doc/conf.py


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Old versions (<=0.16.0) of readthedocs contain a [single-page version](https://readthedocs.org/projects/restic/downloads/) of restic documentation, but after moving to version 2 of the `.readthedocs.yaml` file, `htmlzip` format is no longer generated.
This pool request fixes it.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

https://github.com/restic/restic/issues/4548

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
~~- [ ] I have added tests for all code changes.~~
~~- [ ] I have added documentation for relevant changes (in the manual).~~
~~- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
~~- [ ] I have run `gofmt` on the code in all commits.~~
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
