### PR TITLE
restore: do not delete target if it is a file

### DIFF
--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -347,6 +347,14 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 		}
 	}
 
+	if !res.opts.DryRun {
+		// ensure that the target directory exists and is actually a directory
+		// Using ensureDir is too aggressive here as it also removes unexpected files
+		if err := fs.MkdirAll(dst, 0700); err != nil {
+			return fmt.Errorf("cannot create target directory: %w", err)
+		}
+	}
+
 	idx := NewHardlinkIndex[string]()
 	filerestorer := newFileRestorer(dst, res.repo.LoadBlobsFromPack, res.repo.LookupBlob,
 		res.repo.Connections(), res.opts.Sparse, res.opts.Delete, res.opts.Progress)

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -1372,3 +1372,25 @@ func TestRestoreDelete(t *testing.T) {
 		})
 	}
 }
+
+func TestRestoreToFile(t *testing.T) {
+	snapshot := Snapshot{
+		Nodes: map[string]Node{
+			"foo": File{Data: "content: foo\n"},
+		},
+	}
+
+	repo := repository.TestRepository(t)
+	tempdir := filepath.Join(rtest.TempDir(t), "target")
+
+	// create a file in the place of the target directory
+	rtest.OK(t, os.WriteFile(tempdir, []byte{}, 0o700))
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sn, _ := saveSnapshot(t, repo, snapshot, noopGetGenericAttributes)
+	res := NewRestorer(repo, sn, Options{})
+	err := res.RestoreTo(ctx, tempdir)
+	rtest.Assert(t, strings.Contains(err.Error(), "cannot create target directory"), "unexpected error %v", err)
+}


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Ensure that `restore --target /path/to/file` results in an error. This is implicitly achieved by creating the target directory as the first step, which will fail if a file already exist in its place. After the changes introduced by the restore command rework, `/path/to/file` would have been deleted and replaced with a directory. Now, a `cannot create target directory: mkdir ...` error is returned.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
