### PR TITLE
Use character display width for table padding

### DIFF
--- a/internal/ui/format.go
+++ b/internal/ui/format.go
@@ -8,6 +8,8 @@ import (
 	"math/bits"
 	"strconv"
 	"time"
+
+	"golang.org/x/text/width"
 )
 
 func FormatBytes(c uint64) string {
@@ -104,4 +106,25 @@ func ToJSONString(status interface{}) string {
 		panic(err)
 	}
 	return buf.String()
+}
+
+// TerminalDisplayWidth returns the number of terminal cells needed to display s
+func TerminalDisplayWidth(s string) int {
+	width := 0
+	for _, r := range s {
+		width += terminalDisplayRuneWidth(r)
+	}
+
+	return width
+}
+
+func terminalDisplayRuneWidth(r rune) int {
+	switch width.LookupRune(r).Kind() {
+	case width.EastAsianWide, width.EastAsianFullwidth:
+		return 2
+	case width.EastAsianNarrow, width.EastAsianHalfwidth, width.EastAsianAmbiguous, width.Neutral:
+		return 1
+	default:
+		return 0
+	}
 }

--- a/internal/ui/format_test.go
+++ b/internal/ui/format_test.go
@@ -84,3 +84,21 @@ func TestParseBytesInvalid(t *testing.T) {
 		test.Equals(t, int64(0), v)
 	}
 }
+
+func TestTerminalDisplayWidth(t *testing.T) {
+	for _, c := range []struct {
+		input string
+		want  int
+	}{
+		{"foo", 3},
+		{"aéb", 3},
+		{"ab", 3},
+		{"a’b", 3},
+		{"aあb", 4},
+	} {
+		if got := TerminalDisplayWidth(c.input); got != c.want {
+			t.Errorf("wrong display width for '%s', want %d, got %d", c.input, c.want, got)
+		}
+	}
+
+}

