### PR TITLE
Fix extended attributes handling for VSS snapshots

### DIFF
--- a/changelog/unreleased/pull-4980
+++ b/changelog/unreleased/pull-4980
@@ -8,5 +8,6 @@ Restic now completely skips the attempt to fetch extended attributes
 for such volumes where it is not supported.
 
 https://github.com/restic/restic/pull/4980
+https://github.com/restic/restic/pull/4998
 https://github.com/restic/restic/issues/4955
 https://github.com/restic/restic/issues/4950

--- a/changelog/unreleased/pull-4998
+++ b/changelog/unreleased/pull-4998
@@ -1,0 +1,8 @@
+Bugfix: Fix extended attributes handling for VSS snapshots
+
+Restic was failing to backup extended attributes for VSS snapshots
+after the fix for https://github.com/restic/restic/pull/4980.
+Restic now correctly handles extended attributes for VSS snapshots.
+
+https://github.com/restic/restic/pull/4998
+https://github.com/restic/restic/pull/4980

--- a/changelog/unreleased/pull-4998
+++ b/changelog/unreleased/pull-4998
@@ -1,8 +1,0 @@
-Bugfix: Fix extended attributes handling for VSS snapshots
-
-Restic was failing to backup extended attributes for VSS snapshots
-after the fix for https://github.com/restic/restic/pull/4980.
-Restic now correctly handles extended attributes for VSS snapshots.
-
-https://github.com/restic/restic/pull/4998
-https://github.com/restic/restic/pull/4980

--- a/internal/fs/ea_windows.go
+++ b/internal/fs/ea_windows.go
@@ -8,6 +8,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"strings"
 	"syscall"
 	"unsafe"
 
@@ -297,4 +298,21 @@ func PathSupportsExtendedAttributes(path string) (supported bool, err error) {
 	}
 	supported = (fileSystemFlags & windows.FILE_SUPPORTS_EXTENDED_ATTRIBUTES) != 0
 	return supported, nil
+}
+
+// GetVolumePathName returns the volume path name for the given path.
+func GetVolumePathName(path string) (volumeName string, err error) {
+	utf16Path, err := windows.UTF16PtrFromString(path)
+	if err != nil {
+		return "", err
+	}
+	// Get the volume path (e.g., "D:")
+	var volumePath [windows.MAX_PATH + 1]uint16
+	err = windows.GetVolumePathName(utf16Path, &volumePath[0], windows.MAX_PATH+1)
+	if err != nil {
+		return "", err
+	}
+	// Trim any trailing backslashes
+	volumeName = strings.TrimRight(windows.UTF16ToString(volumePath[:]), "\\")
+	return volumeName, nil
 }

