### PR TITLE
generate: allow passing `-` for stdout output

### DIFF
--- a/changelog/unreleased/issue-2511
+++ b/changelog/unreleased/issue-2511
@@ -1,0 +1,6 @@
+Enhancement: Allow generating shell completions to stdout
+
+Restic `generate` now supports passing `-` passed as file name to `--[shell]-completion` option.
+
+https://github.com/restic/restic/issues/2511
+https://github.com/restic/restic/pull/5053

--- a/cmd/restic/cmd_generate_integration_test.go
+++ b/cmd/restic/cmd_generate_integration_test.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestGenerateStdout(t *testing.T) {
+	testCases := []struct {
+		name string
+		opts generateOptions
+	}{
+		{"bash", generateOptions{BashCompletionFile: "-"}},
+		{"fish", generateOptions{FishCompletionFile: "-"}},
+		{"zsh", generateOptions{ZSHCompletionFile: "-"}},
+		{"powershell", generateOptions{PowerShellCompletionFile: "-"}},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			buf := bytes.NewBuffer(nil)
+			globalOptions.stdout = buf
+			err := runGenerate(tc.opts, []string{})
+			rtest.OK(t, err)
+			completionString := buf.String()
+			rtest.Assert(t, strings.Contains(completionString, "# "+tc.name+" completion for restic"), "has no expected completion header")
+		})
+	}
+
+	t.Run("Generate shell completions to stdout for two shells", func(t *testing.T) {
+		buf := bytes.NewBuffer(nil)
+		globalOptions.stdout = buf
+		opts := generateOptions{BashCompletionFile: "-", FishCompletionFile: "-"}
+		err := runGenerate(opts, []string{})
+		rtest.Assert(t, err != nil, "generate shell completions to stdout for two shells fails")
+	})
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Allow generating shell completions to stdout by supplying `-` as file name. Since generating completions to stdout for multiple shells does not make sense, enforce `-` is supplied only once.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #2511.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
