### PR TITLE
Feat AWS Assume Role add duration in seconds

### DIFF
--- a/changelog/unreleased/pull-4629
+++ b/changelog/unreleased/pull-4629
@@ -1,0 +1,9 @@
+Enhancement: Feat AWS Assume Role add duration in seconds
+
+While using the AWS AssumeRole capability of the S3 storage backend, restic did not allow the duration in seconds to be configured for the STS token issued through the AssumeRole API.
+
+We have added the capability to specify the duration in seconds for the AssumeRole API using the RESTIC_AWS_ASSUME_ROLE_DURATION_IN_SECONDS environment variable.
+
+Note: `minio` currently considers only values above 3600 seconds to be configured.
+
+https://github.com/restic/restic/pull/4629

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -634,6 +634,7 @@ environment variables. The following lists these environment variables:
     RESTIC_AWS_ASSUME_ROLE_POLICY       Inline Amazion IAM session policy
     RESTIC_AWS_ASSUME_ROLE_REGION       Region to use for IAM calls for the role assumption (default: us-east-1)
     RESTIC_AWS_ASSUME_ROLE_STS_ENDPOINT URL to the STS endpoint (default is determined based on RESTIC_AWS_ASSUME_ROLE_REGION). You generally do not need to set this, advanced use only.
+    RESTIC_AWS_ASSUME_ROLE_DURATION_IN_SECONDS The duration, in seconds, of the role session. (default and minimum is 3600 seconds)
 
     AZURE_ACCOUNT_NAME                  Account name for Azure
     AZURE_ACCOUNT_KEY                   Account key for Azure

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -634,7 +634,7 @@ environment variables. The following lists these environment variables:
     RESTIC_AWS_ASSUME_ROLE_POLICY       Inline Amazion IAM session policy
     RESTIC_AWS_ASSUME_ROLE_REGION       Region to use for IAM calls for the role assumption (default: us-east-1)
     RESTIC_AWS_ASSUME_ROLE_STS_ENDPOINT URL to the STS endpoint (default is determined based on RESTIC_AWS_ASSUME_ROLE_REGION). You generally do not need to set this, advanced use only.
-    RESTIC_AWS_ASSUME_ROLE_DURATION_IN_SECONDS The duration, in seconds, of the role session. (default and minimum is 3600 seconds)
+    RESTIC_AWS_ASSUME_ROLE_DURATION_IN_SECONDS The duration, in seconds, of the role session. (default = 3600 seconds, minimum = 3600 seconds)
 
     AZURE_ACCOUNT_NAME                  Account name for Azure
     AZURE_ACCOUNT_KEY                   Account key for Azure

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"time"
 
@@ -147,6 +148,14 @@ func getCredentials(cfg Config) (*credentials.Credentials, error) {
 		policy := os.Getenv("RESTIC_AWS_ASSUME_ROLE_POLICY")
 		stsEndpoint := os.Getenv("RESTIC_AWS_ASSUME_ROLE_STS_ENDPOINT")
 
+		var durationInSeconds int
+		if d := os.Getenv("RESTIC_AWS_ASSUME_ROLE_DURATION_IN_SECONDS"); d != "" {
+			durationInSeconds, err = strconv.Atoi(d)
+			if err != nil {
+				return nil, errors.Wrap(err, "RESTIC_AWS_ASSUME_ROLE_DURATION_IN_SECONDS")
+			}
+		}
+
 		if stsEndpoint == "" {
 			if awsRegion != "" {
 				if strings.HasPrefix(awsRegion, "cn-") {
@@ -168,6 +177,7 @@ func getCredentials(cfg Config) (*credentials.Credentials, error) {
 			ExternalID:      externalID,
 			Policy:          policy,
 			Location:        awsRegion,
+			DurationSeconds: durationInSeconds,
 		}
 
 		creds, err = credentials.NewSTSAssumeRole(stsEndpoint, opts)


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This is w.r.t #4474  which was merged. The AWS AssumeRole endpoint provides the ability to specify the duration in seconds for the validity of the token. Refer: https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html

I see that it was missed in the previous linked PR. The `minio` library used does provide the ability to specify the duration in seconds under the `STSAssumeRoleOptions`.

I want the ability to change the duration in seconds for which the AssumeRole token is issued. I have some long running operation and want to keep 12 hours as the validity for the token I am using.

One thing to note here:
The `minio` library implicitly considers `DurationInSeconds` greater than 3600 seconds. I have updated the documentation as well highlighting the same.

If the environment variable is not set, it is simply ignored and the default value of 3600 seconds is implicitly accepted. 

This must be documented since, AWS AssumeRole allows you to specify durations between 900 and 43200 seconds. Since, `minio` allows only values above 3600 seconds we need to add it.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Related to #4474

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