--- a/internal/restic/node_windows.go
+++ b/internal/restic/node_windows.go
@@ -407,38 +407,72 @@ func (node *Node) fillGenericAttributes(path string, fi os.FileInfo, stat *statT
 // checkAndStoreEASupport checks if the volume of the path supports extended attributes and stores the result in a map
 // If the result is already in the map, it returns the result from the map.
 func checkAndStoreEASupport(path string) (isEASupportedVolume bool, err error) {
-	// Check if it's an extended length path
-	if strings.HasPrefix(path, uncPathPrefix) {
-		// Convert \\?\UNC\ extended path to standard path to get the volume name correctly
-		path = `\\` + path[len(uncPathPrefix):]
-	} else if strings.HasPrefix(path, extendedPathPrefix) {
-		//Extended length path prefix needs to be trimmed to get the volume name correctly
-		path = path[len(extendedPathPrefix):]
-	} else if strings.HasPrefix(path, globalRootPrefix) {
-		// EAs are not supported for \\?\GLOBALROOT i.e. VSS snapshots
-		return false, nil
-	} else {
-		// Use the absolute path
-		path, err = filepath.Abs(path)
-		if err != nil {
-			return false, fmt.Errorf("failed to get absolute path: %w", err)
-		}
-	}
-	volumeName := filepath.VolumeName(path)
-	if volumeName == "" {
-		return false, nil
-	}
-	eaSupportedValue, exists := eaSupportedVolumesMap.Load(volumeName)
-	if exists {
-		return eaSupportedValue.(bool), nil
+	var volumeName string
+	volumeName, err = prepareVolumeName(path)
+	if err != nil {
+		return false, err
 	}
 
-	// Add backslash to the volume name to ensure it is a valid path
-	isEASupportedVolume, err = fs.PathSupportsExtendedAttributes(volumeName + `\`)
-	if err == nil {
-		eaSupportedVolumesMap.Store(volumeName, isEASupportedVolume)
+	if volumeName != "" {
+		// First check if the manually prepared volume name is already in the map
+		eaSupportedValue, exists := eaSupportedVolumesMap.Load(volumeName)
+		if exists {
+			return eaSupportedValue.(bool), nil
+		}
+		// If not found, check if EA is supported with manually prepared volume name
+		isEASupportedVolume, err = fs.PathSupportsExtendedAttributes(volumeName + `\`)
+		if err != nil {
+			return false, err
+		}
 	}
+	// If an entry is not found, get the actual volume name using the GetVolumePathName function
+	volumeNameActual, err := fs.GetVolumePathName(path)
+	if err != nil {
+		return false, err
+	}
+	if volumeNameActual != volumeName {
+		// If the actual volume name is different, check cache for the actual volume name
+		eaSupportedValue, exists := eaSupportedVolumesMap.Load(volumeNameActual)
+		if exists {
+			return eaSupportedValue.(bool), nil
+		}
+		// If the actual volume name is different and is not in the map, again check if the new volume supports extended attributes with the actual volume name
+		isEASupportedVolume, err = fs.PathSupportsExtendedAttributes(volumeNameActual + `\`)
+		if err != nil {
+			return false, err
+		}
+	}
+	eaSupportedVolumesMap.Store(volumeNameActual, isEASupportedVolume)
 	return isEASupportedVolume, err
+}
+
+// prepareVolumeName prepares the volume name for different cases in Windows
+func prepareVolumeName(path string) (volumeName string, err error) {
+	// Check if it's an extended length path
+	if strings.HasPrefix(path, globalRootPrefix) {
+		// Extract the VSS snapshot volume name eg. `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopyXX`
+		if parts := strings.SplitN(path, `\`, 7); len(parts) >= 6 {
+			volumeName = strings.Join(parts[:6], `\`)
+		} else {
+			volumeName = filepath.VolumeName(path)
+		}
+	} else {
+		if strings.HasPrefix(path, uncPathPrefix) {
+			// Convert \\?\UNC\ extended path to standard path to get the volume name correctly
+			path = `\\` + path[len(uncPathPrefix):]
+		} else if strings.HasPrefix(path, extendedPathPrefix) {
+			//Extended length path prefix needs to be trimmed to get the volume name correctly
+			path = path[len(extendedPathPrefix):]
+		} else {
+			// Use the absolute path
+			path, err = filepath.Abs(path)
+			if err != nil {
+				return "", fmt.Errorf("failed to get absolute path: %w", err)
+			}
+		}
+		volumeName = filepath.VolumeName(path)
+	}
+	return volumeName, nil
 }
 
 // windowsAttrsToGenericAttributes converts the WindowsAttributes to a generic attributes map using reflection

--- a/internal/restic/node_windows.go
+++ b/internal/restic/node_windows.go
@@ -417,11 +417,13 @@ func checkAndStoreEASupport(path string) (isEASupportedVolume bool, err error) {
 		// First check if the manually prepared volume name is already in the map
 		eaSupportedValue, exists := eaSupportedVolumesMap.Load(volumeName)
 		if exists {
+			// Cache hit, immediately return the cached value
 			return eaSupportedValue.(bool), nil
 		}
 		// If not found, check if EA is supported with manually prepared volume name
 		isEASupportedVolume, err = fs.PathSupportsExtendedAttributes(volumeName + `\`)
-		if err != nil {
+		// If the prepared volume name is not valid, we will next fetch the actual volume name.
+		if err != nil && !errors.Is(err, windows.DNS_ERROR_INVALID_NAME) {
 			return false, err
 		}
 	}
@@ -434,6 +436,7 @@ func checkAndStoreEASupport(path string) (isEASupportedVolume bool, err error) {
 		// If the actual volume name is different, check cache for the actual volume name
 		eaSupportedValue, exists := eaSupportedVolumesMap.Load(volumeNameActual)
 		if exists {
+			// Cache hit, immediately return the cached value
 			return eaSupportedValue.(bool), nil
 		}
 		// If the actual volume name is different and is not in the map, again check if the new volume supports extended attributes with the actual volume name

--- a/internal/restic/node_windows.go
+++ b/internal/restic/node_windows.go
@@ -42,6 +42,7 @@ const (
 	extendedPathPrefix = `\\?\`
 	uncPathPrefix      = `\\?\UNC\`
 	globalRootPrefix   = `\\?\GLOBALROOT\`
+	volumeGUIDPrefix   = `\\?\Volume{`
 )
 
 // mknod is not supported on Windows.
@@ -422,15 +423,21 @@ func checkAndStoreEASupport(path string) (isEASupportedVolume bool, err error) {
 		}
 		// If not found, check if EA is supported with manually prepared volume name
 		isEASupportedVolume, err = fs.PathSupportsExtendedAttributes(volumeName + `\`)
-		// If the prepared volume name is not valid, we will next fetch the actual volume name.
+		// If the prepared volume name is not valid, we will fetch the actual volume name next.
 		if err != nil && !errors.Is(err, windows.DNS_ERROR_INVALID_NAME) {
-			return false, err
+			debug.Log("Error checking if extended attributes are supported for prepared volume name %s: %v", volumeName, err)
+			// There can be multiple errors like path does not exist, bad network path, etc.
+			// We just gracefully disallow extended attributes for cases.
+			return false, nil
 		}
 	}
 	// If an entry is not found, get the actual volume name using the GetVolumePathName function
 	volumeNameActual, err := fs.GetVolumePathName(path)
 	if err != nil {
-		return false, err
+		debug.Log("Error getting actual volume name %s for path %s: %v", volumeName, path, err)
+		// There can be multiple errors like path does not exist, bad network path, etc.
+		// We just gracefully disallow extended attributes for cases.
+		return false, nil
 	}
 	if volumeNameActual != volumeName {
 		// If the actual volume name is different, check cache for the actual volume name
@@ -441,11 +448,19 @@ func checkAndStoreEASupport(path string) (isEASupportedVolume bool, err error) {
 		}
 		// If the actual volume name is different and is not in the map, again check if the new volume supports extended attributes with the actual volume name
 		isEASupportedVolume, err = fs.PathSupportsExtendedAttributes(volumeNameActual + `\`)
+		// Debug log for cases where the prepared volume name is not valid
 		if err != nil {
-			return false, err
+			debug.Log("Error checking if extended attributes are supported for actual volume name %s: %v", volumeNameActual, err)
+			// There can be multiple errors like path does not exist, bad network path, etc.
+			// We just gracefully disallow extended attributes for cases.
+			return false, nil
+		} else {
+			debug.Log("Checking extended attributes. Prepared volume name: %s, actual volume name: %s, isEASupportedVolume: %v, err: %v", volumeName, volumeNameActual, isEASupportedVolume, err)
 		}
 	}
-	eaSupportedVolumesMap.Store(volumeNameActual, isEASupportedVolume)
+	if volumeNameActual != "" {
+		eaSupportedVolumesMap.Store(volumeNameActual, isEASupportedVolume)
+	}
 	return isEASupportedVolume, err
 }
 
@@ -460,17 +475,19 @@ func prepareVolumeName(path string) (volumeName string, err error) {
 			volumeName = filepath.VolumeName(path)
 		}
 	} else {
-		if strings.HasPrefix(path, uncPathPrefix) {
-			// Convert \\?\UNC\ extended path to standard path to get the volume name correctly
-			path = `\\` + path[len(uncPathPrefix):]
-		} else if strings.HasPrefix(path, extendedPathPrefix) {
-			//Extended length path prefix needs to be trimmed to get the volume name correctly
-			path = path[len(extendedPathPrefix):]
-		} else {
-			// Use the absolute path
-			path, err = filepath.Abs(path)
-			if err != nil {
-				return "", fmt.Errorf("failed to get absolute path: %w", err)
+		if !strings.HasPrefix(path, volumeGUIDPrefix) { // Handle volume GUID path
+			if strings.HasPrefix(path, uncPathPrefix) {
+				// Convert \\?\UNC\ extended path to standard path to get the volume name correctly
+				path = `\\` + path[len(uncPathPrefix):]
+			} else if strings.HasPrefix(path, extendedPathPrefix) {
+				//Extended length path prefix needs to be trimmed to get the volume name correctly
+				path = path[len(extendedPathPrefix):]
+			} else {
+				// Use the absolute path
+				path, err = filepath.Abs(path)
+				if err != nil {
+					return "", fmt.Errorf("failed to get absolute path: %w", err)
+				}
 			}
 		}
 		volumeName = filepath.VolumeName(path)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
After the change in https://github.com/restic/restic/pull/4980 support for extended attributes for VSS snapshot based backups was disabled. This change allows extended attributes to be backed up for VSS snapshots as well.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Follow up to - https://github.com/restic/restic/pull/4980

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
