### PR TITLE
lock: checkForOtherLocks processes each lock at most once

### DIFF
--- a/internal/restic/lock.go
+++ b/internal/restic/lock.go
@@ -163,9 +163,16 @@ func (l *Lock) fillUserInfo() error {
 // exclusive lock is found.
 func (l *Lock) checkForOtherLocks(ctx context.Context) error {
 	var err error
+	checkedIDs := NewIDSet()
+	if l.lockID != nil {
+		checkedIDs.Insert(*l.lockID)
+	}
 	// retry locking a few times
 	for i := 0; i < 3; i++ {
-		err = ForAllLocks(ctx, l.repo, l.lockID, func(id ID, lock *Lock, err error) error {
+		// Store updates in new IDSet to prevent data races
+		var m sync.Mutex
+		newCheckedIDs := NewIDSet(checkedIDs.List()...)
+		err = ForAllLocks(ctx, l.repo, checkedIDs, func(id ID, lock *Lock, err error) error {
 			if err != nil {
 				// if we cannot load a lock then it is unclear whether it can be ignored
 				// it could either be invalid or just unreadable due to network/permission problems
@@ -181,8 +188,13 @@ func (l *Lock) checkForOtherLocks(ctx context.Context) error {
 				return &alreadyLockedError{otherLock: lock}
 			}
 
+			// valid locks will remain valid
+			m.Lock()
+			newCheckedIDs.Insert(id)
+			m.Unlock()
 			return nil
 		})
+		checkedIDs = newCheckedIDs
 		// no lock detected
 		if err == nil {
 			return nil
@@ -417,12 +429,12 @@ func RemoveAllLocks(ctx context.Context, repo Repository) (uint, error) {
 // It is guaranteed that the function is not run concurrently. If the
 // callback returns an error, this function is cancelled and also returns that error.
 // If a lock ID is passed via excludeID, it will be ignored.
-func ForAllLocks(ctx context.Context, repo Repository, excludeID *ID, fn func(ID, *Lock, error) error) error {
+func ForAllLocks(ctx context.Context, repo Repository, excludeIDs IDSet, fn func(ID, *Lock, error) error) error {
 	var m sync.Mutex
 
 	// For locks decoding is nearly for free, thus just assume were only limited by IO
 	return ParallelList(ctx, repo, LockFile, repo.Connections(), func(ctx context.Context, id ID, size int64) error {
-		if excludeID != nil && id.Equal(*excludeID) {
+		if excludeIDs.Has(id) {
 			return nil
 		}
 		if size == 0 {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
If a lock could not be loaded, then restic would check all lock files again. These repeated checks are not useful as the status of a lock file cannot change unless its ID changes too. Thus, skip already check lock files on retries.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
