### PR TITLE
Changelogs should omit problem if its description duplicates the new behavior

### DIFF
--- a/changelog/TEMPLATE
+++ b/changelog/TEMPLATE
@@ -5,6 +5,8 @@ Enhancement: Allow custom bar in the foo command
 
 # Describe the problem in the past tense, the new behavior in the present
 # tense. Mention the affected commands, backends, operating systems, etc.
+# If the problem description just says that a feature was missing, then
+# only explain the new behavior.
 # Focus on user-facing behavior, not the implementation.
 # Use "Restic now ..." instead of "We have changed ...".
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
When adding a new feature, the problem description often just says that feature Y was missing, followed by saying that feature Y is now supported.

This duplication just makes the changelog entries unnecessarily verbose.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Just noticed it again in the changelog of https://github.com/restic/restic/pull/5053. The changelogs for restic 0.17.1 (and earlier versions) already followed that rule.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I'm done! This pull request is ready for review.
