### PR TITLE
Simplify and refactor restoring of timestamps

### DIFF
--- a/internal/fs/node_aix.go
+++ b/internal/fs/node_aix.go
@@ -3,15 +3,7 @@
 
 package fs
 
-import (
-	"syscall"
-
-	"github.com/restic/restic/internal/restic"
-)
-
-func nodeRestoreSymlinkTimestamps(_ string, _ [2]syscall.Timespec) error {
-	return nil
-}
+import "github.com/restic/restic/internal/restic"
 
 // nodeRestoreExtendedAttributes is a no-op on AIX.
 func nodeRestoreExtendedAttributes(_ *restic.Node, _ string) error {

--- a/internal/fs/node_darwin.go
+++ b/internal/fs/node_darwin.go
@@ -1,7 +1,0 @@
-package fs
-
-import "syscall"
-
-func nodeRestoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
-	return nil
-}

--- a/internal/fs/node_linux.go
+++ b/internal/fs/node_linux.go
@@ -1,33 +1,18 @@
 package fs
 
 import (
-	"os"
-	"path/filepath"
 	"syscall"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/restic/restic/internal/errors"
+	"golang.org/x/sys/unix"
 )
 
 func nodeRestoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
-	dir, err := os.Open(fixpath(filepath.Dir(path)))
-	if err != nil {
-		return errors.WithStack(err)
-	}
-
 	times := []unix.Timespec{
 		{Sec: utimes[0].Sec, Nsec: utimes[0].Nsec},
 		{Sec: utimes[1].Sec, Nsec: utimes[1].Nsec},
 	}
 
-	err = unix.UtimesNanoAt(int(dir.Fd()), filepath.Base(path), times, unix.AT_SYMLINK_NOFOLLOW)
-
-	if err != nil {
-		// ignore subsequent errors
-		_ = dir.Close()
-		return errors.Wrap(err, "UtimesNanoAt")
-	}
-
-	return dir.Close()
+	err := unix.UtimesNanoAt(unix.AT_FDCWD, path, times, unix.AT_SYMLINK_NOFOLLOW)
+	return errors.Wrap(err, "UtimesNanoAt")
 }

--- a/internal/fs/node_linux.go
+++ b/internal/fs/node_linux.go
@@ -1,18 +1,15 @@
 package fs
 
 import (
-	"syscall"
-
-	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/restic"
 	"golang.org/x/sys/unix"
 )
 
-func nodeRestoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
+// utimesNano is like syscall.UtimesNano, except that it does not follow symlinks.
+func utimesNano(path string, atime, mtime int64, _ restic.NodeType) error {
 	times := []unix.Timespec{
-		{Sec: utimes[0].Sec, Nsec: utimes[0].Nsec},
-		{Sec: utimes[1].Sec, Nsec: utimes[1].Nsec},
+		unix.NsecToTimespec(atime),
+		unix.NsecToTimespec(mtime),
 	}
-
-	err := unix.UtimesNanoAt(unix.AT_FDCWD, path, times, unix.AT_SYMLINK_NOFOLLOW)
-	return errors.Wrap(err, "UtimesNanoAt")
+	return unix.UtimesNanoAt(unix.AT_FDCWD, path, times, unix.AT_SYMLINK_NOFOLLOW)
 }

