### PR TITLE
GitHub test actions: fix warnings 'Restore cache failed'

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,9 @@ jobs:
       GOPROXY: https://proxy.golang.org
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
       - name: Set up Go ${{ matrix.go }}
         uses: actions/setup-go@v5
         with:
@@ -128,9 +131,6 @@ jobs:
           # add $USERPROFILE/tar/bin to path
           echo $Env:USERPROFILE\tar\bin >> $Env:GITHUB_PATH
         if: matrix.os == 'windows-latest'
-
-      - name: Check out code
-        uses: actions/checkout@v4
 
       - name: Build with build.go
         run: |
@@ -220,13 +220,13 @@ jobs:
     name: Cross Compile for subset ${{ matrix.subset }}
 
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
       - name: Set up Go ${{ env.latest_go }}
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.latest_go }}
-
-      - name: Check out code
-        uses: actions/checkout@v4
 
       - name: Cross-compile for subset ${{ matrix.subset }}
         run: |
@@ -242,13 +242,13 @@ jobs:
       # allow annotating code in the PR
       checks: write
     steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
       - name: Set up Go ${{ env.latest_go }}
         uses: actions/setup-go@v5
         with:
           go-version: ${{ env.latest_go }}
-
-      - name: Check out code
-        uses: actions/checkout@v4
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6


### PR DESCRIPTION
As seen e.g. [here](https://github.com/restic/restic/actions/runs/10424947616), when running the GitHub test action, several warnings are printed out:

```
Restore cache failed: Dependencies file is not found in /home/runner/work/restic/restic.
Supported file pattern: go.sum 
``` 

This PR fixes these warning.

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I'm done! This pull request is ready for review.
