### PR TITLE
restore: skip unchanged files and add `--overwrite if-changed` option

### DIFF
--- a/changelog/unreleased/issue-4817
+++ b/changelog/unreleased/issue-4817
@@ -1,11 +1,22 @@
 Enhancement: Make overwrite behavior of `restore` customizable
 
 The `restore` command now supports an `--overwrite` option to configure whether
-already existing files are overwritten. The default is `--overwrite always`,
-which overwrites existing files. `--overwrite if-newer` only restores files
-from the snapshot that are newer than the local state. And `--overwrite never`
-does not modify existing files.
+already existing files are overwritten. This behavior can now be configured via
+the `--overwrite` option. The following values are supported:
+
+* `--overwrite always` (default): always overwrites already existing files. `restore`
+  will verify the existing file content and only restore mismatching parts to minimize
+  downloads. Updates the metadata of all files.
+* `--overwrite if-changed`: like the previous case, but speeds up the file content check
+  by assuming that files with matching size and modification time (mtime) are already up to date.
+  In case of a mismatch, the full file content is verified. Updates the metadata of all files.
+* `--overwrite if-newer`: only overwrite existing files if the file in the snapshot has a
+  newer modification time (mtime).
+* `--overwrite never`: never overwrite existing files.
 
 https://github.com/restic/restic/issues/4817
 https://github.com/restic/restic/issues/200
+https://github.com/restic/restic/issues/407
+https://github.com/restic/restic/issues/2662
 https://github.com/restic/restic/pull/4837
+https://github.com/restic/restic/pull/4838

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -66,7 +66,7 @@ func init() {
 	initSingleSnapshotFilter(flags, &restoreOptions.SnapshotFilter)
 	flags.BoolVar(&restoreOptions.Sparse, "sparse", false, "restore files as sparse")
 	flags.BoolVar(&restoreOptions.Verify, "verify", false, "verify restored files content")
-	flags.Var(&restoreOptions.Overwrite, "overwrite", "overwrite behavior, one of (always|if-newer|never) (default: always)")
+	flags.Var(&restoreOptions.Overwrite, "overwrite", "overwrite behavior, one of (always|if-changed|if-newer|never) (default: always)")
 }
 
 func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -91,11 +91,20 @@ stored explicitly.
 Restoring in-place
 ------------------
 
-By default, the ``restore`` command overwrites already existing files in the target
-directory. This behavior can be configured via the ``--overwrite`` option. The
-default is ``--overwrite always``. To only overwrite existing files if the file in
-the snapshot is newer, use ``--overwrite if-newer``. To never overwrite existing files,
-use ``--overwrite never``.
+By default, the ``restore`` command overwrites already existing files at the target
+directory. This behavior can be configured via the ``--overwrite`` option. The following
+values are supported:
+
+* ``--overwrite always`` (default): always overwrites already existing files. ``restore``
+  will verify the existing file content and only restore mismatching parts to minimize
+  downloads. Updates the metadata of all files.
+* ``--overwrite if-changed``: like the previous case, but speeds up the file content check
+  by assuming that files with matching size and modification time (mtime) are already up to date.
+  In case of a mismatch, the full file content is verified. Updates the metadata of all files.
+* ``--overwrite if-newer``: only overwrite existing files if the file in the snapshot has a
+  newer modification time (mtime).
+* ``--overwrite never``: never overwrite existing files.
+
 
 Restore using mount
 ===================

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -91,6 +91,12 @@ stored explicitly.
 Restoring in-place
 ------------------
 
+.. note::
+
+    Restoring data in-place can leave files in a partially restored state if the ``restore``
+    operation is interrupted. To ensure you can revert back to the previous state, create
+    a current ``backup`` before restoring a different snapshot.
+
 By default, the ``restore`` command overwrites already existing files at the target
 directory. This behavior can be configured via the ``--overwrite`` option. The following
 values are supported:

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -153,6 +153,12 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 			// in addition, a short chunk will never match r.zeroChunk which would prevent sparseness for short files
 			file.sparse = r.sparse
 		}
