### PR TITLE
restore: improve file type mismatch handling

### DIFF
--- a/changelog/unreleased/issue-4817
+++ b/changelog/unreleased/issue-4817
@@ -20,3 +20,4 @@ https://github.com/restic/restic/issues/407
 https://github.com/restic/restic/issues/2662
 https://github.com/restic/restic/pull/4837
 https://github.com/restic/restic/pull/4838
+https://github.com/restic/restic/pull/4864

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -348,11 +348,6 @@ func (node Node) writeNodeContent(ctx context.Context, repo BlobLoader, f *os.Fi
 }
 
 func (node Node) createSymlinkAt(path string) error {
-
-	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
-		return errors.Wrap(err, "Symlink")
-	}
-
 	if err := fs.Symlink(node.LinkTarget, path); err != nil {
 		return errors.WithStack(err)
 	}

--- a/internal/restic/node_xattr_all_test.go
+++ b/internal/restic/node_xattr_all_test.go
@@ -1,0 +1,44 @@
+//go:build darwin || freebsd || linux || solaris || windows
+// +build darwin freebsd linux solaris windows
+
+package restic
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func setAndVerifyXattr(t *testing.T, file string, attrs []ExtendedAttribute) {
+	node := Node{
+		ExtendedAttributes: attrs,
+	}
+	rtest.OK(t, node.restoreExtendedAttributes(file))
+
+	nodeActual := Node{}
+	rtest.OK(t, nodeActual.fillExtendedAttributes(file, false))
+
+	rtest.Assert(t, nodeActual.sameExtendedAttributes(node), "xattr mismatch got %v expected %v", nodeActual.ExtendedAttributes, node.ExtendedAttributes)
+}
+
+func TestOverwriteXattr(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "file")
+	rtest.OK(t, os.WriteFile(file, []byte("hello world"), 0o600))
+
+	setAndVerifyXattr(t, file, []ExtendedAttribute{
+		{
+			Name:  "user.foo",
+			Value: []byte("bar"),
+		},
+	})
+
+	setAndVerifyXattr(t, file, []ExtendedAttribute{
+		{
+			Name:  "user.other",
+			Value: []byte("some"),
+		},
+	})
+}

--- a/internal/restorer/fileswriter.go
+++ b/internal/restorer/fileswriter.go
@@ -1,11 +1,15 @@
 package restorer
 
 import (
+	"fmt"
+	stdfs "io/fs"
 	"os"
 	"sync"
+	"syscall"
 
 	"github.com/cespare/xxhash/v2"
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
 )
 
@@ -39,13 +43,26 @@ func newFilesWriter(count int) *filesWriter {
 	}
 }
 
-func createFile(path string, createSize int64, sparse bool) (*os.File, error) {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0600)
+func openFile(path string) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_WRONLY|fs.O_NOFOLLOW, 0600)
 	if err != nil {
-		if !fs.IsAccessDenied(err) {
-			return nil, err
-		}
+		return nil, err
+	}
+	fi, err := f.Stat()
+	if err != nil {
+		_ = f.Close()
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		_ = f.Close()
+		return nil, fmt.Errorf("unexpected file type %v at %q", fi.Mode().Type(), path)
+	}
+	return f, nil
+}
 
