### PR TITLE
Fix Azure Container Token Auth

### DIFF
--- a/changelog/unreleased/issue-4004
+++ b/changelog/unreleased/issue-4004
@@ -1,0 +1,12 @@
+Bugfix: Allow use of container level SAS/SAT tokens with Azure backend
+
+When using a SAS/SAT token for authentication with Azure, restic was expecting
+the provided token to be generated at the account level, granting permissions
+to the storage account and all its containers. This caused an error that did
+not allow tokens that were generated at the container level to be used to 
+initalize a repository.
+Restic now allows SAS/SAT tokens that were generated at the account or 
+container level to be used to initalize a repository.
+
+https://github.com/restic/restic/issues/4004
+https://github.com/restic/restic/pull/5093

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -157,6 +157,12 @@ func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (*Backend, er
 		if err != nil {
 			return nil, errors.Wrap(err, "container.Create")
 		}
+	} else if err != nil && bloberror.HasCode(err, bloberror.AuthorizationFailure) {
+		// We ignore this Auth. Failure, as the failure is related to the type
+		// of SAS/SAT, not an actual real failure. If the token is invalid, we
+		// fail later on anyway.
+		// For details see Issue #4004.
+		debug.Log("Ignoring AuthorizationFailure when calling GetProperties")
 	} else if err != nil {
 		return be, errors.Wrap(err, "container.GetProperties")
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This change ignores the Authorization Failed error returned from the Azure Storage Account backend when attempting to use a Shared Access Signature token that was **not** created with the Storage Account key to initalise a new repository.

The issue is caused by the Azure library that we use in the backend. When enumerating the container properties, the library internally calls `container.CreateIfNotExists` which is where things fail, because it tries to create a container, which is denied, as the token doesn'thave permission to create new containers, only poke around in the container it was made for.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #4004

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
