### PR TITLE
backend: Improve timeout error message

### DIFF
--- a/changelog/unreleased/issue-4627
+++ b/changelog/unreleased/issue-4627
@@ -29,3 +29,4 @@ https://github.com/restic/restic/issues/1523
 https://github.com/restic/restic/pull/4520
 https://github.com/restic/restic/pull/4800
 https://github.com/restic/restic/pull/4784
+https://github.com/restic/restic/pull/4844

--- a/internal/backend/http_transport.go
+++ b/internal/backend/http_transport.go
@@ -143,7 +143,7 @@ func Transport(opts TransportOptions) (http.RoundTripper, error) {
 	}
 
 	if feature.Flag.Enabled(feature.BackendErrorRedesign) {
-		rt = newWatchdogRoundtripper(rt, 120*time.Second, 128*1024)
+		rt = newWatchdogRoundtripper(rt, 5*time.Minute, 128*1024)
 	}
 
 	// wrap in the debug round tripper (if active)

--- a/internal/backend/watchdog_roundtriper_test.go
+++ b/internal/backend/watchdog_roundtriper_test.go
@@ -23,8 +23,11 @@ func TestRead(t *testing.T) {
 	onClose := func() {
 		closed = true
 	}
+	isTimeout := func(err error) bool {
+		return false
+	}
 
-	wd := newWatchdogReadCloser(io.NopCloser(bytes.NewReader(data)), 1, kick, onClose)
+	wd := newWatchdogReadCloser(io.NopCloser(bytes.NewReader(data)), 1, kick, onClose, isTimeout)
 
 	out, err := io.ReadAll(wd)
 	rtest.OK(t, err)
@@ -196,6 +199,6 @@ func TestDownloadTimeout(t *testing.T) {
 	rtest.Equals(t, 200, resp.StatusCode, "unexpected status code")
 
 	_, err = io.ReadAll(resp.Body)
-	rtest.Equals(t, context.Canceled, err, "response download not canceled")
+	rtest.Equals(t, errRequestTimeout, err, "response download not canceled")
 	rtest.OK(t, resp.Body.Close())
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
When a request is canceled due to lack of progress, it resulted in a "context canceled" error, which is rather confusing. Now, a "request timeout" error is shown instead. In addition, I've increased the timeout from 2 to 5 minutes.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See https://forum.restic.net/t/context-canceled-errors-on-current-master/7630
Fixes https://github.com/restic/restic/pull/4792
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
