### PR TITLE
docs: correct wrong exit_error message field name

### DIFF
--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -100,7 +100,7 @@ It will hold the error message and the exit code.
 +----------------------+-------------------------------------------+
 | ``code``             | Exit code (see above chart)               |
 +----------------------+-------------------------------------------+
-| ``error``            | Error message                             |
+| ``message``          | Error message                             |
 +----------------------+-------------------------------------------+
 
 Output formats


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

In #4952, I accidentally left the wrong field name in the docs, during churn in the PR process. This updates the scripting docs to be more accurate.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
