### PR TITLE
Restore flags to include from file and exclude from file

### DIFF
--- a/changelog/unreleased/issue-4781
+++ b/changelog/unreleased/issue-4781
@@ -1,0 +1,8 @@
+Enhancement: Add restore flags to read include and exclude patterns from files
+
+Restic now supports reading include and exclude patterns from files using the 
+`--include-file`, `--exclude-file`, `--iinclude-file` and `--iexclude-file` 
+flags.
+
+https://github.com/restic/restic/issues/4781
+https://github.com/restic/restic/pull/4811

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -178,12 +178,12 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 			matched, childMayMatch := includeFn(item)
 			selectedForRestore = selectedForRestore || matched
 			childMayBeSelected = childMayBeSelected || childMayMatch
-			childMayBeSelected = childMayBeSelected && node.Type == "dir"
 
-			if selectedForRestore || childMayBeSelected {
+			if selectedForRestore && childMayBeSelected {
 				break
 			}
 		}
+		childMayBeSelected = childMayBeSelected && node.Type == "dir"
 
 		return selectedForRestore, childMayBeSelected
 	}

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -2,12 +2,10 @@ package main
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
-	"github.com/restic/restic/internal/filter"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/restorer"
 	"github.com/restic/restic/internal/ui"
@@ -45,15 +43,9 @@ Exit status is 0 if the command was successful, and non-zero if there was any er
 
 // RestoreOptions collects all options for the restore command.
 type RestoreOptions struct {
-	Exclude                 []string
-	ExcludeFiles            []string
-	InsensitiveExclude      []string
-	InsensitiveExcludeFiles []string
-	Include                 []string
-	IncludeFiles            []string
-	InsensitiveInclude      []string
-	InsensitiveIncludeFiles []string
-	Target                  string
+	excludePatternOptions
+	includePatternOptions
+	Target string
 	restic.SnapshotFilter
 	Sparse bool
 	Verify bool
@@ -65,15 +57,10 @@ func init() {
 	cmdRoot.AddCommand(cmdRestore)
 
 	flags := cmdRestore.Flags()
-	flags.StringArrayVarP(&restoreOptions.Exclude, "exclude", "e", nil, "exclude a `pattern` (can be specified multiple times)")
-	flags.StringArrayVar(&restoreOptions.InsensitiveExclude, "iexclude", nil, "same as --exclude but ignores the casing of `pattern`")
-	flags.StringArrayVarP(&restoreOptions.Include, "include", "i", nil, "include a `pattern`, exclude everything else (can be specified multiple times)")
-	flags.StringArrayVar(&restoreOptions.InsensitiveInclude, "iinclude", nil, "same as --include but ignores the casing of `pattern`")
 	flags.StringVarP(&restoreOptions.Target, "target", "t", "", "directory to extract data to")
-	flags.StringArrayVar(&restoreOptions.ExcludeFiles, "exclude-file", nil, "read exclude patterns from a `file` (can be specified multiple times)")
-	flags.StringArrayVar(&restoreOptions.InsensitiveExcludeFiles, "iexclude-file", nil, "same as --exclude-file but ignores casing of `file`names in patterns")
-	flags.StringArrayVar(&restoreOptions.IncludeFiles, "include-file", nil, "read include patterns from a `file` (can be specified multiple times)")
-	flags.StringArrayVar(&restoreOptions.InsensitiveIncludeFiles, "iinclude-file", nil, "same as --include-file but ignores casing of `file`names in patterns")
+
+	initExcludePatternOptions(flags, &restoreOptions.excludePatternOptions)
+	initIncludePatternOptions(flags, &restoreOptions.includePatternOptions)
 
 	initSingleSnapshotFilter(flags, &restoreOptions.SnapshotFilter)
 	flags.BoolVar(&restoreOptions.Sparse, "sparse", false, "restore files as sparse")
@@ -83,38 +70,8 @@ func init() {
 func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 	term *termstatus.Terminal, args []string) error {
 
-	hasExcludes := len(opts.Exclude) > 0 || len(opts.InsensitiveExclude) > 0
-	hasIncludes := len(opts.Include) > 0 || len(opts.InsensitiveInclude) > 0
-
-	// Validate provided patterns
-	if len(opts.Exclude) > 0 {
-		if err := filter.ValidatePatterns(opts.Exclude); err != nil {
-			return errors.Fatalf("--exclude: %s", err)
-		}
-	}
-	if len(opts.InsensitiveExclude) > 0 {
-		if err := filter.ValidatePatterns(opts.InsensitiveExclude); err != nil {
-			return errors.Fatalf("--iexclude: %s", err)
-		}
-	}
-	if len(opts.Include) > 0 {
-		if err := filter.ValidatePatterns(opts.Include); err != nil {
-			return errors.Fatalf("--include: %s", err)
-		}
-	}
-	if len(opts.InsensitiveInclude) > 0 {
-		if err := filter.ValidatePatterns(opts.InsensitiveInclude); err != nil {
-			return errors.Fatalf("--iinclude: %s", err)
-		}
-	}
-
-	for i, str := range opts.InsensitiveExclude {
-		opts.InsensitiveExclude[i] = strings.ToLower(str)
-	}
-
-	for i, str := range opts.InsensitiveInclude {
-		opts.InsensitiveInclude[i] = strings.ToLower(str)
-	}
+	hasExcludes := len(opts.Excludes) > 0 || len(opts.InsensitiveExcludes) > 0
+	hasIncludes := len(opts.Includes) > 0 || len(opts.InsensitiveIncludes) > 0
 
 	switch {
 	case len(args) == 0:
@@ -182,94 +139,38 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 		msg.E("Warning: %s\n", message)
 	}
 
-	excludePatterns := filter.ParsePatterns(opts.Exclude)
-	insensitiveExcludePatterns := filter.ParsePatterns(opts.InsensitiveExclude)
-
-	if len(opts.ExcludeFiles) > 0 {
-		patternsFromFile, err := readPatternsFromFiles(opts.ExcludeFiles)
-		if err != nil {
-			return err
-		}
-
-		excludePatternsFromFile := filter.ParsePatterns(patternsFromFile)
-		excludePatterns = append(excludePatterns, excludePatternsFromFile...)
-	}
-
-	if len(opts.InsensitiveExcludeFiles) > 0 {
-		patternsFromFile, err := readPatternsFromFiles(opts.ExcludeFiles)
-		if err != nil {
-			return err
-		}
-
-		for i, str := range patternsFromFile {
-			patternsFromFile[i] = strings.ToLower(str)
-		}
-
-		iexcludePatternsFromFile := filter.ParsePatterns(patternsFromFile)
-		insensitiveExcludePatterns = append(insensitiveExcludePatterns, iexcludePatternsFromFile...)
+	excludePatterns, err := opts.excludePatternOptions.CollectPatterns()
+	if err != nil {
+		return err
 	}
 
 	selectExcludeFilter := func(item string, _ string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
-		matched, err := filter.List(excludePatterns, item)
-		if err != nil {
-			msg.E("error for exclude pattern: %v", err)
+		for _, rejectFn := range excludePatterns {
+			matched := rejectFn(item)
+
+			// An exclude filter is basically a 'wildcard but foo',
+			// so even if a childMayMatch, other children of a dir may not,
+			// therefore childMayMatch does not matter, but we should not go down
+			// unless the dir is selected for restore
+			selectedForRestore = !matched
+			childMayBeSelected = selectedForRestore && node.Type == "dir"
+
+			return selectedForRestore, childMayBeSelected
 		}
-
-		matchedInsensitive, err := filter.List(insensitiveExcludePatterns, strings.ToLower(item))
-		if err != nil {
-			msg.E("error for iexclude pattern: %v", err)
-		}
-
-		// An exclude filter is basically a 'wildcard but foo',
-		// so even if a childMayMatch, other children of a dir may not,
-		// therefore childMayMatch does not matter, but we should not go down
-		// unless the dir is selected for restore
-		selectedForRestore = !matched && !matchedInsensitive
-		childMayBeSelected = selectedForRestore && node.Type == "dir"
-
 		return selectedForRestore, childMayBeSelected
 	}
 
-	includePatterns := filter.ParsePatterns(opts.Include)
-	insensitiveIncludePatterns := filter.ParsePatterns(opts.InsensitiveInclude)
-
-	if len(opts.IncludeFiles) > 0 {
-		patternsFromFile, err := readPatternsFromFiles(opts.IncludeFiles)
-		if err != nil {
-			return err
-		}
-
-		for i, str := range patternsFromFile {
-			patternsFromFile[i] = strings.ToLower(str)
-		}
-
-		includePatternsFromFile := filter.ParsePatterns(patternsFromFile)
-		includePatterns = append(includePatterns, includePatternsFromFile...)
-	}
-
-	if len(opts.InsensitiveIncludeFiles) > 0 {
-		patternsFromFile, err := readPatternsFromFiles(opts.InsensitiveIncludeFiles)
-		if err != nil {
-			return err
-		}
-
-		iincludePatternsFromFile := filter.ParsePatterns(patternsFromFile)
-		insensitiveIncludePatterns = append(insensitiveIncludePatterns, iincludePatternsFromFile...)
+	includePatterns, err := opts.includePatternOptions.CollectPatterns()
+	if err != nil {
+		return err
 	}
 
 	selectIncludeFilter := func(item string, _ string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
-		matched, childMayMatch, err := filter.ListWithChild(includePatterns, item)
-		if err != nil {
-			msg.E("error for include pattern: %v", err)
+		for _, includeFn := range includePatterns {
+			selectedForRestore, childMayBeSelected = includeFn(item)
 		}
 
-		matchedInsensitive, childMayMatchInsensitive, err := filter.ListWithChild(insensitiveIncludePatterns, strings.ToLower(item))
-		if err != nil {
-			msg.E("error for iexclude pattern: %v", err)
-		}
-
-		selectedForRestore = matched || matchedInsensitive
-		childMayBeSelected = (childMayMatch || childMayMatchInsensitive) && node.Type == "dir"
+		childMayBeSelected = childMayBeSelected && node.Type == "dir"
 
 		return selectedForRestore, childMayBeSelected
 	}

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -73,6 +73,16 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 	hasExcludes := len(opts.Excludes) > 0 || len(opts.InsensitiveExcludes) > 0
 	hasIncludes := len(opts.Includes) > 0 || len(opts.InsensitiveIncludes) > 0
 
+	excludePatterns, err := opts.excludePatternOptions.CollectPatterns()
+	if err != nil {
+		return err
+	}
+
+	includePatterns, err := opts.includePatternOptions.CollectPatterns()
+	if err != nil {
+		return err
+	}
+
 	switch {
 	case len(args) == 0:
 		return errors.Fatal("no snapshot ID specified")
@@ -139,11 +149,6 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 		msg.E("Warning: %s\n", message)
 	}
 
-	excludePatterns, err := opts.excludePatternOptions.CollectPatterns()
-	if err != nil {
-		return err
-	}
-
 	selectExcludeFilter := func(item string, _ string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
 		for _, rejectFn := range excludePatterns {
 			matched := rejectFn(item)
@@ -158,11 +163,6 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 			return selectedForRestore, childMayBeSelected
 		}
 		return selectedForRestore, childMayBeSelected
-	}
-
-	includePatterns, err := opts.includePatternOptions.CollectPatterns()
-	if err != nil {
-		return err
 	}
 
 	selectIncludeFilter := func(item string, _ string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -73,12 +73,12 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 	hasExcludes := len(opts.Excludes) > 0 || len(opts.InsensitiveExcludes) > 0
 	hasIncludes := len(opts.Includes) > 0 || len(opts.InsensitiveIncludes) > 0
 
-	excludePatterns, err := opts.excludePatternOptions.CollectPatterns()
+	excludePatternFns, err := opts.excludePatternOptions.CollectPatterns()
 	if err != nil {
 		return err
 	}
 
-	includePatterns, err := opts.includePatternOptions.CollectPatterns()
+	includePatternFns, err := opts.includePatternOptions.CollectPatterns()
 	if err != nil {
 		return err
 	}
@@ -150,7 +150,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 	}
 
 	selectExcludeFilter := func(item string, _ string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
-		for _, rejectFn := range excludePatterns {
+		for _, rejectFn := range excludePatternFns {
 			matched := rejectFn(item)
 
 			// An exclude filter is basically a 'wildcard but foo',
@@ -166,7 +166,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 	}
 
 	selectIncludeFilter := func(item string, _ string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
-		for _, includeFn := range includePatterns {
+		for _, includeFn := range includePatternFns {
 			selectedForRestore, childMayBeSelected = includeFn(item)
 		}
 

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -201,6 +201,10 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 			return err
 		}
 
+		for i, str := range patternsFromFile {
+			patternsFromFile[i] = strings.ToLower(str)
+		}
+
 		iexcludePatternsFromFile := filter.ParsePatterns(patternsFromFile)
 		insensitiveExcludePatterns = append(insensitiveExcludePatterns, iexcludePatternsFromFile...)
 	}
@@ -233,6 +237,10 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 		patternsFromFile, err := readPatternsFromFiles(opts.IncludeFiles)
 		if err != nil {
 			return err
+		}
+
+		for i, str := range patternsFromFile {
+			patternsFromFile[i] = strings.ToLower(str)
 		}
 
 		includePatternsFromFile := filter.ParsePatterns(patternsFromFile)

--- a/cmd/restic/cmd_restore_integration_test.go
+++ b/cmd/restic/cmd_restore_integration_test.go
@@ -58,7 +58,7 @@ func testRunRestoreIncludes(t testing.TB, gopts GlobalOptions, dir string, snaps
 	rtest.OK(t, testRunRestoreAssumeFailure(snapshotID.String(), opts, gopts))
 }
 
-func TestRestoreIncludesComplex(t *testing.T) {
+func TestRestoreIncludes(t *testing.T) {
 	testfiles := []struct {
 		path    string
 		size    uint

--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -443,7 +443,7 @@ func initExcludePatternOptions(f *pflag.FlagSet, opts *excludePatternOptions) {
 	f.StringArrayVarP(&opts.Excludes, "exclude", "e", nil, "exclude a `pattern` (can be specified multiple times)")
 	f.StringArrayVar(&opts.InsensitiveExcludes, "iexclude", nil, "same as --exclude `pattern` but ignores the casing of filenames")
 	f.StringArrayVar(&opts.ExcludeFiles, "exclude-file", nil, "read exclude patterns from a `file` (can be specified multiple times)")
-	f.StringArrayVar(&opts.InsensitiveExcludeFiles, "iexclude-file", nil, "same as --exclude-file but ignores casing of filenames in patterns")
+	f.StringArrayVar(&opts.InsensitiveExcludeFiles, "iexclude-file", nil, "same as --exclude-file but ignores casing of `file`names in patterns")
 }
 
 func (opts *excludePatternOptions) Empty() bool {

--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -443,7 +443,7 @@ func initExcludePatternOptions(f *pflag.FlagSet, opts *excludePatternOptions) {
 	f.StringArrayVarP(&opts.Excludes, "exclude", "e", nil, "exclude a `pattern` (can be specified multiple times)")
 	f.StringArrayVar(&opts.InsensitiveExcludes, "iexclude", nil, "same as --exclude `pattern` but ignores the casing of filenames")
 	f.StringArrayVar(&opts.ExcludeFiles, "exclude-file", nil, "read exclude patterns from a `file` (can be specified multiple times)")
-	f.StringArrayVar(&opts.InsensitiveExcludeFiles, "iexclude-file", nil, "same as --exclude-file but ignores casing of `file`names in patterns")
+	f.StringArrayVar(&opts.InsensitiveExcludeFiles, "iexclude-file", nil, "same as --exclude-file but ignores casing of filenames in patterns")
 }
 
 func (opts *excludePatternOptions) Empty() bool {

--- a/cmd/restic/include.go
+++ b/cmd/restic/include.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/filter"
+	"github.com/spf13/pflag"
+)
+
+// IncludeByNameFunc is a function that takes a filename that should be included
+// in the restore process and returns whether it should be included.
+type IncludeByNameFunc func(item string) (matched bool, childMayMatch bool)
+
+type includePatternOptions struct {
+	Includes                []string
+	InsensitiveIncludes     []string
+	IncludeFiles            []string
+	InsensitiveIncludeFiles []string
+}
+
+func initIncludePatternOptions(f *pflag.FlagSet, opts *includePatternOptions) {
+	f.StringArrayVarP(&opts.Includes, "include", "i", nil, "include a `pattern` (can be specified multiple times)")
+	f.StringArrayVar(&opts.InsensitiveIncludes, "iinclude", nil, "same as --include `pattern` but ignores the casing of filenames")
+	f.StringArrayVar(&opts.IncludeFiles, "include-file", nil, "read include patterns from a `file` (can be specified multiple times)")
+	f.StringArrayVar(&opts.InsensitiveIncludeFiles, "iinclude-file", nil, "same as --include-file but ignores casing of `file`names in patterns")
+}
+
+func (opts includePatternOptions) CollectPatterns() ([]IncludeByNameFunc, error) {
+	var fs []IncludeByNameFunc
+	if len(opts.IncludeFiles) > 0 {
+		includePatterns, err := readPatternsFromFiles(opts.IncludeFiles)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := filter.ValidatePatterns(includePatterns); err != nil {
+			return nil, errors.Fatalf("--include-file: %s", err)
+		}
+
+		opts.Includes = append(opts.Includes, includePatterns...)
+	}
+
+	if len(opts.InsensitiveIncludeFiles) > 0 {
+		includePatterns, err := readPatternsFromFiles(opts.InsensitiveIncludeFiles)
+		if err != nil {
+			return nil, err
+		}
+
+		if err := filter.ValidatePatterns(includePatterns); err != nil {
+			return nil, errors.Fatalf("--iinclude-file: %s", err)
+		}
+
+		opts.InsensitiveIncludes = append(opts.InsensitiveIncludes, includePatterns...)
+	}
+
+	if len(opts.InsensitiveIncludes) > 0 {
+		if err := filter.ValidatePatterns(opts.InsensitiveIncludes); err != nil {
+			return nil, errors.Fatalf("--iinclude: %s", err)
+		}
+
+		fs = append(fs, includeByInsensitivePattern(opts.InsensitiveIncludes))
+	}
+
+	if len(opts.Includes) > 0 {
+		if err := filter.ValidatePatterns(opts.Includes); err != nil {
+			return nil, errors.Fatalf("--include: %s", err)
+		}
+
+		fs = append(fs, includeByPattern(opts.Includes))
+	}
+	return fs, nil
+}
+
+// includeByPattern returns a IncludeByNameFunc which includes files that match
+// one of the patterns.
+func includeByPattern(patterns []string) IncludeByNameFunc {
+	parsedPatterns := filter.ParsePatterns(patterns)
+	return func(item string) (matched bool, childMayMatch bool) {
+		matched, childMayMatch, err := filter.ListWithChild(parsedPatterns, item)
+		if err != nil {
+			Warnf("error for include pattern: %v", err)
+		}
+
+		return matched, childMayMatch
+	}
+}
+
+// includeByInsensitivePattern returns a IncludeByNameFunc which includes files that match
+// one of the patterns, ignoring the casing of the filenames.
+func includeByInsensitivePattern(patterns []string) IncludeByNameFunc {
+	for index, path := range patterns {
+		patterns[index] = strings.ToLower(path)
+	}
+
+	includeFunc := includeByPattern(patterns)
+	return func(item string) (matched bool, childMayMatch bool) {
+		return includeFunc(strings.ToLower(item))
+	}
+}

--- a/cmd/restic/include.go
+++ b/cmd/restic/include.go
@@ -23,7 +23,7 @@ func initIncludePatternOptions(f *pflag.FlagSet, opts *includePatternOptions) {
 	f.StringArrayVarP(&opts.Includes, "include", "i", nil, "include a `pattern` (can be specified multiple times)")
 	f.StringArrayVar(&opts.InsensitiveIncludes, "iinclude", nil, "same as --include `pattern` but ignores the casing of filenames")
 	f.StringArrayVar(&opts.IncludeFiles, "include-file", nil, "read include patterns from a `file` (can be specified multiple times)")
-	f.StringArrayVar(&opts.InsensitiveIncludeFiles, "iinclude-file", nil, "same as --include-file but ignores casing of filenames in patterns")
+	f.StringArrayVar(&opts.InsensitiveIncludeFiles, "iinclude-file", nil, "same as --include-file but ignores casing of `file`names in patterns")
 }
 
 func (opts includePatternOptions) CollectPatterns() ([]IncludeByNameFunc, error) {

--- a/cmd/restic/include.go
+++ b/cmd/restic/include.go
@@ -23,7 +23,7 @@ func initIncludePatternOptions(f *pflag.FlagSet, opts *includePatternOptions) {
 	f.StringArrayVarP(&opts.Includes, "include", "i", nil, "include a `pattern` (can be specified multiple times)")
 	f.StringArrayVar(&opts.InsensitiveIncludes, "iinclude", nil, "same as --include `pattern` but ignores the casing of filenames")
 	f.StringArrayVar(&opts.IncludeFiles, "include-file", nil, "read include patterns from a `file` (can be specified multiple times)")
-	f.StringArrayVar(&opts.InsensitiveIncludeFiles, "iinclude-file", nil, "same as --include-file but ignores casing of `file`names in patterns")
+	f.StringArrayVar(&opts.InsensitiveIncludeFiles, "iinclude-file", nil, "same as --include-file but ignores casing of filenames in patterns")
 }
 
 func (opts includePatternOptions) CollectPatterns() ([]IncludeByNameFunc, error) {

--- a/cmd/restic/include_test.go
+++ b/cmd/restic/include_test.go
@@ -1,0 +1,59 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestIncludeByPattern(t *testing.T) {
+	var tests = []struct {
+		filename string
+		include  bool
+	}{
+		{filename: "/home/user/foo.go", include: true},
+		{filename: "/home/user/foo.c", include: false},
+		{filename: "/home/user/foobar", include: false},
+		{filename: "/home/user/foobar/x", include: false},
+		{filename: "/home/user/README", include: false},
+		{filename: "/home/user/README.md", include: true},
+	}
+
+	patterns := []string{"*.go", "README.md"}
+
+	for _, tc := range tests {
+		t.Run(tc.filename, func(t *testing.T) {
+			includeFunc := includeByPattern(patterns)
+			matched, _ := includeFunc(tc.filename)
+			if matched != tc.include {
+				t.Fatalf("wrong result for filename %v: want %v, got %v",
+					tc.filename, tc.include, matched)
+			}
+		})
+	}
+}
+
+func TestIncludeByInsensitivePattern(t *testing.T) {
+	var tests = []struct {
+		filename string
+		include  bool
+	}{
+		{filename: "/home/user/foo.GO", include: true},
+		{filename: "/home/user/foo.c", include: false},
+		{filename: "/home/user/foobar", include: false},
+		{filename: "/home/user/FOObar/x", include: false},
+		{filename: "/home/user/README", include: false},
+		{filename: "/home/user/readme.MD", include: true},
+	}
+
+	patterns := []string{"*.go", "README.md"}
+
+	for _, tc := range tests {
+		t.Run(tc.filename, func(t *testing.T) {
+			includeFunc := includeByInsensitivePattern(patterns)
+			matched, _ := includeFunc(tc.filename)
+			if matched != tc.include {
+				t.Fatalf("wrong result for filename %v: want %v, got %v",
+					tc.filename, tc.include, matched)
+			}
+		})
+	}
+}

--- a/cmd/restic/integration_filter_pattern_test.go
+++ b/cmd/restic/integration_filter_pattern_test.go
@@ -97,3 +97,58 @@ func TestRestoreFailsWhenUsingInvalidPatterns(t *testing.T) {
 *[._]log[.-][0-9]
 !*[._]log[.-][0-9]`, err.Error())
 }
+
+func TestRestoreFailsWhenUsingInvalidPatternsFromFile(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+
+	// Create an include file with some invalid patterns
+	includeFile := env.base + "/includefile"
+	fileErr := os.WriteFile(includeFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
+	if fileErr != nil {
+		t.Fatalf("Could not write include file: %v", fileErr)
+	}
+
+	err := testRunRestoreAssumeFailure("latest", RestoreOptions{includePatternOptions: includePatternOptions{IncludeFiles: []string{includeFile}}}, env.gopts)
+	rtest.Equals(t, `Fatal: --include-file: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+
+	// Create an exclude file with some invalid patterns
+	excludeFile := env.base + "/excludefile"
+	fileErr = os.WriteFile(excludeFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
+	if fileErr != nil {
+		t.Fatalf("Could not write exclude file: %v", fileErr)
+	}
+
+	err = testRunRestoreAssumeFailure("latest", RestoreOptions{excludePatternOptions: excludePatternOptions{ExcludeFiles: []string{excludeFile}}}, env.gopts)
+	rtest.Equals(t, `Fatal: --exclude-file: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+
+	// Create an insentive include file with some invalid patterns
+	insensitiveIncludeFile := env.base + "/insensitiveincludefile"
+	fileErr = os.WriteFile(insensitiveIncludeFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
+	if fileErr != nil {
+		t.Fatalf("Could not write insensitive include file: %v", fileErr)
+	}
+
+	err = testRunRestoreAssumeFailure("latest", RestoreOptions{includePatternOptions: includePatternOptions{InsensitiveIncludeFiles: []string{insensitiveIncludeFile}}}, env.gopts)
+	rtest.Equals(t, `Fatal: --iinclude-file: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+
+	// Create an insensitive exclude file with some invalid patterns
+	insensitiveExcludeFile := env.base + "/insensitiveexcludefile"
+	fileErr = os.WriteFile(insensitiveExcludeFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
+	if fileErr != nil {
+		t.Fatalf("Could not write insensitive exclude file: %v", fileErr)
+	}
+
+	err = testRunRestoreAssumeFailure("latest", RestoreOptions{excludePatternOptions: excludePatternOptions{InsensitiveExcludeFiles: []string{insensitiveExcludeFile}}}, env.gopts)
+	rtest.Equals(t, `Fatal: --iexclude-file: invalid pattern(s) provided:
+*[._]log[.-][0-9]
+!*[._]log[.-][0-9]`, err.Error())
+}

--- a/cmd/restic/integration_filter_pattern_test.go
+++ b/cmd/restic/integration_filter_pattern_test.go
@@ -105,49 +105,28 @@ func TestRestoreFailsWhenUsingInvalidPatternsFromFile(t *testing.T) {
 	testRunInit(t, env.gopts)
 
 	// Create an include file with some invalid patterns
-	includeFile := env.base + "/includefile"
-	fileErr := os.WriteFile(includeFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
+	patternsFile := env.base + "/patternsFile"
+	fileErr := os.WriteFile(patternsFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
 	if fileErr != nil {
 		t.Fatalf("Could not write include file: %v", fileErr)
 	}
 
-	err := testRunRestoreAssumeFailure("latest", RestoreOptions{includePatternOptions: includePatternOptions{IncludeFiles: []string{includeFile}}}, env.gopts)
+	err := testRunRestoreAssumeFailure("latest", RestoreOptions{includePatternOptions: includePatternOptions{IncludeFiles: []string{patternsFile}}}, env.gopts)
 	rtest.Equals(t, `Fatal: --include-file: invalid pattern(s) provided:
 *[._]log[.-][0-9]
 !*[._]log[.-][0-9]`, err.Error())
 
-	// Create an exclude file with some invalid patterns
-	excludeFile := env.base + "/excludefile"
-	fileErr = os.WriteFile(excludeFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
-	if fileErr != nil {
-		t.Fatalf("Could not write exclude file: %v", fileErr)
-	}
-
-	err = testRunRestoreAssumeFailure("latest", RestoreOptions{excludePatternOptions: excludePatternOptions{ExcludeFiles: []string{excludeFile}}}, env.gopts)
+	err = testRunRestoreAssumeFailure("latest", RestoreOptions{excludePatternOptions: excludePatternOptions{ExcludeFiles: []string{patternsFile}}}, env.gopts)
 	rtest.Equals(t, `Fatal: --exclude-file: invalid pattern(s) provided:
 *[._]log[.-][0-9]
 !*[._]log[.-][0-9]`, err.Error())
 
-	// Create an insentive include file with some invalid patterns
-	insensitiveIncludeFile := env.base + "/insensitiveincludefile"
-	fileErr = os.WriteFile(insensitiveIncludeFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
-	if fileErr != nil {
-		t.Fatalf("Could not write insensitive include file: %v", fileErr)
-	}
-
-	err = testRunRestoreAssumeFailure("latest", RestoreOptions{includePatternOptions: includePatternOptions{InsensitiveIncludeFiles: []string{insensitiveIncludeFile}}}, env.gopts)
+	err = testRunRestoreAssumeFailure("latest", RestoreOptions{includePatternOptions: includePatternOptions{InsensitiveIncludeFiles: []string{patternsFile}}}, env.gopts)
 	rtest.Equals(t, `Fatal: --iinclude-file: invalid pattern(s) provided:
 *[._]log[.-][0-9]
 !*[._]log[.-][0-9]`, err.Error())
 
-	// Create an insensitive exclude file with some invalid patterns
-	insensitiveExcludeFile := env.base + "/insensitiveexcludefile"
-	fileErr = os.WriteFile(insensitiveExcludeFile, []byte("*.go\n*[._]log[.-][0-9]\n!*[._]log[.-][0-9]"), 0644)
-	if fileErr != nil {
-		t.Fatalf("Could not write insensitive exclude file: %v", fileErr)
-	}
-
-	err = testRunRestoreAssumeFailure("latest", RestoreOptions{excludePatternOptions: excludePatternOptions{InsensitiveExcludeFiles: []string{insensitiveExcludeFile}}}, env.gopts)
+	err = testRunRestoreAssumeFailure("latest", RestoreOptions{excludePatternOptions: excludePatternOptions{InsensitiveExcludeFiles: []string{patternsFile}}}, env.gopts)
 	rtest.Equals(t, `Fatal: --iexclude-file: invalid pattern(s) provided:
 *[._]log[.-][0-9]
 !*[._]log[.-][0-9]`, err.Error())

--- a/cmd/restic/integration_filter_pattern_test.go
+++ b/cmd/restic/integration_filter_pattern_test.go
@@ -70,28 +70,28 @@ func TestRestoreFailsWhenUsingInvalidPatterns(t *testing.T) {
 	var err error
 
 	// Test --exclude
-	err = testRunRestoreAssumeFailure("latest", RestoreOptions{Exclude: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}, env.gopts)
+	err = testRunRestoreAssumeFailure("latest", RestoreOptions{excludePatternOptions: excludePatternOptions{Excludes: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}}, env.gopts)
 
 	rtest.Equals(t, `Fatal: --exclude: invalid pattern(s) provided:
 *[._]log[.-][0-9]
 !*[._]log[.-][0-9]`, err.Error())
 
 	// Test --iexclude
-	err = testRunRestoreAssumeFailure("latest", RestoreOptions{InsensitiveExclude: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}, env.gopts)
+	err = testRunRestoreAssumeFailure("latest", RestoreOptions{excludePatternOptions: excludePatternOptions{InsensitiveExcludes: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}}, env.gopts)
 
 	rtest.Equals(t, `Fatal: --iexclude: invalid pattern(s) provided:
 *[._]log[.-][0-9]
 !*[._]log[.-][0-9]`, err.Error())
 
 	// Test --include
-	err = testRunRestoreAssumeFailure("latest", RestoreOptions{Include: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}, env.gopts)
+	err = testRunRestoreAssumeFailure("latest", RestoreOptions{includePatternOptions: includePatternOptions{Includes: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}}, env.gopts)
 
 	rtest.Equals(t, `Fatal: --include: invalid pattern(s) provided:
 *[._]log[.-][0-9]
 !*[._]log[.-][0-9]`, err.Error())
 
 	// Test --iinclude
-	err = testRunRestoreAssumeFailure("latest", RestoreOptions{InsensitiveInclude: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}, env.gopts)
+	err = testRunRestoreAssumeFailure("latest", RestoreOptions{includePatternOptions: includePatternOptions{InsensitiveIncludes: []string{"*[._]log[.-][0-9]", "!*[._]log[.-][0-9]"}}}, env.gopts)
 
 	rtest.Equals(t, `Fatal: --iinclude: invalid pattern(s) provided:
 *[._]log[.-][0-9]

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -68,6 +68,9 @@ There are case insensitive variants of ``--exclude`` and ``--include`` called
 ``--iexclude`` and ``--iinclude``. These options will behave the same way but
 ignore the casing of paths.
 
+There are also ``--include-file``, ``--exclude-file``, ``--iinclude-file`` and
+ ``--iexclude-file`` flags that read the include and exclude patterns from a file.
+
 Restoring symbolic links on windows is only possible when the user has
 ``SeCreateSymbolicLinkPrivilege`` privilege or is running as admin. This is a
 restriction of windows not restic.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Added `--exclude-file`, `--iexclude-file`, `include-file` and `iinclude-file` to the restore command. 

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #4781 

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
