### PR TITLE
Do not retry permanent backend failures

### DIFF
--- a/changelog/unreleased/issue-4515
+++ b/changelog/unreleased/issue-4515
@@ -1,8 +1,0 @@
-Change: Don't retry to load files that don't exist
-
-Restic used to always retry to load files. It now only retries to load
-files if they exist.
-
-https://github.com/restic/restic/issues/4515
-https://github.com/restic/restic/issues/1523
-https://github.com/restic/restic/pull/4520

--- a/changelog/unreleased/issue-4627
+++ b/changelog/unreleased/issue-4627
@@ -1,4 +1,4 @@
-Enhancement: Improve reliability of backend operations
+Change: Redesign backend error handling to improve reliability
 
 Restic now downloads pack files in large chunks instead of using a streaming
 download. This prevents failures due to interrupted streams. The `restore`
@@ -6,12 +6,20 @@ command now also retries downloading individual blobs that cannot be retrieved.
 
 HTTP requests that are stuck for more than two minutes while uploading or
 downloading are now forcibly interrupted. This ensures that stuck requests are
-retried after a short timeout. These new request timeouts can temporarily be
-disabled by setting the environment variable
-`RESTIC_FEATURES=http-timeouts=false`. Note that this feature flag will be
-removed in the next minor restic version.
+retried after a short timeout.
+
+Attempts to access a missing file or a truncated file will no longer be retried.
+This avoids unnecessary retries in those cases.
+
+Most parts of the new backend error handling can temporarily be disabled by
+setting the environment variable
+`RESTIC_FEATURES=backend-error-redesign=false`. Note that this feature flag will
+be removed in the next minor restic version.
 
 https://github.com/restic/restic/issues/4627
 https://github.com/restic/restic/issues/4193
 https://github.com/restic/restic/pull/4605
 https://github.com/restic/restic/pull/4792
