### PR TITLE
backend: return correct error on upload/request timeout

### DIFF
--- a/internal/backend/watchdog_roundtriper.go
+++ b/internal/backend/watchdog_roundtriper.go
@@ -65,6 +65,9 @@ func (w *watchdogRoundtripper) RoundTrip(req *http.Request) (*http.Response, err
 
 	resp, err := w.rt.RoundTrip(req)
 	if err != nil {
+		if isTimeout(err) {
+			err = errRequestTimeout
+		}
 		return nil, err
 	}
 

--- a/internal/backend/watchdog_roundtriper_test.go
+++ b/internal/backend/watchdog_roundtriper_test.go
@@ -135,7 +135,7 @@ func TestUploadTimeout(t *testing.T) {
 	rtest.OK(t, err)
 
 	resp, err := rt.RoundTrip(req)
-	rtest.Equals(t, context.Canceled, err)
+	rtest.Equals(t, errRequestTimeout, err)
 	// make linter happy
 	if resp != nil {
 		rtest.OK(t, resp.Body.Close())
@@ -162,7 +162,7 @@ func TestProcessingTimeout(t *testing.T) {
 	rtest.OK(t, err)
 
 	resp, err := rt.RoundTrip(req)
-	rtest.Equals(t, context.Canceled, err)
+	rtest.Equals(t, errRequestTimeout, err)
 	// make linter happy
 	if resp != nil {
 		rtest.OK(t, resp.Body.Close())


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
If a backend request takes longer than 5 minutes without returning data, this resulted in a "context canceled" errors instead of the intended "request timeout" error.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See for an example: https://github.com/restic/restic/issues/4988
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
