### PR TITLE
termstatus: Do formatting in Message, not Terminal

### DIFF
--- a/internal/ui/message.go
+++ b/internal/ui/message.go
@@ -1,6 +1,10 @@
 package ui
 
-import "github.com/restic/restic/internal/ui/termstatus"
+import (
+	"fmt"
+
+	"github.com/restic/restic/internal/ui/termstatus"
+)
 
 // Message reports progress with messages of different verbosity.
 type Message struct {
@@ -19,27 +23,27 @@ func NewMessage(term *termstatus.Terminal, verbosity uint) *Message {
 
 // E reports an error
 func (m *Message) E(msg string, args ...interface{}) {
-	m.term.Errorf(msg, args...)
+	m.term.Error(fmt.Sprintf(msg, args...))
 }
 
 // P prints a message if verbosity >= 1, this is used for normal messages which
 // are not errors.
 func (m *Message) P(msg string, args ...interface{}) {
 	if m.v >= 1 {
-		m.term.Printf(msg, args...)
+		m.term.Print(fmt.Sprintf(msg, args...))
 	}
 }
 
 // V prints a message if verbosity >= 2, this is used for verbose messages.
 func (m *Message) V(msg string, args ...interface{}) {
 	if m.v >= 2 {
-		m.term.Printf(msg, args...)
+		m.term.Print(fmt.Sprintf(msg, args...))
 	}
 }
 
 // VV prints a message if verbosity >= 3, this is used for debug messages.
 func (m *Message) VV(msg string, args ...interface{}) {
 	if m.v >= 3 {
-		m.term.Printf(msg, args...)
+		m.term.Print(fmt.Sprintf(msg, args...))
 	}
 }

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -252,21 +252,9 @@ func (t *Terminal) Print(line string) {
 	t.print(line, false)
 }
 
-// Printf uses fmt.Sprintf to write a line to the terminal.
-func (t *Terminal) Printf(msg string, args ...interface{}) {
-	s := fmt.Sprintf(msg, args...)
-	t.Print(s)
-}
-
 // Error writes an error to the terminal.
 func (t *Terminal) Error(line string) {
 	t.print(line, true)
-}
-
-// Errorf uses fmt.Sprintf to write an error line to the terminal.
-func (t *Terminal) Errorf(msg string, args ...interface{}) {
-	s := fmt.Sprintf(msg, args...)
-	t.Error(s)
 }
 
 // Truncate s to fit in width (number of terminal cells) w.


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Small follow-up to #4815. termstatus.Terminal has string formatting methods that only serve ui.Message. Let the latter do the formatting instead, for a better separation of concerns.

linux/amd64 binary shrinks by 13.5kiB.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
