### PR TITLE
backup: Fix spurious "A Required Privilege Is Not Held by the Client" error

### DIFF
--- a/changelog/unreleased/issue-5004
+++ b/changelog/unreleased/issue-5004
@@ -1,0 +1,12 @@
+Bugfix: Fix spurious "A Required Privilege Is Not Held by the Client" error
+
+On Windows, creating a backup could sometimes print the following error
+
+```
+error: nodeFromFileInfo [...]: get named security info failed with: a required privilege is not held by the client.
+```
+
+This has been fixed.
+
+https://github.com/restic/restic/issues/5004
+https://github.com/restic/restic/pull/5019

--- a/internal/fs/sd_windows.go
+++ b/internal/fs/sd_windows.go
@@ -59,10 +59,7 @@ func GetSecurityDescriptor(filePath string) (securityDescriptor *[]byte, err err
 		if !useLowerPrivileges && isHandlePrivilegeNotHeldError(err) {
 			// If ERROR_PRIVILEGE_NOT_HELD is encountered, fallback to backups/restores using lower non-admin privileges.
 			lowerPrivileges.Store(true)
-			sd, err = getNamedSecurityInfoLow(filePath)
-			if err != nil {
-				return nil, fmt.Errorf("get low-level named security info failed with: %w", err)
-			}
+			return GetSecurityDescriptor(filePath)
 		} else if errors.Is(err, windows.ERROR_NOT_SUPPORTED) {
 			return nil, nil
 		} else {
@@ -123,10 +120,7 @@ func SetSecurityDescriptor(filePath string, securityDescriptor *[]byte) error {
 		if !useLowerPrivileges && isHandlePrivilegeNotHeldError(err) {
 			// If ERROR_PRIVILEGE_NOT_HELD is encountered, fallback to backups/restores using lower non-admin privileges.
 			lowerPrivileges.Store(true)
-			err = setNamedSecurityInfoLow(filePath, dacl)
-			if err != nil {
-				return fmt.Errorf("set low-level named security info failed with: %w", err)
-			}
+			return SetSecurityDescriptor(filePath, securityDescriptor)
 		} else {
 			return fmt.Errorf("set named security info failed with: %w", err)
 		}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

On Windows, creating a backup could sometimes print the following error

```
error: nodeFromFileInfo [...]: get named security info failed with: a required privilege is not held by the client.
```

This was caused by two threads concurrently retrieving security descriptors and both failing due to missing privileges. Then one thread would correctly enter the fallback path and retry with lower privileges whereas the other one prints an error. The error only occurs for the first files/folders that are processed by `backup`.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/5004
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