+		if file.state != nil {
+			// The restorer currently cannot punch new holes into an existing files.
+			// Thus sections that contained data but should be sparse after restoring
+			// the snapshot would still contain the old data resulting in a corrupt restore.
+			file.sparse = false
+		}
 
 		if err != nil {
 			// repository index is messed up, can't do anything

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -26,6 +26,7 @@ type fileInfo struct {
 	size       int64
 	location   string      // file on local filesystem relative to restorer basedir
 	blobs      interface{} // blobs of the file
+	state      *fileState
 }
 
 type fileBlobInfo struct {
@@ -80,25 +81,25 @@ func newFileRestorer(dst string,
 	}
 }
 
-func (r *fileRestorer) addFile(location string, content restic.IDs, size int64) {
-	r.files = append(r.files, &fileInfo{location: location, blobs: content, size: size})
+func (r *fileRestorer) addFile(location string, content restic.IDs, size int64, state *fileState) {
+	r.files = append(r.files, &fileInfo{location: location, blobs: content, size: size, state: state})
 }
 
 func (r *fileRestorer) targetPath(location string) string {
 	return filepath.Join(r.dst, location)
 }
 
-func (r *fileRestorer) forEachBlob(blobIDs []restic.ID, fn func(packID restic.ID, packBlob restic.Blob)) error {
+func (r *fileRestorer) forEachBlob(blobIDs []restic.ID, fn func(packID restic.ID, packBlob restic.Blob, idx int)) error {
 	if len(blobIDs) == 0 {
 		return nil
 	}
 
-	for _, blobID := range blobIDs {
+	for i, blobID := range blobIDs {
 		packs := r.idx(restic.DataBlob, blobID)
 		if len(packs) == 0 {
 			return errors.Errorf("Unknown blob %s", blobID.String())
 		}
-		fn(packs[0].PackID, packs[0].Blob)
+		fn(packs[0].PackID, packs[0].Blob, i)
 	}
 
 	return nil
@@ -128,8 +129,8 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 			packsMap = make(map[restic.ID][]fileBlobInfo)
 		}
 		fileOffset := int64(0)
-		err := r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob) {
-			if largeFile {
+		err := r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob, idx int) {
+			if largeFile && !file.state.HasMatchingBlob(idx) {
 				packsMap[packID] = append(packsMap[packID], fileBlobInfo{id: blob.ID, offset: fileOffset})
 				fileOffset += int64(blob.DataLength())
 			}
@@ -232,8 +233,8 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 		}
 		if fileBlobs, ok := file.blobs.(restic.IDs); ok {
 			fileOffset := int64(0)
-			err := r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob) {
-				if packID.Equal(pack.id) {
+			err := r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob, idx int) {
+				if packID.Equal(pack.id) && !file.state.HasMatchingBlob(idx) {
 					addBlob(blob, fileOffset)
 				}
 				fileOffset += int64(blob.DataLength())

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -930,6 +931,13 @@ func TestRestorerOverwriteBehavior(t *testing.T) {
 			},
 		},
 		{
+			Overwrite: OverwriteIfChanged,
+			Files: map[string]string{
+				"foo":          "content: new\n",
+				"dirtest/file": "content: file2\n",
+			},
+		},
+		{
 			Overwrite: OverwriteIfNewer,
 			Files: map[string]string{
 				"foo":          "content: new\n",
@@ -980,5 +988,90 @@ func TestRestorerOverwriteBehavior(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRestoreModified(t *testing.T) {
+	// overwrite files between snapshots and also change their filesize
+	snapshots := []Snapshot{
+		{
+			Nodes: map[string]Node{
+				"foo": File{Data: "content: foo\n", ModTime: time.Now()},
+				"bar": File{Data: "content: a\n", ModTime: time.Now()},
+			},
+		},
+		{
+			Nodes: map[string]Node{
+				"foo": File{Data: "content: a\n", ModTime: time.Now()},
+				"bar": File{Data: "content: bar\n", ModTime: time.Now()},
+			},
+		},
+	}
+
+	repo := repository.TestRepository(t)
+	tempdir := filepath.Join(rtest.TempDir(t), "target")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	for _, snapshot := range snapshots {
+		sn, id := saveSnapshot(t, repo, snapshot, noopGetGenericAttributes)
+		t.Logf("snapshot saved as %v", id.Str())
+
+		res := NewRestorer(repo, sn, Options{Overwrite: OverwriteIfChanged})
+		rtest.OK(t, res.RestoreTo(ctx, tempdir))
+		n, err := res.VerifyFiles(ctx, tempdir)
+		rtest.OK(t, err)
+		rtest.Equals(t, 2, n, "unexpected number of verified files")
+	}
+}
+
+func TestRestoreIfChanged(t *testing.T) {
+	origData := "content: foo\n"
+	modData := "content: bar\n"
+	rtest.Equals(t, len(modData), len(origData), "broken testcase")
+	snapshot := Snapshot{
+		Nodes: map[string]Node{
+			"foo": File{Data: origData, ModTime: time.Now()},
+		},
+	}
+
+	repo := repository.TestRepository(t)
+	tempdir := filepath.Join(rtest.TempDir(t), "target")
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sn, id := saveSnapshot(t, repo, snapshot, noopGetGenericAttributes)
+	t.Logf("snapshot saved as %v", id.Str())
+
+	res := NewRestorer(repo, sn, Options{})
+	rtest.OK(t, res.RestoreTo(ctx, tempdir))
+
+	// modify file but maintain size and timestamp
+	path := filepath.Join(tempdir, "foo")
+	f, err := os.OpenFile(path, os.O_RDWR, 0)
+	rtest.OK(t, err)
+	fi, err := f.Stat()
+	rtest.OK(t, err)
+	_, err = f.Write([]byte(modData))
+	rtest.OK(t, err)
+	rtest.OK(t, f.Close())
+	var utimes = [...]syscall.Timespec{
+		syscall.NsecToTimespec(fi.ModTime().UnixNano()),
+		syscall.NsecToTimespec(fi.ModTime().UnixNano()),
+	}
+	rtest.OK(t, syscall.UtimesNano(path, utimes[:]))
+
+	for _, overwrite := range []OverwriteBehavior{OverwriteIfChanged, OverwriteAlways} {
+		res = NewRestorer(repo, sn, Options{Overwrite: overwrite})
+		rtest.OK(t, res.RestoreTo(ctx, tempdir))
+		data, err := os.ReadFile(path)
+		rtest.OK(t, err)
+		if overwrite == OverwriteAlways {
+			// restore should notice the changed file content
+			rtest.Equals(t, origData, string(data), "expected original file content")
+		} else {
+			// restore should not have noticed the changed file content
+			rtest.Equals(t, modData, string(data), "expeced modified file content")
+		}
 	}
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Based on https://github.com/restic/restic/pull/4837 .

On startup, the `restore` command now checks existing files to determine whether these have to be updated. By default, it verifies the full file content. To only checks whether the file size and modification time (mtime) match with those in the snapshot, use `--overwrite if-changed`. Files with matching file content will not be downloaded during the restore operation. Only their file metadata is updated.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See #4817
Fixes https://github.com/restic/restic/issues/407
Fixes https://github.com/restic/restic/issues/2662

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
