### PR TITLE
feat: dump flag --target should be allowed to write existing file

### DIFF
--- a/changelog/unreleased/issue-4678
+++ b/changelog/unreleased/issue-4678
@@ -5,3 +5,4 @@ Restic `dump` always printed to the standard output. It now permits to select a
 
 https://github.com/restic/restic/issues/4678
 https://github.com/restic/restic/pull/4682
+https://github.com/restic/restic/pull/4692

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -174,7 +174,7 @@ func runDump(ctx context.Context, opts DumpOptions, gopts GlobalOptions, args []
 	canWriteArchiveFunc := checkStdoutArchive
 
 	if opts.Target != "" {
-		file, err := os.OpenFile(opts.Target, os.O_RDWR|os.O_CREATE|os.O_EXCL, 0o666)
+		file, err := os.Create(opts.Target)
 		if err != nil {
 			return fmt.Errorf("cannot dump to file: %w", err)
 		}

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -176,8 +176,7 @@ To include the folder content at the root of the archive, you can use the ``<sna
     $ restic -r /srv/restic-repo dump latest:/home/other/work / > restore.tar
 
 It is also possible to ``dump`` the contents of a selected snapshot and folder
-structure to a file using the ``--target`` flag. The ``dump`` command will fail
-if the already file exists.
+structure to a file using the ``--target`` flag.
 
 .. code-block:: console
     $ restic -r /srv/restic-repo dump latest / --target /home/linux.user/output.tar -a tar


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

dump flag --target should be allowed to write existing file

The primary objective of #4678 is to restore a block PVC.
steps:
1. mount the block pvc to a pod as volumeDevice
2. start the pod, write data to the block device inside the pod using restic

The block device is already there, we need to use restic dump to write data into it

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #4678

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
