### PR TITLE
backup: support specifying volume instead of path on Windows

### DIFF
--- a/changelog/unreleased/issue-2004
+++ b/changelog/unreleased/issue-2004
@@ -1,0 +1,19 @@
+Bugfix: Correctly handle passing volume name to `backup` command
+
+On Windows, when the specified backup target only included the volume
+name without a trailing slash, for example, `C:`, then restoring the
+resulting snapshot would result in an error. Note that using `C:\`
+as backup target worked correctly.
+
+Specifying volume names now works correctly.
+
+To restore snapshots created before this bugfix, use the `<snapshot>:<subpath>`
+syntax. For a snapshot with ID `12345678` and a backup of `C:`, the following
+command can be used:
+
+```
+restic restore 12345678:/C/C:./ --target output/folder
+```
+
+https://github.com/restic/restic/issues/2004
+https://github.com/restic/restic/pull/5028

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -715,7 +715,12 @@ func resolveRelativeTargets(filesys fs.FS, targets []string) ([]string, error) {
 	debug.Log("targets before resolving: %v", targets)
 	result := make([]string, 0, len(targets))
 	for _, target := range targets {
-		target = filesys.Clean(target)
+		if target != "" && filesys.VolumeName(target) == target {
+			// special case to allow users to also specify a volume name "C:" instead of a path "C:\"
+			target = target + filesys.Separator()
+		} else {
+			target = filesys.Clean(target)
+		}
 		pc, _ := pathComponents(filesys, target, false)
 		if len(pc) > 0 {
 			result = append(result, target)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Allows `restic backup C:` to create proper snapshots.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/2004
Fixes https://forum.restic.net/t/backup-mounted-veracrypt-volumes/8372
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
