### PR TITLE
Resumable prune & memory-efficient index rewrite

### DIFF
--- a/changelog/unreleased/issue-3806
+++ b/changelog/unreleased/issue-3806
@@ -1,0 +1,11 @@
+Enhancement: Make `prune` command resumable
+
+When `prune` was interrupted, it a latter `prune` run previously started repacking
+the pack files from the start as `prune` did not update the index while repacking.
+
+The `prune` command now supports resuming interrupted prune runs. The update
+of the repository index also has been optimized to use less memory and only
+rewrite parts of the index that have changed.
+
+https://github.com/restic/restic/issues/3806
+https://github.com/restic/restic/pull/4812

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -167,8 +167,7 @@ func runCat(ctx context.Context, gopts GlobalOptions, args []string) error {
 		}
 
 		for _, t := range []restic.BlobType{restic.DataBlob, restic.TreeBlob} {
-			bh := restic.BlobHandle{ID: id, Type: t}
-			if !repo.HasBlob(bh) {
+			if _, ok := repo.LookupBlobSize(id, t); !ok {
 				continue
 			}
 

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -168,7 +168,7 @@ func runCat(ctx context.Context, gopts GlobalOptions, args []string) error {
 
 		for _, t := range []restic.BlobType{restic.DataBlob, restic.TreeBlob} {
 			bh := restic.BlobHandle{ID: id, Type: t}
-			if !repo.Index().Has(bh) {
+			if !repo.HasBlob(bh) {
 				continue
 			}
 

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -167,7 +167,7 @@ func runCat(ctx context.Context, gopts GlobalOptions, args []string) error {
 		}
 
 		for _, t := range []restic.BlobType{restic.DataBlob, restic.TreeBlob} {
-			if _, ok := repo.LookupBlobSize(id, t); !ok {
+			if _, ok := repo.LookupBlobSize(t, id); !ok {
 				continue
 			}
 

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -187,7 +187,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 	packList := restic.NewIDSet()
 
 	enqueue := func(h restic.BlobHandle) {
-		pb := srcRepo.Index().Lookup(h)
+		pb := srcRepo.LookupBlob(h)
 		copyBlobs.Insert(h)
 		for _, p := range pb {
 			packList.Insert(p.PackID)
@@ -202,7 +202,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 
 			// Do we already have this tree blob?
 			treeHandle := restic.BlobHandle{ID: tree.ID, Type: restic.TreeBlob}
-			if !dstRepo.Index().Has(treeHandle) {
+			if !dstRepo.HasBlob(treeHandle) {
 				// copy raw tree bytes to avoid problems if the serialization changes
 				enqueue(treeHandle)
 			}
@@ -212,7 +212,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 				// Copy the blobs for this file.
 				for _, blobID := range entry.Content {
 					h := restic.BlobHandle{Type: restic.DataBlob, ID: blobID}
-					if !dstRepo.Index().Has(h) {
+					if !dstRepo.HasBlob(h) {
 						enqueue(h)
 					}
 				}

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -187,7 +187,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 	packList := restic.NewIDSet()
 
 	enqueue := func(h restic.BlobHandle) {
-		pb := srcRepo.LookupBlob(h)
+		pb := srcRepo.LookupBlob(h.Type, h.ID)
 		copyBlobs.Insert(h)
 		for _, p := range pb {
 			packList.Insert(p.PackID)

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -202,7 +202,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 
 			// Do we already have this tree blob?
 			treeHandle := restic.BlobHandle{ID: tree.ID, Type: restic.TreeBlob}
-			if !dstRepo.HasBlob(treeHandle) {
+			if _, ok := dstRepo.LookupBlobSize(treeHandle.ID, treeHandle.Type); !ok {
 				// copy raw tree bytes to avoid problems if the serialization changes
 				enqueue(treeHandle)
 			}
@@ -212,7 +212,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 				// Copy the blobs for this file.
 				for _, blobID := range entry.Content {
 					h := restic.BlobHandle{Type: restic.DataBlob, ID: blobID}
-					if !dstRepo.HasBlob(h) {
+					if _, ok := dstRepo.LookupBlobSize(h.ID, h.Type); !ok {
 						enqueue(h)
 					}
 				}

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -202,7 +202,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 
 			// Do we already have this tree blob?
 			treeHandle := restic.BlobHandle{ID: tree.ID, Type: restic.TreeBlob}
-			if _, ok := dstRepo.LookupBlobSize(treeHandle.ID, treeHandle.Type); !ok {
+			if _, ok := dstRepo.LookupBlobSize(treeHandle.Type, treeHandle.ID); !ok {
 				// copy raw tree bytes to avoid problems if the serialization changes
 				enqueue(treeHandle)
 			}
@@ -212,7 +212,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 				// Copy the blobs for this file.
 				for _, blobID := range entry.Content {
 					h := restic.BlobHandle{Type: restic.DataBlob, ID: blobID}
-					if _, ok := dstRepo.LookupBlobSize(h.ID, h.Type); !ok {
+					if _, ok := dstRepo.LookupBlobSize(h.Type, h.ID); !ok {
 						enqueue(h)
 					}
 				}

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -492,7 +492,7 @@ func examinePack(ctx context.Context, opts DebugExamineOptions, repo restic.Repo
 
 	blobsLoaded := false
 	// examine all data the indexes have for the pack file
-	for b := range repo.Index().ListPacks(ctx, restic.NewIDSet(id)) {
+	for b := range repo.ListPacksFromIndex(ctx, restic.NewIDSet(id)) {
 		blobs := b.Blobs
 		if len(blobs) == 0 {
 			continue

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -156,7 +156,7 @@ func updateBlobs(repo restic.Loader, blobs restic.BlobSet, stats *DiffStat) {
 			stats.TreeBlobs++
 		}
 
-		size, found := repo.LookupBlobSize(h.ID, h.Type)
+		size, found := repo.LookupBlobSize(h.Type, h.ID)
 		if !found {
 			Warnf("unable to find blob size for %v\n", h)
 			continue

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -509,7 +509,7 @@ func (f *Finder) findObjectPack(id string, t restic.BlobType) {
 		return
 	}
 
-	blobs := f.repo.LookupBlob(restic.BlobHandle{ID: rid, Type: t})
+	blobs := f.repo.LookupBlob(t, rid)
 	if len(blobs) == 0 {
 		Printf("Object %s not found in the index\n", rid.Str())
 		return

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -465,7 +465,7 @@ func (f *Finder) indexPacksToBlobs(ctx context.Context, packIDs map[string]struc
 
 	// remember which packs were found in the index
 	indexPackIDs := make(map[string]struct{})
-	err := f.repo.Index().Each(wctx, func(pb restic.PackedBlob) {
+	err := f.repo.ListBlobs(wctx, func(pb restic.PackedBlob) {
 		idStr := pb.PackID.String()
 		// keep entry in packIDs as Each() returns individual index entries
 		matchingID := false
@@ -503,15 +503,13 @@ func (f *Finder) indexPacksToBlobs(ctx context.Context, packIDs map[string]struc
 }
 
 func (f *Finder) findObjectPack(id string, t restic.BlobType) {
-	idx := f.repo.Index()
-
 	rid, err := restic.ParseID(id)
 	if err != nil {
 		Printf("Note: cannot find pack for object '%s', unable to parse ID: %v\n", id, err)
 		return
 	}
 
-	blobs := idx.Lookup(restic.BlobHandle{ID: rid, Type: t})
+	blobs := f.repo.LookupBlob(restic.BlobHandle{ID: rid, Type: t})
 	if len(blobs) == 0 {
 		Printf("Object %s not found in the index\n", rid.Str())
 		return

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -162,9 +162,6 @@ func runPrune(ctx context.Context, opts PruneOptions, gopts GlobalOptions, term 
 }
 
 func runPruneWithRepo(ctx context.Context, opts PruneOptions, gopts GlobalOptions, repo *repository.Repository, ignoreSnapshots restic.IDSet, term *termstatus.Terminal) error {
-	// we do not need index updates while pruning!
-	repo.DisableAutoIndexUpdate()
-
 	if repo.Cache == nil {
 		Print("warning: running prune without a cache, this may be very slow!\n")
 	}

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -61,7 +61,7 @@ func runRecover(ctx context.Context, gopts GlobalOptions) error {
 	// tree. If it is not referenced, we have a root tree.
 	trees := make(map[restic.ID]bool)
 
-	err = repo.Index().Each(ctx, func(blob restic.PackedBlob) {
+	err = repo.ListBlobs(ctx, func(blob restic.PackedBlob) {
 		if blob.Type == restic.TreeBlob {
 			trees[blob.Blob.ID] = false
 		}

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -97,7 +97,7 @@ func runRepairSnapshots(ctx context.Context, gopts GlobalOptions, opts RepairOpt
 			var newSize uint64
 			// check all contents and remove if not available
 			for _, id := range node.Content {
-				if size, found := repo.LookupBlobSize(id, restic.DataBlob); !found {
+				if size, found := repo.LookupBlobSize(restic.DataBlob, id); !found {
 					ok = false
 				} else {
 					newContent = append(newContent, id)

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -124,7 +124,7 @@ func runStats(ctx context.Context, opts StatsOptions, gopts GlobalOptions, args 
 	if opts.countMode == countModeRawData {
 		// the blob handles have been collected, but not yet counted
 		for blobHandle := range stats.blobs {
-			pbs := repo.LookupBlob(blobHandle)
+			pbs := repo.LookupBlob(blobHandle.Type, blobHandle.ID)
 			if len(pbs) == 0 {
 				return fmt.Errorf("blob %v not found", blobHandle)
 			}

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -124,7 +124,7 @@ func runStats(ctx context.Context, opts StatsOptions, gopts GlobalOptions, args 
 	if opts.countMode == countModeRawData {
 		// the blob handles have been collected, but not yet counted
 		for blobHandle := range stats.blobs {
-			pbs := repo.Index().Lookup(blobHandle)
+			pbs := repo.LookupBlob(blobHandle)
 			if len(pbs) == 0 {
 				return fmt.Errorf("blob %v not found", blobHandle)
 			}
@@ -378,7 +378,7 @@ func statsDebugBlobs(ctx context.Context, repo restic.Repository) ([restic.NumBl
 		hist[i] = newSizeHistogram(2 * chunker.MaxSize)
 	}
 
-	err := repo.Index().Each(ctx, func(pb restic.PackedBlob) {
+	err := repo.ListBlobs(ctx, func(pb restic.PackedBlob) {
 		hist[pb.Type].Add(uint64(pb.Length))
 	})
 

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -238,7 +238,7 @@ func statsWalkTree(repo restic.Loader, opts StatsOptions, stats *statsContainer,
 						}
 						if _, ok := stats.fileBlobs[nodePath][blobID]; !ok {
 							// is always a data blob since we're accessing it via a file's Content array
-							blobSize, found := repo.LookupBlobSize(blobID, restic.DataBlob)
+							blobSize, found := repo.LookupBlobSize(restic.DataBlob, blobID)
 							if !found {
 								return fmt.Errorf("blob %s not found for tree %s", blobID, parentTreeID)
 							}

--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -252,7 +252,7 @@ func listTreePacks(gopts GlobalOptions, t *testing.T) restic.IDSet {
 
 	rtest.OK(t, r.LoadIndex(ctx, nil))
 	treePacks := restic.NewIDSet()
-	rtest.OK(t, r.Index().Each(ctx, func(pb restic.PackedBlob) {
+	rtest.OK(t, r.ListBlobs(ctx, func(pb restic.PackedBlob) {
 		if pb.Type == restic.TreeBlob {
 			treePacks.Insert(pb.PackID)
 		}
@@ -280,7 +280,7 @@ func removePacksExcept(gopts GlobalOptions, t testing.TB, keep restic.IDSet, rem
 	rtest.OK(t, r.LoadIndex(ctx, nil))
 
 	treePacks := restic.NewIDSet()
-	rtest.OK(t, r.Index().Each(ctx, func(pb restic.PackedBlob) {
+	rtest.OK(t, r.ListBlobs(ctx, func(pb restic.PackedBlob) {
 		if pb.Type == restic.TreeBlob {
 			treePacks.Insert(pb.PackID)
 		}

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -276,7 +276,7 @@ func (arch *Archiver) loadSubtree(ctx context.Context, node *restic.Node) (*rest
 }
 
 func (arch *Archiver) wrapLoadTreeError(id restic.ID, err error) error {
-	if arch.Repo.HasBlob(restic.BlobHandle{ID: id, Type: restic.TreeBlob}) {
+	if _, ok := arch.Repo.LookupBlobSize(id, restic.TreeBlob); ok {
 		err = errors.Errorf("tree %v could not be loaded; the repository could be damaged: %v", id, err)
 	} else {
 		err = errors.Errorf("tree %v is not known; the repository could be damaged, run `repair index` to try to repair it", id)
@@ -390,7 +390,7 @@ func (fn *FutureNode) take(ctx context.Context) futureNodeResult {
 func (arch *Archiver) allBlobsPresent(previous *restic.Node) bool {
 	// check if all blobs are contained in index
 	for _, id := range previous.Content {
-		if !arch.Repo.HasBlob(restic.BlobHandle{ID: id, Type: restic.DataBlob}) {
+		if _, ok := arch.Repo.LookupBlobSize(id, restic.DataBlob); !ok {
 			return false
 		}
 	}

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -276,7 +276,7 @@ func (arch *Archiver) loadSubtree(ctx context.Context, node *restic.Node) (*rest
 }
 
 func (arch *Archiver) wrapLoadTreeError(id restic.ID, err error) error {
-	if _, ok := arch.Repo.LookupBlobSize(id, restic.TreeBlob); ok {
+	if _, ok := arch.Repo.LookupBlobSize(restic.TreeBlob, id); ok {
 		err = errors.Errorf("tree %v could not be loaded; the repository could be damaged: %v", id, err)
 	} else {
 		err = errors.Errorf("tree %v is not known; the repository could be damaged, run `repair index` to try to repair it", id)
@@ -390,7 +390,7 @@ func (fn *FutureNode) take(ctx context.Context) futureNodeResult {
 func (arch *Archiver) allBlobsPresent(previous *restic.Node) bool {
 	// check if all blobs are contained in index
 	for _, id := range previous.Content {
-		if _, ok := arch.Repo.LookupBlobSize(id, restic.DataBlob); !ok {
+		if _, ok := arch.Repo.LookupBlobSize(restic.DataBlob, id); !ok {
 			return false
 		}
 	}

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -276,7 +276,7 @@ func (arch *Archiver) loadSubtree(ctx context.Context, node *restic.Node) (*rest
 }
 
 func (arch *Archiver) wrapLoadTreeError(id restic.ID, err error) error {
-	if arch.Repo.Index().Has(restic.BlobHandle{ID: id, Type: restic.TreeBlob}) {
+	if arch.Repo.HasBlob(restic.BlobHandle{ID: id, Type: restic.TreeBlob}) {
 		err = errors.Errorf("tree %v could not be loaded; the repository could be damaged: %v", id, err)
 	} else {
 		err = errors.Errorf("tree %v is not known; the repository could be damaged, run `repair index` to try to repair it", id)
@@ -390,7 +390,7 @@ func (fn *FutureNode) take(ctx context.Context) futureNodeResult {
 func (arch *Archiver) allBlobsPresent(previous *restic.Node) bool {
 	// check if all blobs are contained in index
 	for _, id := range previous.Content {
-		if !arch.Repo.Index().Has(restic.BlobHandle{ID: id, Type: restic.DataBlob}) {
+		if !arch.Repo.HasBlob(restic.BlobHandle{ID: id, Type: restic.DataBlob}) {
 			return false
 		}
 	}

--- a/internal/archiver/archiver_unix_test.go
+++ b/internal/archiver/archiver_unix_test.go
@@ -46,7 +46,7 @@ func wrapFileInfo(fi os.FileInfo) os.FileInfo {
 	return res
 }
 
-func statAndSnapshot(t *testing.T, repo restic.Repository, name string) (*restic.Node, *restic.Node) {
+func statAndSnapshot(t *testing.T, repo archiverRepo, name string) (*restic.Node, *restic.Node) {
 	fi := lstat(t, name)
 	want, err := restic.NodeFromFileInfo(name, fi, false)
 	rtest.OK(t, err)

--- a/internal/archiver/blob_saver_test.go
+++ b/internal/archiver/blob_saver_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/restic/restic/internal/errors"
-	"github.com/restic/restic/internal/index"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 	"golang.org/x/sync/errgroup"
@@ -19,7 +18,6 @@ import (
 var errTest = errors.New("test error")
 
 type saveFail struct {
-	idx    restic.MasterIndex
 	cnt    int32
 	failAt int32
 }
@@ -33,18 +31,12 @@ func (b *saveFail) SaveBlob(_ context.Context, _ restic.BlobType, _ []byte, id r
 	return id, false, 0, nil
 }
 
-func (b *saveFail) Index() restic.MasterIndex {
-	return b.idx
-}
-
 func TestBlobSaver(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
 	wg, ctx := errgroup.WithContext(ctx)
-	saver := &saveFail{
-		idx: index.NewMasterIndex(),
-	}
+	saver := &saveFail{}
 
 	b := NewBlobSaver(ctx, wg, saver, uint(runtime.NumCPU()))
 
@@ -100,7 +92,6 @@ func TestBlobSaverError(t *testing.T) {
 
 			wg, ctx := errgroup.WithContext(ctx)
 			saver := &saveFail{
-				idx:    index.NewMasterIndex(),
 				failAt: int32(test.failAt),
 			}
 

--- a/internal/archiver/testing.go
+++ b/internal/archiver/testing.go
@@ -25,7 +25,7 @@ func TestSnapshot(t testing.TB, repo restic.Repository, path string, parent *res
 		Tags:     []string{"test"},
 	}
 	if parent != nil {
-		sn, err := restic.LoadSnapshot(context.TODO(), arch.Repo, *parent)
+		sn, err := restic.LoadSnapshot(context.TODO(), repo, *parent)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/internal/archiver/testing.go
+++ b/internal/archiver/testing.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/restic"
@@ -239,7 +238,7 @@ func TestEnsureFileContent(ctx context.Context, t testing.TB, repo restic.BlobLo
 		return
 	}
 
-	content := make([]byte, crypto.CiphertextLength(len(file.Content)))
+	content := make([]byte, len(file.Content))
 	pos := 0
 	for _, id := range node.Content {
 		part, err := repo.LoadBlob(ctx, restic.DataBlob, id, content[pos:])

--- a/internal/backend/watchdog_roundtriper_test.go
+++ b/internal/backend/watchdog_roundtriper_test.go
@@ -64,7 +64,7 @@ func TestRoundtrip(t *testing.T) {
 			}))
 			defer srv.Close()
 
-			rt := newWatchdogRoundtripper(http.DefaultTransport, 50*time.Millisecond, 2)
+			rt := newWatchdogRoundtripper(http.DefaultTransport, 100*time.Millisecond, 2)
 			req, err := http.NewRequestWithContext(context.TODO(), "GET", srv.URL, io.NopCloser(newSlowReader(bytes.NewReader(msg), time.Duration(delay)*time.Millisecond)))
 			rtest.OK(t, err)
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -429,7 +429,7 @@ func (c *Checker) checkTree(id restic.ID, tree *restic.Tree) (errs []error) {
 				// unfortunately fails in some cases that are not resolvable
 				// by users, so we omit this check, see #1887
 
-				_, found := c.repo.LookupBlobSize(blobID, restic.DataBlob)
+				_, found := c.repo.LookupBlobSize(restic.DataBlob, blobID)
 				if !found {
 					debug.Log("tree %v references blob %v which isn't contained in index", id, blobID)
 					errs = append(errs, &Error{TreeID: id, Err: errors.Errorf("file %q blob %v not found in index", node.Name, blobID)})

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -461,11 +461,11 @@ func (r *delayRepository) LoadTree(ctx context.Context, id restic.ID) (*restic.T
 	return restic.LoadTree(ctx, r.Repository, id)
 }
 
-func (r *delayRepository) LookupBlobSize(id restic.ID, t restic.BlobType) (uint, bool) {
+func (r *delayRepository) LookupBlobSize(t restic.BlobType, id restic.ID) (uint, bool) {
 	if id == r.DelayTree && t == restic.DataBlob {
 		r.Unblock()
 	}
-	return r.Repository.LookupBlobSize(id, t)
+	return r.Repository.LookupBlobSize(t, id)
 }
 
 func (r *delayRepository) Unblock() {

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -72,7 +72,7 @@ func (f *file) Open(_ context.Context, _ *fuse.OpenRequest, _ *fuse.OpenResponse
 	var bytes uint64
 	cumsize := make([]uint64, 1+len(f.node.Content))
 	for i, id := range f.node.Content {
-		size, found := f.root.repo.LookupBlobSize(id, restic.DataBlob)
+		size, found := f.root.repo.LookupBlobSize(restic.DataBlob, id)
 		if !found {
 			return nil, errors.Errorf("id %v not found in repository", id)
 		}

--- a/internal/fuse/fuse_test.go
+++ b/internal/fuse/fuse_test.go
@@ -89,7 +89,7 @@ func TestFuseFile(t *testing.T) {
 		memfile  []byte
 	)
 	for _, id := range content {
-		size, found := repo.LookupBlobSize(id, restic.DataBlob)
+		size, found := repo.LookupBlobSize(restic.DataBlob, id)
 		rtest.Assert(t, found, "Expected to find blob id %v", id)
 		filesize += uint64(size)
 

--- a/internal/index/index_parallel.go
+++ b/internal/index/index_parallel.go
@@ -11,7 +11,7 @@ import (
 // ForAllIndexes loads all index files in parallel and calls the given callback.
 // It is guaranteed that the function is not run concurrently. If the callback
 // returns an error, this function is cancelled and also returns that error.
-func ForAllIndexes(ctx context.Context, lister restic.Lister, repo restic.ListerLoaderUnpacked,
+func ForAllIndexes(ctx context.Context, lister restic.Lister, repo restic.LoaderUnpacked,
 	fn func(id restic.ID, index *Index, oldFormat bool, err error) error) error {
 
 	// decoding an index can take quite some time such that this can be both CPU- or IO-bound

--- a/internal/index/index_test.go
+++ b/internal/index/index_test.go
@@ -309,8 +309,6 @@ func TestIndexUnserialize(t *testing.T) {
 		{docExampleV1, 1},
 		{docExampleV2, 2},
 	} {
-		oldIdx := restic.IDs{restic.TestParseID("ed54ae36197f4745ebc4b54d10e0f623eaaaedd03013eb7ae90df881b7781452")}
-
 		idx, oldFormat, err := index.DecodeIndex(task.idxBytes, restic.NewRandomID())
 		rtest.OK(t, err)
 		rtest.Assert(t, !oldFormat, "new index format recognized as old format")
@@ -336,8 +334,6 @@ func TestIndexUnserialize(t *testing.T) {
 				t.Fatal("Invalid index version")
 			}
 		}
-
-		rtest.Equals(t, oldIdx, idx.Supersedes())
 
 		blobs := listPack(t, idx, exampleLookupTest.packID)
 		if len(blobs) != len(exampleLookupTest.blobs) {
@@ -446,8 +442,6 @@ func TestIndexUnserializeOld(t *testing.T) {
 		rtest.Equals(t, test.offset, blob.Offset)
 		rtest.Equals(t, test.length, blob.Length)
 	}
-
-	rtest.Equals(t, 0, len(idx.Supersedes()))
 }
 
 func TestIndexPacks(t *testing.T) {

--- a/internal/index/master_index.go
+++ b/internal/index/master_index.go
@@ -312,10 +312,17 @@ func (mi *MasterIndex) Load(ctx context.Context, r restic.ListerLoaderUnpacked, 
 	return mi.MergeFinalIndexes()
 }
 
+type MasterIndexSaveOpts struct {
+	SaveProgress   *progress.Counter
+	DeleteProgress func() *progress.Counter
+	DeleteReport   func(id restic.ID, err error)
+	SkipDeletion   bool
+}
+
 // Save saves all known indexes to index files, leaving out any
 // packs whose ID is contained in packBlacklist from finalized indexes.
 // It also removes the old index files and those listed in extraObsolete.
-func (mi *MasterIndex) Save(ctx context.Context, repo restic.SaverRemoverUnpacked, excludePacks restic.IDSet, extraObsolete restic.IDs, opts restic.MasterIndexSaveOpts) error {
+func (mi *MasterIndex) Save(ctx context.Context, repo restic.SaverRemoverUnpacked, excludePacks restic.IDSet, extraObsolete restic.IDs, opts MasterIndexSaveOpts) error {
 	p := opts.SaveProgress
 	p.SetMax(uint64(len(mi.Packs(excludePacks))))
 

--- a/internal/index/master_index.go
+++ b/internal/index/master_index.go
@@ -23,12 +23,15 @@ type MasterIndex struct {
 
 // NewMasterIndex creates a new master index.
 func NewMasterIndex() *MasterIndex {
+	mi := &MasterIndex{pendingBlobs: restic.NewBlobSet()}
+	mi.clear()
+	return mi
+}
+
+func (mi *MasterIndex) clear() {
 	// Always add an empty final index, such that MergeFinalIndexes can merge into this.
-	// Note that removing this index could lead to a race condition in the rare
-	// situation that only two indexes exist which are saved and merged concurrently.
-	idx := []*Index{NewIndex()}
-	idx[0].Finalize()
-	return &MasterIndex{idx: idx, pendingBlobs: restic.NewBlobSet()}
+	mi.idx = []*Index{NewIndex()}
+	mi.idx[0].Finalize()
 }
 
 func (mi *MasterIndex) MarkCompressed() {

--- a/internal/index/master_index.go
+++ b/internal/index/master_index.go
@@ -395,8 +395,9 @@ func (mi *MasterIndex) Rewrite(ctx context.Context, repo restic.Unpacked, exclud
 		}
 		return nil
 	}
-	// loading an index can take quite some time such that this can be both CPU- or IO-bound
-	loaderCount := int(repo.Connections()) + runtime.GOMAXPROCS(0)
+	// loading an index can take quite some time such that this is probably CPU-bound
+	// the index files are probably already cached at this point
+	loaderCount := runtime.GOMAXPROCS(0)
 	// run workers on ch
 	for i := 0; i < loaderCount; i++ {
 		rewriteWg.Add(1)
@@ -467,8 +468,9 @@ func (mi *MasterIndex) Rewrite(ctx context.Context, repo restic.Unpacked, exclud
 		return nil
 	}
 
-	// encoding an index can take quite some time such that this can be both CPU- or IO-bound
-	workerCount := int(repo.Connections()) + runtime.GOMAXPROCS(0)
+	// encoding an index can take quite some time such that this can be CPU- or IO-bound
+	// do not add repo.Connections() here as there are already the loader goroutines.
+	workerCount := runtime.GOMAXPROCS(0)
 	// run workers on ch
 	for i := 0; i < workerCount; i++ {
 		wg.Go(worker)

--- a/internal/index/master_index.go
+++ b/internal/index/master_index.go
@@ -332,7 +332,7 @@ func (mi *MasterIndex) Save(ctx context.Context, repo restic.SaverRemoverUnpacke
 	debug.Log("start rebuilding index of %d indexes, excludePacks: %v", len(mi.idx), excludePacks)
 
 	newIndex := NewIndex()
-	obsolete := restic.NewIDSet()
+	obsolete := restic.NewIDSet(extraObsolete...)
 
 	// track spawned goroutines using wg, create a new context which is
 	// cancelled as soon as an error occurs.
@@ -351,11 +351,6 @@ func (mi *MasterIndex) Save(ctx context.Context, repo restic.SaverRemoverUnpacke
 				}
 
 				debug.Log("adding index ids %v to supersedes field", ids)
-
-				err = newIndex.AddToSupersedes(ids...)
-				if err != nil {
-					return err
-				}
 				obsolete.Merge(restic.NewIDSet(ids...))
 			} else {
 				debug.Log("index %d isn't final, don't add to supersedes field", i)
@@ -379,12 +374,6 @@ func (mi *MasterIndex) Save(ctx context.Context, repo restic.SaverRemoverUnpacke
 				return wgCtx.Err()
 			}
 		}
-
-		err := newIndex.AddToSupersedes(extraObsolete...)
-		if err != nil {
-			return err
-		}
-		obsolete.Merge(restic.NewIDSet(extraObsolete...))
 
 		select {
 		case ch <- newIndex:

--- a/internal/index/master_index_test.go
+++ b/internal/index/master_index_test.go
@@ -362,7 +362,7 @@ func testIndexSave(t *testing.T, version uint) {
 		t.Fatal(err)
 	}
 
-	err = repo.Index().Save(context.TODO(), repo, nil, nil, restic.MasterIndexSaveOpts{})
+	err = repo.SaveIndex(context.TODO(), nil, nil, restic.MasterIndexSaveOpts{})
 	if err != nil {
 		t.Fatalf("unable to save new index: %v", err)
 	}

--- a/internal/index/master_index_test.go
+++ b/internal/index/master_index_test.go
@@ -364,7 +364,7 @@ func testIndexSave(t *testing.T, version uint) {
 		blobs[pb] = struct{}{}
 	}))
 
-	rtest.OK(t, idx.Save(context.TODO(), repo, nil, nil, index.MasterIndexSaveOpts{}))
+	rtest.OK(t, idx.Rewrite(context.TODO(), repo, nil, nil, nil, index.MasterIndexRewriteOpts{}))
 	idx = index.NewMasterIndex()
 	rtest.OK(t, idx.Load(context.TODO(), repo, nil, nil))
 

--- a/internal/index/master_index_test.go
+++ b/internal/index/master_index_test.go
@@ -364,7 +364,7 @@ func testIndexSave(t *testing.T, version uint) {
 		blobs[pb] = struct{}{}
 	}))
 
-	rtest.OK(t, idx.Save(context.TODO(), repo, nil, nil, restic.MasterIndexSaveOpts{}))
+	rtest.OK(t, idx.Save(context.TODO(), repo, nil, nil, index.MasterIndexSaveOpts{}))
 	idx = index.NewMasterIndex()
 	rtest.OK(t, idx.Load(context.TODO(), repo, nil, nil))
 

--- a/internal/pack/pack.go
+++ b/internal/pack/pack.go
@@ -389,10 +389,10 @@ func CalculateHeaderSize(blobs []restic.Blob) int {
 // If onlyHdr is set to true, only the size of the header is returned
 // Note that this function only gives correct sizes, if there are no
 // duplicates in the index.
-func Size(ctx context.Context, mi restic.MasterIndex, onlyHdr bool) (map[restic.ID]int64, error) {
+func Size(ctx context.Context, mi restic.ListBlobser, onlyHdr bool) (map[restic.ID]int64, error) {
 	packSize := make(map[restic.ID]int64)
 
-	err := mi.Each(ctx, func(blob restic.PackedBlob) {
+	err := mi.ListBlobs(ctx, func(blob restic.PackedBlob) {
 		size, ok := packSize[blob.PackID]
 		if !ok {
 			size = headerSize

--- a/internal/repository/check.go
+++ b/internal/repository/check.go
@@ -158,11 +158,10 @@ func checkPackInner(ctx context.Context, r *Repository, id restic.ID, blobs []re
 		errs = append(errs, errors.Errorf("pack header size does not match, want %v, got %v", idxHdrSize, hdrSize))
 	}
 
-	idx := r.Index()
 	for _, blob := range blobs {
 		// Check if blob is contained in index and position is correct
 		idxHas := false
-		for _, pb := range idx.Lookup(blob.BlobHandle) {
+		for _, pb := range r.LookupBlob(blob.BlobHandle) {
 			if pb.PackID == id && pb.Blob == blob {
 				idxHas = true
 				break

--- a/internal/repository/check.go
+++ b/internal/repository/check.go
@@ -161,7 +161,7 @@ func checkPackInner(ctx context.Context, r *Repository, id restic.ID, blobs []re
 	for _, blob := range blobs {
 		// Check if blob is contained in index and position is correct
 		idxHas := false
-		for _, pb := range r.LookupBlob(blob.BlobHandle) {
+		for _, pb := range r.LookupBlob(blob.BlobHandle.Type, blob.BlobHandle.ID) {
 			if pb.PackID == id && pb.Blob == blob {
 				idxHas = true
 				break

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -200,8 +200,5 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *packe
 	r.idx.StorePack(id, p.Packer.Blobs())
 
 	// Save index if full
-	if r.noAutoIndexUpdate {
-		return nil
-	}
 	return r.idx.SaveFullIndex(ctx, r)
 }

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -21,8 +21,8 @@ import (
 	"github.com/minio/sha256-simd"
 )
 
-// Packer holds a pack.Packer together with a hash writer.
-type Packer struct {
+// packer holds a pack.packer together with a hash writer.
+type packer struct {
 	*pack.Packer
 	tmpfile *os.File
 	bufWr   *bufio.Writer
@@ -32,16 +32,16 @@ type Packer struct {
 type packerManager struct {
 	tpe     restic.BlobType
 	key     *crypto.Key
-	queueFn func(ctx context.Context, t restic.BlobType, p *Packer) error
+	queueFn func(ctx context.Context, t restic.BlobType, p *packer) error
 
 	pm       sync.Mutex
-	packer   *Packer
+	packer   *packer
 	packSize uint
 }
 
 // newPackerManager returns a new packer manager which writes temporary files
 // to a temporary directory
-func newPackerManager(key *crypto.Key, tpe restic.BlobType, packSize uint, queueFn func(ctx context.Context, t restic.BlobType, p *Packer) error) *packerManager {
+func newPackerManager(key *crypto.Key, tpe restic.BlobType, packSize uint, queueFn func(ctx context.Context, t restic.BlobType, p *packer) error) *packerManager {
 	return &packerManager{
 		tpe:      tpe,
 		key:      key,
@@ -114,7 +114,7 @@ func (r *packerManager) SaveBlob(ctx context.Context, t restic.BlobType, id rest
 
 // findPacker returns a packer for a new blob of size bytes. Either a new one is
 // created or one is returned that already has some blobs.
-func (r *packerManager) newPacker() (packer *Packer, err error) {
+func (r *packerManager) newPacker() (pck *packer, err error) {
 	debug.Log("create new pack")
 	tmpfile, err := fs.TempFile("", "restic-temp-pack-")
 	if err != nil {
@@ -123,17 +123,17 @@ func (r *packerManager) newPacker() (packer *Packer, err error) {
 
 	bufWr := bufio.NewWriter(tmpfile)
 	p := pack.NewPacker(r.key, bufWr)
-	packer = &Packer{
+	pck = &packer{
 		Packer:  p,
 		tmpfile: tmpfile,
 		bufWr:   bufWr,
 	}
 
-	return packer, nil
+	return pck, nil
 }
 
 // savePacker stores p in the backend.
-func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *Packer) error {
+func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *packer) error {
 	debug.Log("save packer for %v with %d blobs (%d bytes)\n", t, p.Packer.Count(), p.Packer.Size())
 	err := p.Packer.Finalize()
 	if err != nil {

--- a/internal/repository/packer_manager_test.go
+++ b/internal/repository/packer_manager_test.go
@@ -70,7 +70,7 @@ func testPackerManager(t testing.TB) int64 {
 	rnd := rand.New(rand.NewSource(randomSeed))
 
 	savedBytes := int(0)
-	pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, DefaultPackSize, func(ctx context.Context, tp restic.BlobType, p *Packer) error {
+	pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, DefaultPackSize, func(ctx context.Context, tp restic.BlobType, p *packer) error {
 		err := p.Finalize()
 		if err != nil {
 			return err
@@ -92,7 +92,7 @@ func testPackerManager(t testing.TB) int64 {
 func TestPackerManagerWithOversizeBlob(t *testing.T) {
 	packFiles := int(0)
 	sizeLimit := uint(512 * 1024)
-	pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, sizeLimit, func(ctx context.Context, tp restic.BlobType, p *Packer) error {
+	pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, sizeLimit, func(ctx context.Context, tp restic.BlobType, p *packer) error {
 		packFiles++
 		return nil
 	})
@@ -122,7 +122,7 @@ func BenchmarkPackerManager(t *testing.B) {
 
 	for i := 0; i < t.N; i++ {
 		rnd.Seed(randomSeed)
-		pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, DefaultPackSize, func(ctx context.Context, t restic.BlobType, p *Packer) error {
+		pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, DefaultPackSize, func(ctx context.Context, t restic.BlobType, p *packer) error {
 			return nil
 		})
 		fillPacks(t, rnd, pm, blobBuf)

--- a/internal/repository/packer_uploader.go
+++ b/internal/repository/packer_uploader.go
@@ -7,13 +7,13 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// SavePacker implements saving a pack in the repository.
-type SavePacker interface {
-	savePacker(ctx context.Context, t restic.BlobType, p *Packer) error
+// savePacker implements saving a pack in the repository.
+type savePacker interface {
+	savePacker(ctx context.Context, t restic.BlobType, p *packer) error
 }
 
 type uploadTask struct {
-	packer *Packer
+	packer *packer
 	tpe    restic.BlobType
 }
 
@@ -21,7 +21,7 @@ type packerUploader struct {
 	uploadQueue chan uploadTask
 }
 
-func newPackerUploader(ctx context.Context, wg *errgroup.Group, repo SavePacker, connections uint) *packerUploader {
+func newPackerUploader(ctx context.Context, wg *errgroup.Group, repo savePacker, connections uint) *packerUploader {
 	pu := &packerUploader{
 		uploadQueue: make(chan uploadTask),
 	}
@@ -48,7 +48,7 @@ func newPackerUploader(ctx context.Context, wg *errgroup.Group, repo SavePacker,
 	return pu
 }
 
-func (pu *packerUploader) QueuePacker(ctx context.Context, t restic.BlobType, p *Packer) (err error) {
+func (pu *packerUploader) QueuePacker(ctx context.Context, t restic.BlobType, p *packer) (err error) {
 	select {
 	case <-ctx.Done():
 		return ctx.Err()

--- a/internal/repository/prune.go
+++ b/internal/repository/prune.go
@@ -313,7 +313,7 @@ func packInfoFromIndex(ctx context.Context, idx restic.ListBlobser, usedBlobs re
 	return usedBlobs, indexPack, nil
 }
 
-func decidePackAction(ctx context.Context, opts PruneOptions, repo restic.Repository, indexPack map[restic.ID]packInfo, stats *PruneStats, printer progress.Printer) (PrunePlan, error) {
+func decidePackAction(ctx context.Context, opts PruneOptions, repo *Repository, indexPack map[restic.ID]packInfo, stats *PruneStats, printer progress.Printer) (PrunePlan, error) {
 	removePacksFirst := restic.NewIDSet()
 	removePacks := restic.NewIDSet()
 	repackPacks := restic.NewIDSet()
@@ -322,10 +322,10 @@ func decidePackAction(ctx context.Context, opts PruneOptions, repo restic.Reposi
 	var repackSmallCandidates []packInfoWithID
 	repoVersion := repo.Config().Version
 	// only repack very small files by default
-	targetPackSize := repo.PackSize() / 25
+	targetPackSize := repo.packSize() / 25
 	if opts.RepackSmall {
 		// consider files with at least 80% of the target size as large enough
-		targetPackSize = repo.PackSize() / 5 * 4
+		targetPackSize = repo.packSize() / 5 * 4
 	}
 
 	// loop over all packs and decide what to do
@@ -612,7 +612,7 @@ func (plan *PrunePlan) Execute(ctx context.Context, printer progress.Printer) (e
 	}
 
 	// drop outdated in-memory index
-	repo.ClearIndex()
+	repo.clearIndex()
 
 	printer.P("done\n")
 	return nil

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -54,7 +54,7 @@ func repack(ctx context.Context, repo restic.Repository, dstRepo restic.Reposito
 	downloadQueue := make(chan restic.PackBlobs)
 	wg.Go(func() error {
 		defer close(downloadQueue)
-		for pbs := range repo.Index().ListPacks(wgCtx, packs) {
+		for pbs := range repo.ListPacksFromIndex(wgCtx, packs) {
 			var packBlobs []restic.Blob
 			keepMutex.Lock()
 			// filter out unnecessary blobs

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -146,7 +146,7 @@ func findPacksForBlobs(t *testing.T, repo restic.Repository, blobs restic.BlobSe
 	packs := restic.NewIDSet()
 
 	for h := range blobs {
-		list := repo.LookupBlob(h)
+		list := repo.LookupBlob(h.Type, h.ID)
 		if len(list) == 0 {
 			t.Fatal("Failed to find blob", h.ID.Str(), "with type", h.Type)
 		}
@@ -247,7 +247,7 @@ func testRepack(t *testing.T, version uint) {
 	}
 
 	for h := range keepBlobs {
-		list := repo.LookupBlob(h)
+		list := repo.LookupBlob(h.Type, h.ID)
 		if len(list) == 0 {
 			t.Errorf("unable to find blob %v in repo", h.ID.Str())
 			continue
@@ -311,7 +311,7 @@ func testRepackCopy(t *testing.T, version uint) {
 	reloadIndex(t, dstRepo)
 
 	for h := range keepBlobs {
-		list := dstRepo.LookupBlob(h)
+		list := dstRepo.LookupBlob(h.Type, h.ID)
 		if len(list) == 0 {
 			t.Errorf("unable to find blob %v in repo", h.ID.Str())
 			continue

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -266,7 +266,7 @@ func testRepack(t *testing.T, version uint) {
 	}
 
 	for h := range removeBlobs {
-		if _, found := repo.LookupBlobSize(h.ID, h.Type); found {
+		if _, found := repo.LookupBlobSize(h.Type, h.ID); found {
 			t.Errorf("blob %v still contained in the repo", h)
 		}
 	}

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -145,9 +145,8 @@ func listFiles(t *testing.T, repo restic.Lister, tpe backend.FileType) restic.ID
 func findPacksForBlobs(t *testing.T, repo restic.Repository, blobs restic.BlobSet) restic.IDSet {
 	packs := restic.NewIDSet()
 
-	idx := repo.Index()
 	for h := range blobs {
-		list := idx.Lookup(h)
+		list := repo.LookupBlob(h)
 		if len(list) == 0 {
 			t.Fatal("Failed to find blob", h.ID.Str(), "with type", h.Type)
 		}
@@ -195,7 +194,7 @@ func rebuildIndex(t *testing.T, repo restic.Repository) {
 	})
 	rtest.OK(t, err)
 
-	err = repo.Index().Save(context.TODO(), repo, restic.NewIDSet(), obsoleteIndexes, restic.MasterIndexSaveOpts{})
+	err = repo.SaveIndex(context.TODO(), restic.NewIDSet(), obsoleteIndexes, restic.MasterIndexSaveOpts{})
 	rtest.OK(t, err)
 }
 
@@ -252,10 +251,8 @@ func testRepack(t *testing.T, version uint) {
 		}
 	}
 
-	idx := repo.Index()
-
 	for h := range keepBlobs {
-		list := idx.Lookup(h)
+		list := repo.LookupBlob(h)
 		if len(list) == 0 {
 			t.Errorf("unable to find blob %v in repo", h.ID.Str())
 			continue
@@ -318,10 +315,8 @@ func testRepackCopy(t *testing.T, version uint) {
 	rebuildIndex(t, dstRepo)
 	reloadIndex(t, dstRepo)
 
-	idx := dstRepo.Index()
-
 	for h := range keepBlobs {
-		list := idx.Lookup(h)
+		list := dstRepo.LookupBlob(h)
 		if len(list) == 0 {
 			t.Errorf("unable to find blob %v in repo", h.ID.Str())
 			continue

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -199,11 +199,6 @@ func rebuildIndex(t *testing.T, repo restic.Repository) {
 }
 
 func reloadIndex(t *testing.T, repo restic.Repository) {
-	err := repo.SetIndex(index.NewMasterIndex())
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	if err := repo.LoadIndex(context.TODO(), nil); err != nil {
 		t.Fatalf("error loading new index: %v", err)
 	}

--- a/internal/repository/repair_index.go
+++ b/internal/repository/repair_index.go
@@ -28,6 +28,8 @@ func RepairIndex(ctx context.Context, repo *Repository, opts RepairIndexOptions,
 		if err != nil {
 			return err
 		}
+		repo.clearIndex()
+
 	} else {
 		printer.P("loading indexes...\n")
 		mi := index.NewMasterIndex()
@@ -111,11 +113,11 @@ func RepairIndex(ctx context.Context, repo *Repository, opts RepairIndexOptions,
 	return nil
 }
 
-func rebuildIndexFiles(ctx context.Context, repo restic.Repository, removePacks restic.IDSet, extraObsolete restic.IDs, skipDeletion bool, printer progress.Printer) error {
+func rebuildIndexFiles(ctx context.Context, repo *Repository, removePacks restic.IDSet, extraObsolete restic.IDs, skipDeletion bool, printer progress.Printer) error {
 	printer.P("rebuilding index\n")
 
 	bar := printer.NewCounter("packs processed")
-	return repo.SaveIndex(ctx, removePacks, extraObsolete, restic.MasterIndexSaveOpts{
+	return repo.idx.Save(ctx, repo, removePacks, extraObsolete, index.MasterIndexSaveOpts{
 		SaveProgress: bar,
 		DeleteProgress: func() *progress.Counter {
 			return printer.NewCounter("old indexes deleted")

--- a/internal/repository/repair_index.go
+++ b/internal/repository/repair_index.go
@@ -54,7 +54,7 @@ func RepairIndex(ctx context.Context, repo *Repository, opts RepairIndexOptions,
 		if err != nil {
 			return err
 		}
-		packSizeFromIndex, err = pack.Size(ctx, repo.Index(), false)
+		packSizeFromIndex, err = pack.Size(ctx, repo, false)
 		if err != nil {
 			return err
 		}
@@ -115,7 +115,7 @@ func rebuildIndexFiles(ctx context.Context, repo restic.Repository, removePacks 
 	printer.P("rebuilding index\n")
 
 	bar := printer.NewCounter("packs processed")
-	return repo.Index().Save(ctx, repo, removePacks, extraObsolete, restic.MasterIndexSaveOpts{
+	return repo.SaveIndex(ctx, removePacks, extraObsolete, restic.MasterIndexSaveOpts{
 		SaveProgress: bar,
 		DeleteProgress: func() *progress.Counter {
 			return printer.NewCounter("old indexes deleted")

--- a/internal/repository/repair_index.go
+++ b/internal/repository/repair_index.go
@@ -92,7 +92,7 @@ func RepairIndex(ctx context.Context, repo *Repository, opts RepairIndexOptions,
 		printer.P("reading pack files\n")
 		bar := printer.NewCounter("packs")
 		bar.SetMax(uint64(len(packSizeFromList)))
-		invalidFiles, err := repo.CreateIndexFromPacks(ctx, packSizeFromList, bar)
+		invalidFiles, err := repo.createIndexFromPacks(ctx, packSizeFromList, bar)
 		bar.Done()
 		if err != nil {
 			return err

--- a/internal/repository/repair_index.go
+++ b/internal/repository/repair_index.go
@@ -107,7 +107,7 @@ func RepairIndex(ctx context.Context, repo *Repository, opts RepairIndexOptions,
 	}
 
 	// drop outdated in-memory index
-	repo.ClearIndex()
+	repo.clearIndex()
 	return nil
 }
 

--- a/internal/repository/repair_index_test.go
+++ b/internal/repository/repair_index_test.go
@@ -30,10 +30,6 @@ func testRebuildIndex(t *testing.T, readAllPacks bool, damage func(t *testing.T,
 		ReadAllPacks: readAllPacks,
 	}, &progress.NoopPrinter{}))
 
-	newIndexes := listIndex(t, repo)
-	old := indexes.Intersect(newIndexes)
-	rtest.Assert(t, len(old) == 0, "expected old indexes to be removed, found %v", old)
-
 	checker.TestCheckRepo(t, repo, true)
 }
 

--- a/internal/repository/repair_pack.go
+++ b/internal/repository/repair_pack.go
@@ -21,7 +21,7 @@ func RepairPacks(ctx context.Context, repo restic.Repository, ids restic.IDSet, 
 
 	wg.Go(func() error {
 		// examine all data the indexes have for the pack file
-		for b := range repo.Index().ListPacks(wgCtx, ids) {
+		for b := range repo.ListPacksFromIndex(wgCtx, ids) {
 			blobs := b.Blobs
 			if len(blobs) == 0 {
 				printer.E("no blobs found for pack %v", b.PackID)

--- a/internal/repository/repair_pack.go
+++ b/internal/repository/repair_pack.go
@@ -10,7 +10,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func RepairPacks(ctx context.Context, repo restic.Repository, ids restic.IDSet, printer progress.Printer) error {
+func RepairPacks(ctx context.Context, repo *Repository, ids restic.IDSet, printer progress.Printer) error {
 	wg, wgCtx := errgroup.WithContext(ctx)
 	repo.StartPackUploader(wgCtx, wg)
 

--- a/internal/repository/repair_pack.go
+++ b/internal/repository/repair_pack.go
@@ -56,7 +56,7 @@ func RepairPacks(ctx context.Context, repo *Repository, ids restic.IDSet, printe
 	}
 
 	// remove salvaged packs from index
-	err = rebuildIndexFiles(ctx, repo, ids, nil, false, printer)
+	err = rewriteIndexFiles(ctx, repo, ids, nil, nil, printer)
 	if err != nil {
 		return err
 	}

--- a/internal/repository/repair_pack_test.go
+++ b/internal/repository/repair_pack_test.go
@@ -18,7 +18,7 @@ import (
 
 func listBlobs(repo restic.Repository) restic.BlobSet {
 	blobs := restic.NewBlobSet()
-	_ = repo.Index().Each(context.TODO(), func(pb restic.PackedBlob) {
+	_ = repo.ListBlobs(context.TODO(), func(pb restic.PackedBlob) {
 		blobs.Insert(pb.BlobHandle)
 	})
 	return blobs
@@ -68,7 +68,7 @@ func testRepairBrokenPack(t *testing.T, version uint) {
 
 				// find blob that starts at offset 0
 				var damagedBlob restic.BlobHandle
-				for blobs := range repo.Index().ListPacks(context.TODO(), restic.NewIDSet(damagedID)) {
+				for blobs := range repo.ListPacksFromIndex(context.TODO(), restic.NewIDSet(damagedID)) {
 					for _, blob := range blobs.Blobs {
 						if blob.Offset == 0 {
 							damagedBlob = blob.BlobHandle
@@ -91,7 +91,7 @@ func testRepairBrokenPack(t *testing.T, version uint) {
 
 				// all blobs in the file are broken
 				damagedBlobs := restic.NewBlobSet()
-				for blobs := range repo.Index().ListPacks(context.TODO(), restic.NewIDSet(damagedID)) {
+				for blobs := range repo.ListPacksFromIndex(context.TODO(), restic.NewIDSet(damagedID)) {
 					for _, blob := range blobs.Blobs {
 						damagedBlobs.Insert(blob.BlobHandle)
 					}

--- a/internal/repository/repair_pack_test.go
+++ b/internal/repository/repair_pack_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/restic/restic/internal/backend"
 	backendtest "github.com/restic/restic/internal/backend/test"
-	"github.com/restic/restic/internal/index"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/test"
@@ -118,7 +117,6 @@ func testRepairBrokenPack(t *testing.T, version uint) {
 
 			rtest.OK(t, repository.RepairPacks(context.TODO(), repo, toRepair, &progress.NoopPrinter{}))
 			// reload index
-			rtest.OK(t, repo.SetIndex(index.NewMasterIndex()))
 			rtest.OK(t, repo.LoadIndex(context.TODO(), nil))
 
 			packsAfter := listPacks(t, repo)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -578,10 +578,6 @@ func (r *Repository) Connections() uint {
 	return r.be.Connections()
 }
 
-func (r *Repository) HasBlob(bh restic.BlobHandle) bool {
-	return r.idx.Has(bh)
-}
-
 func (r *Repository) LookupBlob(bh restic.BlobHandle) []restic.PackedBlob {
 	return r.idx.Lookup(bh)
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -42,8 +42,6 @@ type Repository struct {
 
 	opts Options
 
-	noAutoIndexUpdate bool
-
 	packerWg *errgroup.Group
 	uploader *packerUploader
 	treePM   *packerManager
@@ -128,12 +126,6 @@ func New(be backend.Backend, opts Options) (*Repository, error) {
 	}
 
 	return repo, nil
-}
-
-// DisableAutoIndexUpdate deactives the automatic finalization and upload of new
-// indexes once these are full
-func (r *Repository) DisableAutoIndexUpdate() {
-	r.noAutoIndexUpdate = true
 }
 
 // setConfig assigns the given config and updates the repository parameters accordingly
@@ -526,10 +518,6 @@ func (r *Repository) Flush(ctx context.Context) error {
 		return err
 	}
 
-	// Save index after flushing only if noAutoIndexUpdate is not set
-	if r.noAutoIndexUpdate {
-		return nil
-	}
 	return r.idx.SaveIndex(ctx, r)
 }
 

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -146,8 +146,8 @@ func (r *Repository) Config() restic.Config {
 	return r.cfg
 }
 
-// PackSize return the target size of a pack file when uploading
-func (r *Repository) PackSize() uint {
+// packSize return the target size of a pack file when uploading
+func (r *Repository) packSize() uint {
 	return r.opts.PackSize
 }
 
@@ -541,8 +541,8 @@ func (r *Repository) StartPackUploader(ctx context.Context, wg *errgroup.Group) 
 	innerWg, ctx := errgroup.WithContext(ctx)
 	r.packerWg = innerWg
 	r.uploader = newPackerUploader(ctx, innerWg, r, r.be.Connections())
-	r.treePM = newPackerManager(r.key, restic.TreeBlob, r.PackSize(), r.uploader.QueuePacker)
-	r.dataPM = newPackerManager(r.key, restic.DataBlob, r.PackSize(), r.uploader.QueuePacker)
+	r.treePM = newPackerManager(r.key, restic.TreeBlob, r.packSize(), r.uploader.QueuePacker)
+	r.dataPM = newPackerManager(r.key, restic.DataBlob, r.packSize(), r.uploader.QueuePacker)
 
 	wg.Go(func() error {
 		return innerWg.Wait()
@@ -612,7 +612,7 @@ func (r *Repository) SetIndex(i restic.MasterIndex) error {
 	return r.prepareCache()
 }
 
-func (r *Repository) ClearIndex() {
+func (r *Repository) clearIndex() {
 	r.idx = index.NewMasterIndex()
 	r.configureIndex()
 }
@@ -646,7 +646,7 @@ func (r *Repository) LoadIndex(ctx context.Context, p *progress.Counter) error {
 	}
 
 	// reset in-memory index before loading it from the repository
-	r.ClearIndex()
+	r.clearIndex()
 
 	err = index.ForAllIndexes(ctx, indexList, r, func(_ restic.ID, idx *index.Index, _ bool, err error) error {
 		if err != nil {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -583,8 +583,8 @@ func (r *Repository) LookupBlob(bh restic.BlobHandle) []restic.PackedBlob {
 }
 
 // LookupBlobSize returns the size of blob id.
-func (r *Repository) LookupBlobSize(id restic.ID, tpe restic.BlobType) (uint, bool) {
-	return r.idx.LookupSize(restic.BlobHandle{ID: id, Type: tpe})
+func (r *Repository) LookupBlobSize(tpe restic.BlobType, id restic.ID) (uint, bool) {
+	return r.idx.LookupSize(restic.BlobHandle{Type: tpe, ID: id})
 }
 
 func (r *Repository) SaveIndex(ctx context.Context, excludePacks restic.IDSet, extraObsolete restic.IDs, opts restic.MasterIndexSaveOpts) error {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -587,10 +587,6 @@ func (r *Repository) LookupBlobSize(tpe restic.BlobType, id restic.ID) (uint, bo
 	return r.idx.LookupSize(restic.BlobHandle{Type: tpe, ID: id})
 }
 
-func (r *Repository) SaveIndex(ctx context.Context, excludePacks restic.IDSet, extraObsolete restic.IDs, opts restic.MasterIndexSaveOpts) error {
-	return r.idx.Save(ctx, r, excludePacks, extraObsolete, opts)
-}
-
 // ListBlobs runs fn on all blobs known to the index. When the context is cancelled,
 // the index iteration returns immediately with ctx.Err(). This blocks any modification of the index.
 func (r *Repository) ListBlobs(ctx context.Context, fn func(restic.PackedBlob)) error {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -656,10 +656,10 @@ func (r *Repository) LoadIndex(ctx context.Context, p *progress.Counter) error {
 	return r.prepareCache()
 }
 
-// CreateIndexFromPacks creates a new index by reading all given pack files (with sizes).
+// createIndexFromPacks creates a new index by reading all given pack files (with sizes).
 // The index is added to the MasterIndex but not marked as finalized.
 // Returned is the list of pack files which could not be read.
-func (r *Repository) CreateIndexFromPacks(ctx context.Context, packsize map[restic.ID]int64, p *progress.Counter) (invalid restic.IDs, err error) {
+func (r *Repository) createIndexFromPacks(ctx context.Context, packsize map[restic.ID]int64, p *progress.Counter) (invalid restic.IDs, err error) {
 	var m sync.Mutex
 
 	debug.Log("Loading index from pack files")

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -578,8 +578,8 @@ func (r *Repository) Connections() uint {
 	return r.be.Connections()
 }
 
-func (r *Repository) LookupBlob(bh restic.BlobHandle) []restic.PackedBlob {
-	return r.idx.Lookup(bh)
+func (r *Repository) LookupBlob(tpe restic.BlobType, id restic.ID) []restic.PackedBlob {
+	return r.idx.Lookup(restic.BlobHandle{Type: tpe, ID: id})
 }
 
 // LookupBlobSize returns the size of blob id.

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -161,7 +161,7 @@ func TestLoadBlobBroken(t *testing.T) {
 	data, err := repo.LoadBlob(context.TODO(), restic.TreeBlob, id, nil)
 	rtest.OK(t, err)
 	rtest.Assert(t, bytes.Equal(buf, data), "data mismatch")
-	pack := repo.Index().Lookup(restic.BlobHandle{Type: restic.TreeBlob, ID: id})[0].PackID
+	pack := repo.LookupBlob(restic.BlobHandle{Type: restic.TreeBlob, ID: id})[0].PackID
 	rtest.Assert(t, c.Has(backend.Handle{Type: restic.PackFile, Name: pack.String()}), "expected tree pack to be cached")
 }
 
@@ -439,7 +439,7 @@ func TestListPack(t *testing.T) {
 	repo.UseCache(c)
 
 	// Forcibly cache pack file
-	packID := repo.Index().Lookup(restic.BlobHandle{Type: restic.TreeBlob, ID: id})[0].PackID
+	packID := repo.LookupBlob(restic.BlobHandle{Type: restic.TreeBlob, ID: id})[0].PackID
 	rtest.OK(t, be.Load(context.TODO(), backend.Handle{Type: restic.PackFile, IsMetadata: true, Name: packID.String()}, 0, 0, func(rd io.Reader) error { return nil }))
 
 	// Get size to list pack

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -336,7 +336,7 @@ func benchmarkLoadIndex(b *testing.B, version uint) {
 	}
 	idx.Finalize()
 
-	id, err := index.SaveIndex(context.TODO(), repo, idx)
+	id, err := idx.SaveIndex(context.TODO(), repo)
 	rtest.OK(b, err)
 
 	b.Logf("index saved as %v", id.Str())

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -161,7 +161,7 @@ func TestLoadBlobBroken(t *testing.T) {
 	data, err := repo.LoadBlob(context.TODO(), restic.TreeBlob, id, nil)
 	rtest.OK(t, err)
 	rtest.Assert(t, bytes.Equal(buf, data), "data mismatch")
-	pack := repo.LookupBlob(restic.BlobHandle{Type: restic.TreeBlob, ID: id})[0].PackID
+	pack := repo.LookupBlob(restic.TreeBlob, id)[0].PackID
 	rtest.Assert(t, c.Has(backend.Handle{Type: restic.PackFile, Name: pack.String()}), "expected tree pack to be cached")
 }
 
@@ -439,7 +439,7 @@ func TestListPack(t *testing.T) {
 	repo.UseCache(c)
 
 	// Forcibly cache pack file
-	packID := repo.LookupBlob(restic.BlobHandle{Type: restic.TreeBlob, ID: id})[0].PackID
+	packID := repo.LookupBlob(restic.TreeBlob, id)[0].PackID
 	rtest.OK(t, be.Load(context.TODO(), backend.Handle{Type: restic.PackFile, IsMetadata: true, Name: packID.String()}, 0, 0, func(rd io.Reader) error { return nil }))
 
 	// Get size to list pack

--- a/internal/restic/find.go
+++ b/internal/restic/find.go
@@ -11,7 +11,7 @@ import (
 // Loader loads a blob from a repository.
 type Loader interface {
 	LoadBlob(context.Context, BlobType, ID, []byte) ([]byte, error)
-	LookupBlobSize(id ID, tpe BlobType) (uint, bool)
+	LookupBlobSize(tpe BlobType, id ID) (uint, bool)
 	Connections() uint
 }
 

--- a/internal/restic/find_test.go
+++ b/internal/restic/find_test.go
@@ -166,7 +166,7 @@ func (r ForbiddenRepo) LoadBlob(context.Context, restic.BlobType, restic.ID, []b
 	return nil, errors.New("should not be called")
 }
 
-func (r ForbiddenRepo) LookupBlobSize(_ restic.ID, _ restic.BlobType) (uint, bool) {
+func (r ForbiddenRepo) LookupBlobSize(_ restic.BlobType, _ restic.ID) (uint, bool) {
 	return 0, false
 }
 

--- a/internal/restic/idset.go
+++ b/internal/restic/idset.go
@@ -105,3 +105,9 @@ func (s IDSet) String() string {
 	str := s.List().String()
 	return "{" + str[1:len(str)-1] + "}"
 }
+
+func (s IDSet) Clone() IDSet {
+	c := NewIDSet()
+	c.Merge(s)
+	return c
+}

--- a/internal/restic/idset_test.go
+++ b/internal/restic/idset_test.go
@@ -35,4 +35,7 @@ func TestIDSet(t *testing.T) {
 	}
 
 	rtest.Equals(t, "{1285b303 7bb086db f658198b}", set.String())
+
+	copied := set.Clone()
+	rtest.Equals(t, "{1285b303 7bb086db f658198b}", copied.String())
 }

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -25,7 +25,6 @@ type Repository interface {
 	SetIndex(MasterIndex) error
 	SaveIndex(ctx context.Context, excludePacks IDSet, extraObsolete IDs, opts MasterIndexSaveOpts) error
 
-	HasBlob(BlobHandle) bool
 	LookupBlob(BlobHandle) []PackedBlob
 	LookupBlobSize(ID, BlobType) (uint, bool)
 

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -19,11 +19,9 @@ type Repository interface {
 	// Connections returns the maximum number of concurrent backend operations
 	Connections() uint
 	Config() Config
-	PackSize() uint
 	Key() *crypto.Key
 
 	LoadIndex(context.Context, *progress.Counter) error
-	ClearIndex()
 	SetIndex(MasterIndex) error
 	SaveIndex(ctx context.Context, excludePacks IDSet, extraObsolete IDs, opts MasterIndexSaveOpts) error
 

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -26,7 +26,7 @@ type Repository interface {
 	SaveIndex(ctx context.Context, excludePacks IDSet, extraObsolete IDs, opts MasterIndexSaveOpts) error
 
 	LookupBlob(bh BlobHandle) []PackedBlob
-	LookupBlobSize(id ID, t BlobType) (size uint, exists bool)
+	LookupBlobSize(t BlobType, id ID) (size uint, exists bool)
 
 	// ListBlobs runs fn on all blobs known to the index. When the context is cancelled,
 	// the index iteration returns immediately with ctx.Err(). This blocks any modification of the index.

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -23,7 +23,6 @@ type Repository interface {
 
 	LoadIndex(ctx context.Context, p *progress.Counter) error
 	SetIndex(mi MasterIndex) error
-	SaveIndex(ctx context.Context, excludePacks IDSet, extraObsolete IDs, opts MasterIndexSaveOpts) error
 
 	LookupBlob(t BlobType, id ID) []PackedBlob
 	LookupBlobSize(t BlobType, id ID) (size uint, exists bool)
@@ -106,13 +105,6 @@ type PackBlobs struct {
 	Blobs  []Blob
 }
 
-type MasterIndexSaveOpts struct {
-	SaveProgress   *progress.Counter
-	DeleteProgress func() *progress.Counter
-	DeleteReport   func(id ID, err error)
-	SkipDeletion   bool
-}
-
 // MasterIndex keeps track of the blobs are stored within files.
 type MasterIndex interface {
 	Has(bh BlobHandle) bool
@@ -122,8 +114,6 @@ type MasterIndex interface {
 	// the index iteration returns immediately with ctx.Err(). This blocks any modification of the index.
 	Each(ctx context.Context, fn func(PackedBlob)) error
 	ListPacks(ctx context.Context, packs IDSet) <-chan PackBlobs
-
-	Save(ctx context.Context, repo SaverRemoverUnpacked, excludePacks IDSet, extraObsolete IDs, opts MasterIndexSaveOpts) error
 }
 
 // Lister allows listing files in a backend.

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -25,7 +25,7 @@ type Repository interface {
 	SetIndex(mi MasterIndex) error
 	SaveIndex(ctx context.Context, excludePacks IDSet, extraObsolete IDs, opts MasterIndexSaveOpts) error
 
-	LookupBlob(bh BlobHandle) []PackedBlob
+	LookupBlob(t BlobType, id ID) []PackedBlob
 	LookupBlobSize(t BlobType, id ID) (size uint, exists bool)
 
 	// ListBlobs runs fn on all blobs known to the index. When the context is cancelled,

--- a/internal/restic/tree_stream.go
+++ b/internal/restic/tree_stream.go
@@ -77,7 +77,7 @@ func filterTrees(ctx context.Context, repo Loader, trees IDs, loaderChan chan<- 
 				continue
 			}
 
-			treeSize, found := repo.LookupBlobSize(nextTreeID.ID, TreeBlob)
+			treeSize, found := repo.LookupBlobSize(TreeBlob, nextTreeID.ID)
 			if found && treeSize > 50*1024*1024 {
 				loadCh = hugeTreeLoaderChan
 			} else {

--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -35,8 +35,8 @@ type TestRepo struct {
 	loader blobsLoaderFn
 }
 
-func (i *TestRepo) Lookup(bh restic.BlobHandle) []restic.PackedBlob {
-	packs := i.blobs[bh.ID]
+func (i *TestRepo) Lookup(tpe restic.BlobType, id restic.ID) []restic.PackedBlob {
+	packs := i.blobs[id]
 	return packs
 }
 

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -435,7 +435,7 @@ func (res *Restorer) verifyFile(target string, node *restic.Node, buf []byte) ([
 
 	var offset int64
 	for _, blobID := range node.Content {
-		length, found := res.repo.LookupBlobSize(blobID, restic.DataBlob)
+		length, found := res.repo.LookupBlobSize(restic.DataBlob, blobID)
 		if !found {
 			return buf, errors.Errorf("Unable to fetch blob %s", blobID)
 		}

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -240,7 +240,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 	}
 
 	idx := NewHardlinkIndex[string]()
-	filerestorer := newFileRestorer(dst, res.repo.LoadBlobsFromPack, res.repo.Index().Lookup,
+	filerestorer := newFileRestorer(dst, res.repo.LoadBlobsFromPack, res.repo.LookupBlob,
 		res.repo.Connections(), res.sparse, res.progress)
 	filerestorer.Error = res.Error
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

The PR consists of a refactoring of the index and reworks the index rewrite to be much more memory efficient.

The refactoring makes a few noteworthy changes:
- The MasterIndex interface is now integrated into the Repository interface. Now users of a repository never interact directly with the index. This is one of the last missing major cleanups to allow eventually getting rid of the Repository interface.
- Several methods of index/repository are now private. In particular, there is no more `repo.Index().Save(...)` method.
- Loading the index is now done using `MasterIndex.Load(...)`
- The index no longer tracks and stores the `supersedes` field. It was never really used as using it correctly is nearly impossible.

Prune no longer uses `repository.DisableAutoIndexUpdate()`. This allows efficiently resuming interrupted prune runs.

To properly select packs from previous interrupted prune runs, the prune heuristics required a fix. Pack files created by interrupted prune runs, appear to consist only of duplicate blobs on the next run. This caused the previous heuristic to ignore those pack files. Now, a duplicate blob in a specific pack file is also selected if that pack file only contains duplicate blobs. This allows prune to select the already rewritten pack files.

`MasterIndex.Rewrite` implements a streaming rewrite of the index that excludes the given packs. For this it loads all index files from the repository and only modifies those that require changes. This will reduce the index churn when running prune. Rewrite does not require the in-memory index and thus can drop it to significantly reduce the memory usage.

However, `prune --unsafe-recovery` cannot use this strategy and requires a separate method to save the whole in-memory index. This is now handled using `MasterIndex.SaveFallback`.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/3806
The streaming rewrite is part of the roadmap for restic 0.17.0
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
