### PR TITLE
adds option for backing up binary on self-update

### DIFF
--- a/changelog/unreleased/pull-4720
+++ b/changelog/unreleased/pull-4720
@@ -1,0 +1,8 @@
+Enhancement: Adds options for backup of binary file on self-update.
+
+Restic overwrote (on windows only kept the last version of) the binary
+file on self update. It now permits to keep the old version, if the option
+'backup' is used. For the backup file the existing filename is extended
+by ".bak.<version>".
+
+https://github.com/restic/restic/pull/4720

--- a/cmd/restic/cmd_self_update.go
+++ b/cmd/restic/cmd_self_update.go
@@ -35,6 +35,7 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 // SelfUpdateOptions collects all options for the update-restic command.
 type SelfUpdateOptions struct {
 	Output string
+	Backup bool
 }
 
 var selfUpdateOptions SelfUpdateOptions
@@ -44,6 +45,7 @@ func init() {
 
 	flags := cmdSelfUpdate.Flags()
 	flags.StringVar(&selfUpdateOptions.Output, "output", "", "Save the downloaded file as `filename` (default: running binary itself)")
+	flags.BoolVar(&selfUpdateOptions.Backup, "backup", false, "The old binary file is kept or renamed to <filename>.bak.<version> (default: false)")
 }
 
 func runSelfUpdate(ctx context.Context, opts SelfUpdateOptions, gopts GlobalOptions, args []string) error {
@@ -74,7 +76,7 @@ func runSelfUpdate(ctx context.Context, opts SelfUpdateOptions, gopts GlobalOpti
 
 	Verbosef("writing restic to %v\n", opts.Output)
 
-	v, err := selfupdate.DownloadLatestStableRelease(ctx, opts.Output, version, Verbosef)
+	v, err := selfupdate.DownloadLatestStableRelease(ctx, opts.Output, version, opts.Backup, Verbosef)
 	if err != nil {
 		return errors.Fatalf("unable to update restic: %v", err)
 	}


### PR DESCRIPTION
* option name is 'backup' (bool)
* adds version to backup filename

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds the option 'backup' (bool) to the function self-update. If this option is given, the current binary is saved with the version in the filename (<name>.bak.<version>).

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
