### PR TITLE
Fix unusable `mount` on macOS Sonoma

### DIFF
--- a/changelog/unreleased/issue-4971
+++ b/changelog/unreleased/issue-4971
@@ -1,0 +1,9 @@
+Bugfix: Fix unusable `mount` on macOS Sonoma
+
+On macOS Sonoma when using fuse-t, it was not possible to access files in
+a mounted repository.
+
+This issue has been resolved.
+
+https://github.com/restic/restic/issues/4971
+https://github.com/restic/restic/pull/5048

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -20,6 +20,8 @@ import (
 
 // Statically ensure that *dir implement those interface
 var _ = fs.HandleReadDirAller(&dir{})
+var _ = fs.NodeGetxattrer(&dir{})
+var _ = fs.NodeListxattrer(&dir{})
 var _ = fs.NodeStringLookuper(&dir{})
 
 type dir struct {

--- a/internal/fuse/fuse_test.go
+++ b/internal/fuse/fuse_test.go
@@ -119,7 +119,7 @@ func TestFuseFile(t *testing.T) {
 	root := &Root{repo: repo, blobCache: bloblru.New(blobCacheSize)}
 
 	inode := inodeFromNode(1, node)
-	f, err := newFile(root, inode, node)
+	f, err := newFile(root, func() {}, inode, node)
 	rtest.OK(t, err)
 	of, err := f.Open(context.TODO(), nil, nil)
 	rtest.OK(t, err)
@@ -162,7 +162,7 @@ func TestFuseDir(t *testing.T) {
 	}
 	parentInode := inodeFromName(0, "parent")
 	inode := inodeFromName(1, "foo")
-	d, err := newDir(root, inode, parentInode, node)
+	d, err := newDir(root, func() {}, inode, parentInode, node)
 	rtest.OK(t, err)
 
 	// don't open the directory as that would require setting up a proper tree blob
@@ -276,7 +276,7 @@ func TestLink(t *testing.T) {
 		{Name: "foo", Value: []byte("bar")},
 	}}
 
-	lnk, err := newLink(&Root{}, 42, node)
+	lnk, err := newLink(&Root{}, func() {}, 42, node)
 	rtest.OK(t, err)
 	target, err := lnk.Readlink(context.TODO(), nil)
 	rtest.OK(t, err)

--- a/internal/fuse/link.go
+++ b/internal/fuse/link.go
@@ -12,6 +12,8 @@ import (
 )
 
 // Statically ensure that *link implements the given interface
+var _ = fs.NodeGetxattrer(&link{})
+var _ = fs.NodeListxattrer(&link{})
 var _ = fs.NodeReadlinker(&link{})
 
 type link struct {

--- a/internal/fuse/link.go
+++ b/internal/fuse/link.go
@@ -12,18 +12,20 @@ import (
 )
 
 // Statically ensure that *link implements the given interface
+var _ = fs.NodeForgetter(&link{})
 var _ = fs.NodeGetxattrer(&link{})
 var _ = fs.NodeListxattrer(&link{})
 var _ = fs.NodeReadlinker(&link{})
 
 type link struct {
-	root  *Root
-	node  *restic.Node
-	inode uint64
+	root   *Root
+	forget forgetFn
+	node   *restic.Node
+	inode  uint64
 }
 
-func newLink(root *Root, inode uint64, node *restic.Node) (*link, error) {
-	return &link{root: root, inode: inode, node: node}, nil
+func newLink(root *Root, forget forgetFn, inode uint64, node *restic.Node) (*link, error) {
+	return &link{root: root, forget: forget, inode: inode, node: node}, nil
 }
 
 func (l *link) Readlink(_ context.Context, _ *fuse.ReadlinkRequest) (string, error) {
@@ -56,4 +58,8 @@ func (l *link) Listxattr(_ context.Context, req *fuse.ListxattrRequest, resp *fu
 
 func (l *link) Getxattr(_ context.Context, req *fuse.GetxattrRequest, resp *fuse.GetxattrResponse) error {
 	return nodeGetXattr(l.node, req, resp)
+}
+
+func (l *link) Forget() {
+	l.forget()
 }

--- a/internal/fuse/other.go
+++ b/internal/fuse/other.go
@@ -12,16 +12,18 @@ import (
 )
 
 // Statically ensure that *other implements the given interface
+var _ = fs.NodeForgetter(&other{})
 var _ = fs.NodeReadlinker(&other{})
 
 type other struct {
-	root  *Root
-	node  *restic.Node
-	inode uint64
+	root   *Root
+	forget forgetFn
+	node   *restic.Node
+	inode  uint64
 }
 
-func newOther(root *Root, inode uint64, node *restic.Node) (*other, error) {
-	return &other{root: root, inode: inode, node: node}, nil
+func newOther(root *Root, forget forgetFn, inode uint64, node *restic.Node) (*other, error) {
+	return &other{root: root, forget: forget, inode: inode, node: node}, nil
 }
 
 func (l *other) Readlink(_ context.Context, _ *fuse.ReadlinkRequest) (string, error) {
@@ -43,4 +45,8 @@ func (l *other) Attr(_ context.Context, a *fuse.Attr) error {
 	a.Nlink = uint32(l.node.Links)
 
 	return nil
+}
+
+func (l *other) Forget() {
+	l.forget()
 }

--- a/internal/fuse/other.go
+++ b/internal/fuse/other.go
@@ -7,8 +7,12 @@ import (
 	"context"
 
 	"github.com/anacrolix/fuse"
+	"github.com/anacrolix/fuse/fs"
 	"github.com/restic/restic/internal/restic"
 )
+
+// Statically ensure that *other implements the given interface
+var _ = fs.NodeReadlinker(&other{})
 
 type other struct {
 	root  *Root

--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -66,7 +66,7 @@ func NewRoot(repo restic.Repository, cfg Config) *Root {
 		}
 	}
 
-	root.SnapshotsDir = NewSnapshotsDir(root, rootInode, rootInode, NewSnapshotsDirStructure(root, cfg.PathTemplates, cfg.TimeTemplate), "")
+	root.SnapshotsDir = NewSnapshotsDir(root, func() {}, rootInode, rootInode, NewSnapshotsDirStructure(root, cfg.PathTemplates, cfg.TimeTemplate), "")
 
 	return root
 }

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -19,6 +19,7 @@ import (
 // It uses the saved prefix to select the corresponding MetaDirData.
 type SnapshotsDir struct {
 	root        *Root
+	forget      forgetFn
 	inode       uint64
 	parentInode uint64
 	dirStruct   *SnapshotsDirStructure
@@ -28,13 +29,15 @@ type SnapshotsDir struct {
 
 // ensure that *SnapshotsDir implements these interfaces
 var _ = fs.HandleReadDirAller(&SnapshotsDir{})
+var _ = fs.NodeForgetter(&SnapshotsDir{})
 var _ = fs.NodeStringLookuper(&SnapshotsDir{})
 
 // NewSnapshotsDir returns a new directory structure containing snapshots and "latest" links
-func NewSnapshotsDir(root *Root, inode, parentInode uint64, dirStruct *SnapshotsDirStructure, prefix string) *SnapshotsDir {
+func NewSnapshotsDir(root *Root, forget forgetFn, inode, parentInode uint64, dirStruct *SnapshotsDirStructure, prefix string) *SnapshotsDir {
 	debug.Log("create snapshots dir, inode %d", inode)
 	return &SnapshotsDir{
 		root:        root,
+		forget:      forget,
 		inode:       inode,
 		parentInode: parentInode,
 		dirStruct:   dirStruct,
@@ -109,7 +112,7 @@ func (d *SnapshotsDir) Lookup(ctx context.Context, name string) (fs.Node, error)
 		return nil, syscall.ENOENT
 	}
 
-	return d.cache.lookupOrCreate(name, func() (fs.Node, error) {
+	return d.cache.lookupOrCreate(name, func(forget forgetFn) (fs.Node, error) {
 		entry := meta.names[name]
 		if entry == nil {
 			return nil, syscall.ENOENT
@@ -117,27 +120,33 @@ func (d *SnapshotsDir) Lookup(ctx context.Context, name string) (fs.Node, error)
 
 		inode := inodeFromName(d.inode, name)
 		if entry.linkTarget != "" {
-			return newSnapshotLink(d.root, inode, entry.linkTarget, entry.snapshot)
+			return newSnapshotLink(d.root, forget, inode, entry.linkTarget, entry.snapshot)
 		} else if entry.snapshot != nil {
-			return newDirFromSnapshot(d.root, inode, entry.snapshot)
+			return newDirFromSnapshot(d.root, forget, inode, entry.snapshot)
 		}
-		return NewSnapshotsDir(d.root, inode, d.inode, d.dirStruct, d.prefix+"/"+name), nil
+		return NewSnapshotsDir(d.root, forget, inode, d.inode, d.dirStruct, d.prefix+"/"+name), nil
 	})
+}
+
+func (d *SnapshotsDir) Forget() {
+	d.forget()
 }
 
 // SnapshotLink
 type snapshotLink struct {
 	root     *Root
+	forget   forgetFn
 	inode    uint64
 	target   string
 	snapshot *restic.Snapshot
 }
 
+var _ = fs.NodeForgetter(&snapshotLink{})
 var _ = fs.NodeReadlinker(&snapshotLink{})
 
 // newSnapshotLink
-func newSnapshotLink(root *Root, inode uint64, target string, snapshot *restic.Snapshot) (*snapshotLink, error) {
-	return &snapshotLink{root: root, inode: inode, target: target, snapshot: snapshot}, nil
+func newSnapshotLink(root *Root, forget forgetFn, inode uint64, target string, snapshot *restic.Snapshot) (*snapshotLink, error) {
+	return &snapshotLink{root: root, forget: forget, inode: inode, target: target, snapshot: snapshot}, nil
 }
 
 // Readlink
@@ -160,4 +169,8 @@ func (l *snapshotLink) Attr(_ context.Context, a *fuse.Attr) error {
 	a.Nlink = 1
 
 	return nil
+}
+
+func (l *snapshotLink) Forget() {
+	l.forget()
 }

--- a/internal/fuse/tree_cache.go
+++ b/internal/fuse/tree_cache.go
@@ -1,0 +1,38 @@
+//go:build darwin || freebsd || linux
+// +build darwin freebsd linux
+
+package fuse
+
+import (
+	"sync"
+
+	"github.com/anacrolix/fuse/fs"
+)
+
+type treeCache struct {
+	nodes map[string]fs.Node
+	m     sync.Mutex
+}
+
+func newTreeCache() *treeCache {
+	return &treeCache{
+		nodes: map[string]fs.Node{},
+	}
+}
+
+func (t *treeCache) lookupOrCreate(name string, create func() (fs.Node, error)) (fs.Node, error) {
+	t.m.Lock()
+	defer t.m.Unlock()
+
+	if node, ok := t.nodes[name]; ok {
+		return node, nil
+	}
+
+	node, err := create()
+	if err != nil {
+		return nil, err
+	}
+
+	t.nodes[name] = node
+	return node, nil
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Files in mounted repositories were inaccessible on macOS Sonoma when using fuse-t.

The underlying problem is that macOS apparently looks up files twice, which caused the fuse implementation to return two difference instance of the same file. This gets translated to different file handles by fuse-t and as a result confuses macOS.

See https://github.com/macos-fuse-t/fuse-t/issues/61#issuecomment-2336794151 for further detail.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/4971
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
