### PR TITLE
docker: sign container images pushed to GHCR with GitHub OIDC tokens

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,7 +19,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-      id-token: write # needed for signing the images with GitHub OIDC Token
 
     outputs:
       image: ${{ steps.image.outputs.image }}
@@ -43,7 +42,7 @@ jobs:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
             type=sha
-            type=ref, event=branch
+            type=ref,event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -19,6 +19,11 @@ jobs:
     permissions:
       contents: read
       packages: write
+      id-token: write # needed for signing the images with GitHub OIDC Token
+
+    outputs:
+      image: ${{ steps.image.outputs.image }}
+      digest: ${{ steps.build-and-push.outputs.digest }}
 
     steps:
       - name: Checkout repository
@@ -37,7 +42,8 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
-            type=ref,event=branch
+            type=sha
+            type=ref, event=branch
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
 
@@ -55,6 +61,7 @@ jobs:
         if: github.ref != 'refs/heads/master'
 
       - name: Build and push Docker image
+        id: build-and-push
         uses: docker/build-push-action@15560696de535e4014efeff63c48f16952e52dd1
         with:
           push: true
@@ -64,3 +71,26 @@ jobs:
           pull: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+        
+      - name: Output image
+        id: image
+        run: |
+          # NOTE: Set the image as an output because the `env` context is not
+          # available to the inputs of a reusable workflow call.
+          image_name="${REGISTRY}/${IMAGE_NAME}"
+          echo "image=$image_name" >> "$GITHUB_OUTPUT"
+        
+  provenance:
+    needs: [build-and-push-image]
+    permissions:
+      actions: read # for detecting the Github Actions environment.
+      id-token: write # for creating OIDC tokens for signing.
+      packages: write # for uploading attestations.
+    if: github.repository == 'restic/restic'
+    uses: slsa-framework/slsa-github-generator/.github/workflows/generator_container_slsa3.yml@v2.0.0
+    with:
+      image: ${{ needs.build-and-push-image.outputs.image }}
+      digest: ${{ needs.build-and-push-image.outputs.digest }}
+      registry-username: ${{ github.actor }}
+    secrets:
+      registry-password: ${{ secrets.GITHUB_TOKEN }}

--- a/changelog/unreleased/issue-4983
+++ b/changelog/unreleased/issue-4983
@@ -1,0 +1,8 @@
+Enhancement: add SLSA provenance to the Docker images
+
+Restic's Docker image build workflow now includes SLSA provenance generation. 
+This enhancement improves the security and traceability of the Docker images'
+build process.
+
+https://github.com/restic/restic/issues/4983
+https://github.com/restic/restic/pull/4999

--- a/changelog/unreleased/issue-4983
+++ b/changelog/unreleased/issue-4983
@@ -1,8 +1,8 @@
-Enhancement: add SLSA provenance to the Docker images
+Enhancement: add SLSA provenance to the GHCR Container images
 
-Restic's Docker image build workflow now includes SLSA provenance generation. 
-This enhancement improves the security and traceability of the Docker images'
-build process.
+Restic's GitHub Container Registry (GHCR) image build workflow now includes
+SLSA provenance generation. This enhancement improves the security and 
+traceability of images built and pushed to GHCR. 
 
 https://github.com/restic/restic/issues/4983
 https://github.com/restic/restic/pull/4999

--- a/doc/developer_information.rst
+++ b/doc/developer_information.rst
@@ -113,6 +113,34 @@ The following steps are necessary to build the binaries:
         restic/builder \
         go run helpers/build-release-binaries/main.go --version 0.14.0 --verbose
 
+Verifying SLSA Provenance for Docker Images
+*******************************************
+
+Our Docker images are built with SLSA (Supply-chain Levels for Software Artifacts)
+provenance. 
+
+To verify this provenance:
+
+1. Install the `slsa-verifier` tool from https://github.com/slsa-framework/slsa-verifier
+
+2. Run the following command:
+
+   .. code-block:: console
+
+      $ slsa-verifier verify-image \
+        --source-uri github.com/restic/restic \
+        <image-name>@<digest>
+
+   Replace `<tag>` with the Git tag of the release you're verifying, `<image-name>`
+   with the full name of the Docker image (including the registry), and `<digest>`
+   with the SHA256 digest of the image.
+
+3. If the verification is successful, you'll see output indicating that the provenance 
+is valid.
+
+This verification ensures that the Docker image was built by our official GitHub
+Actions workflow and has not been tampered with since its creation.
+
 Verifying the Official Binaries
 *******************************
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
* This allows users to verify the authenticity and integrity of Restic Docker images before using them. 
* This provides users with a verifiable record of how, when and where an artifact was built.

Refer:
1. https://github.blog/security/supply-chain-security/safeguard-container-signing-capability-actions/
2. ~~https://github.com/sigstore/cosign-installer~~
3. [Generation of SLSA3+ provenance for container images](https://github.com/slsa-framework/slsa-github-generator/tree/main/internal/builders/container#generating-provenance)

[Edit]
Changes made to the GitHub Workflow:
* ~~installing cosign v2.4.0~~
* ~~add new step to sign all the images generated during the build and push step~~
* the id-token of the GitHub Actions workflow will be used for image signing
* replace branch-based tagging with SHA-based tagging since, branch names are mutable, SLSA provenance requires immutable tagging
* use official SLSA framework Github Reusable workflow
[\Edit]

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #4983 

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
