### PR TITLE
Format exit errors as JSON if requested

### DIFF
--- a/changelog/unreleased/issue-4948
+++ b/changelog/unreleased/issue-4948
@@ -1,0 +1,6 @@
+Enhancement: Format exit errors as JSON with --json
+
+Restic now prints any exit error messages as JSON when requested.
+
+https://github.com/restic/restic/issues/4948
+https://github.com/restic/restic/pull/4952

--- a/cmd/restic/cmd_version.go
+++ b/cmd/restic/cmd_version.go
@@ -25,17 +25,19 @@ Exit status is 1 if there was any error.
 	Run: func(_ *cobra.Command, _ []string) {
 		if globalOptions.JSON {
 			type jsonVersion struct {
-				Version   string `json:"version"`
-				GoVersion string `json:"go_version"`
-				GoOS      string `json:"go_os"`
-				GoArch    string `json:"go_arch"`
+				MessageType string `json:"message_type"` // version
+				Version     string `json:"version"`
+				GoVersion   string `json:"go_version"`
+				GoOS        string `json:"go_os"`
+				GoArch      string `json:"go_arch"`
 			}
 
 			jsonS := jsonVersion{
-				Version:   version,
-				GoVersion: runtime.Version(),
-				GoOS:      runtime.GOOS,
-				GoArch:    runtime.GOARCH,
+				MessageType: "version",
+				Version:     version,
+				GoVersion:   runtime.Version(),
+				GoOS:        runtime.GOOS,
+				GoArch:      runtime.GOARCH,
 			}
 
 			err := json.NewEncoder(globalOptions.stdout).Encode(jsonS)

--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -83,12 +83,33 @@ JSON output of most restic commands are documented here.
     list of allowed values is documented may be extended at any time.
 
 
+Exit errors
+-----------
+
+Fatal errors will result in a final JSON message on ``stderr`` before the process exits.
+It will hold the error message and the exit code.
+
+.. note::
+    Some errors cannot be caught and reported this way,
+    such as Go runtime errors or command line parsing errors.
+
++----------------------+-------------------------------------------+
+| ``message_type``     | Always "exit_error"                       |
++----------------------+-------------------------------------------+
+| ``code``             | Exit code (see above chart)               |
++----------------------+-------------------------------------------+
+| ``error``            | Error message                             |
++----------------------+-------------------------------------------+
+
 Output formats
 --------------
 
-Currently only the output on ``stdout`` is JSON formatted. Errors printed on ``stderr``
-are still printed as plain text messages. The generated JSON output uses one of the
-following two formats.
+Commands print their main JSON output on ``stdout``.
+The generated JSON output uses one of the following two formats.
+
+.. note::
+    Not all messages and errors have been converted to JSON yet.
+    Feel free to submit a pull request!
 
 Single JSON document
 ^^^^^^^^^^^^^^^^^^^^
@@ -135,6 +156,8 @@ Status
 
 Error
 ^^^^^
+
+These errors are printed on ``stderr``.
 
 +----------------------+-------------------------------------------+
 | ``message_type``     | Always "error"                            |
@@ -542,6 +565,8 @@ Status
 Error
 ^^^^^
 
+These errors are printed on ``stderr``.
+
 +----------------------+-------------------------------------------+
 | ``message_type``     | Always "error"                            |
 +----------------------+-------------------------------------------+
@@ -691,12 +716,14 @@ version
 
 The version command returns a single JSON object.
 
-+----------------+--------------------+
-| ``version``    | restic version     |
-+----------------+--------------------+
-| ``go_version`` | Go compile version |
-+----------------+--------------------+
-| ``go_os``      | Go OS              |
-+----------------+--------------------+
-| ``go_arch``    | Go architecture    |
-+----------------+--------------------+
++------------------+--------------------+
+| ``message_type`` | Always "version"   |
++------------------+--------------------+
+| ``version``      | restic version     |
++------------------+--------------------+
+| ``go_version``   | Go compile version |
++------------------+--------------------+
+| ``go_os``        | Go OS              |
++------------------+--------------------+
+| ``go_arch``      | Go architecture    |
++------------------+--------------------+


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

When using `--json`, exit errors are now formatted as JSON instead of freeform text. And the exit code is included in the JSON blob, for the convenience of any consumers (so they don't have to wait for the exit code and then tie it together with the message).

While I was testing, I also noticed that the `version` command didn't use a `message_type` field in JSON mode - I figured I'd toss one in there for consistency with other messages. If that is undesired, I'm happy to take it out of this PR.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #4948

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~[ ] I have added tests for all code changes.~ (this felt hard to do with the exit call, unless I refactored things a bunch - but I did manually test this)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
