### PR TITLE
update release verification script for latest docker

### DIFF
--- a/doc/developer_information.rst
+++ b/doc/developer_information.rst
@@ -123,7 +123,7 @@ The specified go compiler version must match the one used to build the official
 binaries. For example, for restic 0.16.2 the command would be
 ``helpers/verify-release-binaries.sh 0.16.2 1.21.3``.
 
-The script requires bash, curl, docker, git, gpg, shasum and tar.
+The script requires bash, curl, docker (version >= 25.0), git, gpg, shasum and tar.
 
 The script first downloads all release binaries, checks the SHASUM256 file and its
 signature. Afterwards it checks that the tarball matches the restic git repository

--- a/helpers/verify-release-binaries.sh
+++ b/helpers/verify-release-binaries.sh
@@ -89,13 +89,14 @@ extract_docker() {
     restic_platform=$3
     out=restic_${restic_version}_linux_${restic_platform}.bz2
 
+    # requires at least docker 25.0
     docker image pull --platform "linux/${docker_platform}" ${image}:${restic_version} > /dev/null
     docker image save ${image}:${restic_version} -o docker.tar
 
     mkdir img
-    tar xvf docker.tar -C img --wildcards \*/layer.tar > /dev/null
+    tar xvf docker.tar -C img --wildcards blobs/sha256/\* > /dev/null
     rm docker.tar
-    for i in img/*/layer.tar; do
+    for i in img/blobs/sha256/*; do
         tar -xvf "$i" -C img usr/bin/restic 2> /dev/null 1>&2 || true
         if [[ -f img/usr/bin/restic ]]; then
             if [[ -f restic-docker ]]; then


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The script no longer worked with Docker >= 25.0 as `docker image save` now outputs OCI compliant tarballs. Adapt the script to use the new tarball structure.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
