### PR TITLE
Add a note that the oldest snapshot may be kept additionally

### DIFF
--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -207,9 +207,12 @@ The ``forget`` command accepts the following policy options:
     They also only count hours/days/weeks/etc which have one or more snapshots.
     A value of ``-1`` will be interpreted as "forever", i.e. "keep all".
 
-.. note:: All duration related options (``--keep-{within,-*}``) ignore snapshots
+.. note:: All duration related options (``--keep-{within-,}*``) ignore snapshots
     with a timestamp in the future (relative to when the ``forget`` command is
     run) and these snapshots will hence not be removed.
+
+.. note:: If there are not enough snapshots to keep one for each duration related
+    ``--keep-{within-,}*`` option, the oldest snapshot is kept additionally.
 
 .. note:: Specifying ``--keep-tag ''`` will match untagged snapshots only.
 


### PR DESCRIPTION
> Copy & Paste from https://github.com/joram-berger/restic/pull/1

## What does this PR change? What problem does it solve?

Documentation enhancement: I propose to explain in the docs why the oldest snapshot may be kept even if it does not match any keep policy.

It documents a feature which was introduced in version 0.16.
## Was the change previously discussed in an issue or on the forum?

It was discussed here: https://forum.restic.net/t/multiple-snapshots-kept-per-year/6994/4
## Checklist

This is only a documentation enhancement, so most of the check list below does probably not apply.

  * [x]  I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
  * [ ]  I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
  * [ ]  I have added tests for all code changes.
  * [ ]  I have added documentation for relevant changes (in the manual).
  * [ ]  There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
  * [ ]  I have run `gofmt` on the code in all commits.
  * [ ]  All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
  * [x]  I'm done! This pull request is ready for review.