+func createFile(path string, createSize int64, sparse bool) (*os.File, error) {
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|fs.O_NOFOLLOW, 0600)
+	if err != nil && fs.IsAccessDenied(err) {
 		// If file is readonly, clear the readonly flag by resetting the
 		// permissions of the file and try again
 		// as the metadata will be set again in the second pass and the
@@ -53,40 +70,75 @@ func createFile(path string, createSize int64, sparse bool) (*os.File, error) {
 		if err = fs.ResetPermissions(path); err != nil {
 			return nil, err
 		}
-		if f, err = os.OpenFile(path, os.O_WRONLY, 0600); err != nil {
+		if f, err = os.OpenFile(path, os.O_WRONLY|fs.O_NOFOLLOW, 0600); err != nil {
+			return nil, err
+		}
+	} else if err != nil && (errors.Is(err, syscall.ELOOP) || errors.Is(err, syscall.EISDIR)) {
+		// symlink or directory, try to remove it later on
+		f = nil
+	} else if err != nil {
+		return nil, err
+	}
+
+	var fi stdfs.FileInfo
+	if f != nil {
+		// stat to check that we've opened a regular file
+		fi, err = f.Stat()
+		if err != nil {
+			_ = f.Close()
+			return nil, err
+		}
+	}
+	if f == nil || !fi.Mode().IsRegular() {
+		// close handle if we still have it
+		if f != nil {
+			if err := f.Close(); err != nil {
+				return nil, err
+			}
+		}
+
+		// not what we expected, try to get rid of it
+		if err := os.Remove(path); err != nil {
+			return nil, err
+		}
+		// create a new file, pass O_EXCL to make sure there are no surprises
+		f, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL|fs.O_NOFOLLOW, 0600)
+		if err != nil {
+			return nil, err
+		}
+		fi, err = f.Stat()
+		if err != nil {
+			_ = f.Close()
 			return nil, err
 		}
 	}
 
+	return ensureSize(f, fi, createSize, sparse)
+}
+
+func ensureSize(f *os.File, fi stdfs.FileInfo, createSize int64, sparse bool) (*os.File, error) {
 	if sparse {
-		err = truncateSparse(f, createSize)
+		err := truncateSparse(f, createSize)
 		if err != nil {
 			_ = f.Close()
 			return nil, err
 		}
-	} else {
-		info, err := f.Stat()
+	} else if fi.Size() > createSize {
+		// file is too long must shorten it
+		err := f.Truncate(createSize)
 		if err != nil {
 			_ = f.Close()
 			return nil, err
 		}
-		if info.Size() > createSize {
-			// file is too long must shorten it
-			err = f.Truncate(createSize)
-			if err != nil {
-				_ = f.Close()
-				return nil, err
-			}
-		} else if createSize > 0 {
-			err := fs.PreallocateFile(f, createSize)
-			if err != nil {
-				// Just log the preallocate error but don't let it cause the restore process to fail.
-				// Preallocate might return an error if the filesystem (implementation) does not
-				// support preallocation or our parameters combination to the preallocate call
-				// This should yield a syscall.ENOTSUP error, but some other errors might also
-				// show up.
-				debug.Log("Failed to preallocate %v with size %v: %v", path, createSize, err)
-			}
+	} else if createSize > 0 {
+		err := fs.PreallocateFile(f, createSize)
+		if err != nil {
+			// Just log the preallocate error but don't let it cause the restore process to fail.
+			// Preallocate might return an error if the filesystem (implementation) does not
+			// support preallocation or our parameters combination to the preallocate call
+			// This should yield a syscall.ENOTSUP error, but some other errors might also
+			// show up.
+			debug.Log("Failed to preallocate %v with size %v: %v", f.Name(), createSize, err)
 		}
 	}
 	return f, nil
@@ -110,7 +162,7 @@ func (w *filesWriter) writeToFile(path string, blob []byte, offset int64, create
 			if err != nil {
 				return nil, err
 			}
-		} else if f, err = os.OpenFile(path, os.O_WRONLY, 0600); err != nil {
+		} else if f, err = openFile(path); err != nil {
 			return nil, err
 		}
 

--- a/internal/restorer/fileswriter.go
+++ b/internal/restorer/fileswriter.go
@@ -44,7 +44,7 @@ func newFilesWriter(count int) *filesWriter {
 }
 
 func openFile(path string) (*os.File, error) {
-	f, err := os.OpenFile(path, os.O_WRONLY|fs.O_NOFOLLOW, 0600)
+	f, err := fs.OpenFile(path, fs.O_WRONLY|fs.O_NOFOLLOW, 0600)
 	if err != nil {
 		return nil, err
 	}
@@ -61,7 +61,7 @@ func openFile(path string) (*os.File, error) {
 }
 
 func createFile(path string, createSize int64, sparse bool) (*os.File, error) {
-	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|fs.O_NOFOLLOW, 0600)
+	f, err := fs.OpenFile(path, fs.O_CREATE|fs.O_WRONLY|fs.O_NOFOLLOW, 0600)
 	if err != nil && fs.IsAccessDenied(err) {
 		// If file is readonly, clear the readonly flag by resetting the
 		// permissions of the file and try again
@@ -70,7 +70,7 @@ func createFile(path string, createSize int64, sparse bool) (*os.File, error) {
 		if err = fs.ResetPermissions(path); err != nil {
 			return nil, err
 		}
-		if f, err = os.OpenFile(path, os.O_WRONLY|fs.O_NOFOLLOW, 0600); err != nil {
+		if f, err = fs.OpenFile(path, fs.O_WRONLY|fs.O_NOFOLLOW, 0600); err != nil {
 			return nil, err
 		}
 	} else if err != nil && (errors.Is(err, syscall.ELOOP) || errors.Is(err, syscall.EISDIR)) {
@@ -109,11 +109,11 @@ func createFile(path string, createSize int64, sparse bool) (*os.File, error) {
 		}
 
 		// not what we expected, try to get rid of it
-		if err := os.Remove(path); err != nil {
+		if err := fs.Remove(path); err != nil {
 			return nil, err
 		}
 		// create a new file, pass O_EXCL to make sure there are no surprises
-		f, err = os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_EXCL|fs.O_NOFOLLOW, 0600)
+		f, err = fs.OpenFile(path, fs.O_CREATE|fs.O_WRONLY|fs.O_EXCL|fs.O_NOFOLLOW, 0600)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/restorer/fileswriter_other_test.go
+++ b/internal/restorer/fileswriter_other_test.go
@@ -1,0 +1,10 @@
+//go:build !windows
+// +build !windows
+
+package restorer
+
+import "syscall"
+
+func notEmptyDirError() error {
+	return syscall.ENOTEMPTY
+}

--- a/internal/restorer/fileswriter_test.go
+++ b/internal/restorer/fileswriter_test.go
@@ -1,9 +1,13 @@
 package restorer
 
 import (
+	"fmt"
 	"os"
+	"path/filepath"
+	"syscall"
 	"testing"
 
+	"github.com/restic/restic/internal/errors"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -33,4 +37,77 @@ func TestFilesWriterBasic(t *testing.T) {
 	buf, err = os.ReadFile(f2)
 	rtest.OK(t, err)
 	rtest.Equals(t, []byte{2, 2}, buf)
+}
+
+func TestCreateFile(t *testing.T) {
+	basepath := filepath.Join(t.TempDir(), "test")
+
+	scenarios := []struct {
+		name   string
+		create func(t testing.TB, path string)
+		err    error
+	}{
+		{
+			"file",
+			func(t testing.TB, path string) {
+				rtest.OK(t, os.WriteFile(path, []byte("test-test-test-data"), 0o400))
+			},
+			nil,
+		},
+		{
+			"empty dir",
+			func(t testing.TB, path string) {
+				rtest.OK(t, os.Mkdir(path, 0o400))
+			},
+			nil,
+		},
+		{
+			"symlink",
+			func(t testing.TB, path string) {
+				rtest.OK(t, os.Symlink("./something", path))
+			},
+			nil,
+		},
+		{
+			"filled dir",
+			func(t testing.TB, path string) {
+				rtest.OK(t, os.Mkdir(path, 0o700))
+				rtest.OK(t, os.WriteFile(filepath.Join(path, "file"), []byte("data"), 0o400))
+			},
+			syscall.ENOTEMPTY,
+		},
+	}
+
+	tests := []struct {
+		size     int64
+		isSparse bool
+	}{
+		{5, false},
+		{21, false},
+		{100, false},
+		{5, true},
+		{21, true},
+		{100, true},
+	}
+
+	for i, sc := range scenarios {
+		t.Run(sc.name, func(t *testing.T) {
+			for _, test := range tests {
+				path := basepath + fmt.Sprintf("%v", i)
+				sc.create(t, path)
+				f, err := createFile(path, test.size, test.isSparse)
+				if sc.err == nil {
+					rtest.OK(t, err)
+					fi, err := f.Stat()
+					rtest.OK(t, err)
+					rtest.Assert(t, fi.Mode().IsRegular(), "wrong filetype %v", fi.Mode())
+					rtest.Assert(t, fi.Size() <= test.size, "unexpected file size expected %v, got %v", test.size, fi.Size())
+					rtest.OK(t, f.Close())
+				} else {
+					rtest.Assert(t, errors.Is(err, sc.err), "unexpected error got %v expected %v", err, sc.err)
+				}
+				rtest.OK(t, os.RemoveAll(path))
+			}
+		})
+	}
 }

--- a/internal/restorer/fileswriter_windows_test.go
+++ b/internal/restorer/fileswriter_windows_test.go
@@ -1,0 +1,7 @@
+package restorer
+
+import "syscall"
+
+func notEmptyDirError() error {
+	return syscall.ERROR_DIR_NOT_EMPTY
+}

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -221,6 +221,9 @@ func (res *Restorer) traverseTree(ctx context.Context, target, location string, 
 
 func (res *Restorer) restoreNodeTo(ctx context.Context, node *restic.Node, target, location string) error {
 	debug.Log("restoreNode %v %v %v", node.Name, target, location)
+	if err := fs.Remove(target); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return errors.Wrap(err, "RemoveNode")
+	}
 
 	err := node.CreateAt(ctx, target, res.repo)
 	if err != nil {
@@ -242,7 +245,7 @@ func (res *Restorer) restoreNodeMetadataTo(node *restic.Node, target, location s
 }
 
 func (res *Restorer) restoreHardlinkAt(node *restic.Node, target, path, location string) error {
-	if err := fs.Remove(path); !os.IsNotExist(err) {
+	if err := fs.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 		return errors.Wrap(err, "RemoveCreateHardlink")
 	}
 	err := fs.Link(target, path)

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -541,7 +541,7 @@ func (s *fileState) HasMatchingBlob(i int) bool {
 // Reusing buffers prevents the verifier goroutines allocating all of RAM and
 // flushing the filesystem cache (at least on Linux).
 func (res *Restorer) verifyFile(target string, node *restic.Node, failFast bool, trustMtime bool, buf []byte) (*fileState, []byte, error) {
-	f, err := os.OpenFile(target, fs.O_RDONLY|fs.O_NOFOLLOW, 0)
+	f, err := fs.OpenFile(target, fs.O_RDONLY|fs.O_NOFOLLOW, 0)
 	if err != nil {
 		return nil, buf, err
 	}

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -1040,6 +1040,7 @@ func TestRestorerOverwriteSpecial(t *testing.T) {
 			"link":     Symlink{Target: "foo", ModTime: baseTime},
 			"file":     File{Data: "content: file\n", Inode: 42, Links: 2, ModTime: baseTime},
 			"hardlink": File{Data: "content: file\n", Inode: 42, Links: 2, ModTime: baseTime},
+			"newdir":   File{Data: "content: dir\n", ModTime: baseTime},
 		},
 	}
 	overwriteSnapshot := Snapshot{
@@ -1048,6 +1049,7 @@ func TestRestorerOverwriteSpecial(t *testing.T) {
 			"link":     File{Data: "content: link\n", Inode: 42, Links: 2, ModTime: baseTime.Add(time.Second)},
 			"file":     Symlink{Target: "foo2", ModTime: baseTime},
 			"hardlink": File{Data: "content: link\n", Inode: 42, Links: 2, ModTime: baseTime.Add(time.Second)},
+			"newdir":   Dir{ModTime: baseTime},
 		},
 	}
 

--- a/internal/restorer/sparsewrite.go
+++ b/internal/restorer/sparsewrite.go
@@ -1,6 +1,3 @@
-//go:build !windows
-// +build !windows
-
 package restorer
 
 import (


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
For an in-place restore, the existing file can have a different file type than in the snapshot. This PR adds code for various corner cases that arise in this scenario. Directories are only replaced if they are empty.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Part of #4817
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
