### PR TITLE
restore: add `--dry-run` and extended progress output

### DIFF
--- a/changelog/unreleased/pull-4839
+++ b/changelog/unreleased/pull-4839
@@ -1,0 +1,7 @@
+Enhancement: Add dry-run support to `restore` command
+
+The `restore` command now supports the `--dry-run` option to perform
+a dry run. Pass the `--verbose=2` option to see which files would
+remain unchanged, which would be updated or freshly restored.
+
+https://github.com/restic/restic/pull/4839

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -133,9 +133,9 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 	msg := ui.NewMessage(term, gopts.verbosity)
 	var printer restoreui.ProgressPrinter
 	if gopts.JSON {
-		printer = restoreui.NewJSONProgress(term)
+		printer = restoreui.NewJSONProgress(term, gopts.verbosity)
 	} else {
-		printer = restoreui.NewTextProgress(term)
+		printer = restoreui.NewTextProgress(term, gopts.verbosity)
 	}
 
 	progress := restoreui.NewProgress(printer, calculateProgressInterval(!gopts.Quiet, gopts.JSON))

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -242,7 +242,7 @@ case, specify the ``--skip-if-unchanged`` option.
 Note that when using absolute paths to specify the backup target, then also
 changes to the parent folders result in a changed snapshot. For example, a backup
 of ``/home/user/work`` will create a new snapshot if the metadata of either
- ``/``, ``/home`` or ``/home/user`` change. To avoid this problem run restic from
+``/``, ``/home`` or ``/home/user`` change. To avoid this problem run restic from
 the corresponding folder and use relative paths.
 
 .. code-block:: console

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -111,6 +111,28 @@ values are supported:
   newer modification time (mtime).
 * ``--overwrite never``: never overwrite existing files.
 
+Dry run
+-------
+
+As restore operations can take a long time, it can be useful to perform a dry-run to
+see what would be restored without having to run the full restore operation. The
+restore command supports the ``--dry-run`` option and prints information about the
+restored files when specifying ``--verbose=2``.
+
+.. code-block:: console
+
+    $ restic restore --target /tmp/restore-work --dry-run --verbose=2 latest
+
+    unchanged /restic/internal/walker/walker.go with size 2.812 KiB
+    updated   /restic/internal/walker/walker_test.go with size 11.143 KiB
+    restored  /restic/restic with size 35.318 MiB
+    restored  /restic
+    [...]
+    Summary: Restored 9072 files/dirs (153.597 MiB) in 0:00
+
+Files with already up to date content are reported as ``unchanged``. Files whose content
+was modified are ``updated`` and files that are new are shown as ``restored``. Directories
+and other file types like symlinks are always reported as ``restored``.
 
 Restore using mount
 ===================

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -69,7 +69,7 @@ There are case insensitive variants of ``--exclude`` and ``--include`` called
 ignore the casing of paths.
 
 There are also ``--include-file``, ``--exclude-file``, ``--iinclude-file`` and
- ``--iexclude-file`` flags that read the include and exclude patterns from a file.
+``--iexclude-file`` flags that read the include and exclude patterns from a file.
 
 Restoring symbolic links on windows is only possible when the user has
 ``SeCreateSymbolicLinkPrivilege`` privilege or is running as admin. This is a

--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -511,6 +511,22 @@ Status
 |``bytes_skipped``     | Total size of skipped files                                |
 +----------------------+------------------------------------------------------------+
 
+Verbose Status
+^^^^^^^^^^^^^^
+
+Verbose status provides details about the progress, including details about restored files.
+Only printed if `--verbose=2` is specified.
+
++----------------------+-----------------------------------------------------------+
+| ``message_type``     | Always "verbose_status"                                   |
++----------------------+-----------------------------------------------------------+
+| ``action``           | Either "restored", "updated" or "unchanged"               |
++----------------------+-----------------------------------------------------------+
+| ``item``             | The item in question                                      |
++----------------------+-----------------------------------------------------------+
+| ``size``             | Size of the item in bytes                                 |
++----------------------+-----------------------------------------------------------+
+
 Summary
 ^^^^^^^
 

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -215,7 +215,7 @@ func (r *fileRestorer) restoreEmptyFileAt(location string) error {
 		return err
 	}
 
-	r.progress.AddProgress(location, 0, 0)
+	r.progress.AddProgress(location, false, true, 0, 0)
 	return nil
 }
 
