### PR TITLE
check: fix cachedir creation when using default location

### DIFF
--- a/changelog/unreleased/issue-4437
+++ b/changelog/unreleased/issue-4437
@@ -7,3 +7,4 @@ The  `check` command now attempts to create the cache directory before initializ
 
 https://github.com/restic/restic/issues/4437
 https://github.com/restic/restic/pull/4805
+https://github.com/restic/restic/pull/4883

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -176,12 +176,14 @@ func prepareCheckCache(opts CheckOptions, gopts *GlobalOptions, printer progress
 		cachedir = cache.EnvDir()
 	}
 
-	// use a cache in a temporary directory
-	err := os.MkdirAll(cachedir, 0755)
-	if err != nil {
-		Warnf("unable to create cache directory %s, disabling cache: %v\n", cachedir, err)
-		gopts.NoCache = true
-		return cleanup
+	if cachedir != "" {
+		// use a cache in a temporary directory
+		err := os.MkdirAll(cachedir, 0755)
+		if err != nil {
+			Warnf("unable to create cache directory %s, disabling cache: %v\n", cachedir, err)
+			gopts.NoCache = true
+			return cleanup
+		}
 	}
 	tempdir, err := os.MkdirTemp(cachedir, "restic-check-cache-")
 	if err != nil {

--- a/cmd/restic/cmd_check_test.go
+++ b/cmd/restic/cmd_check_test.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 	"github.com/restic/restic/internal/ui/progress"
@@ -228,4 +229,18 @@ func TestPrepareCheckCache(t *testing.T) {
 			rtest.Assert(t, len(files) == 0, "Expected cache directory to be removed, but it still exists: %v", files)
 		})
 	}
+}
+
+func TestPrepareDefaultCheckCache(t *testing.T) {
+	gopts := GlobalOptions{CacheDir: ""}
+	cleanup := prepareCheckCache(CheckOptions{}, &gopts, &progress.NoopPrinter{})
+	_, err := os.ReadDir(gopts.CacheDir)
+	rtest.OK(t, err)
+
+	// Call the cleanup function to remove the temporary cache directory
+	cleanup()
+
+	// Verify that the cache directory has been removed
+	_, err = os.ReadDir(gopts.CacheDir)
+	rtest.Assert(t, errors.Is(err, os.ErrNotExist), "Expected cache directory to be removed, but it still exists")
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Running `check` resulted in the following error:
```
❯ ../restic/restic check       
unable to create cache directory , disabling cache: mkdir : no such file or directory
create exclusive lock for repository
```
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes #4805
Fixes #4880
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
