### PR TITLE
json output forget command: added id's in snapshots within reasons object

### DIFF
--- a/changelog/unreleased/pull-4737
+++ b/changelog/unreleased/pull-4737
@@ -1,0 +1,5 @@
+Enhancement: include snapshot id in reason field of forget JSON output
+
+The JSON output of the `forget` command now includes the `id` and `short_id` of a snapshot in the `reason` field.
+
+https://github.com/restic/restic/pull/4737

--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -367,13 +367,13 @@ Snapshot object
 
 Reason object
 
-+----------------+---------------------------------------------------------+
-| ``snapshot``   | Snapshot object, without ``id`` and ``short_id`` fields |
-+----------------+---------------------------------------------------------+
-| ``matches``    | Array containing descriptions of the matching criteria  |
-+----------------+---------------------------------------------------------+
-| ``counters``   | Object containing counters used by the policies         |
-+----------------+---------------------------------------------------------+
++----------------+-----------------------------------------------------------+
+| ``snapshot``   | Snapshot object, including ``id`` and ``short_id`` fields |
++----------------+-----------------------------------------------------------+
+| ``matches``    | Array containing descriptions of the matching criteria    |
++----------------+-----------------------------------------------------------+
+| ``counters``   | Object containing counters used by the policies           |
++----------------+-----------------------------------------------------------+
 
 
 init


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------


In order to evaluate the reasons for keep snapshots, there should be also 
the id's within the snapshots in the reasons object to have exact reference.
(See also Issue #3117)


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