@@ -337,7 +337,7 @@ func (r *fileRestorer) downloadBlobs(ctx context.Context, packID restic.ID,
 							createSize = file.size
 						}
 						writeErr := r.filesWriter.writeToFile(r.targetPath(file.location), blobData, offset, createSize, file.sparse)
-						r.progress.AddProgress(file.location, uint64(len(blobData)), uint64(file.size))
+						r.progress.AddProgress(file.location, false, file.state == nil, uint64(len(blobData)), uint64(file.size))
 						return writeErr
 					}
 					err := r.sanitizeError(file, writeToFile())

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -215,7 +215,7 @@ func (r *fileRestorer) restoreEmptyFileAt(location string) error {
 		return err
 	}
 
-	r.progress.AddProgress(location, false, true, 0, 0)
+	r.progress.AddProgress(location, restore.ActionFileRestored, 0, 0)
 	return nil
 }
 
@@ -337,7 +337,11 @@ func (r *fileRestorer) downloadBlobs(ctx context.Context, packID restic.ID,
 							createSize = file.size
 						}
 						writeErr := r.filesWriter.writeToFile(r.targetPath(file.location), blobData, offset, createSize, file.sparse)
-						r.progress.AddProgress(file.location, false, file.state == nil, uint64(len(blobData)), uint64(file.size))
+						action := restore.ActionFileUpdated
+						if file.state == nil {
+							action = restore.ActionFileRestored
+						}
+						r.progress.AddProgress(file.location, action, uint64(len(blobData)), uint64(file.size))
 						return writeErr
 					}
 					err := r.sanitizeError(file, writeToFile())

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -234,7 +234,7 @@ func (res *Restorer) restoreNodeTo(ctx context.Context, node *restic.Node, targe
 		}
 	}
 
-	res.opts.Progress.AddProgress(location, false, true, 0, 0)
+	res.opts.Progress.AddProgress(location, restoreui.ActionFileRestored, 0, 0)
 	return res.restoreNodeMetadataTo(node, target, location)
 }
 
@@ -261,7 +261,7 @@ func (res *Restorer) restoreHardlinkAt(node *restic.Node, target, path, location
 		}
 	}
 
-	res.opts.Progress.AddProgress(location, false, true, 0, 0)
+	res.opts.Progress.AddProgress(location, restoreui.ActionFileRestored, 0, 0)
 	// TODO investigate if hardlinks have separate metadata on any supported system
 	return res.restoreNodeMetadataTo(node, path, location)
 }
@@ -343,8 +343,12 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 					if !res.opts.DryRun {
 						filerestorer.addFile(location, node.Content, int64(node.Size), matches)
 					} else {
+						action := restoreui.ActionFileUpdated
+						if matches == nil {
+							action = restoreui.ActionFileRestored
+						}
 						// immediately mark as completed
-						res.opts.Progress.AddProgress(location, false, matches == nil, node.Size, node.Size)
+						res.opts.Progress.AddProgress(location, action, node.Size, node.Size)
 					}
 				}
 				res.trackFile(location, updateMetadataOnly)
