### PR TITLE
doc: Remove unrelated PR URL from changelog entry

### DIFF
--- a/changelog/unreleased/issue-828
+++ b/changelog/unreleased/issue-828
@@ -8,5 +8,4 @@ further instructions.
 
 https://github.com/restic/restic/issues/828
 https://github.com/restic/restic/pull/4644
-https://github.com/restic/restic/pull/4655
 https://github.com/restic/restic/pull/4882


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Removes one PR URL that is not related to this issue/PR at all, from the changelog entry.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Nope. This is courtesy of Drama Llama who discovered this discrepancy during an informal code review.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
