### PR TITLE
Fix xattr backup on windows

### DIFF
--- a/internal/fs/file_windows.go
+++ b/internal/fs/file_windows.go
@@ -103,3 +103,21 @@ func ClearAttribute(path string, attribute uint32) error {
 	}
 	return nil
 }
+
+// OpenHandleForEA return a file handle for file or dir for setting/getting EAs
+func OpenHandleForEA(nodeType, path string) (handle windows.Handle, err error) {
+	path = fixpath(path)
+	switch nodeType {
+	case "file":
+		utf16Path := windows.StringToUTF16Ptr(path)
+		fileAccessRightReadWriteEA := (0x8 | 0x10)
+		handle, err = windows.CreateFile(utf16Path, uint32(fileAccessRightReadWriteEA), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
+	case "dir":
+		utf16Path := windows.StringToUTF16Ptr(path)
+		fileAccessRightReadWriteEA := (0x8 | 0x10)
+		handle, err = windows.CreateFile(utf16Path, uint32(fileAccessRightReadWriteEA), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	default:
+		return 0, nil
+	}
+	return handle, err
+}

--- a/internal/fs/file_windows.go
+++ b/internal/fs/file_windows.go
@@ -105,17 +105,20 @@ func ClearAttribute(path string, attribute uint32) error {
 }
 
 // OpenHandleForEA return a file handle for file or dir for setting/getting EAs
-func OpenHandleForEA(nodeType, path string) (handle windows.Handle, err error) {
+func OpenHandleForEA(nodeType, path string, writeAccess bool) (handle windows.Handle, err error) {
 	path = fixpath(path)
+	fileAccess := windows.FILE_READ_EA
+	if writeAccess {
+		fileAccess = fileAccess | windows.FILE_WRITE_EA
+	}
+
 	switch nodeType {
 	case "file":
 		utf16Path := windows.StringToUTF16Ptr(path)
-		fileAccessRightReadWriteEA := (0x8 | 0x10)
-		handle, err = windows.CreateFile(utf16Path, uint32(fileAccessRightReadWriteEA), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
+		handle, err = windows.CreateFile(utf16Path, uint32(fileAccess), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
 	case "dir":
 		utf16Path := windows.StringToUTF16Ptr(path)
-		fileAccessRightReadWriteEA := (0x8 | 0x10)
-		handle, err = windows.CreateFile(utf16Path, uint32(fileAccessRightReadWriteEA), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+		handle, err = windows.CreateFile(utf16Path, uint32(fileAccess), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
 	default:
 		return 0, nil
 	}

--- a/internal/restic/node_windows.go
+++ b/internal/restic/node_windows.go
@@ -88,7 +88,7 @@ func (node Node) restoreExtendedAttributes(path string) (err error) {
 // fill extended attributes in the node. This also includes the Generic attributes for windows.
 func (node *Node) fillExtendedAttributes(path string, _ bool) (err error) {
 	var fileHandle windows.Handle
-	if fileHandle, err = getFileHandleForEA(node.Type, path); fileHandle == 0 {
+	if fileHandle, err = fs.OpenHandleForEA(node.Type, path); fileHandle == 0 {
 		return nil
 	}
 	if err != nil {
@@ -118,23 +118,6 @@ func (node *Node) fillExtendedAttributes(path string, _ bool) (err error) {
 	return nil
 }
 
-// Get file handle for file or dir for setting/getting EAs
-func getFileHandleForEA(nodeType, path string) (handle windows.Handle, err error) {
-	switch nodeType {
-	case "file":
-		utf16Path := windows.StringToUTF16Ptr(path)
-		fileAccessRightReadWriteEA := (0x8 | 0x10)
-		handle, err = windows.CreateFile(utf16Path, uint32(fileAccessRightReadWriteEA), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
-	case "dir":
-		utf16Path := windows.StringToUTF16Ptr(path)
-		fileAccessRightReadWriteEA := (0x8 | 0x10)
-		handle, err = windows.CreateFile(utf16Path, uint32(fileAccessRightReadWriteEA), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
-	default:
-		return 0, nil
-	}
-	return handle, err
-}
-
 // closeFileHandle safely closes a file handle and logs any errors.
 func closeFileHandle(fileHandle windows.Handle, path string) {
 	err := windows.CloseHandle(fileHandle)
@@ -147,7 +130,7 @@ func closeFileHandle(fileHandle windows.Handle, path string) {
 // The Windows API requires setting of all the Extended Attributes in one call.
 func restoreExtendedAttributes(nodeType, path string, eas []fs.ExtendedAttribute) (err error) {
 	var fileHandle windows.Handle
-	if fileHandle, err = getFileHandleForEA(nodeType, path); fileHandle == 0 {
+	if fileHandle, err = fs.OpenHandleForEA(nodeType, path); fileHandle == 0 {
 		return nil
 	}
 	if err != nil {

--- a/internal/restic/node_windows.go
+++ b/internal/restic/node_windows.go
@@ -88,7 +88,7 @@ func (node Node) restoreExtendedAttributes(path string) (err error) {
 // fill extended attributes in the node. This also includes the Generic attributes for windows.
 func (node *Node) fillExtendedAttributes(path string, _ bool) (err error) {
 	var fileHandle windows.Handle
-	if fileHandle, err = fs.OpenHandleForEA(node.Type, path); fileHandle == 0 {
+	if fileHandle, err = fs.OpenHandleForEA(node.Type, path, false); fileHandle == 0 {
 		return nil
 	}
 	if err != nil {
@@ -130,7 +130,7 @@ func closeFileHandle(fileHandle windows.Handle, path string) {
 // The Windows API requires setting of all the Extended Attributes in one call.
 func restoreExtendedAttributes(nodeType, path string, eas []fs.ExtendedAttribute) (err error) {
 	var fileHandle windows.Handle
-	if fileHandle, err = fs.OpenHandleForEA(nodeType, path); fileHandle == 0 {
+	if fileHandle, err = fs.OpenHandleForEA(nodeType, path, true); fileHandle == 0 {
 		return nil
 	}
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Fixes running `restic backup c:\some\file` on Windows as regular user. This resulted in a permission denied error when trying to read xattrs from `c:\`.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/pull/4807

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
