### PR TITLE
key add/passwd: handle UTF-16 encoding correctly

### DIFF
--- a/changelog/unreleased/issue-4850
+++ b/changelog/unreleased/issue-4850
@@ -1,0 +1,8 @@
+Bugfix: correctly handle UTF-16 password files in `key add/passwd`
+
+`key add` and `key passwd` did not properly decode UTF-16 encoded password read
+from a password file. This has been fix to match the decoding when opening a
+repository.
+
+https://github.com/restic/restic/issues/4850
+https://github.com/restic/restic/pull/4851

--- a/cmd/restic/cmd_key_add.go
+++ b/cmd/restic/cmd_key_add.go
@@ -3,8 +3,6 @@ package main
 import (
 	"context"
 	"fmt"
-	"os"
-	"strings"
 
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
@@ -121,14 +119,6 @@ func getNewPassword(ctx context.Context, gopts GlobalOptions, newPasswordFile st
 	return ReadPasswordTwice(ctx, newopts,
 		"enter new password: ",
 		"enter password again: ")
-}
-
-func loadPasswordFromFile(pwdFile string) (string, error) {
-	s, err := os.ReadFile(pwdFile)
-	if os.IsNotExist(err) {
-		return "", errors.Fatalf("%s does not exist", pwdFile)
-	}
-	return strings.TrimSpace(string(s)), errors.Wrap(err, "Readfile")
 }
 
 func switchToNewKeyAndRemoveIfBroken(ctx context.Context, repo *repository.Repository, key *repository.Key, pw string) error {

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -268,11 +268,7 @@ func resolvePassword(opts GlobalOptions, envStr string) (string, error) {
 		return (strings.TrimSpace(string(output))), nil
 	}
 	if opts.PasswordFile != "" {
-		s, err := textfile.Read(opts.PasswordFile)
-		if errors.Is(err, os.ErrNotExist) {
-			return "", errors.Fatalf("%s does not exist", opts.PasswordFile)
-		}
-		return strings.TrimSpace(string(s)), errors.Wrap(err, "Readfile")
+		return loadPasswordFromFile(opts.PasswordFile)
 	}
 
 	if pwd := os.Getenv(envStr); pwd != "" {
@@ -280,6 +276,16 @@ func resolvePassword(opts GlobalOptions, envStr string) (string, error) {
 	}
 
 	return "", nil
+}
+
+// loadPasswordFromFile loads a password from a file while stripping a BOM and
+// converting the password to UTF-8.
+func loadPasswordFromFile(pwdFile string) (string, error) {
+	s, err := textfile.Read(pwdFile)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", errors.Fatalf("%s does not exist", pwdFile)
+	}
+	return strings.TrimSpace(string(s)), errors.Wrap(err, "Readfile")
 }
 
 // readPassword reads the password from the given reader directly.


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Just use the exact some function for load a password from a file everywhere.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/4850
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
