### PR TITLE
rest: fix and cleanup closing of http response body

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -35,6 +35,9 @@ linters:
     # parse and typecheck code
     - typecheck
 
+    # ensure that http response bodies are closed
+    - bodyclose
+
 issues:
   # don't use the default exclude rules, this hides (among others) ignored
   # errors from Close() calls

--- a/internal/backend/limiter/static_limiter_test.go
+++ b/internal/backend/limiter/static_limiter_test.go
@@ -118,6 +118,7 @@ func TestRoundTripperReader(t *testing.T) {
 	test.Assert(t, bytes.Equal(data, out.Bytes()), "data ping-pong failed")
 }
 
+// nolint:bodyclose // the http response is just a mock
 func TestRoundTripperCornerCases(t *testing.T) {
 	limiter := NewStaticLimiter(Limits{42 * 1024, 42 * 1024})
 

--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -252,6 +252,7 @@ func newBackend(ctx context.Context, cfg Config, lim limiter.Limiter) (*Backend,
 		return nil, fmt.Errorf("error talking HTTP to rclone: %w", err)
 	}
 
+	_ = res.Body.Close()
 	debug.Log("HTTP status %q returned, moving instance to background", res.Status)
 	err = bg()
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
If client.Do returns an error, then there's no body that has to be closed. For requests for which we are not interested in the response body, immediately drain and close the body to make sure it isn't forgotten later on.

This change in particular adds the missing `Close()` call for the `List()` command.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Might help with https://forum.restic.net/t/error-snapshots-failed-to-write-list-http2-stream-closed/7072
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
