### PR TITLE
Termstatus refactoring

### DIFF
--- a/cmd/restic/termstatus.go
+++ b/cmd/restic/termstatus.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/termstatus"
 )
 
@@ -31,7 +30,7 @@ func setupTermstatus() (*termstatus.Terminal, func()) {
 
 	// use the termstatus for stdout/stderr
 	prevStdout, prevStderr := globalOptions.stdout, globalOptions.stderr
-	globalOptions.stdout, globalOptions.stderr = ui.WrapStdio(term)
+	globalOptions.stdout, globalOptions.stderr = termstatus.WrapStdio(term)
 
 	return term, func() {
 		// shutdown termstatus

--- a/cmd/restic/termstatus.go
+++ b/cmd/restic/termstatus.go
@@ -31,8 +31,7 @@ func setupTermstatus() (*termstatus.Terminal, func()) {
 
 	// use the termstatus for stdout/stderr
 	prevStdout, prevStderr := globalOptions.stdout, globalOptions.stderr
-	stdioWrapper := ui.NewStdioWrapper(term)
-	globalOptions.stdout, globalOptions.stderr = stdioWrapper.Stdout(), stdioWrapper.Stderr()
+	globalOptions.stdout, globalOptions.stderr = ui.WrapStdio(term)
 
 	return term, func() {
 		// shutdown termstatus

--- a/internal/ui/stdio_wrapper.go
+++ b/internal/ui/stdio_wrapper.go
@@ -37,14 +37,14 @@ func (w *StdioWrapper) Stderr() io.WriteCloser {
 }
 
 type lineWriter struct {
-	buf   *bytes.Buffer
+	buf   bytes.Buffer
 	print func(string)
 }
 
 var _ io.WriteCloser = &lineWriter{}
 
 func newLineWriter(print func(string)) *lineWriter {
-	return &lineWriter{buf: bytes.NewBuffer(nil), print: print}
+	return &lineWriter{print: print}
 }
 
 func (w *lineWriter) Write(data []byte) (n int, err error) {

--- a/internal/ui/stdio_wrapper.go
+++ b/internal/ui/stdio_wrapper.go
@@ -7,33 +7,10 @@ import (
 	"github.com/restic/restic/internal/ui/termstatus"
 )
 
-// StdioWrapper provides stdout and stderr integration with termstatus.
-type StdioWrapper struct {
-	stdout *lineWriter
-	stderr *lineWriter
-}
-
-// NewStdioWrapper initializes a new stdio wrapper that can be used in place of
-// os.Stdout or os.Stderr.
-func NewStdioWrapper(term *termstatus.Terminal) *StdioWrapper {
-	return &StdioWrapper{
-		stdout: newLineWriter(term.Print),
-		stderr: newLineWriter(term.Error),
-	}
-}
-
-// Stdout returns a writer that is line buffered and can be used in place of
-// os.Stdout. On Close(), the remaining bytes are written, followed by a line
-// break.
-func (w *StdioWrapper) Stdout() io.WriteCloser {
-	return w.stdout
-}
-
-// Stderr returns a writer that is line buffered and can be used in place of
-// os.Stderr. On Close(), the remaining bytes are written, followed by a line
-// break.
-func (w *StdioWrapper) Stderr() io.WriteCloser {
-	return w.stderr
+// WrapStdio returns line-buffering replacements for os.Stdout and os.Stderr.
+// On Close, the remaining bytes are written, followed by a line break.
+func WrapStdio(term *termstatus.Terminal) (stdout, stderr io.WriteCloser) {
+	return newLineWriter(term.Print), newLineWriter(term.Error)
 }
 
 type lineWriter struct {

--- a/internal/ui/termstatus/stdio_wrapper.go
+++ b/internal/ui/termstatus/stdio_wrapper.go
@@ -1,15 +1,13 @@
-package ui
+package termstatus
 
 import (
 	"bytes"
 	"io"
-
-	"github.com/restic/restic/internal/ui/termstatus"
 )
 
 // WrapStdio returns line-buffering replacements for os.Stdout and os.Stderr.
 // On Close, the remaining bytes are written, followed by a line break.
-func WrapStdio(term *termstatus.Terminal) (stdout, stderr io.WriteCloser) {
+func WrapStdio(term *Terminal) (stdout, stderr io.WriteCloser) {
 	return newLineWriter(term.Print), newLineWriter(term.Error)
 }
 

--- a/internal/ui/termstatus/stdio_wrapper_test.go
+++ b/internal/ui/termstatus/stdio_wrapper_test.go
@@ -1,4 +1,4 @@
-package ui
+package termstatus
 
 import (
 	"strings"


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The first commit is a micro-optimization that removes a level of indirection from ui.lineWriter. The other two refactor the surrounding stdout/stderr wrapping code by removing an untested type that was really just a pair, then moving the remaining code to ui/termstatus to get rid of some imports.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

I don't think so.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
