### PR TITLE
Skip ExtendedAttribute processing in Windows for volumes that do not support EA

### DIFF
--- a/changelog/unreleased/pull-4980
+++ b/changelog/unreleased/pull-4980
@@ -1,10 +1,12 @@
 Bugfix: Skip EA processing in Windows for volumes that do not support EA
 
 Restic was failing to backup files on some windows paths like network
-drives because of errors while fetching ExtendedAttributes.
+drives because of errors while fetching extended attributes.
 Either they return error codes like windows.E_NOT_SET or
 windows.ERROR_INVALID_FUNCTION or it results in slower backups.
-Restic now completely skips the attempt to fetch Extended Attributes
+Restic now completely skips the attempt to fetch extended attributes
 for such volumes where it is not supported.
 
 https://github.com/restic/restic/pull/4980
+https://github.com/restic/restic/issues/4955
+https://github.com/restic/restic/issues/4950

--- a/changelog/unreleased/pull-4980
+++ b/changelog/unreleased/pull-4980
@@ -1,0 +1,10 @@
+Bugfix: Skip EA processing in Windows for volumes that do not support EA
+
+Restic was failing to backup files on some windows paths like network
+drives because of errors while fetching ExtendedAttributes.
+Either they return error codes like windows.E_NOT_SET or
+windows.ERROR_INVALID_FUNCTION or it results in slower backups.
+Restic now completely skips the attempt to fetch Extended Attributes
+for such volumes where it is not supported.
+
+https://github.com/restic/restic/pull/4980

--- a/internal/fs/ea_windows.go
+++ b/internal/fs/ea_windows.go
@@ -61,7 +61,8 @@ var (
 
 const (
 	// fileSupportsExtendedAttributes is a bitmask that indicates whether the file system supports extended attributes.
-	fileSupportsExtendedAttributes = 0x00000004
+	// https://learn.microsoft.com/en-us/windows-hardware/drivers/ddi/ntifs/ns-ntifs-_file_fs_attribute_information
+	fileSupportsExtendedAttributes = 0x00800000
 )
 
 // ExtendedAttribute represents a single Windows EA.

--- a/internal/fs/sd_windows.go
+++ b/internal/fs/sd_windows.go
@@ -11,6 +11,7 @@ import (
 	"unsafe"
 
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 	"golang.org/x/sys/windows"
 )
 
@@ -60,6 +61,8 @@ func GetSecurityDescriptor(filePath string) (securityDescriptor *[]byte, err err
 			if err != nil {
 				return nil, fmt.Errorf("get low-level named security info failed with: %w", err)
 			}
+		} else if errors.Is(err, windows.ERROR_NOT_SUPPORTED) {
+			return nil, nil
 		} else {
 			return nil, fmt.Errorf("get named security info failed with: %w", err)
 		}

--- a/internal/restic/node_windows.go
+++ b/internal/restic/node_windows.go
@@ -392,7 +392,7 @@ func (node *Node) fillGenericAttributes(path string, fi os.FileInfo, stat *statT
 			return false, err
 		}
 		if sd, err = fs.GetSecurityDescriptor(path); err != nil {
-			return true, err
+			return allowExtended, err
 		}
 	}
 	// Add Windows attributes

--- a/internal/restic/node_windows.go
+++ b/internal/restic/node_windows.go
@@ -364,11 +364,13 @@ func (node *Node) fillGenericAttributes(path string, fi os.FileInfo, stat *statT
 		// Also do not allow processing of extended attributes for ADS.
 		return false, nil
 	}
+
 	volumeName := filepath.VolumeName(path)
 	allowExtended, err = checkAndStoreEASupport(volumeName)
 	if err != nil {
 		return false, err
 	}
+
 	if strings.HasSuffix(filepath.Clean(path), `\`) {
 		// filepath.Clean(path) ends with '\' for Windows root volume paths only
 		// Do not process file attributes, created time and sd for windows root volume paths


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Some windows paths like network drives do not support ExtendedAttributes. Either they return error codes like windows.E_NOT_SET or windows.ERROR_INVALID_FUNCTION or it results in slower backups.
This PR aims to skip processing the ExtendedAttributes after detecting if the volume does not support them.
It completely skips the attempt to fetch Extended Attributes instead of trying to handle errors after trying to fetch EA for files on such volumes.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
May resolve https://github.com/restic/restic/issues/4955 and https://github.com/restic/restic/issues/4950

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
