### PR TITLE
prepareCheckCache function: Add MkdirAll() to restic-cache directory if it doesn't exist

### DIFF
--- a/changelog/unreleased/issue-4437
+++ b/changelog/unreleased/issue-4437
@@ -1,0 +1,9 @@
+Enhancement: `check` command creates cache directory if it does not exist
+
+If a custom cache directory was specified for the `check` command but the directory did not exist,
+then `check` continued with cache disabled.
+
+The  `check` command now attempts to create the cache directory before initializing the cache.
+
+https://github.com/restic/restic/issues/4437
+https://github.com/restic/restic/pull/4805

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -173,6 +173,12 @@ func prepareCheckCache(opts CheckOptions, gopts *GlobalOptions) (cleanup func())
 	}
 
 	// use a cache in a temporary directory
+	err := os.MkdirAll(cachedir, 0755)
+	if err != nil {
+		Warnf("unable to create cache directory %s, disabling cache: %v\n", cachedir, err)
+		gopts.NoCache = true
+		return cleanup
+	}
 	tempdir, err := os.MkdirTemp(cachedir, "restic-check-cache-")
 	if err != nil {
 		// if an error occurs, don't use any cache


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Earlier, if the specified cache dir didn't exist, restic continued `check` command with cache disabled.

Henceforth, it tries to create the cache directory.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------


<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

It was previously discussed here: https://github.com/restic/restic/issues/4437

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
