### PR TITLE
restic: restore timestamps after extended attributes

### DIFF
--- a/changelog/unreleased/issue-4969
+++ b/changelog/unreleased/issue-4969
@@ -1,0 +1,7 @@
+Bugfix: Correctly restore timestamp for files with resource forks on macOS
+
+On macOS, timestamps were incorrectly restored for files with resource forks.
+This has been fixed.
+
+https://github.com/restic/restic/issues/4969
+https://github.com/restic/restic/pull/5006

--- a/internal/restic/node.go
+++ b/internal/restic/node.go
@@ -249,13 +249,6 @@ func (node Node) restoreMetadata(path string, warn func(msg string)) error {
 		firsterr = errors.WithStack(err)
 	}
 
-	if err := node.RestoreTimestamps(path); err != nil {
-		debug.Log("error restoring timestamps for dir %v: %v", path, err)
-		if firsterr == nil {
-			firsterr = err
-		}
-	}
-
 	if err := node.restoreExtendedAttributes(path); err != nil {
 		debug.Log("error restoring extended attributes for %v: %v", path, err)
 		if firsterr == nil {
@@ -265,6 +258,13 @@ func (node Node) restoreMetadata(path string, warn func(msg string)) error {
 
 	if err := node.restoreGenericAttributes(path, warn); err != nil {
 		debug.Log("error restoring generic attributes for %v: %v", path, err)
+		if firsterr == nil {
+			firsterr = err
+		}
+	}
+
+	if err := node.RestoreTimestamps(path); err != nil {
+		debug.Log("error restoring timestamps for %v: %v", path, err)
 		if firsterr == nil {
 			firsterr = err
 		}

--- a/internal/restic/node_test.go
+++ b/internal/restic/node_test.go
@@ -248,10 +248,6 @@ func TestNodeRestoreAt(t *testing.T) {
 			rtest.OK(t, test.CreateAt(context.TODO(), nodePath, nil))
 			rtest.OK(t, test.RestoreMetadata(nodePath, func(msg string) { rtest.OK(t, fmt.Errorf("Warning triggered for path: %s: %s", nodePath, msg)) }))
 
-			if test.Type == "dir" {
-				rtest.OK(t, test.RestoreTimestamps(nodePath))
-			}
-
 			fi, err := os.Lstat(nodePath)
 			rtest.OK(t, err)
 

--- a/internal/restic/node_test.go
+++ b/internal/restic/node_test.go
@@ -197,6 +197,20 @@ var nodeTests = []Node{
 			{"user.foo", []byte("bar")},
 		},
 	},
+	{
+		Name:       "testXattrFileMacOSResourceFork",
+		Type:       "file",
+		Content:    IDs{},
+		UID:        uint32(os.Getuid()),
+		GID:        uint32(os.Getgid()),
+		Mode:       0604,
+		ModTime:    parseTime("2005-05-14 21:07:03.111"),
+		AccessTime: parseTime("2005-05-14 21:07:04.222"),
+		ChangeTime: parseTime("2005-05-14 21:07:05.333"),
+		ExtendedAttributes: []ExtendedAttribute{
+			{"com.apple.ResourceFork", []byte("bar")},
+		},
+	},
 }
 
 func TestNodeRestoreAt(t *testing.T) {
@@ -214,6 +228,11 @@ func TestNodeRestoreAt(t *testing.T) {
 					// Iterate through the array using pointers
 					for i := 0; i < len(extAttrArr); i++ {
 						extAttrArr[i].Name = strings.ToUpper(extAttrArr[i].Name)
+					}
+				}
+				for _, attr := range test.ExtendedAttributes {
+					if strings.HasPrefix(attr.Name, "com.apple.") && runtime.GOOS != "darwin" {
+						t.Skipf("attr %v only relevant on macOS", attr.Name)
 					}
 				}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Restoring the xattr containing resource forks on macOS apparently modifies the file modification timestamps. Thus, restore the timestamp after xattrs.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Might fix https://github.com/restic/restic/issues/4969
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
