### PR TITLE
rewrite: skip saving empty indexes during MasterIndex.Rewrite

### DIFF
--- a/internal/repository/index/master_index.go
+++ b/internal/repository/index/master_index.go
@@ -456,6 +456,9 @@ func (mi *MasterIndex) Rewrite(ctx context.Context, repo restic.Unpacked, exclud
 	worker := func() error {
 		for idx := range saveCh {
 			idx.Finalize()
+			if len(idx.packs) == 0 {
+				continue
+			}
 			if _, err := idx.SaveIndex(wgCtx, repo); err != nil {
 				return err
 			}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
adds a check to avoid saving indexes that contain no packs
during the MasterIndex.Rewrite process

based on https://github.com/restic/restic/issues/4949#issuecomment-2258689368

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #4949 

Checklist
---------
- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
~~[ ] I have added tests for all code changes.~~
~~[ ] I have added documentation for relevant changes (in the manual).~~
~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
