### PR TITLE
backend: enforce backend HTTP requests make progress

### DIFF
--- a/internal/backend/timeout_transport.go
+++ b/internal/backend/timeout_transport.go
@@ -1,0 +1,172 @@
+package backend
+
+import (
+	"net"
+	"os"
+	"sync"
+	"time"
+)
+
+// timeoutConn will timeout if no read or write progress is made for progressTimeout.
+// This ensures that stuck network connections are interrupted after some time.
+// By using a timeoutConn within a http transport (via DialContext), sending / receing
+// the request / response body is guarded with a timeout. The read progress part also
+// limits the time until a response header must be received.
+//
+// The progressTimeout must be larger than the IdleConnTimeout of the http transport.
+//
+// The http2.Transport offers a similar functionality via WriteByteTimeout & ReadIdleTimeout.
+// However, those are not available for HTTP/1 connections. Thus, there's no builtin way to
+// enforce progress for sending the request body or reading the response body.
+// See https://github.com/restic/restic/issues/4193#issuecomment-2067988727 for details.
+type timeoutConn struct {
+	conn net.Conn
+	// timeout within which a read/write must make progress, otherwise a connection is considered broken
+	// if no read/write is pending, then the timeout is inactive
+	progressTimeout time.Duration
+
+	// all access to fields below must hold m
+	m sync.Mutex
+
+	// user defined read/write deadline
+	readDeadline  time.Time
+	writeDeadline time.Time
+	// timestamp of last successful write (at least one byte)
+	lastWrite time.Time
+}
+
+var _ net.Conn = &timeoutConn{}
+
+func newTimeoutConn(conn net.Conn, progressTimeout time.Duration) (*timeoutConn, error) {
+	// reset timeouts to ensure a consistent state
+	err := conn.SetDeadline(time.Time{})
+	if err != nil {
+		return nil, err
+	}
+
+	return &timeoutConn{
+		conn:            conn,
+		progressTimeout: progressTimeout,
+	}, nil
+}
+
+func (t *timeoutConn) Write(p []byte) (n int, err error) {
+	t.m.Lock()
+	timeout := t.writeDeadline
+	t.m.Unlock()
+	var zero time.Time
+	if timeout != zero {
+		// fall back to standard behavior if a timeout was set explicitly
+		n, err := t.conn.Write(p)
+		if n > 0 {
+			t.m.Lock()
+			t.lastWrite = time.Now()
+			t.m.Unlock()
+		}
+		return n, err
+	}
+
+	// based on http2stickyErrWriter.Write from go/src/net/http/h2_bundle.go
+	for {
+		_ = t.conn.SetWriteDeadline(time.Now().Add(t.progressTimeout))
+
+		nn, err := t.conn.Write(p[n:])
+		n += nn
+		if nn > 0 {
+			// track write progress
+			t.m.Lock()
+			t.lastWrite = time.Now()
+			t.m.Unlock()
+		}
+
+		if n < len(p) && nn > 0 && err == os.ErrDeadlineExceeded {
+			// some data is still left to send, keep going as long as there is some progress
+			continue
+		}
+
+		t.m.Lock()
+		// restore configured deadline
+		_ = t.conn.SetWriteDeadline(t.writeDeadline)
+		t.m.Unlock()
+		return n, err
+	}
+}
+
+func (t *timeoutConn) Read(b []byte) (n int, err error) {
+	t.m.Lock()
+	timeout := t.readDeadline
+	t.m.Unlock()
+	var zero time.Time
+	if timeout != zero {
+		// fall back to standard behavior if a timeout was set explicitly
+		return t.conn.Read(b)
+	}
+
+	var start = time.Now()
+
+	for {
+		_ = t.conn.SetReadDeadline(start.Add(t.progressTimeout))
+
+		nn, err := t.conn.Read(b)
+		t.m.Lock()
+		lastWrite := t.lastWrite
+		t.m.Unlock()
+		if nn == 0 && err == os.ErrDeadlineExceeded && lastWrite.After(start) {
+			// deadline exceeded, but write made some progress in the meantime
+			start = lastWrite
+			continue
+		}
+
+		t.m.Lock()
+		// restore configured deadline
+		_ = t.conn.SetReadDeadline(t.readDeadline)
+		t.m.Unlock()
+		return nn, err
+	}
+}
+
+func (t *timeoutConn) Close() error {
+	return t.conn.Close()
+}
+
+func (t *timeoutConn) LocalAddr() net.Addr {
+	return t.conn.LocalAddr()
+}
+
+func (t *timeoutConn) RemoteAddr() net.Addr {
+	return t.conn.RemoteAddr()
+}
+
+func (t *timeoutConn) SetDeadline(d time.Time) error {
+	err := t.SetReadDeadline(d)
+	err2 := t.SetWriteDeadline(d)
+	if err != nil {
+		return err
+	}
+	return err2
+}
+
+func (t *timeoutConn) SetReadDeadline(d time.Time) error {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	// track timeout modifications, as the current timeout cannot be queried
+	err := t.conn.SetReadDeadline(d)
+	if err != nil {
+		return err
+	}
+	t.readDeadline = d
+	return nil
+}
+
+func (t *timeoutConn) SetWriteDeadline(d time.Time) error {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	err := t.conn.SetWriteDeadline(d)
+	if err != nil {
+		return err
+	}
+	t.writeDeadline = d
+	return nil
+}

--- a/internal/feature/registry.go
+++ b/internal/feature/registry.go
@@ -8,6 +8,7 @@ const (
 	DeprecateLegacyIndex    FlagName = "deprecate-legacy-index"
 	DeprecateS3LegacyLayout FlagName = "deprecate-s3-legacy-layout"
 	DeviceIDForHardlinks    FlagName = "device-id-for-hardlinks"
+	HTTPTimeouts            FlagName = "http-timeouts"
 )
 
 func init() {
@@ -15,5 +16,6 @@ func init() {
 		DeprecateLegacyIndex:    {Type: Beta, Description: "disable support for index format used by restic 0.1.0. Use `restic repair index` to update the index if necessary."},
 		DeprecateS3LegacyLayout: {Type: Beta, Description: "disable support for S3 legacy layout used up to restic 0.7.0. Use `RESTIC_FEATURES=deprecate-s3-legacy-layout=false restic migrate s3_layout` to migrate your S3 repository if necessary."},
 		DeviceIDForHardlinks:    {Type: Alpha, Description: "store deviceID only for hardlinks to reduce metadata changes for example when using btrfs subvolumes. Will be removed in a future restic version after repository format 3 is available"},
+		HTTPTimeouts:            {Type: Beta, Description: "improve handling of stuck HTTP connections using timeouts."},
 	})
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Implements net.Conn based timeouts for connections as discussed in https://github.com/restic/restic/issues/4193#issuecomment-2067988727 . 

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #4193.
Part of https://github.com/restic/restic/issues/4627 .
Depends on #4605.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
