### PR TITLE
Properly report the ID of newly added keys

### DIFF
--- a/changelog/unreleased/issue-4656
+++ b/changelog/unreleased/issue-4656
@@ -1,0 +1,7 @@
+Bugfix: Properly report the ID of newly added keys
+
+`restic key add` now reports the ID of a newly added key. This simplifies
+selecting a specific key using the `--key-hint key` option.
+
+https://github.com/restic/restic/issues/4656
+https://github.com/restic/restic/pull/4657

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -142,7 +142,7 @@ func addKey(ctx context.Context, repo *repository.Repository, gopts GlobalOption
 		return err
 	}
 
-	Verbosef("saved new key as %s\n", id)
+	Verbosef("saved new key with ID %s\n", id.ID())
 
 	return nil
 }


### PR DESCRIPTION

What does this PR change? What problem does it solve?
-----------------------------------------------------

Other commands like key list and key remove show the key's ID.

Showing the ID here lets users easily reuse the ID as a key hint for subsequent commands. In particular, a key hint is needed when the repository has many keys - otherwise opening the repository may fail with "Fatal: maximum number of keys reached" even when a proper password is provided.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes #4656


- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [ ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [X] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