--- a/internal/ui/table/table.go
+++ b/internal/ui/table/table.go
@@ -141,16 +141,18 @@ func (t *Table) Write(w io.Writer) error {
 	columnWidths := make([]int, columns)
 	for i, desc := range t.columns {
 		for _, line := range strings.Split(desc, "\n") {
-			if columnWidths[i] < ui.TerminalDisplayWidth(line) {
-				columnWidths[i] = ui.TerminalDisplayWidth(line)
+			width := ui.TerminalDisplayWidth(line)
+			if columnWidths[i] < width {
+				columnWidths[i] = width
 			}
 		}
 	}
 	for _, line := range lines {
 		for i, content := range line {
 			for _, l := range strings.Split(content, "\n") {
-				if columnWidths[i] < ui.TerminalDisplayWidth(l) {
-					columnWidths[i] = ui.TerminalDisplayWidth(l)
+				width := ui.TerminalDisplayWidth(l)
+				if columnWidths[i] < width {
+					columnWidths[i] = width
 				}
 			}
 		}

--- a/internal/ui/table/table.go
+++ b/internal/ui/table/table.go
@@ -142,7 +142,7 @@ func (t *Table) Write(w io.Writer) error {
 	for i, desc := range t.columns {
 		for _, line := range strings.Split(desc, "\n") {
 			if columnWidths[i] < ui.TerminalDisplayWidth(line) {
-				columnWidths[i] = ui.TerminalDisplayWidth(desc)
+				columnWidths[i] = ui.TerminalDisplayWidth(line)
 			}
 		}
 	}

--- a/internal/ui/table/table.go
+++ b/internal/ui/table/table.go
@@ -6,6 +6,8 @@ import (
 	"strings"
 
 	"text/template"
+
+	"github.com/restic/restic/internal/ui"
 )
 
 // Table contains data for a table to be printed.
@@ -89,7 +91,7 @@ func printLine(w io.Writer, print func(io.Writer, string) error, sep string, dat
 			}
 
 			// apply padding
-			pad := widths[fieldNum] - len(v)
+			pad := widths[fieldNum] - ui.TerminalDisplayWidth(v)
 			if pad > 0 {
 				v += strings.Repeat(" ", pad)
 			}
@@ -139,16 +141,16 @@ func (t *Table) Write(w io.Writer) error {
 	columnWidths := make([]int, columns)
 	for i, desc := range t.columns {
 		for _, line := range strings.Split(desc, "\n") {
-			if columnWidths[i] < len(line) {
-				columnWidths[i] = len(desc)
+			if columnWidths[i] < ui.TerminalDisplayWidth(line) {
+				columnWidths[i] = ui.TerminalDisplayWidth(desc)
 			}
 		}
 	}
 	for _, line := range lines {
 		for i, content := range line {
 			for _, l := range strings.Split(content, "\n") {
-				if columnWidths[i] < len(l) {
-					columnWidths[i] = len(l)
+				if columnWidths[i] < ui.TerminalDisplayWidth(l) {
+					columnWidths[i] = ui.TerminalDisplayWidth(l)
 				}
 			}
 		}
@@ -159,7 +161,7 @@ func (t *Table) Write(w io.Writer) error {
 	for _, width := range columnWidths {
 		totalWidth += width
 	}
-	totalWidth += (columns - 1) * len(t.CellSeparator)
+	totalWidth += (columns - 1) * ui.TerminalDisplayWidth(t.CellSeparator)
 
 	// write header
 	if len(t.columns) > 0 {

--- a/internal/ui/table/table_test.go
+++ b/internal/ui/table/table_test.go
@@ -126,7 +126,7 @@ foo        2018-08-19 22:22:22  xxx  other  /home/user/other
 					Time       string
 					Tags, Dirs []string
 				}
-				table.AddRow(data{"foo", "2018-08-19 22:22:22", []string{"work", "go"}, []string{"/home/user/work", "/home/user/go"}})
+				table.AddRow(data{"foo", "2018-08-19 22:22:22", []string{"work", "go’s"}, []string{"/home/user/work", "/home/user/go"}})
 				table.AddRow(data{"foo", "2018-08-19 22:22:22", []string{"other"}, []string{"/home/user/other"}})
 				table.AddRow(data{"foo", "2018-08-19 22:22:22", []string{"other", "bar"}, []string{"/home/user/other"}})
 				return table
@@ -135,7 +135,7 @@ foo        2018-08-19 22:22:22  xxx  other  /home/user/other
 host name  time                 zz   tags   dirs
 ------------------------------------------------------------
 foo        2018-08-19 22:22:22  xxx  work   /home/user/work
-                                     go     /home/user/go
+                                     go’s   /home/user/go
 foo        2018-08-19 22:22:22  xxx  other  /home/user/other
 foo        2018-08-19 22:22:22  xxx  other  /home/user/other
                                      bar

--- a/internal/ui/table/table_test.go
+++ b/internal/ui/table/table_test.go
@@ -34,6 +34,21 @@ data: first data field
 		{
 			func(t testing.TB) *Table {
 				table := New()
+				table.AddColumn("first\ncolumn", "{{.First}}")
+				table.AddRow(struct{ First string }{"data"})
+				return table
+			},
+			`
+first
+column
+------
+data
+------
+`,
+		},
+		{
+			func(t testing.TB) *Table {
+				table := New()
 				table.AddColumn("  first column  ", "data: {{.First}}")
 				table.AddRow(struct{ First string }{"d"})
 				return table


### PR DESCRIPTION


<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Using len(...) for table cell padding produced wrong results for unicode chracters leading to misaligned tables. Implementation changed to take the actual terminal display width into consideration. 
I chose to implement a simple helper function for the width calculation. There are libraries like  [go-runewidth](https://github.com/mattn/go-runewidth) that do a better job and take more edge cases into consideration. But i'm not sure its worth the dependency.

See before/after:
![20240605_09h57m56s_grim](https://github.com/restic/restic/assets/347446/4502cbc1-a287-4517-acb1-a37417b06314)
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #4834 
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
