### PR TITLE
fix panic in fs_reader

### DIFF
--- a/changelog/unreleased/issue-4975
+++ b/changelog/unreleased/issue-4975
@@ -1,0 +1,6 @@
+Bugfix: Prevent `backup --stdin-from-command` from panicking
+
+If --stdin-from-command is used, restic now checks whether there is a command behind it.
+
+https://github.com/restic/restic/issues/4975
+https://github.com/restic/restic/pull/4976

--- a/internal/fs/fs_reader_command.go
+++ b/internal/fs/fs_reader_command.go
@@ -29,6 +29,10 @@ type CommandReader struct {
 }
 
 func NewCommandReader(ctx context.Context, args []string, logOutput io.Writer) (*CommandReader, error) {
+	if len(args) == 0 {
+		return nil, fmt.Errorf("no command was specified as argument")
+	}
+
 	// Prepare command and stdout
 	command := exec.CommandContext(ctx, args[0], args[1:]...)
 	stdout, err := command.StdoutPipe()

--- a/internal/fs/fs_reader_command_test.go
+++ b/internal/fs/fs_reader_command_test.go
@@ -34,6 +34,11 @@ func TestCommandReaderInvalid(t *testing.T) {
 	test.Assert(t, err != nil, "missing error")
 }
 
+func TestCommandReaderEmptyArgs(t *testing.T) {
+	_, err := fs.NewCommandReader(context.TODO(), []string{}, io.Discard)
+	test.Assert(t, err != nil, "missing error")
+}
+
 func TestCommandReaderOutput(t *testing.T) {
 	reader, err := fs.NewCommandReader(context.TODO(), []string{"echo", "hello world"}, io.Discard)
 	test.OK(t, err)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
It prevent's panic on using the restic backup --stdin-from-command without a command at the end
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
no
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
Closes #4975

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
