### PR TITLE
azure: Improve error message in azure.Create()

### DIFF
--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -161,7 +161,7 @@ func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (*Backend, er
 			return nil, errors.Wrap(err, "container.Create")
 		}
 	} else if err != nil {
-		return be, err
+		return be, errors.Wrap(err, "container.GetProperties")
 	}
 
 	return be, nil


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It just wraps an error message shown when repository initialization fails, so that it's more clear what operation was attempted.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Not at all, it was just discovered when trying to initialize a repository without the needed permission to get properties for a container. Without this clarification to the error message, it wasn't very clear what the cause of the problem was.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
