### PR TITLE
Add --new-path-remove and --new-path-add to rewrite command

### DIFF
--- a/changelog/unreleased/pull-4603
+++ b/changelog/unreleased/pull-4603
@@ -1,0 +1,5 @@
+Enhancement: Add `--new-path-add` and `--new-path-remove` options to `rewrite` command
+
+`restic rewrite` now allows rewriting the path metadata of a snapshot.
+
+https://github.com/restic/restic/pull/4603

--- a/changelog/unreleased/pull-4604
+++ b/changelog/unreleased/pull-4604
@@ -2,4 +2,4 @@ Enhancement: Add `--new-path-add` and `--new-path-remove` options to `rewrite` c
 
 `restic rewrite` now allows rewriting the path metadata of a snapshot.
 
-https://github.com/restic/restic/pull/4603
+https://github.com/restic/restic/pull/4604

--- a/cmd/restic/cmd_rewrite_integration_test.go
+++ b/cmd/restic/cmd_rewrite_integration_test.go
@@ -105,3 +105,17 @@ func TestRewriteMetadata(t *testing.T) {
 		testRewriteMetadata(t, metadata)
 	}
 }
+
+func TestRewriteChangePath(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	snapshotID := createBasicRewriteRepo(t, env)
+
+	// exclude some data
+	testRunRewriteExclude(t, env.gopts, []string{"3"}, true, snapshotMetadataArgs{PathRemove: "", PathAdd: ""})
+	newSnapshotIDs := testListSnapshots(t, env.gopts, 1)
+	rtest.Assert(t, snapshotID != newSnapshotIDs[0], "snapshot id should have changed")
+	// check forbids unused blobs, thus remove them first
+	testRunPrune(t, env.gopts, PruneOptions{MaxUnused: "0"})
+	testRunCheck(t, env.gopts)
+}

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -241,6 +241,12 @@ Sometimes it may be desirable to change the metadata of an existing snapshot.
 Currently, rewriting the hostname and the time of the backup is supported. 
 This is possible using the ``rewrite`` command with the option ``--new-host`` followed by the desired new hostname or the option ``--new-time`` followed by the desired new timestamp.
 
+To change the paths, use ``--new-path-remove`` to specify the prefix to be
+removed and ``--new-path-added`` to specify the prefix to be added. For example,
+if paths are ``/local/path/1`` and ``/local/path/2``, using 
+``--new-path-remove /local --new-path-add /my`` will change them to 
+``/my/path/1`` and ``/my/path/2``.
+
 .. code-block:: console
     $ restic rewrite --new-host newhost --new-time "1999-01-01 11:11:11"
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds `--new-path-remove` and `--new-path-add` to rewrite command.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Related to https://github.com/restic/restic/issues/2654.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
