### PR TITLE
Allow custom User-Agent to be specified for outgoing requests

### DIFF
--- a/changelog/unreleased/issue-4768
+++ b/changelog/unreleased/issue-4768
@@ -1,0 +1,8 @@
+Enhancement: Allow custom User-Agent to be specified for outgoing requests
+
+Restic now permits setting a custom `User-Agent` for outgoing HTTP requests 
+using the global flag `--http-user-agent` or the `RESTIC_HTTP_USER_AGENT` 
+environment variable.
+
+https://github.com/restic/restic/issues/4768
+https://github.com/restic/restic/pull/4810

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -135,6 +135,7 @@ func init() {
 	f.IntVar(&globalOptions.Limits.DownloadKb, "limit-download", 0, "limits downloads to a maximum `rate` in KiB/s. (default: unlimited)")
 	f.UintVar(&globalOptions.PackSize, "pack-size", 0, "set target pack `size` in MiB, created pack files may be larger (default: $RESTIC_PACK_SIZE)")
 	f.StringSliceVarP(&globalOptions.Options, "option", "o", []string{}, "set extended option (`key=value`, can be specified multiple times)")
+	f.StringVar(&globalOptions.HTTPUserAgent, "http-user-agent", "", "set a http user agent for outgoing http requests")
 	// Use our "generate" command instead of the cobra provided "completion" command
 	cmdRoot.CompletionOptions.DisableDefaultCmd = true
 
@@ -155,6 +156,10 @@ func init() {
 	// parse target pack size from env, on error the default value will be used
 	targetPackSize, _ := strconv.ParseUint(os.Getenv("RESTIC_PACK_SIZE"), 10, 32)
 	globalOptions.PackSize = uint(targetPackSize)
+
+	if os.Getenv("RESTIC_HTTP_USER_AGENT") != "" {
+		globalOptions.HTTPUserAgent = os.Getenv("RESTIC_HTTP_USER_AGENT")
+	}
 }
 
 func stdinIsTerminal() bool {

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -54,6 +54,7 @@ Usage help is available:
           --cleanup-cache              auto remove old cache directories
           --compression mode           compression mode (only available for repository format version 2), one of (auto|off|max) (default: $RESTIC_COMPRESSION) (default auto)
       -h, --help                       help for restic
+          --http-user-agent value      set a custom user agent for outgoing http requests
           --insecure-no-password       use an empty password for the repository, must be passed to every restic command (insecure)
           --insecure-tls               skip TLS certificate verification when connecting to the repository (insecure)
           --json                       set output mode to JSON for commands that support it
@@ -134,6 +135,7 @@ command:
           --cache-dir directory        set the cache directory. (default: use system default cache directory)
           --cleanup-cache              auto remove old cache directories
           --compression mode           compression mode (only available for repository format version 2), one of (auto|off|max) (default: $RESTIC_COMPRESSION) (default auto)
+          --http-user-agent value      set a custom user agent for outgoing http requests
           --insecure-no-password       use an empty password for the repository, must be passed to every restic command (insecure)
           --insecure-tls               skip TLS certificate verification when connecting to the repository (insecure)
           --json                       set output mode to JSON for commands that support it

--- a/internal/backend/http_transport.go
+++ b/internal/backend/http_transport.go
@@ -28,6 +28,9 @@ type TransportOptions struct {
 
 	// Skip TLS certificate verification
 	InsecureTLS bool
+
+	// Specify Custom User-Agent for the http Client
+	HTTPUserAgent string
 }
 
 // readPEMCertKey reads a file and returns the PEM encoded certificate and key
@@ -132,6 +135,13 @@ func Transport(opts TransportOptions) (http.RoundTripper, error) {
 	}
 
 	rt := http.RoundTripper(tr)
+
+	// if the userAgent is set in the Transport Options, wrap the
+	// http.RoundTripper
+	if opts.HTTPUserAgent != "" {
+		rt = newCustomUserAgentRoundTripper(rt, opts.HTTPUserAgent)
+	}
+
 	if feature.Flag.Enabled(feature.BackendErrorRedesign) {
 		rt = newWatchdogRoundtripper(rt, 120*time.Second, 128*1024)
 	}

--- a/internal/backend/httpuseragent_roundtripper.go
+++ b/internal/backend/httpuseragent_roundtripper.go
@@ -1,0 +1,25 @@
+package backend
+
+import "net/http"
+
+// httpUserAgentRoundTripper is a custom http.RoundTripper that modifies the User-Agent header
+// of outgoing HTTP requests.
+type httpUserAgentRoundTripper struct {
+	userAgent string
+	rt        http.RoundTripper
+}
+
+func newCustomUserAgentRoundTripper(rt http.RoundTripper, userAgent string) *httpUserAgentRoundTripper {
+	return &httpUserAgentRoundTripper{
+		rt:        rt,
+		userAgent: userAgent,
+	}
+}
+
+// RoundTrip modifies the User-Agent header of the request and then delegates the request
+// to the underlying RoundTripper.
+func (c *httpUserAgentRoundTripper) RoundTrip(req *http.Request) (*http.Response, error) {
+	req = req.Clone(req.Context())
+	req.Header.Set("User-Agent", c.userAgent)
+	return c.rt.RoundTrip(req)
+}

--- a/internal/backend/httpuseragent_roundtripper_test.go
+++ b/internal/backend/httpuseragent_roundtripper_test.go
@@ -1,0 +1,50 @@
+package backend
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCustomUserAgentTransport(t *testing.T) {
+	// Create a mock HTTP handler that checks the User-Agent header
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		userAgent := r.Header.Get("User-Agent")
+		if userAgent != "TestUserAgent" {
+			t.Errorf("Expected User-Agent: TestUserAgent, got: %s", userAgent)
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	// Create a test server with the mock handler
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	// Create a custom user agent transport
+	customUserAgent := "TestUserAgent"
+	transport := &httpUserAgentRoundTripper{
+		userAgent: customUserAgent,
+		rt:        http.DefaultTransport,
+	}
+
+	// Create an HTTP client with the custom transport
+	client := &http.Client{
+		Transport: transport,
+	}
+
+	// Make a request to the test server
+	resp, err := client.Get(server.URL)
+	if err != nil {
+		t.Fatalf("Unexpected error: %v", err)
+	}
+	defer func() {
+		if err := resp.Body.Close(); err != nil {
+			t.Log("failed to close response body")
+		}
+	}()
+
+	// Check the response status code
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("Expected status code: %d, got: %d", http.StatusOK, resp.StatusCode)
+	}
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Allow custom User-Agent to be specified for outgoing requests. ~~Restic currently uses the default `User-Agent` of the `net/http` package for all outgoing HTTP requests. ~~

The customisable User-Agent can be used to differentiate between Restic HTTP client and other golang http clients at a Frontend Gateway or Load Balancer.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Added a global option flag `--http-user-agent`. ~~This will wrap the default `http.RoundTripper` to set the custom `User-Agent` header. If the flag is not specified, the default `User-Agent` from the `net/http` package  is used for outgoing requests.~~

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
#4768 

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
