### PR TITLE
Azure: add option to force use of CLI credential

### DIFF
--- a/changelog/unreleased/pull-4799
+++ b/changelog/unreleased/pull-4799
@@ -1,0 +1,5 @@
+Enhancement: Add option to force use of Azure CLI credential
+
+A new environment variable `AZURE_FORCE_CLI_CREDENTIAL=true` allows forcing the use of Azure CLI credential, ignoring other credentials like managed identity.
+
+https://github.com/restic/restic/pull/4799

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -550,16 +550,22 @@ For authentication export one of the following variables:
     # For SAS
     $ export AZURE_ACCOUNT_SAS=<SAS_TOKEN>
 
-For authentication using ``az login`` set the resource group name and ensure the user has
-the minimum permissions of the role assignment ``Storage Blob Data Contributor`` on Azure RBAC.
+For authentication using ``az login`` ensure the user has
+the minimum permissions of the role assignment ``Storage Blob Data Contributor`` on Azure RBAC
+for the storage account.
 
 .. code-block:: console
 
-    $ export AZURE_RESOURCE_GROUP=<RESOURCE_GROUP_NAME>
     $ az login
 
-Alternatively, if run on Azure, restic will automatically uses service accounts configured
+Alternatively, if run on Azure, restic will automatically use service accounts configured
 via the standard environment variables or Workload / Managed Identities.
+
+To enforce the use of the Azure CLI credential when other credentials are present, set the following environment variable:
+
+.. code-block:: console
+
+    $ export AZURE_FORCE_CLI_CREDENTIAL=true
 
 Restic will by default use Azure's global domain ``core.windows.net`` as endpoint suffix.
 You can specify other suffixes as follows:

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -673,6 +673,7 @@ environment variables. The following lists these environment variables:
     AZURE_ACCOUNT_KEY                   Account key for Azure
     AZURE_ACCOUNT_SAS                   Shared access signatures (SAS) for Azure
     AZURE_ENDPOINT_SUFFIX               Endpoint suffix for Azure Storage (default: core.windows.net)
+    AZURE_FORCE_CLI_CREDENTIAL          Force the use of Azure CLI credentials for authentication
 
     B2_ACCOUNT_ID                       Account ID or applicationKeyId for Backblaze B2
     B2_ACCOUNT_KEY                      Account Key or applicationKey for Backblaze B2

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -101,23 +101,21 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "NewAccountSASClientFromEndpointToken")
 		}
-	} else if cfg.ForceCliCredential {
-		debug.Log(" - using AzureCLICredential")
-
-		cred, err := azidentity.NewAzureCLICredential(nil)
-		if err != nil {
-			return nil, errors.Wrap(err, "NewAzureCLICredential")
-		}
-
-		client, err = azContainer.NewClient(url, cred, opts)
-		if err != nil {
-			return nil, errors.Wrap(err, "NewClient")
-		}
 	} else {
-		debug.Log(" - using DefaultAzureCredential")
-		cred, err := azidentity.NewDefaultAzureCredential(nil)
-		if err != nil {
-			return nil, errors.Wrap(err, "NewDefaultAzureCredential")
+		var cred azcore.TokenCredential
+
+		if cfg.ForceCliCredential {
+			debug.Log(" - using AzureCLICredential")
+			cred, err = azidentity.NewAzureCLICredential(nil)
+			if err != nil {
+				return nil, errors.Wrap(err, "NewAzureCLICredential")
+			}
+		} else {
+			debug.Log(" - using DefaultAzureCredential")
+			cred, err = azidentity.NewDefaultAzureCredential(nil)
+			if err != nil {
+				return nil, errors.Wrap(err, "NewDefaultAzureCredential")
+			}
 		}
 
 		client, err = azContainer.NewClient(url, cred, opts)

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -101,6 +101,18 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 		if err != nil {
 			return nil, errors.Wrap(err, "NewAccountSASClientFromEndpointToken")
 		}
+	} else if cfg.ForceCliCredential {
+		debug.Log(" - using AzureCLICredential")
+
+		cred, err := azidentity.NewAzureCLICredential(nil)
+		if err != nil {
+			return nil, errors.Wrap(err, "NewAzureCLICredential")
+		}
+
+		client, err = azContainer.NewClient(url, cred, opts)
+		if err != nil {
+			return nil, errors.Wrap(err, "NewClient")
+		}
 	} else {
 		debug.Log(" - using DefaultAzureCredential")
 		cred, err := azidentity.NewDefaultAzureCredential(nil)

--- a/internal/backend/azure/config.go
+++ b/internal/backend/azure/config.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"os"
 	"path"
+	"strconv"
 	"strings"
 
 	"github.com/restic/restic/internal/backend"
@@ -13,12 +14,13 @@ import (
 // Config contains all configuration necessary to connect to an azure compatible
 // server.
 type Config struct {
-	AccountName    string
-	AccountSAS     options.SecretString
-	AccountKey     options.SecretString
-	EndpointSuffix string
-	Container      string
-	Prefix         string
+	AccountName        string
+	AccountSAS         options.SecretString
+	AccountKey         options.SecretString
+	ForceCliCredential bool
+	EndpointSuffix     string
+	Container          string
+	Prefix             string
 
 	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
 }
@@ -71,6 +73,11 @@ func (cfg *Config) ApplyEnvironment(prefix string) {
 
 	if cfg.AccountSAS.String() == "" {
 		cfg.AccountSAS = options.NewSecretString(os.Getenv(prefix + "AZURE_ACCOUNT_SAS"))
+	}
+
+	var forceCliCred, err = strconv.ParseBool(os.Getenv(prefix + "AZURE_FORCE_CLI_CREDENTIAL"))
+	if err == nil {
+		cfg.ForceCliCredential = forceCliCred
 	}
 
 	if cfg.EndpointSuffix == "" {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

In Azure, VMs can have multiple identities at the same time, for example a managed identity and an Azure CLI identity. Sometimes the managed identity is not under control of the user but the user can still login with the Azure CLI. In those cases, being able to use the Azure CLI identity with restic makes sense.

`DefaultAzureCredential` first tries environment variables, managed identity, workload identity, and eventually Azure CLI identity. This PR introduces a new environment variable that forces use of the Azure CLI identity:

```
export AZURE_FORCE_CLI_CREDENTIAL=true
```

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
  - [x] Manually tested. 
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
