### PR TITLE
backup: Improve help text for `--stdin-from-command`

### DIFF
--- a/changelog/unreleased/issue-4251
+++ b/changelog/unreleased/issue-4251
@@ -1,15 +1,16 @@
-Enhancement: Support reading backup from a program's standard output
-
-When reading data from stdin, the `backup` command could not verify whether the
-corresponding command completed successfully.
+Enhancement: Support reading backup from a commands's standard output
 
 The `backup` command now supports the `--stdin-from-command` option. When using
-this option, the arguments to `backup` are interpreted as a command. `backup`
-then executes the command and stores its standard output in the backup. This
-enables restic to verify that the command completes with exit code zero. A
-non-zero exit code causes the backup to fail.
+this option, the arguments to `backup` are interpreted as a command instead of
+paths to back up. `backup` then executes the given command and stores the
+standard output from it in the backup, similar to the what the `--stdin` option
+does. This also enables restic to verify that the command completes with exit
+code zero. A non-zero exit code causes the backup to fail.
 
-Example: `restic backup --stdin-from-command mysqldump [...]`
+Note that the `--stdin` option does not have to be specified at the same time,
+and that the `--stdin-filename` option also applies to `--stdin-from-command`.
+
+Example: `restic backup --stdin-from-command --stdin-filename dump.sql mysqldump [...]`
 
 https://github.com/restic/restic/issues/4251
 https://github.com/restic/restic/pull/4410

--- a/changelog/unreleased/issue-4251
+++ b/changelog/unreleased/issue-4251
@@ -3,10 +3,11 @@ Enhancement: Support reading backup from a program's standard output
 When reading data from stdin, the `backup` command could not verify whether the
 corresponding command completed successfully.
 
-The `backup` command now supports starting an arbitrary command and sourcing
-the backup content from its standard output. This enables restic to verify that
-the command completes with exit code zero. A non-zero exit code causes the
-backup to fail.
+The `backup` command now supports the `--stdin-from-command` option. When using
+this option, the arguments to `backup` are interpreted as a command. `backup`
+then executes the command and stores its standard output in the backup. This
+enables restic to verify that the command completes with exit code zero. A
+non-zero exit code causes the backup to fail.
 
 Example: `restic backup --stdin-from-command mysqldump [...]`
 

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -135,7 +135,7 @@ func init() {
 	f.StringVar(&backupOptions.ExcludeLargerThan, "exclude-larger-than", "", "max `size` of the files to be backed up (allowed suffixes: k/K, m/M, g/G, t/T)")
 	f.BoolVar(&backupOptions.Stdin, "stdin", false, "read backup from stdin")
 	f.StringVar(&backupOptions.StdinFilename, "stdin-filename", "stdin", "`filename` to use when reading from stdin")
-	f.BoolVar(&backupOptions.StdinCommand, "stdin-from-command", false, "execute command and store its stdout")
+	f.BoolVar(&backupOptions.StdinCommand, "stdin-from-command", false, "interpret arguments as command to execute and store its stdout")
 	f.Var(&backupOptions.Tags, "tag", "add `tags` for the new snapshot in the format `tag[,tag,...]` (can be specified multiple times)")
 	f.UintVar(&backupOptions.ReadConcurrency, "read-concurrency", 0, "read `n` files concurrently (default: $RESTIC_READ_CONCURRENCY or 2)")
 	f.StringVarP(&backupOptions.Host, "host", "H", "", "set the `hostname` for the snapshot manually. To prevent an expensive rescan use the \"parent\" flag")


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
