### PR TITLE
doc: Clarify number of blobs are added

### DIFF
--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -214,9 +214,9 @@ Summary is the last output line in a successful backup.
 +---------------------------+---------------------------------------------------------+
 | ``dirs_unmodified``       | Number of directories that did not change               |
 +---------------------------+---------------------------------------------------------+
-| ``data_blobs``            | Number of data blobs                                    |
+| ``data_blobs``            | Number of data blobs added                              |
 +---------------------------+---------------------------------------------------------+
-| ``tree_blobs``            | Number of tree blobs                                    |
+| ``tree_blobs``            | Number of tree blobs added                              |
 +---------------------------+---------------------------------------------------------+
 | ``data_added``            | Amount of (uncompressed) data added, in bytes           |
 +---------------------------+---------------------------------------------------------+
@@ -676,9 +676,9 @@ was created.
 +---------------------------+---------------------------------------------------------+
 | ``dirs_unmodified``       | Number of directories that did not change               |
 +---------------------------+---------------------------------------------------------+
-| ``data_blobs``            | Number of data blobs                                    |
+| ``data_blobs``            | Number of data blobs added                              |
 +---------------------------+---------------------------------------------------------+
-| ``tree_blobs``            | Number of tree blobs                                    |
+| ``tree_blobs``            | Number of tree blobs added                              |
 +---------------------------+---------------------------------------------------------+
 | ``data_added``            | Amount of (uncompressed) data added, in bytes           |
 +---------------------------+---------------------------------------------------------+


### PR DESCRIPTION
The numbers reported as `data_blobs` and `tree_blobs` are not total numbers of blobs but numbers of blobs added with the given snapshot.

See also: https://forum.restic.net/t/understanding-snapshot-summaries-and-stats-ouput/8467/5

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

It clarifies the meaning of numbers in the JSON objects describing snapshots.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

It was discussed here: https://forum.restic.net/t/understanding-snapshot-summaries-and-stats-ouput/8467

Checklist
---------

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I have run `gofmt` on the code in all commits.
- [ ] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
