### PR TITLE
check: improve output if repository is damaged

### DIFF
--- a/changelog/unreleased/issue-828
+++ b/changelog/unreleased/issue-828
@@ -1,11 +1,12 @@
 Enhancement: Improve `repair packs` command
 
 The `repair packs` command has been improved to also be able to process
-truncated pack files. The `check --read-data` command will provide instructions
-on using the command if necessary to repair a repository. See the guide at
-https://restic.readthedocs.io/en/stable/077_troubleshooting.html for further
-instructions.
+truncated pack files. The `check` and `check --read-data` command will provide
+instructions on using the command if necessary to repair a repository. See the
+guide at https://restic.readthedocs.io/en/stable/077_troubleshooting.html for
+further instructions.
 
 https://github.com/restic/restic/issues/828
 https://github.com/restic/restic/pull/4644
 https://github.com/restic/restic/pull/4655
+https://github.com/restic/restic/pull/4882

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -296,7 +296,8 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 		}
 	}
 
-	if orphanedPacks > 0 {
+	if orphanedPacks > 0 && !errorsFound {
+		// hide notice if repository is damaged
 		printer.P("%d additional files were found in the repo, which likely contain duplicate data.\nThis is non-critical, you can run `restic prune` to correct this.\n", orphanedPacks)
 	}
 	if ctx.Err() != nil {

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -264,7 +264,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 		term.Print("Duplicate packs are non-critical, you can run `restic repair index' to correct this.\n")
 	}
 	if suggestLegacyIndexRebuild {
-		printer.E("Found indexes using the legacy format, you must run `restic repair index' to correct this.\n")
+		printer.E("error: Found indexes using the legacy format, you must run `restic repair index' to correct this.\n")
 	}
 	if mixedFound {
 		term.Print("Mixed packs with tree and data blobs are non-critical, you can run `restic prune` to correct this.\n")
@@ -288,7 +288,8 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 			orphanedPacks++
 			printer.P("%v\n", err)
 		} else if err == checker.ErrLegacyLayout {
-			printer.P("repository still uses the S3 legacy layout\nPlease run `restic migrate s3legacy` to correct this.\n")
+			errorsFound = true
+			printer.E("error: repository still uses the S3 legacy layout\nYou must run `restic migrate s3legacy` to correct this.\n")
 		} else {
 			errorsFound = true
 			printer.E("%v\n", err)

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -274,7 +274,9 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 		for _, err := range errs {
 			printer.E("error: %v\n", err)
 		}
-		return errors.Fatal("LoadIndex returned errors")
+
+		printer.E("\nThe repository index is damaged and must be repaired. You must run `restic repair index' to correct this.\n\n")
+		return errors.Fatal("repository contains errors")
 	}
 
 	orphanedPacks := 0

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -367,13 +367,13 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 		p.Done()
 
 		if len(salvagePacks) > 0 {
-			printer.E("\nThe repository contains pack files with damaged blobs. These blobs must be removed to repair the repository. This can be done using the following commands. Please read the troubleshooting guide at https://restic.readthedocs.io/en/stable/077_troubleshooting.html first.\n\n")
+			printer.E("\nThe repository contains damaged pack files. These damaged files must be removed to repair the repository. This can be done using the following commands. Please read the troubleshooting guide at https://restic.readthedocs.io/en/stable/077_troubleshooting.html first.\n\n")
 			var strIDs []string
 			for _, id := range salvagePacks {
 				strIDs = append(strIDs, id.String())
 			}
 			printer.E("restic repair packs %v\nrestic repair snapshots --forget\n\n", strings.Join(strIDs, " "))
-			printer.E("Corrupted blobs are either caused by hardware problems or bugs in restic. Please open an issue at https://github.com/restic/restic/issues/new/choose for further troubleshooting!\n")
+			printer.E("Damaged pack files can be caused by backend problem, hardware problems or bugs in restic. Please open an issue at https://github.com/restic/restic/issues/new/choose for further troubleshooting!\n")
 		}
 	}
 

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -289,7 +289,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 		if errors.As(err, &packErr) {
 			if packErr.Orphaned {
 				orphanedPacks++
-				printer.P("%v\n", err)
+				printer.V("%v\n", err)
 			} else {
 				if packErr.Truncated {
 					salvagePacks.Insert(packErr.ID)

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -431,6 +431,9 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 	}
 
 	if errorsFound {
+		if len(salvagePacks) == 0 {
+			printer.E("\nThe repository is damaged and must be repaired. Please follow the troubleshooting guide at https://restic.readthedocs.io/en/stable/077_troubleshooting.html .\n\n")
+		}
 		return errors.Fatal("repository contains errors")
 	}
 	printer.P("no errors were found\n")

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -368,10 +368,22 @@ detect this and yield the same error as when you tried to restore:
     $ restic -r /srv/restic-repo check
     ...
     load indexes
-    error: error loading index de30f323: load <index/de30f3231c>: invalid data returned
-    Fatal: LoadIndex returned errors
+    error: error loading index de30f3231ca2e6a59af4aa84216dfe2ef7339c549dc11b09b84000997b139628: LoadRaw(<index/de30f3231c>): invalid data returned
 
-If the repository structure is intact, restic will show that no errors were found:
+    The repository index is damaged and must be repaired. You must run `restic repair index' to correct this.
+
+    Fatal: repository contains errors
+
+.. warning::
+
+    If ``check`` reports an error in the repository, then you must repair the repository.
+    As long as a repository is damaged, restoring some files or directories will fail. New
+    snapshots are not guaranteed to be restorable either.
+
+    For instructions how to repair a damaged repository, see the :ref:`troubleshooting`
+    section or follow the instructions provided by the ``check`` command.
+
+If the repository structure is intact, restic will show that ``no errors were found``:
 
 .. code-block:: console
 

--- a/doc/077_troubleshooting.rst
+++ b/doc/077_troubleshooting.rst
@@ -10,6 +10,8 @@
   ^ for subsubsections
   " for paragraphs
 
+.. _troubleshooting:
+
 #########################
 Troubleshooting
 #########################

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -183,20 +183,14 @@ func (c *Checker) LoadIndex(ctx context.Context, p *progress.Counter) (hints []e
 
 // PackError describes an error with a specific pack.
 type PackError struct {
-	ID       restic.ID
-	Orphaned bool
-	Err      error
+	ID        restic.ID
+	Orphaned  bool
+	Truncated bool
+	Err       error
 }
 
 func (e *PackError) Error() string {
 	return "pack " + e.ID.String() + ": " + e.Err.Error()
-}
-
-// IsOrphanedPack returns true if the error describes a pack which is not
-// contained in any index.
-func IsOrphanedPack(err error) bool {
-	var e *PackError
-	return errors.As(err, &e) && e.Orphaned
 }
 
 func isS3Legacy(b backend.Backend) bool {
@@ -250,7 +244,7 @@ func (c *Checker) Packs(ctx context.Context, errChan chan<- error) {
 			select {
 			case <-ctx.Done():
 				return
-			case errChan <- &PackError{ID: id, Err: errors.Errorf("unexpected file size: got %d, expected %d", reposize, size)}:
+			case errChan <- &PackError{ID: id, Truncated: true, Err: errors.Errorf("unexpected file size: got %d, expected %d", reposize, size)}:
 			}
 		}
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
See the individual commits for details, the main changes are the following:
- Also report `repository contains errors` if the index cannot be loaded
- Guide users to the troubleshooting docs if an error was found
- `additional files were found in the repo` is only shown if there is no actual error. This message has proven to be rather confusing to users. Thus hide it if there's a bigger problem.
- The orphaned pack files warnings are now also only visible for `check -v`.
- Also suggest using `repair pack` if `check` (without `--read-data`) detects truncated pack files.
- Slightly expand docs on check errors
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/4801
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-  [x] I'm done! This pull request is ready for review.
