### PR TITLE
ls: fix handling of toplevel directories in ncdu output

### DIFF
--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -222,6 +222,10 @@ func lsNcduNode(_ string, node *restic.Node) ([]byte, error) {
 	if node.Mode&os.ModeSticky != 0 {
 		outNode.Mode |= 0o1000
 	}
+	if outNode.Mtime < 0 {
+		// ncdu does not allow negative times
+		outNode.Mtime = 0
+	}
 
 	return json.Marshal(outNode)
 }

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -178,7 +178,7 @@ func (p *ncduLsPrinter) Snapshot(sn *restic.Snapshot) {
 		Warnf("JSON encode failed: %v\n", err)
 	}
 	p.depth++
-	fmt.Fprintf(p.out, "[%d, %d, %s, [{\"name\":\"\"}", NcduMajorVer, NcduMinorVer, string(snapshotBytes))
+	fmt.Fprintf(p.out, "[%d, %d, %s, [{\"name\":\"/\"}", NcduMajorVer, NcduMinorVer, string(snapshotBytes))
 }
 
 func lsNcduNode(_ string, node *restic.Node) ([]byte, error) {

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -178,7 +178,7 @@ func (p *ncduLsPrinter) Snapshot(sn *restic.Snapshot) {
 		Warnf("JSON encode failed: %v\n", err)
 	}
 	p.depth++
-	fmt.Fprintf(p.out, "[%d, %d, %s", NcduMajorVer, NcduMinorVer, string(snapshotBytes))
+	fmt.Fprintf(p.out, "[%d, %d, %s, [{\"name\":\"\"}", NcduMajorVer, NcduMinorVer, string(snapshotBytes))
 }
 
 func lsNcduNode(_ string, node *restic.Node) ([]byte, error) {
@@ -246,7 +246,7 @@ func (p *ncduLsPrinter) LeaveDir(_ string) {
 }
 
 func (p *ncduLsPrinter) Close() {
-	fmt.Fprint(p.out, "\n]\n")
+	fmt.Fprint(p.out, "\n]\n]\n")
 }
 
 type textLsPrinter struct {

--- a/cmd/restic/cmd_ls_integration_test.go
+++ b/cmd/restic/cmd_ls_integration_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"path/filepath"
 	"strings"
 	"testing"
 
@@ -26,9 +25,10 @@ func testRunLs(t testing.TB, gopts GlobalOptions, snapshotID string) []string {
 
 func assertIsValidJSON(t *testing.T, data []byte) {
 	// Sanity check: output must be valid JSON.
-	var v interface{}
+	var v []any
 	err := json.Unmarshal(data, &v)
 	rtest.OK(t, err)
+	rtest.Assert(t, len(v) == 4, "invalid ncdu output, expected 4 array elements, got %v", len(v))
 }
 
 func TestRunLsNcdu(t *testing.T) {
@@ -37,12 +37,13 @@ func TestRunLsNcdu(t *testing.T) {
 
 	testSetupBackupData(t, env)
 	opts := BackupOptions{}
-	testRunBackup(t, filepath.Dir(env.testdata), []string{"testdata"}, opts, env.gopts)
+	// backup such that there are multiple toplevel elements
+	testRunBackup(t, env.testdata+"/0", []string{"."}, opts, env.gopts)
 
 	for _, paths := range [][]string{
 		{"latest"},
-		{"latest", "/testdata"},
-		{"latest", "/testdata/0", "/testdata/0/tests"},
+		{"latest", "/0"},
+		{"latest", "/0", "/0/9"},
 	} {
 		ncdu := testRunLsWithOpts(t, env.gopts, LsOptions{Ncdu: true}, paths)
 		assertIsValidJSON(t, ncdu)

--- a/cmd/restic/cmd_ls_test.go
+++ b/cmd/restic/cmd_ls_test.go
@@ -149,11 +149,12 @@ func TestLsNcdu(t *testing.T) {
 	printer.LeaveDir("/directory")
 	printer.Close()
 
-	rtest.Equals(t, `[1, 2, {"time":"0001-01-01T00:00:00Z","tree":null,"paths":["/example"],"hostname":"host"},
+	rtest.Equals(t, `[1, 2, {"time":"0001-01-01T00:00:00Z","tree":null,"paths":["/example"],"hostname":"host"}, [{"name":""},
   [
     {"name":"directory","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":0,"mtime":-62135596800},
     {"name":"data","asize":42,"dsize":512,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":0,"mtime":-62135596800}
   ]
+]
 ]
 `, buf.String())
 }

--- a/cmd/restic/cmd_ls_test.go
+++ b/cmd/restic/cmd_ls_test.go
@@ -149,7 +149,7 @@ func TestLsNcdu(t *testing.T) {
 	printer.LeaveDir("/directory")
 	printer.Close()
 
-	rtest.Equals(t, `[1, 2, {"time":"0001-01-01T00:00:00Z","tree":null,"paths":["/example"],"hostname":"host"}, [{"name":""},
+	rtest.Equals(t, `[1, 2, {"time":"0001-01-01T00:00:00Z","tree":null,"paths":["/example"],"hostname":"host"}, [{"name":"/"},
   [
     {"name":"directory","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":0,"mtime":-62135596800},
     {"name":"data","asize":42,"dsize":512,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":0,"mtime":-62135596800}

--- a/cmd/restic/cmd_ls_test.go
+++ b/cmd/restic/cmd_ls_test.go
@@ -109,11 +109,11 @@ func TestLsNodeJSON(t *testing.T) {
 
 func TestLsNcduNode(t *testing.T) {
 	for i, expect := range []string{
-		`{"name":"baz","asize":12345,"dsize":12800,"dev":0,"ino":0,"nlink":1,"notreg":false,"uid":10000000,"gid":20000000,"mode":0,"mtime":-62135596800}`,
-		`{"name":"empty","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":3840,"notreg":false,"uid":1001,"gid":1001,"mode":0,"mtime":-62135596800}`,
-		`{"name":"link","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":0,"notreg":true,"uid":0,"gid":0,"mode":511,"mtime":-62135596800}`,
+		`{"name":"baz","asize":12345,"dsize":12800,"dev":0,"ino":0,"nlink":1,"notreg":false,"uid":10000000,"gid":20000000,"mode":0,"mtime":0}`,
+		`{"name":"empty","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":3840,"notreg":false,"uid":1001,"gid":1001,"mode":0,"mtime":0}`,
+		`{"name":"link","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":0,"notreg":true,"uid":0,"gid":0,"mode":511,"mtime":0}`,
 		`{"name":"directory","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":493,"mtime":1577934245}`,
-		`{"name":"sticky","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":4077,"mtime":-62135596800}`,
+		`{"name":"sticky","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":4077,"mtime":0}`,
 	} {
 		c := lsTestNodes[i]
 		out, err := lsNcduNode(c.path, &c.Node)
@@ -132,27 +132,30 @@ func TestLsNcdu(t *testing.T) {
 	printer := &ncduLsPrinter{
 		out: &buf,
 	}
+	modTime := time.Date(2020, 1, 2, 3, 4, 5, 0, time.UTC)
 
 	printer.Snapshot(&restic.Snapshot{
 		Hostname: "host",
 		Paths:    []string{"/example"},
 	})
 	printer.Node("/directory", &restic.Node{
-		Type: "dir",
-		Name: "directory",
+		Type:    "dir",
+		Name:    "directory",
+		ModTime: modTime,
 	}, false)
 	printer.Node("/directory/data", &restic.Node{
-		Type: "file",
-		Name: "data",
-		Size: 42,
+		Type:    "file",
+		Name:    "data",
+		Size:    42,
+		ModTime: modTime,
 	}, false)
 	printer.LeaveDir("/directory")
 	printer.Close()
 
 	rtest.Equals(t, `[1, 2, {"time":"0001-01-01T00:00:00Z","tree":null,"paths":["/example"],"hostname":"host"}, [{"name":"/"},
   [
-    {"name":"directory","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":0,"mtime":-62135596800},
-    {"name":"data","asize":42,"dsize":512,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":0,"mtime":-62135596800}
+    {"name":"directory","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":0,"mtime":1577934245},
+    {"name":"data","asize":42,"dsize":512,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":0,"mtime":1577934245}
   ]
 ]
 ]

--- a/cmd/restic/cmd_ls_test.go
+++ b/cmd/restic/cmd_ls_test.go
@@ -150,13 +150,20 @@ func TestLsNcdu(t *testing.T) {
 		ModTime: modTime,
 	}, false)
 	printer.LeaveDir("/directory")
+	printer.Node("/file", &restic.Node{
+		Type:    "file",
+		Name:    "file",
+		Size:    12345,
+		ModTime: modTime,
+	}, false)
 	printer.Close()
 
 	rtest.Equals(t, `[1, 2, {"time":"0001-01-01T00:00:00Z","tree":null,"paths":["/example"],"hostname":"host"}, [{"name":"/"},
   [
     {"name":"directory","asize":0,"dsize":0,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":0,"mtime":1577934245},
     {"name":"data","asize":42,"dsize":512,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":0,"mtime":1577934245}
-  ]
+  ],
+  {"name":"file","asize":12345,"dsize":12800,"dev":0,"ino":0,"nlink":0,"notreg":false,"uid":0,"gid":0,"mode":0,"mtime":1577934245}
 ]
 ]
 `, buf.String())


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The ncdu format expects that the outer-most array contains exactly four elements. This implicitly requires wrapping all directory elements in the snapshot's toplevel directory into a directory elements. Otherwise a snapshot with more than one toplevel element will be rendered incorrectly.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/4919
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
