### PR TITLE
docs: make s3-compatible section standalone

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -314,8 +314,16 @@ this command.
 S3-compatible Storage
 *********************
 
-For an S3-compatible server that is not Amazon, you can specify the URL to the server
+For an S3-compatible storage service that is not Amazon, you can specify the URL to the server
 like this: ``s3:https://server:port/bucket_name``.
+
+You must also set credentials for authentication to the service.
+
+.. code-block:: console
+
+    $ export AWS_ACCESS_KEY_ID=<YOUR-ACCESS-KEY-ID>
+    $ export AWS_SECRET_ACCESS_KEY=<YOUR-SECRET-ACCESS-KEY>
+    $ restic -r s3:https://server:port/bucket_name init
 
 If needed, you can manually specify the region to use by either setting the
 environment variable ``AWS_DEFAULT_REGION`` or calling restic with an option


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The section on setup with s3-compatible storage services now also describes the basic authentication setup using the AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY environment variables.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
