### PR TITLE
cache: fix race condition in cache cleanup or similar.

### DIFF
--- a/changelog/unreleased/pull-5047
+++ b/changelog/unreleased/pull-5047
@@ -1,0 +1,7 @@
+Bugfix: Fix possible error on concurrent cache cleanup
+
+Fix for multiple restic processes executing concurrently and racing to
+remove obsolete snapshots from the local backend cache.  Restic now suppresses the `no
+such file or directory` error.
+
+https://github.com/restic/restic/pull/5047

--- a/internal/backend/cache/file.go
+++ b/internal/backend/cache/file.go
@@ -210,6 +210,10 @@ func (c *Cache) list(t restic.FileType) (restic.IDSet, error) {
 	dir := filepath.Join(c.path, cacheLayoutPaths[t])
 	err := filepath.Walk(dir, func(name string, fi os.FileInfo, err error) error {
 		if err != nil {
+			// ignore ErrNotExist to gracefully handle multiple processes clearing the cache
+			if errors.Is(err, os.ErrNotExist) {
+				return nil
+			}
 			return errors.Wrap(err, "Walk")
 		}
 


### PR DESCRIPTION
Fix for multiple restic processes executing concurrently and racing to remove obsolete snapshots from the local backend cache.


What does this PR change? What problem does it solve?
-----------------------------------------------------

This change tests the error returned from the closure/anonymous function, and if the error is that the given file does not exist, then skip the missing file in the results by returning nil.

The purpose is to silence the error generated from a race condition where multiple restic processes are executing concurrently and one unlinks a snapshot file, after another retrieves the file's path from a readdir, but before it attempts an lstat.  It is in response to the following error message:

```
error clearing snapshot files in cache: Walk: lstat /home/<username>/.cache/restic/23fa6bedac5c6d4...a6079eea2b3e3/snapshots/3f/3f4e3de8f8...38f8de1c995e3d: no such file or directory
```

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

I didn't raise an issue, as its quite trivial.  It is related to #4760, that was resolved in an identical way.  

I'm not a go developer, so please review this PR carefully.  I modelled the patch on #4760 but may have made errors.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
