### PR TITLE
restorer: only show size in text output for files

### DIFF
--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -278,7 +278,7 @@ func (res *Restorer) restoreNodeTo(ctx context.Context, node *restic.Node, targe
 		}
 	}
 
-	res.opts.Progress.AddProgress(location, restoreui.ActionFileRestored, 0, 0)
+	res.opts.Progress.AddProgress(location, restoreui.ActionOtherRestored, 0, 0)
 	return res.restoreNodeMetadataTo(node, target, location)
 }
 
@@ -305,7 +305,7 @@ func (res *Restorer) restoreHardlinkAt(node *restic.Node, target, path, location
 		}
 	}
 
-	res.opts.Progress.AddProgress(location, restoreui.ActionFileRestored, 0, 0)
+	res.opts.Progress.AddProgress(location, restoreui.ActionOtherRestored, 0, 0)
 	// TODO investigate if hardlinks have separate metadata on any supported system
 	return res.restoreNodeMetadataTo(node, path, location)
 }

--- a/internal/ui/restore/json.go
+++ b/internal/ui/restore/json.go
@@ -52,6 +52,8 @@ func (t *jsonPrinter) CompleteItem(messageType ItemAction, item string, size uin
 		action = "restored"
 	case ActionFileRestored:
 		action = "restored"
+	case ActionOtherRestored:
+		action = "restored"
 	case ActionFileUpdated:
 		action = "updated"
 	case ActionFileUnchanged:

--- a/internal/ui/restore/progress.go
+++ b/internal/ui/restore/progress.go
@@ -51,6 +51,7 @@ const (
 	ActionFileRestored  ItemAction = "file restored"
 	ActionFileUpdated   ItemAction = "file updated"
 	ActionFileUnchanged ItemAction = "file unchanged"
+	ActionOtherRestored ItemAction = "other restored"
 	ActionDeleted       ItemAction = "deleted"
 )
 

--- a/internal/ui/restore/text.go
+++ b/internal/ui/restore/text.go
@@ -44,6 +44,8 @@ func (t *textPrinter) CompleteItem(messageType ItemAction, item string, size uin
 		action = "restored"
 	case ActionFileRestored:
 		action = "restored"
+	case ActionOtherRestored:
+		action = "restored"
 	case ActionFileUpdated:
 		action = "updated"
 	case ActionFileUnchanged:
@@ -54,7 +56,7 @@ func (t *textPrinter) CompleteItem(messageType ItemAction, item string, size uin
 		panic("unknown message type")
 	}
 
-	if messageType == ActionDirRestored || messageType == ActionDeleted {
+	if messageType == ActionDirRestored || messageType == ActionOtherRestored || messageType == ActionDeleted {
 		t.terminal.Print(fmt.Sprintf("%-9v %v", action, item))
 	} else {
 		t.terminal.Print(fmt.Sprintf("%-9v %v with size %v", action, item, ui.FormatBytes(size)))

--- a/internal/ui/restore/text_test.go
+++ b/internal/ui/restore/text_test.go
@@ -63,6 +63,7 @@ func TestPrintCompleteItem(t *testing.T) {
 	}{
 		{ActionDirRestored, 0, "restored  test"},
 		{ActionFileRestored, 123, "restored  test with size 123 B"},
+		{ActionOtherRestored, 0, "restored  test"},
 		{ActionFileUpdated, 123, "updated   test with size 123 B"},
 		{ActionFileUnchanged, 123, "unchanged test with size 123 B"},
 		{ActionDeleted, 0, "deleted   test"},


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

The restore text output reported `restored  /some/symlink with size 0 B`. The size is not misleading, thus remove it.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See https://github.com/restic/restic/issues/4923
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
