### PR TITLE
cache: Fix handling of invalid filenames

### DIFF
--- a/cmd/restic/cmd_init_integration_test.go
+++ b/cmd/restic/cmd_init_integration_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/restic/restic/internal/repository"
@@ -16,6 +18,11 @@ func testRunInit(t testing.TB, opts GlobalOptions) {
 
 	rtest.OK(t, runInit(context.TODO(), InitOptions{}, opts, nil))
 	t.Logf("repository initialized at %v", opts.Repo)
+
+	// create temporary junk files to verify that restic does not trip over them
+	for _, path := range []string{"index", "snapshots", "keys", "locks", filepath.Join("data", "00")} {
+		rtest.OK(t, os.WriteFile(filepath.Join(opts.Repo, path, "tmp12345"), []byte("junk file"), 0o600))
+	}
 }
 
 func TestInitCopyChunkerParams(t *testing.T) {

--- a/cmd/restic/cmd_prune_integration_test.go
+++ b/cmd/restic/cmd_prune_integration_test.go
@@ -146,10 +146,9 @@ func TestPruneWithDamagedRepository(t *testing.T) {
 		env.gopts.backendTestHook = oldHook
 	}()
 	// prune should fail
-	rtest.Assert(t, withTermStatus(env.gopts, func(ctx context.Context, term *termstatus.Terminal) error {
+	rtest.Equals(t, repository.ErrPacksMissing, withTermStatus(env.gopts, func(ctx context.Context, term *termstatus.Terminal) error {
 		return runPrune(context.TODO(), pruneDefaultOptions, env.gopts, term)
-	}) == repository.ErrPacksMissing,
-		"prune should have reported index not complete error")
+	}), "prune should have reported index not complete error")
 }
 
 // Test repos for edge cases

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -80,7 +80,7 @@ func TestListOnce(t *testing.T) {
 	defer cleanup()
 
 	env.gopts.backendTestHook = func(r backend.Backend) (backend.Backend, error) {
-		return newListOnceBackend(r), nil
+		return newOrderedListOnceBackend(r), nil
 	}
 	pruneOpts := PruneOptions{MaxUnused: "0"}
 	checkOpts := CheckOptions{ReadData: true, CheckUnused: true}
@@ -148,7 +148,7 @@ func TestFindListOnce(t *testing.T) {
 	defer cleanup()
 
 	env.gopts.backendTestHook = func(r backend.Backend) (backend.Backend, error) {
-		return newListOnceBackend(r), nil
+		return newOrderedListOnceBackend(r), nil
 	}
 
 	testSetupBackupData(t, env)

--- a/internal/backend/cache/backend.go
+++ b/internal/backend/cache/backend.go
@@ -231,9 +231,8 @@ func (b *Backend) List(ctx context.Context, t backend.FileType, fn func(f backen
 	wrapFn := func(f backend.FileInfo) error {
 		id, err := restic.ParseID(f.Name)
 		if err != nil {
-			// returning error here since, if we cannot parse the ID, the file
-			// is invalid and the list must exit.
-			return err
+			// ignore files with invalid name
+			return nil
 		}
 
 		ids.Insert(id)

--- a/internal/backend/cache/backend_test.go
+++ b/internal/backend/cache/backend_test.go
@@ -296,3 +296,20 @@ func TestAutomaticCacheClear(t *testing.T) {
 		t.Errorf("cache doesn't have file2 after list")
 	}
 }
+
+func TestAutomaticCacheClearInvalidFilename(t *testing.T) {
+	be := mem.New()
+	c := TestNewCache(t)
+
+	data := test.Random(rand.Int(), 42)
+	h := backend.Handle{
+		Type: backend.IndexFile,
+		Name: "tmp12345",
+	}
+	save(t, be, h, data)
+
+	wbe := c.Wrap(be)
+
+	// list all files in the backend
+	list(t, wbe, func(_ backend.FileInfo) error { return nil })
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The changes in https://github.com/restic/restic/pull/4981 caused commands to fail if the backend returned a file with a filename that is not an ID. These should be ignored just like everywhere else.

To prevent this type of problems from reappearing, now the repository used for most integration tests also contains files with an invalid filename.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/pull/4981
Thanks to @akrabu for finding the bug.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~ Not yet released.
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
