### PR TITLE
Improve windows path handling

### DIFF
--- a/changelog/unreleased/issue-4953
+++ b/changelog/unreleased/issue-4953
@@ -1,0 +1,7 @@
+Bugfix: Correctly handle long paths on older Windows versions
+
+When using older Windows versions, like Windows Server 2012, restic 0.17.0
+failed to back up files with long paths. This has been fixed.
+
+https://github.com/restic/restic/issues/4953
+https://github.com/restic/restic/pull/4954

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -134,7 +134,7 @@ func IsAccessDenied(err error) bool {
 // ResetPermissions resets the permissions of the file at the specified path
 func ResetPermissions(path string) error {
 	// Set the default file permissions
-	if err := os.Chmod(path, 0600); err != nil {
+	if err := os.Chmod(fixpath(path), 0600); err != nil {
 		return err
 	}
 	return nil

--- a/internal/fs/file_windows.go
+++ b/internal/fs/file_windows.go
@@ -85,7 +85,7 @@ func ClearSystem(path string) error {
 
 // ClearAttribute removes the specified attribute from the file.
 func ClearAttribute(path string, attribute uint32) error {
-	ptr, err := windows.UTF16PtrFromString(path)
+	ptr, err := windows.UTF16PtrFromString(fixpath(path))
 	if err != nil {
 		return err
 	}

--- a/internal/fs/sd_windows.go
+++ b/internal/fs/sd_windows.go
@@ -129,22 +129,22 @@ func SetSecurityDescriptor(filePath string, securityDescriptor *[]byte) error {
 
 // getNamedSecurityInfoHigh gets the higher level SecurityDescriptor which requires admin permissions.
 func getNamedSecurityInfoHigh(filePath string) (*windows.SECURITY_DESCRIPTOR, error) {
-	return windows.GetNamedSecurityInfo(filePath, windows.SE_FILE_OBJECT, highSecurityFlags)
+	return windows.GetNamedSecurityInfo(fixpath(filePath), windows.SE_FILE_OBJECT, highSecurityFlags)
 }
 
 // getNamedSecurityInfoLow gets the lower level SecurityDescriptor which requires no admin permissions.
 func getNamedSecurityInfoLow(filePath string) (*windows.SECURITY_DESCRIPTOR, error) {
-	return windows.GetNamedSecurityInfo(filePath, windows.SE_FILE_OBJECT, lowBackupSecurityFlags)
+	return windows.GetNamedSecurityInfo(fixpath(filePath), windows.SE_FILE_OBJECT, lowBackupSecurityFlags)
 }
 
 // setNamedSecurityInfoHigh sets the higher level SecurityDescriptor which requires admin permissions.
 func setNamedSecurityInfoHigh(filePath string, owner *windows.SID, group *windows.SID, dacl *windows.ACL, sacl *windows.ACL) error {
-	return windows.SetNamedSecurityInfo(filePath, windows.SE_FILE_OBJECT, highSecurityFlags, owner, group, dacl, sacl)
+	return windows.SetNamedSecurityInfo(fixpath(filePath), windows.SE_FILE_OBJECT, highSecurityFlags, owner, group, dacl, sacl)
 }
 
 // setNamedSecurityInfoLow sets the lower level SecurityDescriptor which requires no admin permissions.
 func setNamedSecurityInfoLow(filePath string, dacl *windows.ACL) error {
-	return windows.SetNamedSecurityInfo(filePath, windows.SE_FILE_OBJECT, lowRestoreSecurityFlags, nil, nil, dacl, nil)
+	return windows.SetNamedSecurityInfo(fixpath(filePath), windows.SE_FILE_OBJECT, lowRestoreSecurityFlags, nil, nil, dacl, nil)
 }
 
 // enableBackupPrivilege enables privilege for backing up security descriptors


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Fix handling of long Windows paths in several places.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Manually tested in https://github.com/restic/restic/issues/4953#issuecomment-2262183138 .

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Related to https://github.com/restic/restic/issues/4953
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes. (even though I've found no way so far to make the test fail)
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
