### PR TITLE
Add explanation to restic diff symbols

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -498,7 +498,7 @@ You can combine all three options with each other and with the normal file argum
 Comparing Snapshots
 *******************
 
-Restic has a `diff` command which shows the difference between two snapshots
+Restic has a ``diff`` command which shows the difference between two snapshots
 and displays a small statistic, just pass the command two snapshot IDs:
 
 .. code-block:: console
@@ -506,9 +506,9 @@ and displays a small statistic, just pass the command two snapshot IDs:
     $ restic -r /srv/restic-repo diff 5845b002 2ab627a6
     comparing snapshot ea657ce5 to 2ab627a6:
 
-     C   /restic/cmd_diff.go
+     M   /restic/cmd_diff.go
     +    /restic/foo
-     C   /restic/restic
+     M   /restic/restic
 
     Files:           0 new,     0 removed,     2 changed
     Dirs:            1 new,     0 removed
@@ -527,6 +527,24 @@ folder, you could use the following command:
 
     $ restic -r /srv/restic-repo diff 5845b002:/restic 2ab627a6:/restic
 
+By default, the ``diff`` command only lists differences in file contents.
+The flag `--metadata` shows changes to file metadata, too.
+
+The characters left of the file path show what has changed for this file:
+
++-------+-----------------------+
+| ``+`` | added                 |
++-------+-----------------------+
+| ``-`` | removed               |
++-------+-----------------------+
+| ``T`` | entry type changed    |
++-------+-----------------------+
+| ``M`` | file content changed  |
++-------+-----------------------+
+| ``U`` | metadata changed      |
++-------+-----------------------+
+| ``?`` | bitrot detected       |
++-------+-----------------------+
 
 Backing up special items and metadata
 *************************************

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -506,9 +506,9 @@ and displays a small statistic, just pass the command two snapshot IDs:
     $ restic -r /srv/restic-repo diff 5845b002 2ab627a6
     comparing snapshot ea657ce5 to 2ab627a6:
 
-     M   /restic/cmd_diff.go
+    M    /restic/cmd_diff.go
     +    /restic/foo
-     M   /restic/restic
+    M    /restic/restic
 
     Files:           0 new,     0 removed,     2 changed
     Dirs:            1 new,     0 removed
@@ -528,7 +528,7 @@ folder, you could use the following command:
     $ restic -r /srv/restic-repo diff 5845b002:/restic 2ab627a6:/restic
 
 By default, the ``diff`` command only lists differences in file contents.
-The flag `--metadata` shows changes to file metadata, too.
+The flag ``--metadata`` shows changes to file metadata, too.
 
 The characters left of the file path show what has changed for this file:
 


### PR DESCRIPTION
Explain what the characters for each file in a restic diff output mean.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

It adds an explanation of the restic diff output to the documentation.
The wording is taken from the [Scripting section](https://restic.readthedocs.io/en/latest/075_scripting.html#change) the man pages have a different wording. The "?" is missing there.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

It is a response to a question in the forum: https://forum.restic.net/t/check-if-file-contents-stayed-the-same/7968

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
