### PR TITLE
fs: fix restoring timestamps on older Windows versions for long paths

### DIFF
--- a/changelog/unreleased/issue-1843
+++ b/changelog/unreleased/issue-1843
@@ -1,0 +1,9 @@
+Bugfix: Correctly restore timestamp on long filepaths on old Windows versions
+
+The `restore` command did not restore timestamps on file paths longer than 256
+characters on Windows versions before Windows 10 1607.
+
+This issue is now resolved.
+
+https://github.com/restic/restic/issues/1843
+https://github.com/restic/restic/pull/5061

--- a/internal/fs/node.go
+++ b/internal/fs/node.go
@@ -315,7 +315,7 @@ func nodeRestoreTimestamps(node *restic.Node, path string) error {
 		return nodeRestoreSymlinkTimestamps(path, utimes)
 	}
 
-	if err := syscall.UtimesNano(path, utimes[:]); err != nil {
+	if err := syscall.UtimesNano(fixpath(path), utimes[:]); err != nil {
 		return errors.Wrap(err, "UtimesNano")
 	}
 

--- a/internal/fs/node_windows.go
+++ b/internal/fs/node_windows.go
@@ -202,7 +202,7 @@ func genericAttributesToWindowsAttrs(attrs map[restic.GenericAttributeType]json.
 // restoreCreationTime gets the creation time from the data and sets it to the file/folder at
 // the specified path.
 func restoreCreationTime(path string, creationTime *syscall.Filetime) (err error) {
-	pathPointer, err := syscall.UTF16PtrFromString(path)
+	pathPointer, err := syscall.UTF16PtrFromString(fixpath(path))
 	if err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ func restoreCreationTime(path string, creationTime *syscall.Filetime) (err error
 // restoreFileAttributes gets the File Attributes from the data and sets them to the file/folder
 // at the specified path.
 func restoreFileAttributes(path string, fileAttributes *uint32) (err error) {
-	pathPointer, err := syscall.UTF16PtrFromString(path)
+	pathPointer, err := syscall.UTF16PtrFromString(fixpath(path))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Go automagically enables long-path support on Windows 10 >=1607 (see https://github.com/golang/go/issues/41734). The standard library calls are also wrapped accordingly to support older Windows versions. However, for some filesystem operations we have to use the syscalls package directly which does not wrap paths. 

Most places should already contain a corresponding `fixpath(...)` call, this PR fixes restoring the timestamp and file attributes.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/1843
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
