### PR TITLE
Dump multiple paths

### DIFF
--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -209,14 +209,6 @@ func runDump(ctx context.Context, opts DumpOptions, gopts GlobalOptions, args []
 		return errors.Fatal("no file and no snapshot ID specified")
 	}
 
-	if opts.Archive == "" && opts.Compress {
-		return errors.Fatal("compressing is only supported when dumping to an archive")
-	}
-
-	if len(args) > 2 && opts.Archive == "" {
-		return errors.Fatal("multiple files can only be dumped to an archive")
-	}
-
 	switch opts.Archive {
 	case "tar", "zip":
 	default:

--- a/cmd/restic/cmd_dump_test.go
+++ b/cmd/restic/cmd_dump_test.go
@@ -25,3 +25,31 @@ func TestDumpSplitPath(t *testing.T) {
 		rtest.Equals(t, path.result, parts)
 	}
 }
+
+func TestDumpPreparePathList(t *testing.T) {
+	testPaths := []struct {
+		paths  []string
+		result [][]string
+	}{
+		{
+			[]string{"test", "test/dir", "test/dir/sub"},
+			[][]string{{"test"}},
+		},
+		{
+			[]string{"/", "man", "doc", "doc/icons"},
+			[][]string{{""}},
+		},
+		{
+			[]string{"doc"},
+			[][]string{{"doc"}},
+		},
+		{
+			[]string{"man/", "doc", "doc/icons"},
+			[][]string{{"man"}, {"doc"}},
+		},
+	}
+	for _, path := range testPaths {
+		parts := preparePathList(path.paths)
+		rtest.Equals(t, path.result, parts)
+	}
+}

--- a/internal/dump/common.go
+++ b/internal/dump/common.go
@@ -1,6 +1,9 @@
 package dump
 
 import (
+	"archive/tar"
+	"archive/zip"
+	"compress/gzip"
 	"context"
 	"io"
 	"path"
@@ -15,10 +18,13 @@ import (
 // A Dumper writes trees and files from a repository to a Writer
 // in an archive format.
 type Dumper struct {
-	cache  *bloblru.Cache
-	format string
-	repo   restic.Loader
-	w      io.Writer
+	cache      *bloblru.Cache
+	format     string
+	repo       restic.Loader
+	w          io.Writer
+	gzipWriter *gzip.Writer
+	zipWriter  *zip.Writer
+	tarWriter  *tar.Writer
 }
 
 func New(format string, repo restic.Loader, w io.Writer) *Dumper {
@@ -28,6 +34,28 @@ func New(format string, repo restic.Loader, w io.Writer) *Dumper {
 		repo:   repo,
 		w:      w,
 	}
+}
+
+func (d *Dumper) Close() error {
+	if d.tarWriter != nil {
+		err := d.tarWriter.Close()
+		if err != nil {
+			return errors.Wrap(err, "Close tarWriter")
+		}
+
+		if d.gzipWriter != nil {
+			err := d.gzipWriter.Close()
+			if err != nil {
+				return errors.Wrap(err, "Close gzipWriter")
+			}
+		}
+	}
+
+	if d.zipWriter != nil {
+		return d.zipWriter.Close()
+	}
+
+	return nil
 }
 
 func (d *Dumper) DumpTree(ctx context.Context, tree *restic.Tree, rootPath string) error {

--- a/internal/dump/common_test.go
+++ b/internal/dump/common_test.go
@@ -89,6 +89,8 @@ func WriteTest(t *testing.T, format string, cd CheckDump) {
 			if err := d.DumpTree(ctx, tree, tt.target); err != nil {
 				t.Fatalf("Dumper.Run error = %v", err)
 			}
+			d.Close()
+
 			if err := cd(t, tmpdir, dst); err != nil {
 				t.Errorf("WriteDump() = does not match: %v", err)
 			}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Before this change, `dump` accepted one path to dump, now multiple paths are accepted.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

#4173

Checklist
---------

- [X] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [ ] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [ ] I'm done! This pull request is ready for review.
