### PR TITLE
Fix dangerous forget-all operation which drops all snapshots

### DIFF
--- a/changelog/unreleased/issue-4569
+++ b/changelog/unreleased/issue-4569
@@ -1,0 +1,11 @@
+Bugfix: Prevent restic forget from deleting all snapshots accidentally
+
+The command `restic forget --keep-tag=SomeUnusedTag --dry-run`
+used to drop all snapshots. This would be very dangerous and probably
+unwanted.
+
+Restic now only allows --keep-tag together with other --keep-* options.
+
+https://github.com/restic/restic/issues/4569
+https://github.com/restic/restic/pull/4568
+https://forum.restic.net/t/delete-all-snapshots-in-one-command-is-this-feature-intentional/6923/3

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -141,11 +141,22 @@ func verifyForgetOptions(opts *ForgetOptions) error {
 		return errors.Fatal("negative values other than -1 are not allowed for --keep-*")
 	}
 
+	var allKeepWithinXUndefined = true
 	for _, d := range []restic.Duration{opts.Within, opts.WithinHourly, opts.WithinDaily,
 		opts.WithinMonthly, opts.WithinWeekly, opts.WithinYearly} {
 		if d.Hours < 0 || d.Days < 0 || d.Months < 0 || d.Years < 0 {
 			return errors.Fatal("durations containing negative values are not allowed for --keep-within*")
 		}
+		if d.Hours != 0 || d.Days != 0 || d.Months != 0 || d.Years != 0 {
+			allKeepWithinXUndefined = false
+		}
+	}
+
+	allKeepXUndefined := opts.Last == 0 && opts.Hourly == 0 && opts.Daily == 0 && opts.Weekly == 0 &&
+		opts.Monthly == 0 && opts.Yearly == 0
+
+	if len(opts.KeepTags) > 0 && allKeepXUndefined && allKeepWithinXUndefined {
+		return errors.Fatal("--keep-tags can only be used together with other --keep-* options.")
 	}
 
 	return nil

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -115,7 +115,7 @@ func init() {
 	f.VarP(&forgetOptions.WithinWeekly, "keep-within-weekly", "", "keep weekly snapshots that are newer than `duration` (eg. 1y5m7d2h) relative to the latest snapshot")
 	f.VarP(&forgetOptions.WithinMonthly, "keep-within-monthly", "", "keep monthly snapshots that are newer than `duration` (eg. 1y5m7d2h) relative to the latest snapshot")
 	f.VarP(&forgetOptions.WithinYearly, "keep-within-yearly", "", "keep yearly snapshots that are newer than `duration` (eg. 1y5m7d2h) relative to the latest snapshot")
-	f.Var(&forgetOptions.KeepTags, "keep-tag", "keep snapshots with this `taglist` (can be specified multiple times)")
+	f.Var(&forgetOptions.KeepTags, "keep-tag", "keep snapshots with this `taglist` (can be specified multiple times, `taglist`s will be combined into one). this is a \"has all\" condition, i.e. a snapshot is only kept when it has all tags in `taglist`.")
 
 	initMultiSnapshotFilter(f, &forgetOptions.SnapshotFilter, false)
 	f.StringArrayVar(&forgetOptions.Hosts, "hostname", nil, "only consider snapshots with the given `hostname` (can be specified multiple times)")

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -138,6 +138,7 @@ func init() {
 func verifyForgetOptions(opts *ForgetOptions) error {
 	if opts.Last < -1 || opts.Hourly < -1 || opts.Daily < -1 || opts.Weekly < -1 ||
 		opts.Monthly < -1 || opts.Yearly < -1 {
+		// This condition is already catched in ForgetPolicyCount's Set(s string)
 		return errors.Fatal("negative values other than -1 are not allowed for --keep-*")
 	}
 

--- a/cmd/restic/cmd_forget_test.go
+++ b/cmd/restic/cmd_forget_test.go
@@ -40,6 +40,7 @@ func TestForgetPolicyValues(t *testing.T) {
 func TestForgetOptionValues(t *testing.T) {
 	const negValErrorMsg = "Fatal: negative values other than -1 are not allowed for --keep-*"
 	const negDurationValErrorMsg = "Fatal: durations containing negative values are not allowed for --keep-within*"
+	const keepTagsAloneMsg = "Fatal: --keep-tags can only be used together with other --keep-* options."
 	testCases := []struct {
 		input    ForgetOptions
 		errorMsg string
@@ -80,6 +81,7 @@ func TestForgetOptionValues(t *testing.T) {
 		{ForgetOptions{WithinWeekly: restic.ParseDurationOrPanic("1y2m3d-3h")}, negDurationValErrorMsg},
 		{ForgetOptions{WithinMonthly: restic.ParseDurationOrPanic("-2y4m6d8h")}, negDurationValErrorMsg},
 		{ForgetOptions{WithinYearly: restic.ParseDurationOrPanic("2y-4m6d8h")}, negDurationValErrorMsg},
+		{ForgetOptions{KeepTags: []restic.TagList{[]string{"tag1"}}}, keepTagsAloneMsg},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION

What does this PR change? What problem does it solve?
-----------------------------------------------------

```
restic forget --keep-tag=SomeUnusedTag --dry-run
```

This command would drop all snapshots. This is very dangerous and probably unwanted.

A suggested fix (see forum) is to only allow `--keep-tag` together with other `--keep-*` options.

While working on this, I noticed that another if case seem to have no effect, see comment in diff.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

See also https://forum.restic.net/t/delete-all-snapshots-in-one-command-is-this-feature-intentional/6923/3

Fixes #4569

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
