### PR TITLE
restore: fix cancelation and partial updates of large files

### DIFF
--- a/changelog/unreleased/issue-4817
+++ b/changelog/unreleased/issue-4817
@@ -21,3 +21,4 @@ https://github.com/restic/restic/issues/2662
 https://github.com/restic/restic/pull/4837
 https://github.com/restic/restic/pull/4838
 https://github.com/restic/restic/pull/4864
+https://github.com/restic/restic/pull/4921

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -192,6 +192,7 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 
 	// the main restore loop
 	wg.Go(func() error {
+		defer close(downloadCh)
 		for _, id := range packOrder {
 			pack := packs[id]
 			// allow garbage collection of packInfo
@@ -203,7 +204,6 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 				debug.Log("Scheduled download pack %s", pack.id.Str())
 			}
 		}
-		close(downloadCh)
 		return nil
 	})
 

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -327,6 +327,11 @@ func (r *fileRestorer) downloadBlobs(ctx context.Context, packID restic.ID,
 			}
 			for file, offsets := range blob.files {
 				for _, offset := range offsets {
+					// avoid long cancelation delays for frequently used blobs
+					if ctx.Err() != nil {
+						return ctx.Err()
+					}
+
 					writeToFile := func() error {
 						// this looks overly complicated and needs explanation
 						// two competing requirements:

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -273,10 +273,13 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 }
 
 func (r *fileRestorer) sanitizeError(file *fileInfo, err error) error {
-	if err != nil {
-		err = r.Error(file.location, err)
+	switch err {
+	case nil, context.Canceled, context.DeadlineExceeded:
+		// Context errors are permanent.
+		return err
+	default:
+		return r.Error(file.location, err)
 	}
-	return err
 }
 
 func (r *fileRestorer) reportError(blobs blobToFileOffsetsMapping, processedBlobs restic.BlobSet, err error) error {

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -136,8 +136,8 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 		err := r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob, idx int) {
 			if largeFile && !file.state.HasMatchingBlob(idx) {
 				packsMap[packID] = append(packsMap[packID], fileBlobInfo{id: blob.ID, offset: fileOffset})
-				fileOffset += int64(blob.DataLength())
 			}
+			fileOffset += int64(blob.DataLength())
 			pack, ok := packs[packID]
 			if !ok {
 				pack = &packInfo{

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -363,7 +363,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) error {
 	err = res.traverseTree(ctx, dst, *res.sn.Tree, treeVisitor{
 		enterDir: func(_ *restic.Node, target, location string) error {
 			debug.Log("first pass, enterDir: mkdir %q, leaveDir should restore metadata", location)
-			if location != "/" {
+			if location != string(filepath.Separator) {
 				res.opts.Progress.AddFile(0)
 			}
 			return res.ensureDir(target)

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -65,18 +65,6 @@ func getBlockCount(t *testing.T, filename string) int64 {
 	return st.Blocks
 }
 
-type printerMock struct {
-	s restoreui.State
-}
-
-func (p *printerMock) Update(_ restoreui.State, _ time.Duration) {
-}
-func (p *printerMock) CompleteItem(action restoreui.ItemAction, item string, size uint64) {
-}
-func (p *printerMock) Finish(s restoreui.State, _ time.Duration) {
-	p.s = s
-}
-
 func TestRestorerProgressBar(t *testing.T) {
 	testRestorerProgressBar(t, false)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Fixes several bugs in the restore command:
- Canceling restore using ctrl-c no longer causes restore to hang
- Improved error logging when canceling the restore command
- Restoring large, partially up to date files now correctly restores the file content
- Fix progress bar for partially up to date files
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes the issues reported in https://forum.restic.net/t/upcoming-restic-0-17-0-release/7967/15
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
