### PR TITLE
Add support for specifying --host via environment variable

### DIFF
--- a/changelog/unreleased/issue-4733
+++ b/changelog/unreleased/issue-4733
@@ -1,0 +1,9 @@
+Enhancement: Allow specifying `--host` via environment variable
+
+Restic commands that operate on snapshots, such as `restic backup` and
+`restic snapshots`, support the `--host` flag to specify the hostname for
+grouoping snapshots. They now permit selecting the hostname via the
+environment variable `RESTIC_HOST`. `--host` still takes precedence over the
+environment variable.
+
+https://github.com/restic/restic/issues/4733

--- a/changelog/unreleased/issue-4733
+++ b/changelog/unreleased/issue-4733
@@ -7,3 +7,4 @@ environment variable `RESTIC_HOST`. `--host` still takes precedence over the
 environment variable.
 
 https://github.com/restic/restic/issues/4733
+https://github.com/restic/restic/pull/4734

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -114,7 +114,7 @@ func init() {
 	f.BoolVar(&backupOptions.StdinCommand, "stdin-from-command", false, "interpret arguments as command to execute and store its stdout")
 	f.Var(&backupOptions.Tags, "tag", "add `tags` for the new snapshot in the format `tag[,tag,...]` (can be specified multiple times)")
 	f.UintVar(&backupOptions.ReadConcurrency, "read-concurrency", 0, "read `n` files concurrently (default: $RESTIC_READ_CONCURRENCY or 2)")
-	f.StringVarP(&backupOptions.Host, "host", "H", "", "set the `hostname` for the snapshot manually. To prevent an expensive rescan use the \"parent\" flag")
+	f.StringVarP(&backupOptions.Host, "host", "H", "", "set the `hostname` for the snapshot manually (default: $RESTIC_HOST). To prevent an expensive rescan use the \"parent\" flag")
 	f.StringVar(&backupOptions.Host, "hostname", "", "set the `hostname` for the snapshot manually")
 	err := f.MarkDeprecated("hostname", "use --host")
 	if err != nil {
@@ -137,6 +137,11 @@ func init() {
 	// parse read concurrency from env, on error the default value will be used
 	readConcurrency, _ := strconv.ParseUint(os.Getenv("RESTIC_READ_CONCURRENCY"), 10, 32)
 	backupOptions.ReadConcurrency = uint(readConcurrency)
+
+	// parse host from env, if not exists or empty the default value will be used
+	if host := os.Getenv("RESTIC_HOST"); host != "" {
+		backupOptions.Host = host
+	}
 }
 
 // filterExisting returns a slice of all existing items, or an error if no

--- a/cmd/restic/find.go
+++ b/cmd/restic/find.go
@@ -19,11 +19,9 @@ func initMultiSnapshotFilter(flags *pflag.FlagSet, filt *restic.SnapshotFilter, 
 	flags.Var(&filt.Tags, "tag", "only consider snapshots including `tag[,tag,...]` (can be specified multiple times)")
 	flags.StringArrayVar(&filt.Paths, "path", nil, "only consider snapshots including this (absolute) `path` (can be specified multiple times)")
 
-	if len(filt.Hosts) == 0 {
-		// parse host from env, if not exists or empty the default value will be used
-		if host := os.Getenv("RESTIC_HOST"); host != "" {
-			filt.Hosts = []string{host}
-		}
+	// set default based on env if set
+	if host := os.Getenv("RESTIC_HOST"); host != "" {
+		filt.Hosts = []string{host}
 	}
 }
 
@@ -34,11 +32,9 @@ func initSingleSnapshotFilter(flags *pflag.FlagSet, filt *restic.SnapshotFilter)
 	flags.Var(&filt.Tags, "tag", "only consider snapshots including `tag[,tag,...]`, when snapshot ID \"latest\" is given (can be specified multiple times)")
 	flags.StringArrayVar(&filt.Paths, "path", nil, "only consider snapshots including this (absolute) `path`, when snapshot ID \"latest\" is given (can be specified multiple times)")
 
-	if len(filt.Hosts) == 0 {
-		// parse host from env, if not exists or empty the default value will be used
-		if host := os.Getenv("RESTIC_HOST"); host != "" {
-			filt.Hosts = []string{host}
-		}
+	// set default based on env if set
+	if host := os.Getenv("RESTIC_HOST"); host != "" {
+		filt.Hosts = []string{host}
 	}
 }
 

--- a/cmd/restic/find.go
+++ b/cmd/restic/find.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"os"
 
 	"github.com/restic/restic/internal/restic"
 	"github.com/spf13/pflag"
@@ -14,17 +15,31 @@ func initMultiSnapshotFilter(flags *pflag.FlagSet, filt *restic.SnapshotFilter, 
 	if !addHostShorthand {
 		hostShorthand = ""
 	}
-	flags.StringArrayVarP(&filt.Hosts, "host", hostShorthand, nil, "only consider snapshots for this `host` (can be specified multiple times)")
+	flags.StringArrayVarP(&filt.Hosts, "host", hostShorthand, nil, "only consider snapshots for this `host` (can be specified multiple times) (default: $RESTIC_HOST)")
 	flags.Var(&filt.Tags, "tag", "only consider snapshots including `tag[,tag,...]` (can be specified multiple times)")
 	flags.StringArrayVar(&filt.Paths, "path", nil, "only consider snapshots including this (absolute) `path` (can be specified multiple times)")
+
+	if len(filt.Hosts) == 0 {
+		// parse host from env, if not exists or empty the default value will be used
+		if host := os.Getenv("RESTIC_HOST"); host != "" {
+			filt.Hosts = []string{host}
+		}
+	}
 }
 
 // initSingleSnapshotFilter is used for commands that work on a single snapshot
 // MUST be combined with restic.FindFilteredSnapshot
 func initSingleSnapshotFilter(flags *pflag.FlagSet, filt *restic.SnapshotFilter) {
-	flags.StringArrayVarP(&filt.Hosts, "host", "H", nil, "only consider snapshots for this `host`, when snapshot ID \"latest\" is given (can be specified multiple times)")
+	flags.StringArrayVarP(&filt.Hosts, "host", "H", nil, "only consider snapshots for this `host`, when snapshot ID \"latest\" is given (can be specified multiple times) (default: $RESTIC_HOST)")
 	flags.Var(&filt.Tags, "tag", "only consider snapshots including `tag[,tag,...]`, when snapshot ID \"latest\" is given (can be specified multiple times)")
 	flags.StringArrayVar(&filt.Paths, "path", nil, "only consider snapshots including this (absolute) `path`, when snapshot ID \"latest\" is given (can be specified multiple times)")
+
+	if len(filt.Hosts) == 0 {
+		// parse host from env, if not exists or empty the default value will be used
+		if host := os.Getenv("RESTIC_HOST"); host != "" {
+			filt.Hosts = []string{host}
+		}
+	}
 }
 
 // FindFilteredSnapshots yields Snapshots, either given explicitly by `snapshotIDs` or filtered from the list of all snapshots.

--- a/cmd/restic/find_test.go
+++ b/cmd/restic/find_test.go
@@ -1,0 +1,61 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+	"github.com/spf13/pflag"
+)
+
+func TestSnapshotFilter(t *testing.T) {
+	for _, test := range []struct {
+		name     string
+		args     []string
+		expected []string
+		env      string
+	}{
+		{
+			"no value",
+			[]string{},
+			nil,
+			"",
+		},
+		{
+			"args only",
+			[]string{"--host", "abc"},
+			[]string{"abc"},
+			"",
+		},
+		{
+			"env default",
+			[]string{},
+			[]string{"def"},
+			"def",
+		},
+		{
+			"both",
+			[]string{"--host", "abc"},
+			[]string{"abc"},
+			"def",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("RESTIC_HOST", test.env)
+
+			for _, mode := range []bool{false, true} {
+				set := pflag.NewFlagSet("test", pflag.PanicOnError)
+				flt := &restic.SnapshotFilter{}
+				if mode {
+					initMultiSnapshotFilter(set, flt, false)
+				} else {
+					initSingleSnapshotFilter(set, flt)
+				}
+				err := set.Parse(test.args)
+				rtest.OK(t, err)
+
+				rtest.Equals(t, test.expected, flt.Hosts, "unexpected hosts")
+			}
+		})
+	}
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds the ability to set the hostname for most commands that accept the `--host` flag via the `RESTIC_HOST` environment variable. This allows the user to set the hostname once and not have to specify it for every command. Commands that accept `--host` but do not work on snapshots (e.g. `restic key ...`) are not affected by this change. The `--host` flag is still accepted and takes precedence over the `RESTIC_HOST` environment variable.

The changes are in `cmd_backup.go` for the `backup` command and `find.go` for commands that use the `restic.SnapshotFilter` options.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closees #4733

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x]  There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.