@@ -393,7 +397,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 		leaveDir: func(node *restic.Node, target, location string) error {
 			err := res.restoreNodeMetadataTo(node, target, location)
 			if err == nil {
-				res.opts.Progress.AddProgress(location, false, true, 0, 0)
+				res.opts.Progress.AddProgress(location, restoreui.ActionDirRestored, 0, 0)
 			}
 			return err
 		},

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -76,6 +76,8 @@ type printerMock struct {
 
 func (p *printerMock) Update(_ restoreui.State, _ time.Duration) {
 }
+func (p *printerMock) CompleteItem(action restoreui.ItemAction, item string, size uint64) {
+}
 func (p *printerMock) Finish(s restoreui.State, _ time.Duration) {
 	p.s = s
 }

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -83,6 +83,14 @@ func (p *printerMock) Finish(s restoreui.State, _ time.Duration) {
 }
 
 func TestRestorerProgressBar(t *testing.T) {
+	testRestorerProgressBar(t, false)
+}
+
+func TestRestorerProgressBarDryRun(t *testing.T) {
+	testRestorerProgressBar(t, true)
+}
+
+func testRestorerProgressBar(t *testing.T, dryRun bool) {
 	repo := repository.TestRepository(t)
 
 	sn, _ := saveSnapshot(t, repo, Snapshot{
@@ -99,7 +107,7 @@ func TestRestorerProgressBar(t *testing.T) {
 
 	mock := &printerMock{}
 	progress := restoreui.NewProgress(mock, 0)
-	res := NewRestorer(repo, sn, Options{Progress: progress})
+	res := NewRestorer(repo, sn, Options{Progress: progress, DryRun: dryRun})
 	res.SelectFilter = func(item string, dstpath string, node *restic.Node) (selectedForRestore bool, childMayBeSelected bool) {
 		return true, true
 	}

--- a/internal/ui/restore/json.go
+++ b/internal/ui/restore/json.go
@@ -7,12 +7,14 @@ import (
 )
 
 type jsonPrinter struct {
-	terminal term
+	terminal  term
+	verbosity uint
 }
 
-func NewJSONProgress(terminal term) ProgressPrinter {
+func NewJSONProgress(terminal term, verbosity uint) ProgressPrinter {
 	return &jsonPrinter{
-		terminal: terminal,
+		terminal:  terminal,
+		verbosity: verbosity,
 	}
 }
 
@@ -36,6 +38,34 @@ func (t *jsonPrinter) Update(p State, duration time.Duration) {
 		status.PercentDone = float64(p.AllBytesWritten) / float64(p.AllBytesTotal)
 	}
 
+	t.print(status)
+}
+
+func (t *jsonPrinter) CompleteItem(messageType ItemAction, item string, size uint64) {
+	if t.verbosity < 3 {
+		return
+	}
+
+	var action string
+	switch messageType {
+	case ActionDirRestored:
+		action = "restored"
+	case ActionFileRestored:
+		action = "restored"
+	case ActionFileUpdated:
+		action = "updated"
+	case ActionFileUnchanged:
+		action = "unchanged"
+	default:
+		panic("unknown message type")
+	}
+
+	status := verboseUpdate{
+		MessageType: "verbose_status",
+		Action:      action,
+		Item:        item,
+		Size:        size,
+	}
 	t.print(status)
 }
 
@@ -63,6 +93,13 @@ type statusUpdate struct {
 	TotalBytes     uint64  `json:"total_bytes,omitempty"`
 	BytesRestored  uint64  `json:"bytes_restored,omitempty"`
 	BytesSkipped   uint64  `json:"bytes_skipped,omitempty"`
+}
+
+type verboseUpdate struct {
+	MessageType string `json:"message_type"` // "verbose_status"
+	Action      string `json:"action"`
+	Item        string `json:"item"`
+	Size        uint64 `json:"size"`
 }
 
 type summaryOutput struct {

--- a/internal/ui/restore/json_test.go
+++ b/internal/ui/restore/json_test.go
@@ -7,37 +7,55 @@ import (
 	"github.com/restic/restic/internal/test"
 )
 
-func TestJSONPrintUpdate(t *testing.T) {
+func createJSONProgress() (*mockTerm, ProgressPrinter) {
 	term := &mockTerm{}
-	printer := NewJSONProgress(term)
+	printer := NewJSONProgress(term, 3)
+	return term, printer
+}
+
+func TestJSONPrintUpdate(t *testing.T) {
+	term, printer := createJSONProgress()
 	printer.Update(State{3, 11, 0, 29, 47, 0}, 5*time.Second)
 	test.Equals(t, []string{"{\"message_type\":\"status\",\"seconds_elapsed\":5,\"percent_done\":0.6170212765957447,\"total_files\":11,\"files_restored\":3,\"total_bytes\":47,\"bytes_restored\":29}\n"}, term.output)
 }
 
 func TestJSONPrintUpdateWithSkipped(t *testing.T) {
-	term := &mockTerm{}
-	printer := NewJSONProgress(term)
+	term, printer := createJSONProgress()
 	printer.Update(State{3, 11, 2, 29, 47, 59}, 5*time.Second)
 	test.Equals(t, []string{"{\"message_type\":\"status\",\"seconds_elapsed\":5,\"percent_done\":0.6170212765957447,\"total_files\":11,\"files_restored\":3,\"files_skipped\":2,\"total_bytes\":47,\"bytes_restored\":29,\"bytes_skipped\":59}\n"}, term.output)
 }
 
 func TestJSONPrintSummaryOnSuccess(t *testing.T) {
-	term := &mockTerm{}
-	printer := NewJSONProgress(term)
+	term, printer := createJSONProgress()
 	printer.Finish(State{11, 11, 0, 47, 47, 0}, 5*time.Second)
 	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_restored\":11,\"total_bytes\":47,\"bytes_restored\":47}\n"}, term.output)
 }
 
 func TestJSONPrintSummaryOnErrors(t *testing.T) {
-	term := &mockTerm{}
-	printer := NewJSONProgress(term)
+	term, printer := createJSONProgress()
 	printer.Finish(State{3, 11, 0, 29, 47, 0}, 5*time.Second)
 	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_restored\":3,\"total_bytes\":47,\"bytes_restored\":29}\n"}, term.output)
 }
 
 func TestJSONPrintSummaryOnSuccessWithSkipped(t *testing.T) {
-	term := &mockTerm{}
-	printer := NewJSONProgress(term)
+	term, printer := createJSONProgress()
 	printer.Finish(State{11, 11, 2, 47, 47, 59}, 5*time.Second)
 	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_restored\":11,\"files_skipped\":2,\"total_bytes\":47,\"bytes_restored\":47,\"bytes_skipped\":59}\n"}, term.output)
+}
+
+func TestJSONPrintCompleteItem(t *testing.T) {
+	for _, data := range []struct {
+		action   ItemAction
+		size     uint64
+		expected string
+	}{
+		{ActionDirRestored, 0, "{\"message_type\":\"verbose_status\",\"action\":\"restored\",\"item\":\"test\",\"size\":0}\n"},
+		{ActionFileRestored, 123, "{\"message_type\":\"verbose_status\",\"action\":\"restored\",\"item\":\"test\",\"size\":123}\n"},
+		{ActionFileUpdated, 123, "{\"message_type\":\"verbose_status\",\"action\":\"updated\",\"item\":\"test\",\"size\":123}\n"},
+		{ActionFileUnchanged, 123, "{\"message_type\":\"verbose_status\",\"action\":\"unchanged\",\"item\":\"test\",\"size\":123}\n"},
+	} {
+		term, printer := createJSONProgress()
+		printer.CompleteItem(data.action, "test", data.size)
+		test.Equals(t, []string{data.expected}, term.output)
+	}
 }

--- a/internal/ui/restore/progress.go
+++ b/internal/ui/restore/progress.go
@@ -39,8 +39,19 @@ type term interface {
 
 type ProgressPrinter interface {
 	Update(progress State, duration time.Duration)
+	CompleteItem(action ItemAction, item string, size uint64)
 	Finish(progress State, duration time.Duration)
 }
+
+type ItemAction string
+
+// Constants for the different CompleteItem actions.
+const (
+	ActionDirRestored   ItemAction = "dir restored"
+	ActionFileRestored  ItemAction = "file restored"
+	ActionFileUpdated   ItemAction = "file updated"
+	ActionFileUnchanged ItemAction = "file unchanged"
+)
 
 func NewProgress(printer ProgressPrinter, interval time.Duration) *Progress {
 	p := &Progress{
@@ -77,7 +88,7 @@ func (p *Progress) AddFile(size uint64) {
 }
 
 // AddProgress accumulates the number of bytes written for a file
-func (p *Progress) AddProgress(name string, bytesWrittenPortion uint64, bytesTotal uint64) {
+func (p *Progress) AddProgress(name string, isDir bool, isNew bool, bytesWrittenPortion uint64, bytesTotal uint64) {
 	if p == nil {
 		return
 	}
@@ -96,10 +107,18 @@ func (p *Progress) AddProgress(name string, bytesWrittenPortion uint64, bytesTot
 	if entry.bytesWritten == entry.bytesTotal {
 		delete(p.progressInfoMap, name)
 		p.s.FilesFinished++
+
+		action := ActionFileUpdated
+		if isDir {
+			action = ActionDirRestored
+		} else if isNew {
+			action = ActionFileRestored
+		}
+		p.printer.CompleteItem(action, name, bytesTotal)
 	}
 }
 
-func (p *Progress) AddSkippedFile(size uint64) {
+func (p *Progress) AddSkippedFile(name string, size uint64) {
 	if p == nil {
 		return
 	}
@@ -109,6 +128,8 @@ func (p *Progress) AddSkippedFile(size uint64) {
 
 	p.s.FilesSkipped++
 	p.s.AllBytesSkipped += size
+
+	p.printer.CompleteItem(ActionFileUnchanged, name, size)
 }
 
 func (p *Progress) Finish() {

--- a/internal/ui/restore/progress.go
+++ b/internal/ui/restore/progress.go
@@ -88,7 +88,7 @@ func (p *Progress) AddFile(size uint64) {
 }
 
 // AddProgress accumulates the number of bytes written for a file
-func (p *Progress) AddProgress(name string, isDir bool, isNew bool, bytesWrittenPortion uint64, bytesTotal uint64) {
+func (p *Progress) AddProgress(name string, action ItemAction, bytesWrittenPortion uint64, bytesTotal uint64) {
 	if p == nil {
 		return
 	}
@@ -108,12 +108,6 @@ func (p *Progress) AddProgress(name string, isDir bool, isNew bool, bytesWritten
 		delete(p.progressInfoMap, name)
 		p.s.FilesFinished++
 
-		action := ActionFileUpdated
-		if isDir {
-			action = ActionDirRestored
-		} else if isNew {
-			action = ActionFileRestored
-		}
 		p.printer.CompleteItem(action, name, bytesTotal)
 	}
 }

--- a/internal/ui/restore/progress_test.go
+++ b/internal/ui/restore/progress_test.go
@@ -16,8 +16,16 @@ type printerTraceEntry struct {
 
 type printerTrace []printerTraceEntry
 
+type itemTraceEntry struct {
+	action ItemAction
+	item   string
+	size   uint64
+}
+
+type itemTrace []itemTraceEntry
 type mockPrinter struct {
 	trace printerTrace
+	items itemTrace
 }
 
 const mockFinishDuration = 42 * time.Second
@@ -25,95 +33,109 @@ const mockFinishDuration = 42 * time.Second
 func (p *mockPrinter) Update(progress State, duration time.Duration) {
 	p.trace = append(p.trace, printerTraceEntry{progress, duration, false})
 }
+func (p *mockPrinter) CompleteItem(action ItemAction, item string, size uint64) {
+	p.items = append(p.items, itemTraceEntry{action, item, size})
+}
 func (p *mockPrinter) Finish(progress State, _ time.Duration) {
 	p.trace = append(p.trace, printerTraceEntry{progress, mockFinishDuration, true})
 }
 
-func testProgress(fn func(progress *Progress) bool) printerTrace {
+func testProgress(fn func(progress *Progress) bool) (printerTrace, itemTrace) {
 	printer := &mockPrinter{}
 	progress := NewProgress(printer, 0)
 	final := fn(progress)
 	progress.update(0, final)
 	trace := append(printerTrace{}, printer.trace...)
+	items := append(itemTrace{}, printer.items...)
 	// cleanup to avoid goroutine leak, but copy trace first
 	progress.Finish()
-	return trace
+	return trace, items
 }
 
 func TestNew(t *testing.T) {
-	result := testProgress(func(progress *Progress) bool {
+	result, items := testProgress(func(progress *Progress) bool {
 		return false
 	})
 	test.Equals(t, printerTrace{
 		printerTraceEntry{State{0, 0, 0, 0, 0, 0}, 0, false},
 	}, result)
+	test.Equals(t, itemTrace{}, items)
 }
 
 func TestAddFile(t *testing.T) {
 	fileSize := uint64(100)
 
-	result := testProgress(func(progress *Progress) bool {
+	result, items := testProgress(func(progress *Progress) bool {
 		progress.AddFile(fileSize)
 		return false
 	})
 	test.Equals(t, printerTrace{
 		printerTraceEntry{State{0, 1, 0, 0, fileSize, 0}, 0, false},
 	}, result)
+	test.Equals(t, itemTrace{}, items)
 }
 
 func TestFirstProgressOnAFile(t *testing.T) {
 	expectedBytesWritten := uint64(5)
 	expectedBytesTotal := uint64(100)
 
-	result := testProgress(func(progress *Progress) bool {
+	result, items := testProgress(func(progress *Progress) bool {
 		progress.AddFile(expectedBytesTotal)
-		progress.AddProgress("test", expectedBytesWritten, expectedBytesTotal)
+		progress.AddProgress("test", false, false, expectedBytesWritten, expectedBytesTotal)
 		return false
 	})
 	test.Equals(t, printerTrace{
 		printerTraceEntry{State{0, 1, 0, expectedBytesWritten, expectedBytesTotal, 0}, 0, false},
 	}, result)
+	test.Equals(t, itemTrace{}, items)
 }
 
 func TestLastProgressOnAFile(t *testing.T) {
 	fileSize := uint64(100)
 
-	result := testProgress(func(progress *Progress) bool {
+	result, items := testProgress(func(progress *Progress) bool {
 		progress.AddFile(fileSize)
-		progress.AddProgress("test", 30, fileSize)
-		progress.AddProgress("test", 35, fileSize)
-		progress.AddProgress("test", 35, fileSize)
+		progress.AddProgress("test", false, false, 30, fileSize)
+		progress.AddProgress("test", false, false, 35, fileSize)
+		progress.AddProgress("test", false, false, 35, fileSize)
 		return false
 	})
 	test.Equals(t, printerTrace{
 		printerTraceEntry{State{1, 1, 0, fileSize, fileSize, 0}, 0, false},
 	}, result)
+	test.Equals(t, itemTrace{
+		itemTraceEntry{action: ActionFileUpdated, item: "test", size: fileSize},
+	}, items)
 }
 
 func TestLastProgressOnLastFile(t *testing.T) {
 	fileSize := uint64(100)
 
-	result := testProgress(func(progress *Progress) bool {
+	result, items := testProgress(func(progress *Progress) bool {
 		progress.AddFile(fileSize)
 		progress.AddFile(50)
-		progress.AddProgress("test1", 50, 50)
-		progress.AddProgress("test2", 50, fileSize)
-		progress.AddProgress("test2", 50, fileSize)
+		progress.AddProgress("test1", false, false, 50, 50)
+		progress.AddProgress("test2", false, false, 50, fileSize)
+		progress.AddProgress("test2", false, false, 50, fileSize)
 		return false
 	})
 	test.Equals(t, printerTrace{
 		printerTraceEntry{State{2, 2, 0, 50 + fileSize, 50 + fileSize, 0}, 0, false},
 	}, result)
+	test.Equals(t, itemTrace{
+		itemTraceEntry{action: ActionFileUpdated, item: "test1", size: 50},
+		itemTraceEntry{action: ActionFileUpdated, item: "test2", size: fileSize},
+	}, items)
 }
 
 func TestSummaryOnSuccess(t *testing.T) {
 	fileSize := uint64(100)
 
-	result := testProgress(func(progress *Progress) bool {
+	result, _ := testProgress(func(progress *Progress) bool {
 		progress.AddFile(fileSize)
 		progress.AddFile(50)
-		progress.AddProgress("test1", 50, 50)
-		progress.AddProgress("test2", fileSize, fileSize)
+		progress.AddProgress("test1", false, false, 50, 50)
+		progress.AddProgress("test2", false, false, fileSize, fileSize)
 		return true
 	})
 	test.Equals(t, printerTrace{
@@ -124,11 +146,11 @@ func TestSummaryOnSuccess(t *testing.T) {
 func TestSummaryOnErrors(t *testing.T) {
 	fileSize := uint64(100)
 
-	result := testProgress(func(progress *Progress) bool {
+	result, _ := testProgress(func(progress *Progress) bool {
 		progress.AddFile(fileSize)
 		progress.AddFile(50)
-		progress.AddProgress("test1", 50, 50)
-		progress.AddProgress("test2", fileSize/2, fileSize)
+		progress.AddProgress("test1", false, false, 50, 50)
+		progress.AddProgress("test2", false, false, fileSize/2, fileSize)
 		return true
 	})
 	test.Equals(t, printerTrace{
@@ -139,11 +161,30 @@ func TestSummaryOnErrors(t *testing.T) {
 func TestSkipFile(t *testing.T) {
 	fileSize := uint64(100)
 
-	result := testProgress(func(progress *Progress) bool {
-		progress.AddSkippedFile(fileSize)
+	result, items := testProgress(func(progress *Progress) bool {
+		progress.AddSkippedFile("test", fileSize)
 		return true
 	})
 	test.Equals(t, printerTrace{
 		printerTraceEntry{State{0, 0, 1, 0, 0, fileSize}, mockFinishDuration, true},
 	}, result)
+	test.Equals(t, itemTrace{
+		itemTraceEntry{ActionFileUnchanged, "test", fileSize},
+	}, items)
+}
+
+func TestProgressTypes(t *testing.T) {
+	fileSize := uint64(100)
+
+	_, items := testProgress(func(progress *Progress) bool {
+		progress.AddFile(fileSize)
+		progress.AddFile(0)
+		progress.AddProgress("dir", true, false, fileSize, fileSize)
+		progress.AddProgress("new", false, true, 0, 0)
+		return true
+	})
+	test.Equals(t, itemTrace{
+		itemTraceEntry{ActionDirRestored, "dir", fileSize},
+		itemTraceEntry{ActionFileRestored, "new", 0},
+	}, items)
 }

--- a/internal/ui/restore/progress_test.go
+++ b/internal/ui/restore/progress_test.go
@@ -81,7 +81,7 @@ func TestFirstProgressOnAFile(t *testing.T) {
 
 	result, items := testProgress(func(progress *Progress) bool {
 		progress.AddFile(expectedBytesTotal)
-		progress.AddProgress("test", false, false, expectedBytesWritten, expectedBytesTotal)
+		progress.AddProgress("test", ActionFileUpdated, expectedBytesWritten, expectedBytesTotal)
 		return false
 	})
 	test.Equals(t, printerTrace{
@@ -95,9 +95,9 @@ func TestLastProgressOnAFile(t *testing.T) {
 
 	result, items := testProgress(func(progress *Progress) bool {
 		progress.AddFile(fileSize)
-		progress.AddProgress("test", false, false, 30, fileSize)
-		progress.AddProgress("test", false, false, 35, fileSize)
-		progress.AddProgress("test", false, false, 35, fileSize)
+		progress.AddProgress("test", ActionFileUpdated, 30, fileSize)
+		progress.AddProgress("test", ActionFileUpdated, 35, fileSize)
+		progress.AddProgress("test", ActionFileUpdated, 35, fileSize)
 		return false
 	})
 	test.Equals(t, printerTrace{
@@ -114,9 +114,9 @@ func TestLastProgressOnLastFile(t *testing.T) {
 	result, items := testProgress(func(progress *Progress) bool {
 		progress.AddFile(fileSize)
 		progress.AddFile(50)
-		progress.AddProgress("test1", false, false, 50, 50)
-		progress.AddProgress("test2", false, false, 50, fileSize)
-		progress.AddProgress("test2", false, false, 50, fileSize)
+		progress.AddProgress("test1", ActionFileUpdated, 50, 50)
+		progress.AddProgress("test2", ActionFileUpdated, 50, fileSize)
+		progress.AddProgress("test2", ActionFileUpdated, 50, fileSize)
 		return false
 	})
 	test.Equals(t, printerTrace{
@@ -134,8 +134,8 @@ func TestSummaryOnSuccess(t *testing.T) {
 	result, _ := testProgress(func(progress *Progress) bool {
 		progress.AddFile(fileSize)
 		progress.AddFile(50)
-		progress.AddProgress("test1", false, false, 50, 50)
-		progress.AddProgress("test2", false, false, fileSize, fileSize)
+		progress.AddProgress("test1", ActionFileUpdated, 50, 50)
+		progress.AddProgress("test2", ActionFileUpdated, fileSize, fileSize)
 		return true
 	})
 	test.Equals(t, printerTrace{
@@ -149,8 +149,8 @@ func TestSummaryOnErrors(t *testing.T) {
 	result, _ := testProgress(func(progress *Progress) bool {
 		progress.AddFile(fileSize)
 		progress.AddFile(50)
-		progress.AddProgress("test1", false, false, 50, 50)
-		progress.AddProgress("test2", false, false, fileSize/2, fileSize)
+		progress.AddProgress("test1", ActionFileUpdated, 50, 50)
+		progress.AddProgress("test2", ActionFileUpdated, fileSize/2, fileSize)
 		return true
 	})
 	test.Equals(t, printerTrace{
@@ -179,8 +179,8 @@ func TestProgressTypes(t *testing.T) {
 	_, items := testProgress(func(progress *Progress) bool {
 		progress.AddFile(fileSize)
 		progress.AddFile(0)
-		progress.AddProgress("dir", true, false, fileSize, fileSize)
-		progress.AddProgress("new", false, true, 0, 0)
+		progress.AddProgress("dir", ActionDirRestored, fileSize, fileSize)
+		progress.AddProgress("new", ActionFileRestored, 0, 0)
 		return true
 	})
 	test.Equals(t, itemTrace{

--- a/internal/ui/restore/text.go
+++ b/internal/ui/restore/text.go
@@ -8,12 +8,14 @@ import (
 )
 
 type textPrinter struct {
-	terminal term
+	terminal  term
+	verbosity uint
 }
 
-func NewTextProgress(terminal term) ProgressPrinter {
+func NewTextProgress(terminal term, verbosity uint) ProgressPrinter {
 	return &textPrinter{
-		terminal: terminal,
+		terminal:  terminal,
+		verbosity: verbosity,
 	}
 }
 
@@ -29,6 +31,32 @@ func (t *textPrinter) Update(p State, duration time.Duration) {
 	}
 
 	t.terminal.SetStatus([]string{progress})
+}
+
+func (t *textPrinter) CompleteItem(messageType ItemAction, item string, size uint64) {
+	if t.verbosity < 3 {
+		return
+	}
+
+	var action string
+	switch messageType {
+	case ActionDirRestored:
+		action = "restored"
+	case ActionFileRestored:
+		action = "restored"
+	case ActionFileUpdated:
+		action = "updated"
+	case ActionFileUnchanged:
+		action = "unchanged"
+	default:
+		panic("unknown message type")
+	}
+
+	if messageType == ActionDirRestored {
+		t.terminal.Print(fmt.Sprintf("restored  %v", item))
+	} else {
+		t.terminal.Print(fmt.Sprintf("%-9v %v with size %v", action, item, ui.FormatBytes(size)))
+	}
 }
 
 func (t *textPrinter) Finish(p State, duration time.Duration) {

--- a/internal/ui/restore/text_test.go
+++ b/internal/ui/restore/text_test.go
@@ -19,37 +19,55 @@ func (m *mockTerm) SetStatus(lines []string) {
 	m.output = append([]string{}, lines...)
 }
 
-func TestPrintUpdate(t *testing.T) {
+func createTextProgress() (*mockTerm, ProgressPrinter) {
 	term := &mockTerm{}
-	printer := NewTextProgress(term)
+	printer := NewTextProgress(term, 3)
+	return term, printer
+}
+
+func TestPrintUpdate(t *testing.T) {
+	term, printer := createTextProgress()
 	printer.Update(State{3, 11, 0, 29, 47, 0}, 5*time.Second)
 	test.Equals(t, []string{"[0:05] 61.70%  3 files/dirs 29 B, total 11 files/dirs 47 B"}, term.output)
 }
 
 func TestPrintUpdateWithSkipped(t *testing.T) {
-	term := &mockTerm{}
-	printer := NewTextProgress(term)
+	term, printer := createTextProgress()
 	printer.Update(State{3, 11, 2, 29, 47, 59}, 5*time.Second)
 	test.Equals(t, []string{"[0:05] 61.70%  3 files/dirs 29 B, total 11 files/dirs 47 B, skipped 2 files/dirs 59 B"}, term.output)
 }
 
 func TestPrintSummaryOnSuccess(t *testing.T) {
-	term := &mockTerm{}
-	printer := NewTextProgress(term)
+	term, printer := createTextProgress()
 	printer.Finish(State{11, 11, 0, 47, 47, 0}, 5*time.Second)
 	test.Equals(t, []string{"Summary: Restored 11 files/dirs (47 B) in 0:05"}, term.output)
 }
 
 func TestPrintSummaryOnErrors(t *testing.T) {
-	term := &mockTerm{}
-	printer := NewTextProgress(term)
+	term, printer := createTextProgress()
 	printer.Finish(State{3, 11, 0, 29, 47, 0}, 5*time.Second)
 	test.Equals(t, []string{"Summary: Restored 3 / 11 files/dirs (29 B / 47 B) in 0:05"}, term.output)
 }
 
 func TestPrintSummaryOnSuccessWithSkipped(t *testing.T) {
-	term := &mockTerm{}
-	printer := NewTextProgress(term)
+	term, printer := createTextProgress()
 	printer.Finish(State{11, 11, 2, 47, 47, 59}, 5*time.Second)
 	test.Equals(t, []string{"Summary: Restored 11 files/dirs (47 B) in 0:05, skipped 2 files/dirs 59 B"}, term.output)
+}
+
+func TestPrintCompleteItem(t *testing.T) {
+	for _, data := range []struct {
+		action   ItemAction
+		size     uint64
+		expected string
+	}{
+		{ActionDirRestored, 0, "restored  test"},
+		{ActionFileRestored, 123, "restored  test with size 123 B"},
+		{ActionFileUpdated, 123, "updated   test with size 123 B"},
+		{ActionFileUnchanged, 123, "unchanged test with size 123 B"},
+	} {
+		term, printer := createTextProgress()
+		printer.CompleteItem(data.action, "test", data.size)
+		test.Equals(t, []string{data.expected}, term.output)
+	}
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Based on https://github.com/restic/restic/pull/4837 and https://github.com/restic/restic/pull/4838

Add a `--dry-run` option for the restore command. Using this option, restore will only work on metadata basis. In addition, the PR introduces a new verbose status output for the `restore` command. See the docs changes for an example snippet. Other possible line prefixes except `restored` are `skipped` (due to --overwrite=...) and `unchanged` (if the verification of existing files considers a file to be up-to-date).

- [ ] Discuss and polish restore output

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
`restore --dry-run` has been discussed in various places, including https://github.com/restic/restic/issues/2796 . However, no details on the log messages have been discussed.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
