### PR TITLE
Neclepsio rewrite path

### DIFF
--- a/cmd/restic/cmd_rewrite_integration_test.go
+++ b/cmd/restic/cmd_rewrite_integration_test.go
@@ -105,3 +105,17 @@ func TestRewriteMetadata(t *testing.T) {
 		testRewriteMetadata(t, metadata)
 	}
 }
+
+func TestRewriteChangePath(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	snapshotID := createBasicRewriteRepo(t, env)
+
+	// exclude some data
+	testRunRewriteExclude(t, env.gopts, []string{"3"}, true, snapshotMetadataArgs{PathRemove: "", PathAdd: ""})
+	newSnapshotIDs := testListSnapshots(t, env.gopts, 1)
+	rtest.Assert(t, snapshotID != newSnapshotIDs[0], "snapshot id should have changed")
+	// check forbids unused blobs, thus remove them first
+	testRunPrune(t, env.gopts, PruneOptions{MaxUnused: "0"})
+	testRunCheck(t, env.gopts)
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds `--new-path-remove` and `--new-path-add` to rewrite command.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Related to https://github.com/restic/restic/issues/2654.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
