### PR TITLE
fs: move NodeFromFileInfo into FS interface

### DIFF
--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -256,7 +256,7 @@ func (arch *Archiver) trackItem(item string, previous, current *restic.Node, s I
 
 // nodeFromFileInfo returns the restic node from an os.FileInfo.
 func (arch *Archiver) nodeFromFileInfo(snPath, filename string, fi os.FileInfo, ignoreXattrListError bool) (*restic.Node, error) {
-	node, err := fs.NodeFromFileInfo(filename, fi, ignoreXattrListError)
+	node, err := arch.FS.NodeFromFileInfo(filename, fi, ignoreXattrListError)
 	if !arch.WithAtime {
 		node.AccessTime = node.ModTime
 	}

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -556,7 +556,7 @@ func rename(t testing.TB, oldname, newname string) {
 	}
 }
 
-func nodeFromFI(t testing.TB, filename string, fi os.FileInfo) *restic.Node {
+func nodeFromFI(t testing.TB, fs fs.FS, filename string, fi os.FileInfo) *restic.Node {
 	node, err := fs.NodeFromFileInfo(filename, fi, false)
 	if err != nil {
 		t.Fatal(err)
@@ -688,7 +688,7 @@ func TestFileChanged(t *testing.T) {
 
 			fs := &fs.Local{}
 			fiBefore := lstat(t, filename)
-			node := nodeFromFI(t, filename, fiBefore)
+			node := nodeFromFI(t, fs, filename, fiBefore)
 
 			if fileChanged(fs, fiBefore, node, 0) {
 				t.Fatalf("unchanged file detected as changed")
@@ -729,7 +729,7 @@ func TestFilChangedSpecialCases(t *testing.T) {
 
 	t.Run("type-change", func(t *testing.T) {
 		fi := lstat(t, filename)
-		node := nodeFromFI(t, filename, fi)
+		node := nodeFromFI(t, &fs.Local{}, filename, fi)
 		node.Type = "restic.NodeTypeSymlink"
 		if !fileChanged(&fs.Local{}, fi, node, 0) {
 			t.Fatal("node with changed type detected as unchanged")
@@ -2275,13 +2275,14 @@ func TestMetadataChanged(t *testing.T) {
 
 	// get metadata
 	fi := lstat(t, "testfile")
-	want, err := fs.NodeFromFileInfo("testfile", fi, false)
+	localFS := &fs.Local{}
+	want, err := localFS.NodeFromFileInfo("testfile", fi, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	fs := &StatFS{
-		FS: fs.Local{},
+		FS: localFS,
 		OverrideLstat: map[string]os.FileInfo{
 			"testfile": fi,
 		},

--- a/internal/archiver/archiver_unix_test.go
+++ b/internal/archiver/archiver_unix_test.go
@@ -58,10 +58,11 @@ func wrapIrregularFileInfo(fi os.FileInfo) os.FileInfo {
 
 func statAndSnapshot(t *testing.T, repo archiverRepo, name string) (*restic.Node, *restic.Node) {
 	fi := lstat(t, name)
+	fs := &fs.Local{}
 	want, err := fs.NodeFromFileInfo(name, fi, false)
 	rtest.OK(t, err)
 
-	_, node := snapshot(t, repo, fs.Local{}, nil, name)
+	_, node := snapshot(t, repo, fs, nil, name)
 	return want, node
 }
 

--- a/internal/archiver/file_saver_test.go
+++ b/internal/archiver/file_saver_test.go
@@ -30,7 +30,7 @@ func createTestFiles(t testing.TB, num int) (files []string) {
 	return files
 }
 
-func startFileSaver(ctx context.Context, t testing.TB) (*fileSaver, context.Context, *errgroup.Group) {
+func startFileSaver(ctx context.Context, t testing.TB, fs fs.FS) (*fileSaver, context.Context, *errgroup.Group) {
 	wg, ctx := errgroup.WithContext(ctx)
 
 	saveBlob := func(ctx context.Context, tpe restic.BlobType, buf *buffer, _ string, cb func(saveBlobResponse)) {
@@ -67,7 +67,7 @@ func TestFileSaver(t *testing.T) {
 	completeFn := func(*restic.Node, ItemStats) {}
 
 	testFs := fs.Local{}
-	s, ctx, wg := startFileSaver(ctx, t)
+	s, ctx, wg := startFileSaver(ctx, t, testFs)
 
 	var results []futureNode
 

--- a/internal/fs/fs_local.go
+++ b/internal/fs/fs_local.go
@@ -3,6 +3,8 @@ package fs
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/restic/restic/internal/restic"
 )
 
 // Local is the local file system. Most methods are just passed on to the stdlib.
@@ -55,6 +57,10 @@ func (fs Local) DeviceID(fi os.FileInfo) (id uint64, err error) {
 // ExtendedStat converts the give FileInfo into ExtendedFileInfo.
 func (fs Local) ExtendedStat(fi os.FileInfo) ExtendedFileInfo {
 	return ExtendedStat(fi)
+}
+
+func (fs Local) NodeFromFileInfo(path string, fi os.FileInfo, ignoreXattrListError bool) (*restic.Node, error) {
+	return nodeFromFileInfo(path, fi, ignoreXattrListError)
 }
 
 // Join joins any number of path elements into a single path, adding a

--- a/internal/fs/fs_reader.go
+++ b/internal/fs/fs_reader.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/restic"
 )
 
 // Reader is a file system which provides a directory with a single file. When
@@ -130,6 +131,17 @@ func (fs *Reader) ExtendedStat(fi os.FileInfo) ExtendedFileInfo {
 	return ExtendedFileInfo{
 		FileInfo: fi,
 	}
+}
+
+func (fs *Reader) NodeFromFileInfo(path string, fi os.FileInfo, _ bool) (*restic.Node, error) {
+	node := buildBasicNode(path, fi)
+
+	// fill minimal info with current values for uid, gid
+	node.UID = uint32(os.Getuid())
+	node.GID = uint32(os.Getgid())
+	node.ChangeTime = node.ModTime
+
+	return node, nil
 }
 
 // Join joins any number of path elements into a single path, adding a

--- a/internal/fs/interface.go
+++ b/internal/fs/interface.go
@@ -3,6 +3,8 @@ package fs
 import (
 	"io"
 	"os"
+
+	"github.com/restic/restic/internal/restic"
 )
 
 // FS bundles all methods needed for a file system.
@@ -12,6 +14,7 @@ type FS interface {
 	Lstat(name string) (os.FileInfo, error)
 	DeviceID(fi os.FileInfo) (deviceID uint64, err error)
 	ExtendedStat(fi os.FileInfo) ExtendedFileInfo
+	NodeFromFileInfo(path string, fi os.FileInfo, ignoreXattrListError bool) (*restic.Node, error)
 
 	Join(elem ...string) string
 	Separator() string

--- a/internal/fs/node_test.go
+++ b/internal/fs/node_test.go
@@ -29,11 +29,12 @@ func BenchmarkNodeFillUser(t *testing.B) {
 	}
 
 	path := tempfile.Name()
+	fs := Local{}
 
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		_, err := NodeFromFileInfo(path, fi, false)
+		_, err := fs.NodeFromFileInfo(path, fi, false)
 		rtest.OK(t, err)
 	}
 
@@ -53,11 +54,12 @@ func BenchmarkNodeFromFileInfo(t *testing.B) {
 	}
 
 	path := tempfile.Name()
+	fs := Local{}
 
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		_, err := NodeFromFileInfo(path, fi, false)
+		_, err := fs.NodeFromFileInfo(path, fi, false)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -250,9 +252,10 @@ func TestNodeRestoreAt(t *testing.T) {
 			fi, err := os.Lstat(nodePath)
 			rtest.OK(t, err)
 
-			n2, err := NodeFromFileInfo(nodePath, fi, false)
+			fs := &Local{}
+			n2, err := fs.NodeFromFileInfo(nodePath, fi, false)
 			rtest.OK(t, err)
-			n3, err := NodeFromFileInfo(nodePath, fi, true)
+			n3, err := fs.NodeFromFileInfo(nodePath, fi, true)
 			rtest.OK(t, err)
 			rtest.Assert(t, n2.Equals(*n3), "unexpected node info mismatch %v", cmp.Diff(n2, n3))
 

--- a/internal/fs/node_unix_test.go
+++ b/internal/fs/node_unix_test.go
@@ -119,7 +119,8 @@ func TestNodeFromFileInfo(t *testing.T) {
 				return
 			}
 
-			node, err := NodeFromFileInfo(test.filename, fi, false)
+			fs := &Local{}
+			node, err := fs.NodeFromFileInfo(test.filename, fi, false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/fs/node_windows_test.go
+++ b/internal/fs/node_windows_test.go
@@ -221,10 +221,11 @@ func restoreAndGetNode(t *testing.T, tempDir string, testNode *restic.Node, warn
 	})
 	test.OK(t, errors.Wrapf(err, "Failed to restore metadata for: %s", testPath))
 
-	fi, err := os.Lstat(testPath)
+	fs := &Local{}
+	fi, err := fs.Lstat(testPath)
 	test.OK(t, errors.Wrapf(err, "Could not Lstat for path: %s", testPath))
 
-	nodeFromFileInfo, err := NodeFromFileInfo(testPath, fi, false)
+	nodeFromFileInfo, err := fs.NodeFromFileInfo(testPath, fi, false)
 	test.OK(t, errors.Wrapf(err, "Could not get NodeFromFileInfo for path: %s", testPath))
 
 	return testPath, nodeFromFileInfo

--- a/internal/restic/tree_test.go
+++ b/internal/restic/tree_test.go
@@ -84,7 +84,8 @@ func TestNodeMarshal(t *testing.T) {
 }
 
 func TestNodeComparison(t *testing.T) {
-	fi, err := os.Lstat("tree_test.go")
+	fs := &fs.Local{}
+	fi, err := fs.Lstat("tree_test.go")
 	rtest.OK(t, err)
 
 	node, err := fs.NodeFromFileInfo("tree_test.go", fi, false)
@@ -126,7 +127,8 @@ func TestTreeEqualSerialization(t *testing.T) {
 		builder := restic.NewTreeJSONBuilder()
 
 		for _, fn := range files[:i] {
-			fi, err := os.Lstat(fn)
+			fs := &fs.Local{}
+			fi, err := fs.Lstat(fn)
 			rtest.OK(t, err)
 			node, err := fs.NodeFromFileInfo(fn, fi, false)
 			rtest.OK(t, err)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Move NodeFromFileInfo into FS interface. With this change the archiver code performs all filesystem interactions via the FS interface. This now also allows removing hacks that were necessary to generate a restic.Node from a fs.Reader filesystem.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Part of https://github.com/restic/restic/issues/5021
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