+https://github.com/restic/restic/issues/4515
+https://github.com/restic/restic/issues/1523
+https://github.com/restic/restic/pull/4520

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -38,7 +38,9 @@ type Backend interface {
 
 	// Load runs fn with a reader that yields the contents of the file at h at the
 	// given offset. If length is larger than zero, only a portion of the file
-	// is read.
+	// is read. If the length is larger than zero and the file is too short to return
+	// the requested length bytes, then an error MUST be returned that is recognized
+	// by IsPermanentError().
 	//
 	// The function fn may be called multiple times during the same Load invocation
 	// and therefore must be idempotent.
@@ -65,6 +67,12 @@ type Backend interface {
 	// The argument may be a wrapped error. The implementation is responsible
 	// for unwrapping it.
 	IsNotExist(err error) bool
+
+	// IsPermanentError returns true if the error can very likely not be resolved
+	// by retrying the operation. Backends should return true if the file is missing,
+	// the requested range does not (completely) exist in the file or the user is
+	// not authorized to perform the requested operation.
+	IsPermanentError(err error) bool
 
 	// Delete removes all data in the backend.
 	Delete(ctx context.Context) error

--- a/internal/backend/dryrun/dry_backend.go
+++ b/internal/backend/dryrun/dry_backend.go
@@ -72,6 +72,10 @@ func (be *Backend) IsNotExist(err error) bool {
 	return be.b.IsNotExist(err)
 }
 
+func (be *Backend) IsPermanentError(err error) bool {
+	return be.b.IsPermanentError(err)
+}
+
 func (be *Backend) List(ctx context.Context, t backend.FileType, fn func(backend.FileInfo) error) error {
 	return be.b.List(ctx, t, fn)
 }

--- a/internal/backend/dryrun/dry_backend_test.go
+++ b/internal/backend/dryrun/dry_backend_test.go
@@ -96,7 +96,7 @@ func TestDry(t *testing.T) {
 			}
 		case "load":
 			data := ""
-			err = step.be.Load(ctx, handle, 100, 0, func(rd io.Reader) error {
+			err = step.be.Load(ctx, handle, 0, 0, func(rd io.Reader) error {
 				buf, err := io.ReadAll(rd)
 				data = string(buf)
 				return err

--- a/internal/backend/http_transport.go
+++ b/internal/backend/http_transport.go
@@ -89,7 +89,7 @@ func Transport(opts TransportOptions) (http.RoundTripper, error) {
 	if err != nil {
 		panic(err)
 	}
-	if feature.Flag.Enabled(feature.HTTPTimeouts) {
+	if feature.Flag.Enabled(feature.BackendErrorRedesign) {
 		h2.WriteByteTimeout = 120 * time.Second
 		h2.ReadIdleTimeout = 60 * time.Second
 		h2.PingTimeout = 60 * time.Second
@@ -132,7 +132,7 @@ func Transport(opts TransportOptions) (http.RoundTripper, error) {
 	}
 
 	rt := http.RoundTripper(tr)
-	if feature.Flag.Enabled(feature.HTTPTimeouts) {
+	if feature.Flag.Enabled(feature.BackendErrorRedesign) {
 		rt = newWatchdogRoundtripper(rt, 120*time.Second, 128*1024)
 	}
 

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -43,6 +43,7 @@ func NewFactory() location.Factory {
 }
 
 var errNotFound = fmt.Errorf("not found")
+var errTooSmall = errors.New("access beyond end of file")
 
 const connectionCount = 2
 
@@ -67,6 +68,10 @@ func New() *MemoryBackend {
 // IsNotExist returns true if the file does not exist.
 func (be *MemoryBackend) IsNotExist(err error) bool {
 	return errors.Is(err, errNotFound)
+}
+
+func (be *MemoryBackend) IsPermanentError(err error) bool {
+	return be.IsNotExist(err) || errors.Is(err, errTooSmall)
 }
 
 // Save adds new Data to the backend.
@@ -131,12 +136,12 @@ func (be *MemoryBackend) openReader(ctx context.Context, h backend.Handle, lengt
 	}
 
 	buf := be.data[h]
-	if offset > int64(len(buf)) {
-		return nil, errors.New("offset beyond end of file")
+	if offset+int64(length) > int64(len(buf)) {
+		return nil, errTooSmall
 	}
 
 	buf = buf[offset:]
-	if length > 0 && len(buf) > length {
+	if length > 0 {
 		buf = buf[:length]
 	}
 

--- a/internal/backend/mock/backend.go
+++ b/internal/backend/mock/backend.go
@@ -13,6 +13,7 @@ import (
 type Backend struct {
 	CloseFn            func() error
 	IsNotExistFn       func(err error) bool
+	IsPermanentErrorFn func(err error) bool
 	SaveFn             func(ctx context.Context, h backend.Handle, rd backend.RewindReader) error
 	OpenReaderFn       func(ctx context.Context, h backend.Handle, length int, offset int64) (io.ReadCloser, error)
 	StatFn             func(ctx context.Context, h backend.Handle) (backend.FileInfo, error)
@@ -81,6 +82,14 @@ func (m *Backend) IsNotExist(err error) bool {
 	}
 
 	return m.IsNotExistFn(err)
+}
+
+func (m *Backend) IsPermanentError(err error) bool {
+	if m.IsPermanentErrorFn == nil {
+		return false
+	}
+
+	return m.IsPermanentErrorFn(err)
 }
 
 // Save data in the backend.

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -30,6 +30,20 @@ type Backend struct {
 	layout.Layout
 }
 
+// restError is returned whenever the server returns a non-successful HTTP status.
+type restError struct {
+	backend.Handle
+	StatusCode int
+	Status     string
+}
+
+func (e *restError) Error() string {
+	if e.StatusCode == http.StatusNotFound && e.Handle.Type.String() != "invalid" {
+		return fmt.Sprintf("%v does not exist", e.Handle)
+	}
+	return fmt.Sprintf("unexpected HTTP response (%v): %v", e.StatusCode, e.Status)
+}
+
 func NewFactory() location.Factory {
 	return location.NewHTTPBackendFactory("rest", ParseConfig, StripPassword, Create, Open)
 }
@@ -96,7 +110,7 @@ func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (*Backend, er
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("server response unexpected: %v (%v)", resp.Status, resp.StatusCode)
+		return nil, &restError{backend.Handle{}, resp.StatusCode, resp.Status}
 	}
 
 	return be, nil
@@ -150,26 +164,31 @@ func (b *Backend) Save(ctx context.Context, h backend.Handle, rd backend.RewindR
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("server response unexpected: %v (%v)", resp.Status, resp.StatusCode)
+		return &restError{h, resp.StatusCode, resp.Status}
 	}
 
 	return nil
 }
 
-// notExistError is returned whenever the requested file does not exist on the
-// server.
-type notExistError struct {
-	backend.Handle
-}
-
-func (e *notExistError) Error() string {
-	return fmt.Sprintf("%v does not exist", e.Handle)
-}
-
 // IsNotExist returns true if the error was caused by a non-existing file.
 func (b *Backend) IsNotExist(err error) bool {
-	var e *notExistError
-	return errors.As(err, &e)
+	var e *restError
+	return errors.As(err, &e) && e.StatusCode == http.StatusNotFound
+}
+
+func (b *Backend) IsPermanentError(err error) bool {
+	if b.IsNotExist(err) {
+		return true
+	}
+
+	var rerr *restError
+	if errors.As(err, &rerr) {
+		if rerr.StatusCode == http.StatusRequestedRangeNotSatisfiable || rerr.StatusCode == http.StatusUnauthorized || rerr.StatusCode == http.StatusForbidden {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Load runs fn with a reader that yields the contents of the file at h at the
@@ -221,14 +240,13 @@ func (b *Backend) openReader(ctx context.Context, h backend.Handle, length int, 
 		return nil, errors.Wrap(err, "client.Do")
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
-		_ = drainAndClose(resp)
-		return nil, &notExistError{h}
-	}
-
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusPartialContent {
 		_ = drainAndClose(resp)
-		return nil, errors.Errorf("unexpected HTTP response (%v): %v", resp.StatusCode, resp.Status)
+		return nil, &restError{h, resp.StatusCode, resp.Status}
+	}
+
+	if length > 0 && resp.ContentLength != int64(length) {
+		return nil, &restError{h, http.StatusRequestedRangeNotSatisfiable, "partial out of bounds read"}
 	}
 
 	return resp.Body, nil
@@ -251,12 +269,8 @@ func (b *Backend) Stat(ctx context.Context, h backend.Handle) (backend.FileInfo,
 		return backend.FileInfo{}, err
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
-		return backend.FileInfo{}, &notExistError{h}
-	}
-
 	if resp.StatusCode != http.StatusOK {
-		return backend.FileInfo{}, errors.Errorf("unexpected HTTP response (%v): %v", resp.StatusCode, resp.Status)
+		return backend.FileInfo{}, &restError{h, resp.StatusCode, resp.Status}
 	}
 
 	if resp.ContentLength < 0 {
@@ -288,12 +302,8 @@ func (b *Backend) Remove(ctx context.Context, h backend.Handle) error {
 		return err
 	}
 
-	if resp.StatusCode == http.StatusNotFound {
-		return &notExistError{h}
-	}
-
 	if resp.StatusCode != http.StatusOK {
-		return errors.Errorf("blob not removed, server response: %v (%v)", resp.Status, resp.StatusCode)
+		return &restError{h, resp.StatusCode, resp.Status}
 	}
 
 	return nil
@@ -330,7 +340,7 @@ func (b *Backend) List(ctx context.Context, t backend.FileType, fn func(backend.
 
 	if resp.StatusCode != http.StatusOK {
 		_ = drainAndClose(resp)
-		return errors.Errorf("List failed, server response: %v (%v)", resp.Status, resp.StatusCode)
+		return &restError{backend.Handle{Type: t}, resp.StatusCode, resp.Status}
 	}
 
 	if resp.Header.Get("Content-Type") == ContentTypeV2 {

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -17,6 +17,7 @@ import (
 	"github.com/restic/restic/internal/backend/util"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/feature"
 )
 
 // make sure the rest backend implements backend.Backend
@@ -245,7 +246,7 @@ func (b *Backend) openReader(ctx context.Context, h backend.Handle, length int, 
 		return nil, &restError{h, resp.StatusCode, resp.Status}
 	}
 
-	if length > 0 && resp.ContentLength != int64(length) {
+	if feature.Flag.Enabled(feature.BackendErrorRedesign) && length > 0 && resp.ContentLength != int64(length) {
 		return nil, &restError{h, http.StatusRequestedRangeNotSatisfiable, "partial out of bounds read"}
 	}
 

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -17,6 +17,7 @@ import (
 	"github.com/restic/restic/internal/backend/util"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/feature"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -404,7 +405,7 @@ func (be *Backend) openReader(ctx context.Context, h backend.Handle, length int,
 		return nil, err
 	}
 
-	if length > 0 {
+	if feature.Flag.Enabled(feature.BackendErrorRedesign) && length > 0 {
 		if info.Size > 0 && info.Size != int64(length) {
 			_ = rd.Close()
 			return nil, minio.ErrorResponse{Code: "InvalidRange", Message: "restic-file-too-short"}

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -20,6 +20,7 @@ import (
 	"github.com/restic/restic/internal/backend/util"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/feature"
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/sftp"
@@ -426,7 +427,7 @@ func (r *SFTP) checkNoSpace(dir string, size int64, origErr error) error {
 // given offset.
 func (r *SFTP) Load(ctx context.Context, h backend.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
 	return util.DefaultLoad(ctx, h, length, offset, r.openReader, func(rd io.Reader) error {
-		if length == 0 {
+		if length == 0 || !feature.Flag.Enabled(feature.BackendErrorRedesign) {
 			return fn(rd)
 		}
 

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -19,6 +19,7 @@ import (
 	"github.com/restic/restic/internal/backend/util"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/feature"
 
 	"github.com/ncw/swift/v2"
 )
@@ -156,7 +157,7 @@ func (be *beSwift) openReader(ctx context.Context, h backend.Handle, length int,
 		return nil, fmt.Errorf("conn.ObjectOpen: %w", err)
 	}
 
-	if length > 0 {
+	if feature.Flag.Enabled(feature.BackendErrorRedesign) && length > 0 {
 		// get response length, but don't cause backend calls
 		cctx, cancel := context.WithCancel(context.Background())
 		cancel()

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -153,7 +153,18 @@ func (be *beSwift) openReader(ctx context.Context, h backend.Handle, length int,
 
 	obj, _, err := be.conn.ObjectOpen(ctx, be.container, objName, false, headers)
 	if err != nil {
-		return nil, errors.Wrap(err, "conn.ObjectOpen")
+		return nil, fmt.Errorf("conn.ObjectOpen: %w", err)
+	}
+
+	if length > 0 {
+		// get response length, but don't cause backend calls
+		cctx, cancel := context.WithCancel(context.Background())
+		cancel()
+		objLength, e := obj.Length(cctx)
+		if e == nil && objLength != int64(length) {
+			_ = obj.Close()
+			return nil, &swift.Error{StatusCode: http.StatusRequestedRangeNotSatisfiable, Text: "restic-file-too-short"}
+		}
 	}
 
 	return obj, nil
@@ -240,6 +251,21 @@ func (be *beSwift) List(ctx context.Context, t backend.FileType, fn func(backend
 func (be *beSwift) IsNotExist(err error) bool {
 	var e *swift.Error
 	return errors.As(err, &e) && e.StatusCode == http.StatusNotFound
+}
+
+func (be *beSwift) IsPermanentError(err error) bool {
+	if be.IsNotExist(err) {
+		return true
+	}
+
+	var serr *swift.Error
+	if errors.As(err, &serr) {
+		if serr.StatusCode == http.StatusRequestedRangeNotSatisfiable || serr.StatusCode == http.StatusUnauthorized || serr.StatusCode == http.StatusForbidden {
+			return true
+		}
+	}
+
+	return false
 }
 
 // Delete removes all restic objects in the container.

--- a/internal/backend/test/tests.go
+++ b/internal/backend/test/tests.go
@@ -99,6 +99,7 @@ func (s *Suite[C]) TestConfig(t *testing.T) {
 		t.Fatalf("did not get expected error for non-existing config")
 	}
 	test.Assert(t, b.IsNotExist(err), "IsNotExist() did not recognize error from LoadAll(): %v", err)
+	test.Assert(t, b.IsPermanentError(err), "IsPermanentError() did not recognize error from LoadAll(): %v", err)
 
 	err = b.Save(context.TODO(), backend.Handle{Type: backend.ConfigFile}, backend.NewByteReader([]byte(testString), b.Hasher()))
 	if err != nil {
@@ -135,6 +136,7 @@ func (s *Suite[C]) TestLoad(t *testing.T) {
 		t.Fatalf("Load() did not return an error for non-existing blob")
 	}
 	test.Assert(t, b.IsNotExist(err), "IsNotExist() did not recognize non-existing blob: %v", err)
+	test.Assert(t, b.IsPermanentError(err), "IsPermanentError() did not recognize non-existing blob: %v", err)
 
 	length := rand.Intn(1<<24) + 2000
 
@@ -181,8 +183,12 @@ func (s *Suite[C]) TestLoad(t *testing.T) {
 		}
 
 		getlen := l
-		if l >= len(d) && rand.Float32() >= 0.5 {
-			getlen = 0
+		if l >= len(d) {
+			if rand.Float32() >= 0.5 {
+				getlen = 0
+			} else {
+				getlen = len(d)
+			}
 		}
 
 		if l > 0 && l < len(d) {
@@ -223,6 +229,18 @@ func (s *Suite[C]) TestLoad(t *testing.T) {
 			t.Errorf("Load(%d, %d) returned wrong bytes", l, o)
 			continue
 		}
+	}
+
+	// test error checking for partial and fully out of bounds read
+	// only test for length > 0 as we currently do not need strict out of bounds handling for length==0
+	for _, offset := range []int{length - 99, length - 50, length, length + 100} {
+		err = b.Load(context.TODO(), handle, 100, int64(offset), func(rd io.Reader) (ierr error) {
+			_, ierr = io.ReadAll(rd)
+			return ierr
+		})
+		test.Assert(t, err != nil, "Load() did not return error on out of bounds read! o %v, l %v, filelength %v", offset, 100, length)
+		test.Assert(t, b.IsPermanentError(err), "IsPermanentError() did not recognize out of range read: %v", err)
+		test.Assert(t, !b.IsNotExist(err), "IsNotExist() must not recognize out of range read: %v", err)
 	}
 
 	test.OK(t, b.Remove(context.TODO(), handle))
@@ -762,6 +780,7 @@ func (s *Suite[C]) TestBackend(t *testing.T) {
 	defer s.close(t, b)
 
 	test.Assert(t, !b.IsNotExist(nil), "IsNotExist() recognized nil error")
+	test.Assert(t, !b.IsPermanentError(nil), "IsPermanentError() recognized nil error")
 
 	for _, tpe := range []backend.FileType{
 		backend.PackFile, backend.KeyFile, backend.LockFile,
@@ -782,11 +801,13 @@ func (s *Suite[C]) TestBackend(t *testing.T) {
 			_, err = b.Stat(context.TODO(), h)
 			test.Assert(t, err != nil, "blob data could be extracted before creation")
 			test.Assert(t, b.IsNotExist(err), "IsNotExist() did not recognize Stat() error: %v", err)
+			test.Assert(t, b.IsPermanentError(err), "IsPermanentError() did not recognize Stat() error: %v", err)
 
 			// try to read not existing blob
 			err = testLoad(b, h)
 			test.Assert(t, err != nil, "blob could be read before creation")
 			test.Assert(t, b.IsNotExist(err), "IsNotExist() did not recognize Load() error: %v", err)
+			test.Assert(t, b.IsPermanentError(err), "IsPermanentError() did not recognize Load() error: %v", err)
 
 			// try to get string out, should fail
 			ret, err = beTest(context.TODO(), b, h)

--- a/internal/cache/file.go
+++ b/internal/cache/file.go
@@ -61,7 +61,7 @@ func (c *Cache) load(h backend.Handle, length int, offset int64) (io.ReadCloser,
 	if size < offset+int64(length) {
 		_ = f.Close()
 		_ = c.remove(h)
-		return nil, errors.Errorf("cached file %v is too small, removing", h)
+		return nil, errors.Errorf("cached file %v is too short, removing", h)
 	}
 
 	if offset > 0 {

--- a/internal/crypto/crypto.go
+++ b/internal/crypto/crypto.go
@@ -299,7 +299,7 @@ func (k *Key) Open(dst, nonce, ciphertext, _ []byte) ([]byte, error) {
 
 	// check for plausible length
 	if len(ciphertext) < k.Overhead() {
-		return nil, errors.Errorf("trying to decrypt invalid data: ciphertext too small")
+		return nil, errors.Errorf("trying to decrypt invalid data: ciphertext too short")
 	}
 
 	l := len(ciphertext) - macSize

--- a/internal/feature/registry.go
+++ b/internal/feature/registry.go
@@ -5,17 +5,17 @@ var Flag = New()
 
 // flag names are written in kebab-case
 const (
+	BackendErrorRedesign    FlagName = "backend-error-redesign"
 	DeprecateLegacyIndex    FlagName = "deprecate-legacy-index"
 	DeprecateS3LegacyLayout FlagName = "deprecate-s3-legacy-layout"
 	DeviceIDForHardlinks    FlagName = "device-id-for-hardlinks"
-	HTTPTimeouts            FlagName = "http-timeouts"
 )
 
 func init() {
 	Flag.SetFlags(map[FlagName]FlagDesc{
+		BackendErrorRedesign:    {Type: Beta, Description: "enforce timeouts for stuck HTTP requests and use new backend error handling design."},
 		DeprecateLegacyIndex:    {Type: Beta, Description: "disable support for index format used by restic 0.1.0. Use `restic repair index` to update the index if necessary."},
 		DeprecateS3LegacyLayout: {Type: Beta, Description: "disable support for S3 legacy layout used up to restic 0.7.0. Use `RESTIC_FEATURES=deprecate-s3-legacy-layout=false restic migrate s3_layout` to migrate your S3 repository if necessary."},
 		DeviceIDForHardlinks:    {Type: Alpha, Description: "store deviceID only for hardlinks to reduce metadata changes for example when using btrfs subvolumes. Will be removed in a future restic version after repository format 3 is available"},
-		HTTPTimeouts:            {Type: Beta, Description: "enforce timeouts for stuck HTTP requests."},
 	})
 }

--- a/internal/index/indexmap.go
+++ b/internal/index/indexmap.go
@@ -204,7 +204,7 @@ func (h *hashedArrayTree) Size() uint {
 func (h *hashedArrayTree) grow() {
 	idx, subIdx := h.index(h.size)
 	if int(idx) == len(h.blockList) {
-		// blockList is too small -> double list and block size
+		// blockList is too short -> double list and block size
 		h.blockSize *= 2
 		h.mask = h.mask*2 + 1
 		h.maskShift++

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -239,7 +239,7 @@ func readRecords(rd io.ReaderAt, size int64, bufsize int) ([]byte, int, error) {
 	case hlen == 0:
 		err = InvalidFileError{Message: "header length is zero"}
 	case hlen < crypto.Extension:
-		err = InvalidFileError{Message: "header length is too small"}
+		err = InvalidFileError{Message: "header length is too short"}
 	case int64(hlen) > size-int64(headerLengthSize):
 		err = InvalidFileError{Message: "header is larger than file"}
 	case int64(hlen) > MaxHeaderSize-int64(headerLengthSize):
@@ -263,7 +263,7 @@ func readRecords(rd io.ReaderAt, size int64, bufsize int) ([]byte, int, error) {
 func readHeader(rd io.ReaderAt, size int64) ([]byte, error) {
 	debug.Log("size: %v", size)
 	if size < int64(minFileSize) {
-		err := InvalidFileError{Message: "file is too small"}
+		err := InvalidFileError{Message: "file is too short"}
 		return nil, errors.Wrap(err, "readHeader")
 	}
 
@@ -305,7 +305,7 @@ func List(k *crypto.Key, rd io.ReaderAt, size int64) (entries []restic.Blob, hdr
 	}
 
 	if len(buf) < crypto.CiphertextLength(0) {
-		return nil, 0, errors.New("invalid header, too small")
+		return nil, 0, errors.New("invalid header, too short")
 	}
 
 	hdrSize = headerLengthSize + uint32(len(buf))

--- a/internal/repository/prune.go
+++ b/internal/repository/prune.go
@@ -444,7 +444,7 @@ func decidePackAction(ctx context.Context, opts PruneOptions, repo restic.Reposi
 	// This is equivalent to sorting by unused / total space.
 	// Instead of unused[i] / used[i] > unused[j] / used[j] we use
 	// unused[i] * used[j] > unused[j] * used[i] as uint32*uint32 < uint64
-	// Moreover packs containing trees and too small packs are sorted to the beginning
+	// Moreover packs containing trees and too short packs are sorted to the beginning
 	sort.Slice(repackCandidates, func(i, j int) bool {
 		pi := repackCandidates[i].packInfo
 		pj := repackCandidates[j].packInfo


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Restic currently retries attempts to access a non-existing file or out of bound reads for truncated files. These errors are however permanent and cannot be fixed by retrying. This PR adds the necessary infrastructure to let the RetryBackend detect these cases and stop the useless retries.

In addition, the RetryBackend now implements a circuit breaker for inaccessible files. If accessing a file exhausts its retries, then the file is considered broken and won't be accessed again for one hour. This also benefits https://github.com/restic/restic/pull/4800 , as the fallback paths will immediately fail for such broken files.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Not really, but this is another prerequisite (and hopefully the last one) for https://github.com/restic/restic/pull/4784 .
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
