### PR TITLE
Fix error checks that accidentally returned nil instead of the error

### DIFF
--- a/internal/backend/limiter/limiter_backend_test.go
+++ b/internal/backend/limiter/limiter_backend_test.go
@@ -29,7 +29,7 @@ func TestLimitBackendSave(t *testing.T) {
 		buf := new(bytes.Buffer)
 		_, err := io.Copy(buf, rd)
 		if err != nil {
-			return nil
+			return err
 		}
 		if !bytes.Equal(data, buf.Bytes()) {
 			return fmt.Errorf("data mismatch")

--- a/internal/backend/util/defaults.go
+++ b/internal/backend/util/defaults.go
@@ -38,7 +38,7 @@ func DefaultDelete(ctx context.Context, be backend.Backend) error {
 			return be.Remove(ctx, backend.Handle{Type: t, Name: fi.Name})
 		})
 		if err != nil {
-			return nil
+			return err
 		}
 	}
 	err := be.Remove(ctx, backend.Handle{Type: backend.ConfigFile})


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Both instances are only relevant for tests.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
