### PR TITLE
Implement `--insecure-no-password` option.

### DIFF
--- a/changelog/unreleased/issue-1786
+++ b/changelog/unreleased/issue-1786
@@ -1,0 +1,19 @@
+Enhancement: Support repositories with empty password
+
+Restic refused to create or operate on repositories with an emtpy password.
+Using the new option `--insecure-no-password` it is now possible to disable
+this check. Restic will not prompt for a password when using this option.
+For security reasons, the option must always be specified when operating on
+repositories with an empty password.
+
+Specifying `--insecure-no-password` while also passing a password to restic
+via a CLI option or via environment variable results in an error.
+
+The `init` and `copy` command also support the option `--from-insecure-no-password`
+which applies to the source repository. The `key add` and `key passwd` comands
+include the `--new-insecure-no-password` option to add or set an emtpy password.
+
+https://github.com/restic/restic/issues/1786
+https://github.com/restic/restic/issues/4326
+https://github.com/restic/restic/pull/4698
+https://github.com/restic/restic/pull/4808

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -257,7 +257,7 @@ func readFilenamesRaw(r io.Reader) (names []string, err error) {
 
 // Check returns an error when an invalid combination of options was set.
 func (opts BackupOptions) Check(gopts GlobalOptions, args []string) error {
-	if gopts.password == "" {
+	if gopts.password == "" && !gopts.InsecureNoPassword {
 		if opts.Stdin {
 			return errors.Fatal("cannot read both password and data from stdin")
 		}

--- a/cmd/restic/cmd_backup_integration_test.go
+++ b/cmd/restic/cmd_backup_integration_test.go
@@ -627,3 +627,17 @@ func TestStdinFromCommandFailNoOutputAndExitCode(t *testing.T) {
 
 	testRunCheck(t, env.gopts)
 }
+
+func TestBackupEmptyPassword(t *testing.T) {
+	// basic sanity test that empty passwords work
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	env.gopts.password = ""
+	env.gopts.InsecureNoPassword = true
+
+	testSetupBackupData(t, env)
+	testRunBackup(t, filepath.Dir(env.testdata), []string{"testdata"}, BackupOptions{}, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+	testRunCheck(t, env.gopts)
+}

--- a/cmd/restic/cmd_copy_integration_test.go
+++ b/cmd/restic/cmd_copy_integration_test.go
@@ -13,10 +13,12 @@ func testRunCopy(t testing.TB, srcGopts GlobalOptions, dstGopts GlobalOptions) {
 	gopts := srcGopts
 	gopts.Repo = dstGopts.Repo
 	gopts.password = dstGopts.password
+	gopts.InsecureNoPassword = dstGopts.InsecureNoPassword
 	copyOpts := CopyOptions{
 		secondaryRepoOptions: secondaryRepoOptions{
-			Repo:     srcGopts.Repo,
-			password: srcGopts.password,
+			Repo:               srcGopts.Repo,
+			password:           srcGopts.password,
+			InsecureNoPassword: srcGopts.InsecureNoPassword,
 		},
 	}
 
@@ -133,4 +135,23 @@ func TestCopyUnstableJSON(t *testing.T) {
 	testRunCopy(t, env.gopts, env2.gopts)
 	testRunCheck(t, env2.gopts)
 	testListSnapshots(t, env2.gopts, 1)
+}
+
+func TestCopyToEmptyPassword(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	env2, cleanup2 := withTestEnvironment(t)
+	defer cleanup2()
+	env2.gopts.password = ""
+	env2.gopts.InsecureNoPassword = true
+
+	testSetupBackupData(t, env)
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9")}, BackupOptions{}, env.gopts)
+
+	testRunInit(t, env2.gopts)
+	testRunCopy(t, env.gopts, env2.gopts)
+
+	testListSnapshots(t, env.gopts, 1)
+	testListSnapshots(t, env2.gopts, 1)
+	testRunCheck(t, env2.gopts)
 }

--- a/cmd/restic/cmd_key_add.go
+++ b/cmd/restic/cmd_key_add.go
@@ -9,6 +9,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 var cmdKeyAdd = &cobra.Command{
@@ -23,26 +24,28 @@ EXIT STATUS
 Exit status is 0 if the command is successful, and non-zero if there was any error.
 	`,
 	DisableAutoGenTag: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return runKeyAdd(cmd.Context(), globalOptions, keyAddOpts, args)
-	},
 }
 
 type KeyAddOptions struct {
-	NewPasswordFile string
-	Username        string
-	Hostname        string
+	NewPasswordFile    string
+	Username           string
+	Hostname           string
 }
 
-var keyAddOpts KeyAddOptions
+func (opts *KeyAddOptions) Add(flags *pflag.FlagSet) {
+	flags.StringVarP(&opts.NewPasswordFile, "new-password-file", "", "", "`file` from which to read the new password")
+	flags.StringVarP(&opts.Username, "user", "", "", "the username for new key")
+	flags.StringVarP(&opts.Hostname, "host", "", "", "the hostname for new key")
+}
 
 func init() {
 	cmdKey.AddCommand(cmdKeyAdd)
 
-	flags := cmdKeyAdd.Flags()
-	flags.StringVarP(&keyAddOpts.NewPasswordFile, "new-password-file", "", "", "`file` from which to read the new password")
-	flags.StringVarP(&keyAddOpts.Username, "user", "", "", "the username for new key")
-	flags.StringVarP(&keyAddOpts.Hostname, "host", "", "", "the hostname for new key")
+	var keyAddOpts KeyAddOptions
+	keyAddOpts.Add(cmdKeyAdd.Flags())
+	cmdKeyAdd.RunE = func(cmd *cobra.Command, args []string) error {
+		return runKeyAdd(cmd.Context(), globalOptions, keyAddOpts, args)
+	}
 }
 
 func runKeyAdd(ctx context.Context, gopts GlobalOptions, opts KeyAddOptions, args []string) error {

--- a/cmd/restic/cmd_key_add.go
+++ b/cmd/restic/cmd_key_add.go
@@ -28,12 +28,14 @@ Exit status is 0 if the command is successful, and non-zero if there was any err
 
 type KeyAddOptions struct {
 	NewPasswordFile    string
+	InsecureNoPassword bool
 	Username           string
 	Hostname           string
 }
 
 func (opts *KeyAddOptions) Add(flags *pflag.FlagSet) {
 	flags.StringVarP(&opts.NewPasswordFile, "new-password-file", "", "", "`file` from which to read the new password")
+	flags.BoolVar(&opts.InsecureNoPassword, "new-insecure-no-password", false, "add an empty password for the repository (insecure)")
 	flags.StringVarP(&opts.Username, "user", "", "", "the username for new key")
 	flags.StringVarP(&opts.Hostname, "host", "", "", "the hostname for new key")
 }
@@ -63,7 +65,7 @@ func runKeyAdd(ctx context.Context, gopts GlobalOptions, opts KeyAddOptions, arg
 }
 
 func addKey(ctx context.Context, repo *repository.Repository, gopts GlobalOptions, opts KeyAddOptions) error {
-	pw, err := getNewPassword(ctx, gopts, opts.NewPasswordFile)
+	pw, err := getNewPassword(ctx, gopts, opts.NewPasswordFile, opts.InsecureNoPassword)
 	if err != nil {
 		return err
 	}
@@ -86,19 +88,35 @@ func addKey(ctx context.Context, repo *repository.Repository, gopts GlobalOption
 // testKeyNewPassword is used to set a new password during integration testing.
 var testKeyNewPassword string
 
-func getNewPassword(ctx context.Context, gopts GlobalOptions, newPasswordFile string) (string, error) {
+func getNewPassword(ctx context.Context, gopts GlobalOptions, newPasswordFile string, insecureNoPassword bool) (string, error) {
 	if testKeyNewPassword != "" {
 		return testKeyNewPassword, nil
 	}
 
+	if insecureNoPassword {
+		if newPasswordFile != "" {
+			return "", fmt.Errorf("only either --new-password-file or --new-insecure-no-password may be specified")
+		}
+		return "", nil
+	}
+
 	if newPasswordFile != "" {
-		return loadPasswordFromFile(newPasswordFile)
+		password, err := loadPasswordFromFile(newPasswordFile)
+		if err != nil {
+			return "", err
+		}
+		if password == "" {
+			return "", fmt.Errorf("an empty password is not allowed by default. Pass the flag `--new-insecure-no-password` to restic to disable this check")
+		}
+		return password, nil
 	}
 
 	// Since we already have an open repository, temporary remove the password
 	// to prompt the user for the passwd.
 	newopts := gopts
 	newopts.password = ""
+	// empty passwords are already handled above
+	newopts.InsecureNoPassword = false
 
 	return ReadPasswordTwice(ctx, newopts,
 		"enter new password: ",

--- a/cmd/restic/cmd_key_passwd.go
+++ b/cmd/restic/cmd_key_passwd.go
@@ -53,7 +53,7 @@ func runKeyPasswd(ctx context.Context, gopts GlobalOptions, opts KeyPasswdOption
 }
 
 func changePassword(ctx context.Context, repo *repository.Repository, gopts GlobalOptions, opts KeyPasswdOptions) error {
-	pw, err := getNewPassword(ctx, gopts, opts.NewPasswordFile)
+	pw, err := getNewPassword(ctx, gopts, opts.NewPasswordFile, opts.InsecureNoPassword)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_key_passwd.go
+++ b/cmd/restic/cmd_key_passwd.go
@@ -22,24 +22,20 @@ EXIT STATUS
 Exit status is 0 if the command is successful, and non-zero if there was any error.
 	`,
 	DisableAutoGenTag: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		return runKeyPasswd(cmd.Context(), globalOptions, keyPasswdOpts, args)
-	},
 }
 
 type KeyPasswdOptions struct {
 	KeyAddOptions
 }
 
-var keyPasswdOpts KeyPasswdOptions
-
 func init() {
 	cmdKey.AddCommand(cmdKeyPasswd)
 
-	flags := cmdKeyPasswd.Flags()
-	flags.StringVarP(&keyPasswdOpts.NewPasswordFile, "new-password-file", "", "", "`file` from which to read the new password")
-	flags.StringVarP(&keyPasswdOpts.Username, "user", "", "", "the username for new key")
-	flags.StringVarP(&keyPasswdOpts.Hostname, "host", "", "", "the hostname for new key")
+	var keyPasswdOpts KeyPasswdOptions
+	keyPasswdOpts.KeyAddOptions.Add(cmdKeyPasswd.Flags())
+	cmdKeyPasswd.RunE = func(cmd *cobra.Command, args []string) error {
+		return runKeyPasswd(cmd.Context(), globalOptions, keyPasswdOpts, args)
+	}
 }
 
 func runKeyPasswd(ctx context.Context, gopts GlobalOptions, opts KeyPasswdOptions, args []string) error {

--- a/cmd/restic/global_test.go
+++ b/cmd/restic/global_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	rtest "github.com/restic/restic/internal/test"
@@ -49,4 +51,15 @@ func TestReadRepo(t *testing.T) {
 	if err == nil {
 		t.Fatal("must not read repository path from invalid file path")
 	}
+}
+
+func TestReadEmptyPassword(t *testing.T) {
+	opts := GlobalOptions{InsecureNoPassword: true}
+	password, err := ReadPassword(context.TODO(), opts, "test")
+	rtest.OK(t, err)
+	rtest.Equals(t, "", password, "got unexpected password")
+
+	opts.password = "invalid"
+	_, err = ReadPassword(context.TODO(), opts, "test")
+	rtest.Assert(t, strings.Contains(err.Error(), "must not be specified together with providing a password via a cli option or environment variable"), "unexpected error message, got %v", err)
 }

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -852,3 +852,26 @@ and then grants read/write permissions for group access.
 .. note:: To manage who has access to the repository you can use
           ``usermod`` on Linux systems, to change which group controls
           repository access ``chgrp -R`` is your friend.
+
+
+Repositories with empty password
+********************************
+
+Restic by default refuses to create or operate on repositories that use an
+empty password. Since restic 0.17.0, the option ``--insecure-no-password`` allows
+disabling this check. Restic will not prompt for a password when using this option.
+Specifying ``--insecure-no-password`` while also passing a password to restic
+via a CLI option or via environment variable results in an error.
+
+For security reasons, the option must always be specified when operating on
+repositories with an empty password. For example to create a new repository
+with an empty password, use the following command.
+
+.. code-block:: console
+
+    restic init --insecure-no-password
+
+
+The ``init`` and ``copy`` command also support the option ``--from-insecure-no-password``
+which applies to the source repository. The ``key add`` and ``key passwd`` comands
+include the ``--new-insecure-no-password`` option to add or set and emtpy password.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Implement https://github.com/restic/restic/issues/4326#issuecomment-1950297875 . Different from that comment, 
there are two additional options `--from-insecure-no-password`  and  `--new-insecure-no-password`.  `--from-insecure-no-password`  is used for commands that require specifying a source repository, and    `--new-insecure-no-password` for the `key add` and `key passwd`  commands.

Those options are required to allow copying from a repository without password to one with a password. Or the add/set an new empty password.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/1786
Fixes https://github.com/restic/restic/issues/4326
Replaces https://github.com/restic/restic/pull/4698/files
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
