### PR TITLE
Fix error handling bug + clean up error messages

### DIFF
--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -280,7 +280,7 @@ func readPassword(in io.Reader) (password string, err error) {
 	sc := bufio.NewScanner(in)
 	sc.Scan()
 
-	return sc.Text(), errors.Wrap(err, "Scan")
+	return sc.Text(), errors.WithStack(sc.Err())
 }
 
 // readPasswordTerminal reads the password from the given reader which must be a

--- a/cmd/restic/global_test.go
+++ b/cmd/restic/global_test.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/restic/restic/internal/errors"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -20,6 +21,16 @@ func Test_PrintFunctionsRespectsGlobalStdout(t *testing.T) {
 		})
 		rtest.Equals(t, "message\n", buf.String())
 	}
+}
+
+type errorReader struct{ err error }
+
+func (r *errorReader) Read([]byte) (int, error) { return 0, r.err }
+
+func TestReadPassword(t *testing.T) {
+	want := errors.New("foo")
+	_, err := readPassword(&errorReader{want})
+	rtest.Assert(t, errors.Is(err, want), "wrong error %v", err)
 }
 
 func TestReadRepo(t *testing.T) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

readPassword in cmd/restic/global.go was ignoring errors.

Also cleaned up error messages in backend/gs, which were talking about local variables that no longer exist and older versions of the Google SDK.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
