### PR TITLE
ui/termstatus: fix clearing status lines

### DIFF
--- a/cmd/restic/progress.go
+++ b/cmd/restic/progress.go
@@ -53,7 +53,7 @@ func newGenericProgressMax(show bool, max uint64, description string, print func
 func newTerminalProgressMax(show bool, max uint64, description string, term *termstatus.Terminal) *progress.Counter {
 	return newGenericProgressMax(show, max, description, func(status string, final bool) {
 		if final {
-			term.SetStatus([]string{})
+			term.SetStatus(nil)
 			term.Print(status)
 		} else {
 			term.SetStatus([]string{status})

--- a/internal/ui/backup/text.go
+++ b/internal/ui/backup/text.go
@@ -121,7 +121,7 @@ func (b *TextProgress) ReportTotal(start time.Time, s archiver.ScanStats) {
 // Reset status
 func (b *TextProgress) Reset() {
 	if b.term.CanUpdateStatus() {
-		b.term.SetStatus([]string{""})
+		b.term.SetStatus(nil)
 	}
 }
 

--- a/internal/ui/restore/text.go
+++ b/internal/ui/restore/text.go
@@ -62,7 +62,7 @@ func (t *textPrinter) CompleteItem(messageType ItemAction, item string, size uin
 }
 
 func (t *textPrinter) Finish(p State, duration time.Duration) {
-	t.terminal.SetStatus([]string{})
+	t.terminal.SetStatus(nil)
 
 	timeLeft := ui.FormatDuration(duration)
 	formattedAllBytesTotal := ui.FormatBytes(p.AllBytesTotal)

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -315,11 +315,8 @@ func sanitizeLines(lines []string, width int) []string {
 
 // SetStatus updates the status lines.
 // The lines should not contain newlines; this method adds them.
+// Pass nil or an empty array to remove the status lines.
 func (t *Terminal) SetStatus(lines []string) {
-	if len(lines) == 0 {
-		return
-	}
-
 	// only truncate interactive status output
 	var width int
 	if t.canUpdateStatus {

--- a/internal/ui/termstatus/status_test.go
+++ b/internal/ui/termstatus/status_test.go
@@ -32,6 +32,15 @@ func TestSetStatus(t *testing.T) {
 	term.SetStatus([]string{"first"})
 	exp := home + clear + "first" + home
 
+	term.SetStatus([]string{""})
+	exp += home + clear + "" + home
+
+	term.SetStatus([]string{})
+	exp += home + clear + "" + home
+
+	// already empty status
+	term.SetStatus([]string{})
+
 	term.SetStatus([]string{"foo", "bar", "baz"})
 	exp += home + clear + "foo\n" + home + clear + "bar\n" +
 		home + clear + "baz" + home + up + up


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
To clear the status lines, commands should be set to an empty array to prevent future updates of those lines. Setting the status lines to an array containing an empty string is wrong as this causes the output to continuously add that empty status line after each message.

This fixes the progress bar for the `restore` command, but also for `check` after https://github.com/restic/restic/pull/4823 as well as the index loading progress for each command using `termstatus.Terminal`.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Part of https://github.com/restic/restic/issues/4795

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
