### PR TITLE
S3: Don't archive metadata files on S3 Glacier

### DIFF
--- a/changelog/unreleased/issue-4583
+++ b/changelog/unreleased/issue-4583
@@ -1,0 +1,9 @@
+Bugfix: Ignoring the s3.storage-class option for metadata when archive tier is specified
+
+Restic now will save snapshot metadata to non-archive storage tier whatsoever,
+this will help avoid issues when data is being saved to archive storage class.
+It is not providing any support for cold storages in restic, 
+only saving users from making backups unusable.
+
+https://github.com/restic/restic/issues/4583
+https://github.com/restic/restic/issues/3202

--- a/changelog/unreleased/issue-4583
+++ b/changelog/unreleased/issue-4583
@@ -1,9 +1,12 @@
-Bugfix: Ignoring the s3.storage-class option for metadata when archive tier is specified
+Enhancement: Ignore s3.storage-class for metadata if archive tier is specified
 
-Restic now will save snapshot metadata to non-archive storage tier whatsoever,
-this will help avoid issues when data is being saved to archive storage class.
-It is not providing any support for cold storages in restic, 
-only saving users from making backups unusable.
+There is no official cold storage support in restic, use this option at your
+own risk.
+
+Restic always stored all files on s3 using the specified `s3.storage-class`.
+Now, restic will store metadata using a non-archive storage tier to avoid
+problems when accessing a repository. To restore any data, it is still
+necessary to manually warm up the required data beforehand.
 
 https://github.com/restic/restic/issues/4583
-https://github.com/restic/restic/issues/3202
+https://github.com/restic/restic/pull/4584

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -326,8 +326,10 @@ func (be *Backend) Path() string {
 }
 
 // useStorageClass returns whether file should be saved in the provided Storage Class
+// For archive storage classes, only data files are stored using that class; metadata
+// must remain instantly accessible.
 func (be *Backend) useStorageClass(h backend.Handle) bool {
-	var notArchiveClass bool = be.cfg.StorageClass != "GLACIER" && be.cfg.StorageClass != "DEEP_ARCHIVE"
+	notArchiveClass := be.cfg.StorageClass != "GLACIER" && be.cfg.StorageClass != "DEEP_ARCHIVE"
 	isDataFile := h.Type == backend.PackFile && !h.IsMetadata
 	return isDataFile || notArchiveClass
 }
@@ -336,15 +338,16 @@ func (be *Backend) useStorageClass(h backend.Handle) bool {
 func (be *Backend) Save(ctx context.Context, h backend.Handle, rd backend.RewindReader) error {
 	objName := be.Filename(h)
 
-	opts := minio.PutObjectOptions{ContentType: "application/octet-stream"}
-
+	opts := minio.PutObjectOptions{
+		ContentType: "application/octet-stream",
+		// the only option with the high-level api is to let the library handle the checksum computation
+		SendContentMd5: true,
+		// only use multipart uploads for very large files
+		PartSize: 200 * 1024 * 1024,
+	}
 	if be.useStorageClass(h) {
 		opts.StorageClass = be.cfg.StorageClass
 	}
-	// the only option with the high-level api is to let the library handle the checksum computation
-	opts.SendContentMd5 = true
-	// only use multipart uploads for very large files
-	opts.PartSize = 200 * 1024 * 1024
 
 	info, err := be.client.PutObject(ctx, be.cfg.Bucket, objName, io.NopCloser(rd), int64(rd.Length()), opts)
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
It fixes issue when you upload snapshot to S3 Glacier, and metadata isn't available from any machine without cache.

It sets a fallback for the case where storage class should not be set - for metadata AND ONLY when specified tier will move files to archive. For the code simplicity it is done through the inverse logic operators: set storage class when file is `data/` OR when  storage class is not instant accessible (such as Standard etc. including 'Glacier Instant Retrieval').


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #4583

Checklist
---------


- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
