### PR TITLE
fix: drop reference to signature and define MAC

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -48,7 +48,7 @@ be used instead of the complete filename.
 Apart from the files stored within the ``keys`` and ``data`` directories,
 all files are encrypted with AES-256 in counter mode (CTR). The integrity
 of the encrypted data is secured by a Poly1305-AES message authentication
-code (sometimes also referred to as a "signature").
+code (MAC).
 Files in the ``data`` directory ("pack files") consist of multiple parts
 which are all independently encrypted and authenticated, see below.
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR hopefully improves the clarity of the design documentation:

* Poly1305-AES is not a signature, so don't mention that.
* The term MAC was used without being defined, so add a definition.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
