### PR TITLE
restore: Fix truncation of uptodate files

### DIFF
--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -138,6 +138,8 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 				restoredBlobs = true
 			} else {
 				r.reportBlobProgress(file, uint64(blob.DataLength()))
+				// completely ignore blob
+				return
 			}
 			pack, ok := packs[packID]
 			if !ok {

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -93,17 +93,20 @@ func (r *fileRestorer) targetPath(location string) string {
 	return filepath.Join(r.dst, location)
 }
 
-func (r *fileRestorer) forEachBlob(blobIDs []restic.ID, fn func(packID restic.ID, packBlob restic.Blob, idx int)) error {
+func (r *fileRestorer) forEachBlob(blobIDs []restic.ID, fn func(packID restic.ID, packBlob restic.Blob, idx int, fileOffset int64)) error {
 	if len(blobIDs) == 0 {
 		return nil
 	}
 
+	fileOffset := int64(0)
 	for i, blobID := range blobIDs {
 		packs := r.idx(restic.DataBlob, blobID)
 		if len(packs) == 0 {
 			return errors.Errorf("Unknown blob %s", blobID.String())
 		}
-		fn(packs[0].PackID, packs[0].Blob, i)
+		pb := packs[0]
+		fn(pb.PackID, pb.Blob, i, fileOffset)
+		fileOffset += int64(pb.DataLength())
 	}
 
 	return nil
@@ -124,10 +127,10 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 		var packsMap map[restic.ID][]fileBlobInfo
 		if largeFile {
 			packsMap = make(map[restic.ID][]fileBlobInfo)
+			file.blobs = packsMap
 		}
-		fileOffset := int64(0)
 		restoredBlobs := false
-		err := r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob, idx int) {
+		err := r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob, idx int, fileOffset int64) {
 			if !file.state.HasMatchingBlob(idx) {
 				if largeFile {
 					packsMap[packID] = append(packsMap[packID], fileBlobInfo{id: blob.ID, offset: fileOffset})
@@ -136,7 +139,6 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 			} else {
 				r.reportBlobProgress(file, uint64(blob.DataLength()))
 			}
-			fileOffset += int64(blob.DataLength())
 			pack, ok := packs[packID]
 			if !ok {
 				pack = &packInfo{
@@ -151,6 +153,11 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 				file.sparse = r.sparse
 			}
 		})
+		if err != nil {
+			// repository index is messed up, can't do anything
+			return err
+		}
+
 		if len(fileBlobs) == 1 {
 			// no need to preallocate files with a single block, thus we can always consider them to be sparse
 			// in addition, a short chunk will never match r.zeroChunk which would prevent sparseness for short files
@@ -161,14 +168,6 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 			// Thus sections that contained data but should be sparse after restoring
 			// the snapshot would still contain the old data resulting in a corrupt restore.
 			file.sparse = false
-		}
-
-		if err != nil {
-			// repository index is messed up, can't do anything
-			return err
-		}
-		if largeFile {
-			file.blobs = packsMap
 		}
 
 		// empty file or one with already uptodate content. Make sure that the file size is correct
@@ -249,12 +248,10 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 			blobInfo.files[file] = append(blobInfo.files[file], fileOffset)
 		}
 		if fileBlobs, ok := file.blobs.(restic.IDs); ok {
-			fileOffset := int64(0)
-			err := r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob, idx int) {
+			err := r.forEachBlob(fileBlobs, func(packID restic.ID, blob restic.Blob, idx int, fileOffset int64) {
 				if packID.Equal(pack.id) && !file.state.HasMatchingBlob(idx) {
 					addBlob(blob, fileOffset)
 				}
-				fileOffset += int64(blob.DataLength())
 			})
 			if err != nil {
 				// restoreFiles should have caught this error before

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -1003,6 +1003,7 @@ func TestRestorerOverwriteBehavior(t *testing.T) {
 			"dirtest": Dir{
 				Nodes: map[string]Node{
 					"file": File{Data: "content: file\n", ModTime: baseTime},
+					"foo":  File{Data: "content: foobar", ModTime: baseTime},
 				},
 				ModTime: baseTime,
 			},
@@ -1014,6 +1015,7 @@ func TestRestorerOverwriteBehavior(t *testing.T) {
 			"dirtest": Dir{
 				Nodes: map[string]Node{
 					"file": File{Data: "content: file2\n", ModTime: baseTime.Add(-time.Second)},
+					"foo":  File{Data: "content: foo", ModTime: baseTime},
 				},
 			},
 		},
@@ -1029,13 +1031,14 @@ func TestRestorerOverwriteBehavior(t *testing.T) {
 			Files: map[string]string{
 				"foo":          "content: new\n",
 				"dirtest/file": "content: file2\n",
+				"dirtest/foo":  "content: foo",
 			},
 			Progress: restoreui.State{
-				FilesFinished:   3,
-				FilesTotal:      3,
+				FilesFinished:   4,
+				FilesTotal:      4,
 				FilesSkipped:    0,
-				AllBytesWritten: 28,
-				AllBytesTotal:   28,
+				AllBytesWritten: 40,
+				AllBytesTotal:   40,
 				AllBytesSkipped: 0,
 			},
 		},
@@ -1044,13 +1047,14 @@ func TestRestorerOverwriteBehavior(t *testing.T) {
 			Files: map[string]string{
 				"foo":          "content: new\n",
 				"dirtest/file": "content: file2\n",
+				"dirtest/foo":  "content: foo",
 			},
 			Progress: restoreui.State{
-				FilesFinished:   3,
-				FilesTotal:      3,
+				FilesFinished:   4,
+				FilesTotal:      4,
 				FilesSkipped:    0,
-				AllBytesWritten: 28,
-				AllBytesTotal:   28,
+				AllBytesWritten: 40,
+				AllBytesTotal:   40,
 				AllBytesSkipped: 0,
 			},
 		},
@@ -1059,14 +1063,15 @@ func TestRestorerOverwriteBehavior(t *testing.T) {
 			Files: map[string]string{
 				"foo":          "content: new\n",
 				"dirtest/file": "content: file\n",
+				"dirtest/foo":  "content: foobar",
 			},
 			Progress: restoreui.State{
 				FilesFinished:   2,
 				FilesTotal:      2,
-				FilesSkipped:    1,
+				FilesSkipped:    2,
 				AllBytesWritten: 13,
 				AllBytesTotal:   13,
-				AllBytesSkipped: 15,
+				AllBytesSkipped: 27,
 			},
 		},
 		{
@@ -1074,14 +1079,15 @@ func TestRestorerOverwriteBehavior(t *testing.T) {
 			Files: map[string]string{
 				"foo":          "content: foo\n",
 				"dirtest/file": "content: file\n",
+				"dirtest/foo":  "content: foobar",
 			},
 			Progress: restoreui.State{
 				FilesFinished:   1,
 				FilesTotal:      1,
-				FilesSkipped:    2,
+				FilesSkipped:    3,
 				AllBytesWritten: 0,
 				AllBytesTotal:   0,
-				AllBytesSkipped: 28,
+				AllBytesSkipped: 40,
 			},
 		},
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
When overwriting an existing file that is already uptodate, then the restorer did not truncate it. This PR adds a special case to properly truncate files for which no blobs have to be written.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/4923
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
