### PR TITLE
Catch SIGTERM, run cleanup

### DIFF
--- a/changelog/unreleased/pull-4703
+++ b/changelog/unreleased/pull-4703
@@ -1,0 +1,9 @@
+Bugfix: Shutdown cleanly when SIGTERM is received
+
+Prior, if restic received SIGTERM it'd just immediately terminate skipping
+cleanup- resulting in potential issues like stale locks being left behind.
+
+This primarily effected containerized restic invocations- they use SIGTERM-
+but this could be triggered via a simple `killall restic` in addition.
+
+https://github.com/restic/restic/pull/4703

--- a/cmd/restic/cleanup.go
+++ b/cmd/restic/cleanup.go
@@ -56,7 +56,7 @@ func RunCleanupHandlers(code int) int {
 	return code
 }
 
-// CleanupHandler handles the SIGINT signals.
+// CleanupHandler handles the SIGINT and SIGTERM signals.
 func CleanupHandler(c <-chan os.Signal) {
 	for s := range c {
 		debug.Log("signal %v received, cleaning up", s)

--- a/cmd/restic/cleanup.go
+++ b/cmd/restic/cleanup.go
@@ -19,7 +19,7 @@ var cleanupHandlers struct {
 func init() {
 	cleanupHandlers.ch = make(chan os.Signal, 1)
 	go CleanupHandler(cleanupHandlers.ch)
-	signal.Notify(cleanupHandlers.ch, syscall.SIGINT)
+	signal.Notify(cleanupHandlers.ch, syscall.SIGINT, syscall.SIGTERM)
 }
 
 // AddCleanupHandler adds the function f to the list of cleanup handlers so
@@ -70,7 +70,7 @@ func CleanupHandler(c <-chan os.Signal) {
 
 		code := 0
 
-		if s == syscall.SIGINT {
+		if s == syscall.SIGINT || s == syscall.SIGTERM {
 			code = 130
 		} else {
 			code = 1


### PR DESCRIPTION
The previous code only ran cleanup (lock release for example) on SIGINT.  For anyone running restic in a container, the signal is going to be SIGTERM which means containerized execution would leave locks behind.

While this could be addressed via interposing dumb-init to translate the signal, a `kill` invocation is going to default to SIGTERM, so the same problem exists for non container users.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This change ensures restic shuts down cleanly when SIGTERM'd.  It currently handles SIGINT only.

For the containerized docker image, any stopping of the container results in restic being SIGTERM'd which means it
leaves behind locks and other undesirables.  This problem can also exist for CLI invocation of restic- `killall restic` would accomplish the same.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Ish.  People talk in the forums of shutting restic down with SIGINT/SIGTERM (https://forum.restic.net/t/robustness-of-repository-issue-resolved/1475/3 for example), but nothing in the codebases history- that I can find- has SIGTERM awareness.

Minimally, manual testing of current restic confirms it lacks SIGTERM handling, so I assume folks were just... assuming...

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes. (no tests pre-exist for SIGINT)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [X] I'm done! This pull request is ready for review.
