### PR TITLE
restore: Add progress bar to 'restore --verify'

### DIFF
--- a/changelog/unreleased/issue-4795
+++ b/changelog/unreleased/issue-4795
@@ -1,0 +1,7 @@
+Enhancement: `restore --verify` shows progress with a progress bar
+
+If restore command was run with `--verify` restic didn't show any progress indication, now it shows a progress bar while 'verification' is running.
+The progress bar is text only for now and doesn't respect `--json` flag.
+
+https://github.com/restic/restic/issues/4795
+https://github.com/restic/restic/pull/4989

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -221,7 +221,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 		msg.P("restoring %s to %s\n", res.Snapshot(), opts.Target)
 	}
 
-	err = res.RestoreTo(ctx, opts.Target)
+	countRestoredFiles, err := res.RestoreTo(ctx, opts.Target)
 	if err != nil {
 		return err
 	}
@@ -238,7 +238,8 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 		}
 		var count int
 		t0 := time.Now()
-		count, err = res.VerifyFiles(ctx, opts.Target)
+		bar := newTerminalProgressMax(!gopts.Quiet && !gopts.JSON && stdoutIsTerminal(), 0, "files verified", term)
+		count, err = res.VerifyFiles(ctx, opts.Target, countRestoredFiles, bar)
 		if err != nil {
 			return err
 		}

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/ui/progress"
 	restoreui "github.com/restic/restic/internal/ui/restore"
 	"golang.org/x/sync/errgroup"
 )
@@ -403,13 +404,13 @@ func TestRestorer(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			err := res.RestoreTo(ctx, tempdir)
+			countRestoredFiles, err := res.RestoreTo(ctx, tempdir)
 			if err != nil {
 				t.Fatal(err)
 			}
 
 			if len(test.ErrorsMust)+len(test.ErrorsMay) == 0 {
-				_, err = res.VerifyFiles(ctx, tempdir)
+				_, err = res.VerifyFiles(ctx, tempdir, countRestoredFiles, nil)
 				rtest.OK(t, err)
 			}
 
@@ -501,13 +502,18 @@ func TestRestorerRelative(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			err := res.RestoreTo(ctx, "restore")
+			countRestoredFiles, err := res.RestoreTo(ctx, "restore")
 			if err != nil {
 				t.Fatal(err)
 			}
-			nverified, err := res.VerifyFiles(ctx, "restore")
+			p := progress.NewCounter(time.Second, countRestoredFiles, func(value uint64, total uint64, runtime time.Duration, final bool) {})
+			defer p.Done()
+			nverified, err := res.VerifyFiles(ctx, "restore", countRestoredFiles, p)
 			rtest.OK(t, err)
 			rtest.Equals(t, len(test.Files), nverified)
+			counterValue, maxValue := p.Get()
+			rtest.Equals(t, counterValue, uint64(2))
+			rtest.Equals(t, maxValue, uint64(2))
 
 			for filename, err := range errors {
 				t.Errorf("unexpected error for %v found: %v", filename, err)
@@ -524,6 +530,13 @@ func TestRestorerRelative(t *testing.T) {
 					t.Errorf("file %v has wrong content: want %q, got %q", filename, content, data)
 				}
 			}
+
+			// verify that restoring the same snapshot again results in countRestoredFiles == 0
+			countRestoredFiles, err = res.RestoreTo(ctx, "restore")
+			if err != nil {
+				t.Fatal(err)
+			}
+			rtest.Equals(t, uint64(0), countRestoredFiles)
 		})
 	}
 }
