### PR TITLE
docs: add pkgx install option

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -84,6 +84,12 @@ If you are using macOS, you can install restic using the
 
     $ brew install restic
 
+On Linux and macOS, you can also install it using `pkgx <https://pkgx.sh/>`__:
+
+.. code-block:: console
+
+    $ pkgx install restic
+
 You may also install it using `MacPorts <https://www.macports.org/>`__:
 
 .. code-block:: console


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

adds install option in documentation for `pkgx`

restic pkg:
https://pkgx.dev/pkgs/restic.net/restic/

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No, only made visible in https://github.com/pkgxdev/pantry/pull/4098


Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
