### PR TITLE
backup: read extended metadata from snapshot

### DIFF
--- a/changelog/unreleased/issue-5063
+++ b/changelog/unreleased/issue-5063
@@ -1,0 +1,10 @@
+Bugfix: Correctly `backup` extended metadata when using VSS on Windows
+
+On Windows, when creating a backup using the `--use-fs-snapshot` option,
+then the extended metadata was not read from the filesystem snapshot. This
+could result in errors when files have been removed in the meantime.
+
+This issue has been resolved.
+
+https://github.com/restic/restic/issues/5063
+https://github.com/restic/restic/pull/5097

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -97,6 +97,7 @@ type BackupOptions struct {
 }
 
 var backupOptions BackupOptions
+var backupFSTestHook func(fs fs.FS) fs.FS
 
 // ErrInvalidSourceData is used to report an incomplete backup
 var ErrInvalidSourceData = errors.New("at least one source file could not be read")
@@ -580,6 +581,10 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 			ReadCloser: source,
 		}
 		targets = []string{filename}
+	}
+
+	if backupFSTestHook != nil {
+		targetFS = backupFSTestHook(targetFS)
 	}
 
 	// rejectFuncs collect functions that can reject items from the backup based on path and file info

--- a/internal/archiver/file_saver.go
+++ b/internal/archiver/file_saver.go
@@ -156,7 +156,7 @@ func (s *fileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 
 	debug.Log("%v", snPath)
 
-	node, err := s.NodeFromFileInfo(snPath, f.Name(), fi, false)
+	node, err := s.NodeFromFileInfo(snPath, target, fi, false)
 	if err != nil {
 		_ = f.Close()
 		completeError(err)

--- a/internal/fs/fs_local_vss.go
+++ b/internal/fs/fs_local_vss.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/options"
+	"github.com/restic/restic/internal/restic"
 )
 
 // VSSConfig holds extended options of windows volume shadow copy service.
@@ -138,6 +139,10 @@ func (fs *LocalVss) Stat(name string) (os.FileInfo, error) {
 // Lstat wraps the Lstat method of the underlying file system.
 func (fs *LocalVss) Lstat(name string) (os.FileInfo, error) {
 	return os.Lstat(fs.snapshotPath(name))
+}
+
+func (fs *LocalVss) NodeFromFileInfo(path string, fi os.FileInfo, ignoreXattrListError bool) (*restic.Node, error) {
+	return fs.FS.NodeFromFileInfo(fs.snapshotPath(path), fi, ignoreXattrListError)
 }
 
 // isMountPointIncluded  is true if given mountpoint included by user.

--- a/internal/fs/fs_local_vss.go
+++ b/internal/fs/fs_local_vss.go
@@ -128,17 +128,17 @@ func (fs *LocalVss) DeleteSnapshots() {
 
 // OpenFile wraps the Open method of the underlying file system.
 func (fs *LocalVss) OpenFile(name string, flag int, perm os.FileMode) (File, error) {
-	return os.OpenFile(fs.snapshotPath(name), flag, perm)
+	return fs.FS.OpenFile(fs.snapshotPath(name), flag, perm)
 }
 
 // Stat wraps the Stat method of the underlying file system.
 func (fs *LocalVss) Stat(name string) (os.FileInfo, error) {
-	return os.Stat(fs.snapshotPath(name))
+	return fs.FS.Stat(fs.snapshotPath(name))
 }
 
 // Lstat wraps the Lstat method of the underlying file system.
 func (fs *LocalVss) Lstat(name string) (os.FileInfo, error) {
-	return os.Lstat(fs.snapshotPath(name))
+	return fs.FS.Lstat(fs.snapshotPath(name))
 }
 
 func (fs *LocalVss) NodeFromFileInfo(path string, fi os.FileInfo, ignoreXattrListError bool) (*restic.Node, error) {

--- a/internal/fs/fs_reader.go
+++ b/internal/fs/fs_reader.go
@@ -232,7 +232,7 @@ func (r *readerFile) Close() error {
 var _ File = &readerFile{}
 
 // fakeFile implements all File methods, but only returns errors for anything
-// except Stat() and Name().
+// except Stat()
 type fakeFile struct {
 	name string
 	os.FileInfo
@@ -255,10 +255,6 @@ func (f fakeFile) Close() error {
 
 func (f fakeFile) Stat() (os.FileInfo, error) {
 	return f.FileInfo, nil
-}
-
-func (f fakeFile) Name() string {
-	return f.name
 }
 
 // fakeDir implements Readdirnames and Readdir, everything else is delegated to fakeFile.

--- a/internal/fs/interface.go
+++ b/internal/fs/interface.go
@@ -34,5 +34,4 @@ type File interface {
 
 	Readdirnames(n int) ([]string, error)
 	Stat() (os.FileInfo, error)
-	Name() string
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
When creating a `backup` using VSS, the extended file metadata was not read from the snapshot but instead from the original. This can cause errors if the original file has been removed in the meantime.

The `LocalVss` now correctly intercepts the path passed to `NodeFromFileInfo`. This change is complemented with a bunch of tests to ensure that all paths are correctly intercepted.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/5063
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