--- a/internal/fs/node_linux_test.go
+++ b/internal/fs/node_linux_test.go
@@ -1,0 +1,19 @@
+package fs
+
+import (
+	"io/fs"
+	"strings"
+	"testing"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestRestoreSymlinkTimestampsError(t *testing.T) {
+	d := t.TempDir()
+	node := restic.Node{Type: restic.NodeTypeSymlink}
+	err := nodeRestoreTimestamps(&node, d+"/nosuchfile")
+	rtest.Assert(t, errors.Is(err, fs.ErrNotExist), "want ErrNotExist, got %q", err)
+	rtest.Assert(t, strings.Contains(err.Error(), d), "filename not in %q", err)
+}

--- a/internal/fs/node_netbsd.go
+++ b/internal/fs/node_netbsd.go
@@ -1,14 +1,6 @@
 package fs
 
-import (
-	"syscall"
-
-	"github.com/restic/restic/internal/restic"
-)
-
-func nodeRestoreSymlinkTimestamps(_ string, _ [2]syscall.Timespec) error {
-	return nil
-}
+import "github.com/restic/restic/internal/restic"
 
 // nodeRestoreExtendedAttributes is a no-op on netbsd.
 func nodeRestoreExtendedAttributes(_ *restic.Node, _ string) error {

--- a/internal/fs/node_openbsd.go
+++ b/internal/fs/node_openbsd.go
@@ -1,14 +1,6 @@
 package fs
 
-import (
-	"syscall"
-
-	"github.com/restic/restic/internal/restic"
-)
-
-func nodeRestoreSymlinkTimestamps(_ string, _ [2]syscall.Timespec) error {
-	return nil
-}
+import "github.com/restic/restic/internal/restic"
 
 // nodeRestoreExtendedAttributes is a no-op on openbsd.
 func nodeRestoreExtendedAttributes(_ *restic.Node, _ string) error {

--- a/internal/fs/node_solaris.go
+++ b/internal/fs/node_solaris.go
@@ -1,7 +1,0 @@
-package fs
-
-import "syscall"
-
-func nodeRestoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
-	return nil
-}

--- a/internal/fs/node_unix_notlinux.go
+++ b/internal/fs/node_unix_notlinux.go
@@ -1,0 +1,21 @@
+//go:build !linux && unix
+
+package fs
+
+import (
+	"syscall"
+
+	"github.com/restic/restic/internal/restic"
+)
+
+// utimesNano is like syscall.UtimesNano, except that it skips symlinks.
+func utimesNano(path string, atime, mtime int64, typ restic.NodeType) error {
+	if typ == restic.NodeTypeSymlink {
+		return nil
+	}
+
+	return syscall.UtimesNano(path, []syscall.Timespec{
+		syscall.NsecToTimespec(atime),
+		syscall.NsecToTimespec(mtime),
+	})
+}

--- a/internal/fs/node_windows.go
+++ b/internal/fs/node_windows.go
@@ -42,8 +42,8 @@ func lchown(_ string, _ int, _ int) (err error) {
 	return nil
 }
 
-// restoreSymlinkTimestamps restores timestamps for symlinks
-func nodeRestoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error {
+// utimesNano is like syscall.UtimesNano, except that it sets FILE_FLAG_OPEN_REPARSE_POINT.
+func utimesNano(path string, atime, mtime int64, _ restic.NodeType) error {
 	// tweaked version of UtimesNano from go/src/syscall/syscall_windows.go
 	pathp, e := syscall.UTF16PtrFromString(fixpath(path))
 	if e != nil {
@@ -63,8 +63,8 @@ func nodeRestoreSymlinkTimestamps(path string, utimes [2]syscall.Timespec) error
 		}
 	}()
 
-	a := syscall.NsecToFiletime(syscall.TimespecToNsec(utimes[0]))
-	w := syscall.NsecToFiletime(syscall.TimespecToNsec(utimes[1]))
+	a := syscall.NsecToFiletime(atime)
+	w := syscall.NsecToFiletime(mtime)
 	return syscall.SetFileTime(h, nil, &a, &w)
 }
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

On Linux, we currently need three system calls to restore timestamps on a symlink: open the containing directory, utimensat, close directory. This can be done in a single call to utimensat with the pseudo-file descriptor AT_FDCWD, as done in the first commit.

Having changed this, the implementation is so simple that it can also be used as a general replacement for syscall.UtimesNano. The same is true of the Windows version of nodeRestoreSymlinkTimestamps. The second commit implements this and gets rid of some 40 lines of code (while adding 20 in a test).

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
