### PR TITLE
backup: warn but store store item if extended metadata is incomplete

### DIFF
--- a/changelog/unreleased/pull-4977
+++ b/changelog/unreleased/pull-4977
@@ -1,0 +1,15 @@
+Change: let `backup` store files with incomplete metadata
+
+If restic failed to read the extended metadata for a file or folder while
+creating a backup, then the file or folder was not included in the resulting
+snapshot. Instead, only a warning message was printed along with exiting
+with exit code 3.
+
+Now, restic also includes items for which the extended metadata could not
+be read in a snapshot. The warning message has been changed to read
+```
+incomplete metadata for /path/to/file: details on error
+```
+
+https://github.com/restic/restic/issues/4953
+https://github.com/restic/restic/pull/4977

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -263,7 +263,8 @@ func (arch *Archiver) nodeFromFileInfo(snPath, filename string, fi os.FileInfo, 
 	// overwrite name to match that within the snapshot
 	node.Name = path.Base(snPath)
 	if err != nil {
-		return node, fmt.Errorf("nodeFromFileInfo %v: %w", filename, err)
+		err = fmt.Errorf("incomplete metadata for %v: %w", filename, err)
+		return node, arch.error(filename, err)
 	}
 	return node, err
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Files were not included in the backup if the extended metadata for the file could not be read. This is rather drastic. Instead settle on returning a warning but still including the file in the backup.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/4953 .
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
