### PR TITLE
doc: fix typo in 047_tuning_backup_parameters.rst

### DIFF
--- a/doc/047_tuning_backup_parameters.rst
+++ b/doc/047_tuning_backup_parameters.rst
@@ -121,7 +121,7 @@ Feature flags allow disabling or enabling certain experimental restic features. 
 can be specified via the ``RESTIC_FEATURES`` environment variable. The variable expects a
 comma-separated list of ``key[=value],key2[=value2]`` pairs. The key is the name of a feature
 flag. The value is optional and can contain either the value ``true`` (default if omitted)
-or ``false``. The list of currently available feautre flags is shown by the ``features``
+or ``false``. The list of currently available feature flags is shown by the ``features``
 command.
 
 Restic will return an error if an invalid feature flag is specified. No longer relevant


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Fixes a typo.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
