### PR TITLE
bloblru: Fix flaky test due to race condition

### DIFF
--- a/internal/bloblru/cache.go
+++ b/internal/bloblru/cache.go
@@ -97,13 +97,13 @@ func (c *Cache) GetOrCompute(id restic.ID, compute func() ([]byte, error)) ([]by
 	// check for parallel download or start our own
 	finish := make(chan struct{})
 	c.mu.Lock()
-	waitForResult, isDownloading := c.inProgress[id]
-	if !isDownloading {
+	waitForResult, isComputing := c.inProgress[id]
+	if !isComputing {
 		c.inProgress[id] = finish
 	}
 	c.mu.Unlock()
 
-	if isDownloading {
+	if isComputing {
 		// wait for result of parallel download
 		<-waitForResult
 	} else {
@@ -116,7 +116,7 @@ func (c *Cache) GetOrCompute(id restic.ID, compute func() ([]byte, error)) ([]by
 		}()
 	}
 
-	// try again. This is necessary independent of whether isDownloading is true or not.
+	// try again. This is necessary independent of whether isComputing is true or not.
 	// The calls to `c.Get()` and checking/adding the entry in `c.inProgress` are not atomic,
 	// thus the item might have been computed in the meantime.
 	// The following scenario would compute() the value multiple times otherwise:

--- a/internal/bloblru/cache.go
+++ b/internal/bloblru/cache.go
@@ -114,10 +114,19 @@ func (c *Cache) GetOrCompute(id restic.ID, compute func() ([]byte, error)) ([]by
 	if isDownloading {
 		// wait for result of parallel download
 		<-waitForResult
-		blob, ok := c.Get(id)
-		if ok {
-			return blob, nil
-		}
+	}
+
+	// try again. This is necessary independent of whether isDownloading is true or not.
+	// The calls to `c.Get()` and checking/adding the entry in `c.inProgress` are not atomic,
+	// thus the item might have been computed in the meantime.
+	// The following scenario would compute() the value multiple times otherwise:
+	// Goroutine A does not find a value in the initial call to `c.Get`, then goroutine B
+	// takes over, caches the computed value and cleans up its channel in c.inProgress.
+	// Then goroutine A continues, does not detect a parallel computation and would try
+	// to call compute() again.
+	blob, ok = c.Get(id)
+	if ok {
+		return blob, nil
 	}
 
 	// download it


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The test failed from time to time with the following error:
```
--- FAIL: TestCacheGetOrCompute (0.00s)
    cache_test.go:119: 
        
        	expected exactly one call of the compute function
        
        	exp: 1
        
        	got: 2
        
FAIL
```

See the commits / code for more details

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
