### PR TITLE
rest: improve handling of HTTP2 goaway

### DIFF
--- a/changelog/unreleased/pull-5018
+++ b/changelog/unreleased/pull-5018
@@ -1,0 +1,13 @@
+Bugfix: Improve HTTP2 support for rest backend
+
+If rest-server tried to gracefully shut down an HTTP2 connection still used by the client,
+this could result in the following error.
+
+```
+http2: Transport: cannot retry err [http2: Transport received Server's graceful shutdown GOAWAY] after Request.Body was written; define Request.GetBody to avoid this error
+```
+
+This has been fixed.
+
+https://github.com/restic/restic/pull/5018
+https://forum.restic.net/t/receiving-http2-goaway-messages-with-windows-restic-v0-17-0/8367

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -143,6 +143,12 @@ func (b *Backend) Save(ctx context.Context, h backend.Handle, rd backend.RewindR
 	if err != nil {
 		return errors.WithStack(err)
 	}
+	req.GetBody = func() (io.ReadCloser, error) {
+		if err := rd.Rewind(); err != nil {
+			return nil, err
+		}
+		return io.NopCloser(rd), nil
+	}
 	req.Header.Set("Content-Type", "application/octet-stream")
 	req.Header.Set("Accept", ContentTypeV2)
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The HTTP client can only retry HTTP2 requests after receiving a GOAWAY response if it can rewind the body. As we use a custom data type, explicitly provide an implementation of `GetBody`.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://forum.restic.net/t/receiving-http2-goaway-messages-with-windows-restic-v0-17-0/8367
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
