### PR TITLE
restore: clean up error handling when restoring metadata

### DIFF
--- a/changelog/unreleased/pull-4958
+++ b/changelog/unreleased/pull-4958
@@ -1,0 +1,7 @@
+Bugfix: Don't ignore metadata-setting errors during restore
+
+Restic was accidentally ignoring errors when setting timestamps,
+attributes, or file modes during restore. It will now report those
+errors (unless it's just a permission error when not running as root).
+
+https://github.com/restic/restic/pull/4958

--- a/internal/restic/node_test.go
+++ b/internal/restic/node_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/test"
 	rtest "github.com/restic/restic/internal/test"
 )
@@ -381,4 +382,15 @@ func TestSymlinkSerializationFormat(t *testing.T) {
 		test.Equals(t, d.linkTarget, n2.LinkTarget)
 		test.Assert(t, n2.LinkTargetRaw == nil, "quoted link target is just a helper field and must be unset after decoding")
 	}
+}
+
+func TestNodeRestoreMetadataError(t *testing.T) {
+	tempdir := t.TempDir()
+
+	node := nodeTests[0]
+	nodePath := filepath.Join(tempdir, node.Name)
+
+	// This will fail because the target file does not exist
+	err := node.RestoreMetadata(nodePath, func(msg string) { rtest.OK(t, fmt.Errorf("Warning triggered for path: %s: %s", nodePath, msg)) })
+	test.Assert(t, errors.Is(err, os.ErrNotExist), "failed for an unexpected reason")
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
- Fix a logic error that instead of reporting the *first* metadata-setting error that appears, we were instead reporting the *last* error (and only if the lchown call failed!).
- Don't show any errors when setting metadata for files in non-root mode (things like timestamps, attributes). Previously, only lchown errors were skipped. But other kinds of attribute errors make sense to skip as well. The code path happened to work correctly before because of the above logic error. But once that was fixed, this change needed to happen too.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No - but it's a break out of #4946

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