@@ -835,7 +848,7 @@ func TestRestorerConsistentTimestampsAndPermissions(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := res.RestoreTo(ctx, tempdir)
+	_, err := res.RestoreTo(ctx, tempdir)
 	rtest.OK(t, err)
 
 	var testPatterns = []struct {
@@ -872,9 +885,9 @@ func TestVerifyCancel(t *testing.T) {
 	tempdir := rtest.TempDir(t)
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-
-	rtest.OK(t, res.RestoreTo(ctx, tempdir))
-	err := os.WriteFile(filepath.Join(tempdir, "foo"), []byte("bar"), 0644)
+	countRestoredFiles, err := res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
+	err = os.WriteFile(filepath.Join(tempdir, "foo"), []byte("bar"), 0644)
 	rtest.OK(t, err)
 
 	var errs []error
@@ -883,7 +896,7 @@ func TestVerifyCancel(t *testing.T) {
 		return err
 	}
 
-	nverified, err := res.VerifyFiles(ctx, tempdir)
+	nverified, err := res.VerifyFiles(ctx, tempdir, countRestoredFiles, nil)
 	rtest.Equals(t, 0, nverified)
 	rtest.Assert(t, err != nil, "nil error from VerifyFiles")
 	rtest.Equals(t, 1, len(errs))
@@ -915,7 +928,7 @@ func TestRestorerSparseFiles(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err = res.RestoreTo(ctx, tempdir)
+	_, err = res.RestoreTo(ctx, tempdir)
 	rtest.OK(t, err)
 
 	filename := filepath.Join(tempdir, "zeros")
@@ -952,15 +965,17 @@ func saveSnapshotsAndOverwrite(t *testing.T, baseSnapshot Snapshot, overwriteSna
 	t.Logf("base snapshot saved as %v", id.Str())
 
 	res := NewRestorer(repo, sn, baseOptions)
-	rtest.OK(t, res.RestoreTo(ctx, tempdir))
+	_, err := res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
 
 	// overwrite snapshot
 	sn, id = saveSnapshot(t, repo, overwriteSnapshot, noopGetGenericAttributes)
 	t.Logf("overwrite snapshot saved as %v", id.Str())
 	res = NewRestorer(repo, sn, overwriteOptions)
-	rtest.OK(t, res.RestoreTo(ctx, tempdir))
+	countRestoredFiles, err := res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
 
-	_, err := res.VerifyFiles(ctx, tempdir)
+	_, err = res.VerifyFiles(ctx, tempdir, countRestoredFiles, nil)
 	rtest.OK(t, err)
 
 	return tempdir
@@ -1238,8 +1253,9 @@ func TestRestoreModified(t *testing.T) {
 		t.Logf("snapshot saved as %v", id.Str())
 
 		res := NewRestorer(repo, sn, Options{Overwrite: OverwriteIfChanged})
-		rtest.OK(t, res.RestoreTo(ctx, tempdir))
-		n, err := res.VerifyFiles(ctx, tempdir)
+		countRestoredFiles, err := res.RestoreTo(ctx, tempdir)
+		rtest.OK(t, err)
+		n, err := res.VerifyFiles(ctx, tempdir, countRestoredFiles, nil)
 		rtest.OK(t, err)
 		rtest.Equals(t, 2, n, "unexpected number of verified files")
 	}
@@ -1264,7 +1280,8 @@ func TestRestoreIfChanged(t *testing.T) {
 	t.Logf("snapshot saved as %v", id.Str())
 
 	res := NewRestorer(repo, sn, Options{})
-	rtest.OK(t, res.RestoreTo(ctx, tempdir))
+	_, err := res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
 
 	// modify file but maintain size and timestamp
 	path := filepath.Join(tempdir, "foo")
@@ -1283,7 +1300,8 @@ func TestRestoreIfChanged(t *testing.T) {
 
 	for _, overwrite := range []OverwriteBehavior{OverwriteIfChanged, OverwriteAlways} {
 		res = NewRestorer(repo, sn, Options{Overwrite: overwrite})
-		rtest.OK(t, res.RestoreTo(ctx, tempdir))
+		_, err := res.RestoreTo(ctx, tempdir)
+		rtest.OK(t, err)
 		data, err := os.ReadFile(path)
 		rtest.OK(t, err)
 		if overwrite == OverwriteAlways {
@@ -1319,9 +1337,10 @@ func TestRestoreDryRun(t *testing.T) {
 	t.Logf("snapshot saved as %v", id.Str())
 
 	res := NewRestorer(repo, sn, Options{DryRun: true})
-	rtest.OK(t, res.RestoreTo(ctx, tempdir))
+	_, err := res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
 
-	_, err := os.Stat(tempdir)
+	_, err = os.Stat(tempdir)
 	rtest.Assert(t, errors.Is(err, os.ErrNotExist), "expected no file to be created, got %v", err)
 }
 
@@ -1345,7 +1364,8 @@ func TestRestoreDryRunDelete(t *testing.T) {
 
 	sn, _ := saveSnapshot(t, repo, snapshot, noopGetGenericAttributes)
 	res := NewRestorer(repo, sn, Options{DryRun: true, Delete: true})
-	rtest.OK(t, res.RestoreTo(ctx, tempdir))
+	_, err = res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
 
 	_, err = os.Stat(tempfile)
 	rtest.Assert(t, err == nil, "expected file to still exist, got error %v", err)
@@ -1463,14 +1483,14 @@ func TestRestoreDelete(t *testing.T) {
 			ctx, cancel := context.WithCancel(context.Background())
 			defer cancel()
 
-			err := res.RestoreTo(ctx, tempdir)
+			_, err := res.RestoreTo(ctx, tempdir)
 			rtest.OK(t, err)
 
 			res = NewRestorer(repo, deleteSn, Options{Delete: true})
 			if test.selectFilter != nil {
 				res.SelectFilter = test.selectFilter
 			}
-			err = res.RestoreTo(ctx, tempdir)
+			_, err = res.RestoreTo(ctx, tempdir)
 			rtest.OK(t, err)
 
 			for fn, shouldExist := range test.fileState {
@@ -1503,7 +1523,7 @@ func TestRestoreToFile(t *testing.T) {
 
 	sn, _ := saveSnapshot(t, repo, snapshot, noopGetGenericAttributes)
 	res := NewRestorer(repo, sn, Options{})
-	err := res.RestoreTo(ctx, tempdir)
+	_, err := res.RestoreTo(ctx, tempdir)
 	rtest.Assert(t, strings.Contains(err.Error(), "cannot create target directory"), "unexpected error %v", err)
 }
 
@@ -1535,7 +1555,8 @@ func TestRestorerLongPath(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	rtest.OK(t, res.RestoreTo(ctx, tmp))
-	_, err = res.VerifyFiles(ctx, tmp)
+	countRestoredFiles, err := res.RestoreTo(ctx, tmp)
+	rtest.OK(t, err)
+	_, err = res.VerifyFiles(ctx, tmp, countRestoredFiles, nil)
 	rtest.OK(t, err)
 }

--- a/internal/restorer/restorer_unix_test.go
+++ b/internal/restorer/restorer_unix_test.go
@@ -37,7 +37,7 @@ func TestRestorerRestoreEmptyHardlinkedFields(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := res.RestoreTo(ctx, tempdir)
+	_, err := res.RestoreTo(ctx, tempdir)
 	rtest.OK(t, err)
 
 	f1, err := os.Stat(filepath.Join(tempdir, "dirtest/file1"))
@@ -96,7 +96,7 @@ func testRestorerProgressBar(t *testing.T, dryRun bool) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := res.RestoreTo(ctx, tempdir)
+	_, err := res.RestoreTo(ctx, tempdir)
 	rtest.OK(t, err)
 	progress.Finish()
 
@@ -126,7 +126,8 @@ func TestRestorePermissions(t *testing.T) {
 	t.Logf("snapshot saved as %v", id.Str())
 
 	res := NewRestorer(repo, sn, Options{})
-	rtest.OK(t, res.RestoreTo(ctx, tempdir))
+	_, err := res.RestoreTo(ctx, tempdir)
+	rtest.OK(t, err)
 
 	for _, overwrite := range []OverwriteBehavior{OverwriteIfChanged, OverwriteAlways} {
 		// tamper with permissions
@@ -134,7 +135,8 @@ func TestRestorePermissions(t *testing.T) {
 		rtest.OK(t, os.Chmod(path, 0o700))
 
 		res = NewRestorer(repo, sn, Options{Overwrite: overwrite})
-		rtest.OK(t, res.RestoreTo(ctx, tempdir))
+		_, err := res.RestoreTo(ctx, tempdir)
+		rtest.OK(t, err)
 		fi, err := os.Stat(path)
 		rtest.OK(t, err)
 		rtest.Equals(t, fs.FileMode(0o600), fi.Mode().Perm(), "unexpected permissions")

--- a/internal/restorer/restorer_windows_test.go
+++ b/internal/restorer/restorer_windows_test.go
@@ -181,7 +181,7 @@ func runAttributeTests(t *testing.T, fileInfo NodeInfo, existingFileAttr FileAtt
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := res.RestoreTo(ctx, testDir)
+	_, err := res.RestoreTo(ctx, testDir)
 	rtest.OK(t, err)
 
 	mainFilePath := path.Join(testDir, fileInfo.parentDir, fileInfo.name)
@@ -562,11 +562,11 @@ func TestRestoreDeleteCaseInsensitive(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	err := res.RestoreTo(ctx, tempdir)
+	_, err := res.RestoreTo(ctx, tempdir)
 	rtest.OK(t, err)
 
 	res = NewRestorer(repo, deleteSn, Options{Delete: true})
-	err = res.RestoreTo(ctx, tempdir)
+	_, err = res.RestoreTo(ctx, tempdir)
 	rtest.OK(t, err)
 
 	// anotherfile must still exist


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

This MR introduces a progress bar to the `restic restore --verify` flow when verify is in-progress. Earlier, there was no output when files were being verified.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

https://github.com/restic/restic/issues/4795

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
