### PR TITLE
docs: Replace all uses of target in relation to backup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -603,7 +603,7 @@ restic users. The changes are ordered by importance.
  * Enhancement #3941: Support `--group-by` for backup parent selection
 
    Previously, the `backup` command by default selected the parent snapshot based on the
-   hostname and the backup targets. When the backup path list changed, the `backup` command was
+   hostname and the backup paths. When the backup path list changed, the `backup` command was
    unable to determine a suitable parent snapshot and had to read all files again.
 
    The new `--group-by` option for the `backup` command allows filtering snapshots for the
@@ -2575,10 +2575,10 @@ restic users. The changes are ordered by importance.
    https://github.com/restic/restic/issues/3166
    https://github.com/restic/restic/pull/3207
 
- * Bugfix #3232: Correct statistics for overlapping targets
+ * Bugfix #3232: Correct statistics for overlapping backup sources
 
    A user reported that restic's statistics and progress information during backup was not
-   correctly calculated when the backup targets (files/dirs to save) overlap. For example,
+   correctly calculated when the backup sources (files/dirs to save) overlap. For example,
    consider a directory `foo` which contains (among others) a file `foo/bar`. When `restic
    backup foo foo/bar` was run, restic counted the size of the file `foo/bar` twice, so the
    completeness percentage as well as the number of files was wrong. This is now corrected.

--- a/changelog/0.12.0_2021-02-14/issue-3232
+++ b/changelog/0.12.0_2021-02-14/issue-3232
@@ -1,7 +1,7 @@
-Bugfix: Correct statistics for overlapping targets
+Bugfix: Correct statistics for overlapping backup sources
 
 A user reported that restic's statistics and progress information during backup
-was not correctly calculated when the backup targets (files/dirs to save)
+was not correctly calculated when the backup sources (files/dirs to save)
 overlap. For example, consider a directory `foo` which contains (among others)
 a file `foo/bar`. When `restic backup foo foo/bar` was run, restic counted the
 size of the file `foo/bar` twice, so the completeness percentage as well as the

--- a/changelog/0.16.0_2023-07-31/issue-3941
+++ b/changelog/0.16.0_2023-07-31/issue-3941
@@ -1,7 +1,7 @@
 Enhancement: Support `--group-by` for backup parent selection
 
 Previously, the `backup` command by default selected the parent snapshot based
-on the hostname and the backup targets. When the backup path list changed, the
+on the hostname and the backup paths. When the backup path list changed, the
 `backup` command was unable to determine a suitable parent snapshot and had to
 read all files again.
 

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -239,7 +239,7 @@ By default, restic always creates a new snapshot even if nothing has changed
 compared to the parent snapshot. To omit the creation of a new snapshot in this
 case, specify the ``--skip-if-unchanged`` option.
 
-Note that when using absolute paths to specify the backup target, then also
+Note that when using absolute paths to specify the backup source, then also
 changes to the parent folders result in a changed snapshot. For example, a backup
 of ``/home/user/work`` will create a new snapshot if the metadata of either
 ``/``, ``/home`` or ``/home/user`` change. To avoid this problem run restic from

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -634,7 +634,7 @@ func (arch *Archiver) saveTree(ctx context.Context, snPath string, atree *Tree, 
 		}
 
 		debug.Log("%v, dir node data loaded from %v", snPath, atree.FileInfoPath)
-		// in some cases reading xattrs for directories above the backup target is not allowed
+		// in some cases reading xattrs for directories above the backup source is not allowed
 		// thus ignore errors for such folders.
 		node, err = arch.nodeFromFileInfo(snPath, atree.FileInfoPath, fi, true)
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Replace the last remnants of `backup target` with `backup source` or `backup paths`.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Follow-up to https://github.com/restic/restic/pull/4822
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
