### PR TITLE
Group CLI commands and show features/options

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -55,6 +55,7 @@ Exit status is 12 if the password is incorrect.
 			backupOptions.Host = hostname
 		}
 	},
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		term, cancel := setupTermstatus()

--- a/cmd/restic/cmd_cache.go
+++ b/cmd/restic/cmd_cache.go
@@ -28,6 +28,7 @@ EXIT STATUS
 Exit status is 0 if the command was successful.
 Exit status is 1 if there was any error.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(_ *cobra.Command, args []string) error {
 		return runCache(cacheOptions, globalOptions, args)

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -29,6 +29,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runCat(cmd.Context(), globalOptions, args)

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -41,6 +41,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		term, cancel := setupTermstatus()

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -41,6 +41,7 @@ Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
 	GroupID:           cmdGroupDefault,
+	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runCopy(cmd.Context(), copyOptions, globalOptions, args)
 	},

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -40,6 +40,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runCopy(cmd.Context(), copyOptions, globalOptions, args)
 	},

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -32,6 +32,7 @@ var cmdDebug = &cobra.Command{
 	Use:               "debug",
 	Short:             "Debug commands",
 	GroupID:           cmdGroupDefault,
+	DisableAutoGenTag: true,
 }
 
 var cmdDebugDump = &cobra.Command{

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -29,8 +29,9 @@ import (
 )
 
 var cmdDebug = &cobra.Command{
-	Use:   "debug",
-	Short: "Debug commands",
+	Use:               "debug",
+	Short:             "Debug commands",
+	GroupID:           cmdGroupDefault,
 }
 
 var cmdDebugDump = &cobra.Command{

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -45,6 +45,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runDiff(cmd.Context(), diffOptions, globalOptions, args)

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -40,6 +40,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runDump(cmd.Context(), dumpOptions, globalOptions, args)

--- a/cmd/restic/cmd_features.go
+++ b/cmd/restic/cmd_features.go
@@ -31,7 +31,7 @@ EXIT STATUS
 Exit status is 0 if the command was successful.
 Exit status is 1 if there was any error.
 `,
-	Hidden:            true,
+	GroupID:           cmdGroupAdvanced,
 	DisableAutoGenTag: true,
 	RunE: func(_ *cobra.Command, args []string) error {
 		if len(args) != 0 {

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -39,6 +39,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runFind(cmd.Context(), findOptions, globalOptions, args)

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -41,6 +41,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		term, cancel := setupTermstatus()

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -26,6 +26,7 @@ EXIT STATUS
 Exit status is 0 if the command was successful.
 Exit status is 1 if there was any error.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runInit(cmd.Context(), initOptions, globalOptions, args)

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -11,6 +11,7 @@ var cmdKey = &cobra.Command{
 The "key" command allows you to set multiple access keys or passwords
 per repository.
 	`,
+	GroupID:           cmdGroupDefault,
 }
 
 func init() {

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -11,6 +11,7 @@ var cmdKey = &cobra.Command{
 The "key" command allows you to set multiple access keys or passwords
 per repository.
 	`,
+	DisableAutoGenTag: true,
 	GroupID:           cmdGroupDefault,
 }
 

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -26,6 +26,7 @@ Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
 	DisableAutoGenTag: true,
+	GroupID:           cmdGroupDefault,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runList(cmd.Context(), globalOptions, args)
 	},

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -46,6 +46,7 @@ Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
 	DisableAutoGenTag: true,
+	GroupID:           cmdGroupDefault,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runLs(cmd.Context(), lsOptions, globalOptions, args)
 	},

--- a/cmd/restic/cmd_migrate.go
+++ b/cmd/restic/cmd_migrate.go
@@ -29,6 +29,7 @@ Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
 	DisableAutoGenTag: true,
+	GroupID:           cmdGroupDefault,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		term, cancel := setupTermstatus()
 		defer cancel()

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -71,6 +71,7 @@ Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
 	DisableAutoGenTag: true,
+	GroupID:           cmdGroupDefault,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runMount(cmd.Context(), mountOptions, globalOptions, args)
 	},

--- a/cmd/restic/cmd_options.go
+++ b/cmd/restic/cmd_options.go
@@ -20,7 +20,7 @@ EXIT STATUS
 Exit status is 0 if the command was successful.
 Exit status is 1 if there was any error.
 `,
-	Hidden:            true,
+	GroupID:           cmdGroupAdvanced,
 	DisableAutoGenTag: true,
 	Run: func(_ *cobra.Command, _ []string) {
 		fmt.Printf("All Extended Options:\n")

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -34,6 +34,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		term, cancel := setupTermstatus()

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -28,6 +28,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return runRecover(cmd.Context(), globalOptions)

--- a/cmd/restic/cmd_repair.go
+++ b/cmd/restic/cmd_repair.go
@@ -8,6 +8,7 @@ var cmdRepair = &cobra.Command{
 	Use:               "repair",
 	Short:             "Repair the repository",
 	GroupID:           cmdGroupDefault,
+	DisableAutoGenTag: true,
 }
 
 func init() {

--- a/cmd/restic/cmd_repair.go
+++ b/cmd/restic/cmd_repair.go
@@ -5,8 +5,9 @@ import (
 )
 
 var cmdRepair = &cobra.Command{
-	Use:   "repair",
-	Short: "Repair the repository",
+	Use:               "repair",
+	Short:             "Repair the repository",
+	GroupID:           cmdGroupDefault,
 }
 
 func init() {

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -38,6 +38,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		term, cancel := setupTermstatus()

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -44,6 +44,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runRewrite(cmd.Context(), rewriteOptions, globalOptions, args)

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -29,6 +29,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runSnapshots(cmd.Context(), snapshotOptions, globalOptions, args)

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -55,6 +55,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runStats(cmd.Context(), statsOptions, globalOptions, args)

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -31,6 +31,7 @@ Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		return runTag(cmd.Context(), tagOptions, globalOptions, args)

--- a/cmd/restic/cmd_unlock.go
+++ b/cmd/restic/cmd_unlock.go
@@ -19,6 +19,7 @@ EXIT STATUS
 Exit status is 0 if the command was successful.
 Exit status is 1 if there was any error.
 `,
+	GroupID:           cmdGroupDefault,
 	DisableAutoGenTag: true,
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return runUnlock(cmd.Context(), unlockOptions, globalOptions)

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -84,6 +84,22 @@ The full documentation can be found at https://restic.readthedocs.io/ .
 	},
 }
 
+var cmdGroupDefault = "default"
+var cmdGroupAdvanced = "advanced"
+
+func init() {
+	cmdRoot.AddGroup(
+		&cobra.Group{
+			ID:    cmdGroupDefault,
+			Title: "Available Commands:",
+		},
+		&cobra.Group{
+			ID:    cmdGroupAdvanced,
+			Title: "Advanced Options:",
+		},
+	)
+}
+
 // Distinguish commands that need the password from those that work without,
 // so we don't run $RESTIC_PASSWORD_COMMAND for no reason (it might prompt the
 // user for authentication).

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -28,8 +28,6 @@ Usage help is available:
       dump          Print a backed-up file to stdout
       find          Find a file, a directory or restic IDs
       forget        Remove snapshots from the repository
-      generate      Generate manual pages and auto-completion files (bash, fish, zsh, powershell)
-      help          Help about any command
       init          Initialize a new repository
       key           Manage keys (passwords)
       list          List objects in the repository
@@ -41,11 +39,19 @@ Usage help is available:
       repair        Repair the repository
       restore       Extract the data from a snapshot
       rewrite       Rewrite snapshots to exclude unwanted files
-      self-update   Update the restic binary
       snapshots     List all snapshots
       stats         Scan the repository and show basic statistics
       tag           Modify tags on snapshots
       unlock        Remove locks other processes created
+
+    Advanced Options:
+      features      Print list of feature flags
+      options       Print list of extended options
+
+    Additional Commands:
+      generate      Generate manual pages and auto-completion files (bash, fish, zsh, powershell)
+      help          Help about any command
+      self-update   Update the restic binary
       version       Print version information
 
     Flags:


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Make the `features` and `options` commands visible and group the commands into `available commands`, `advanced options` (contains `features` and `options`) and `additional commands` (contains `generate`, `help`, `self-update` and `version`). See the docs change for the output of `restic --help`.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Partially requested in https://github.com/restic/restic/issues/4601#issuecomment-2254114529
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
