### PR TITLE
Allow excluding xattrs at restore time

### DIFF
--- a/changelog/unreleased/issue-5089
+++ b/changelog/unreleased/issue-5089
@@ -1,0 +1,22 @@
+Enhancement: Allow including or excluding extended file attributes
+during restore.
+
+# Describe the problem in the past tense, the new behavior in the present
+# tense. Mention the affected commands, backends, operating systems, etc.
+# If the problem description just says that a feature was missing, then
+# only explain the new behavior.
+# Focus on user-facing behavior, not the implementation.
+# Use "Restic now ..." instead of "We have changed ...".
+#
+Restic restore used to attempt to restore all extended file attributes.
+Now two new command line flags are added to restore to control which
+extended file attributes will be restored.
+
+The new flags are `--exclude-xattr` and `--include-xattr`.
+
+If the flags are not provided, restic will default to restoring
+only `user` namespaced extended file attributes on Linux, and all
+extended file attributes on other operating systems.
+
+https://github.com/restic/restic/issues/5089
+https://github.com/restic/restic/pull/5129

--- a/changelog/unreleased/issue-5089
+++ b/changelog/unreleased/issue-5089
@@ -1,22 +1,13 @@
-Enhancement: Allow including or excluding extended file attributes
-during restore.
+Enhancement: Allow including/excluding extended file attributes during restore
 
-# Describe the problem in the past tense, the new behavior in the present
-# tense. Mention the affected commands, backends, operating systems, etc.
-# If the problem description just says that a feature was missing, then
-# only explain the new behavior.
-# Focus on user-facing behavior, not the implementation.
-# Use "Restic now ..." instead of "We have changed ...".
-#
-Restic restore used to attempt to restore all extended file attributes.
+Restic restore attempts to restore all extended file attributes.
 Now two new command line flags are added to restore to control which
 extended file attributes will be restored.
 
 The new flags are `--exclude-xattr` and `--include-xattr`.
 
 If the flags are not provided, restic will default to restoring
-only `user` namespaced extended file attributes on Linux, and all
-extended file attributes on other operating systems.
+all extended file attributes.
 
 https://github.com/restic/restic/issues/5089
 https://github.com/restic/restic/pull/5129

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/restic/restic/internal/debug"
@@ -300,6 +301,14 @@ func getXattrSelectFilter(opts RestoreOptions) (func(xattrName string) bool, err
 		}, nil
 	}
 
-	// no includes or excludes, set default of including all xattrs
+	// User has not specified any xattr includes or excludes
+	if runtime.GOOS == "linux" {
+		// For Linux, set default of including only user.* xattrs
+		return func(xattrName string) bool {
+			shouldInclude, _ := filter.IncludeByPattern([]string{"user.*"}, Warnf)(xattrName)
+			return shouldInclude
+		}, nil
+	}
+	// Not linux, default to including all xattrs
 	return func(_ string) bool { return true }, nil
 }

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -3,7 +3,6 @@ package main
 import (
 	"context"
 	"path/filepath"
-	"runtime"
 	"time"
 
 	"github.com/restic/restic/internal/debug"
@@ -301,14 +300,6 @@ func getXattrSelectFilter(opts RestoreOptions) (func(xattrName string) bool, err
 		}, nil
 	}
 
-	// User has not specified any xattr includes or excludes
-	if runtime.GOOS == "linux" {
-		// For Linux, set default of including only user.* xattrs
-		return func(xattrName string) bool {
-			shouldInclude, _ := filter.IncludeByPattern([]string{"user.*"}, Warnf)(xattrName)
-			return shouldInclude
-		}, nil
-	}
-	// Not linux, default to including all xattrs
+	// default to including all xattrs
 	return func(_ string) bool { return true }, nil
 }

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -88,6 +88,22 @@ disk space. Note that the exact location of the holes can differ from those in
 the original file, as their location is determined while restoring and is not
 stored explicitly.
 
+Restoring extended file attributes
+----------------------------------
+
+By default, user namespaced extended attributes for files are restored on Linux,
+and all extended attributes are restored for other operating systems.
+
+Use ``--exclude-xattr`` and ``--include-xattr`` to control which extended
+attributes are restored for files in the snapshot. For example, to restore
+user and security namespaced extended attributes for files:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo restore 79766175 --target /tmp/restore-work --include-xattr user.* --include-xattr security.*
+    enter password for repository:
+    restoring <Snapshot of [/home/user/work] at 2015-05-08 21:40:19.884408621 +0200 CEST> to /tmp/restore-work
+
 Restoring in-place
 ------------------
 

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -91,10 +91,9 @@ stored explicitly.
 Restoring extended file attributes
 ----------------------------------
 
-By default, user namespaced extended attributes for files are restored on Linux,
-and all extended attributes are restored for other operating systems.
+By default, all extended attributes for files are restored.
 
-Use ``--exclude-xattr`` and ``--include-xattr`` to control which extended
+Use only ``--exclude-xattr`` or ``--include-xattr`` to control which extended
 attributes are restored for files in the snapshot. For example, to restore
 user and security namespaced extended attributes for files:
 

--- a/internal/fs/node.go
+++ b/internal/fs/node.go
@@ -230,8 +230,8 @@ func mkfifo(path string, mode uint32) (err error) {
 }
 
 // NodeRestoreMetadata restores node metadata
-func NodeRestoreMetadata(node *restic.Node, path string, warn func(msg string)) error {
-	err := nodeRestoreMetadata(node, path, warn)
+func NodeRestoreMetadata(node *restic.Node, path string, warn func(msg string), xattrSelectFilter func(xattrName string) bool) error {
+	err := nodeRestoreMetadata(node, path, warn, xattrSelectFilter)
 	if err != nil {
 		// It is common to have permission errors for folders like /home
 		// unless you're running as root, so ignore those.
@@ -246,14 +246,14 @@ func NodeRestoreMetadata(node *restic.Node, path string, warn func(msg string)) 
 	return err
 }
 
-func nodeRestoreMetadata(node *restic.Node, path string, warn func(msg string)) error {
+func nodeRestoreMetadata(node *restic.Node, path string, warn func(msg string), xattrSelectFilter func(xattrName string) bool) error {
 	var firsterr error
 
 	if err := lchown(path, int(node.UID), int(node.GID)); err != nil {
 		firsterr = errors.WithStack(err)
 	}
 
-	if err := nodeRestoreExtendedAttributes(node, path); err != nil {
+	if err := nodeRestoreExtendedAttributes(node, path, xattrSelectFilter); err != nil {
 		debug.Log("error restoring extended attributes for %v: %v", path, err)
 		if firsterr == nil {
 			firsterr = err

--- a/internal/fs/node_noxattr.go
+++ b/internal/fs/node_noxattr.go
@@ -8,7 +8,7 @@ import (
 )
 
 // nodeRestoreExtendedAttributes is a no-op
-func nodeRestoreExtendedAttributes(_ *restic.Node, _ string) error {
+func nodeRestoreExtendedAttributes(_ *restic.Node, _ string, _ func(xattrName string) bool) error {
 	return nil
 }
 

--- a/internal/fs/node_test.go
+++ b/internal/fs/node_test.go
@@ -217,8 +217,9 @@ func TestNodeRestoreAt(t *testing.T) {
 				nodePath = filepath.Join(tempdir, test.Name)
 			}
 			rtest.OK(t, NodeCreateAt(&test, nodePath))
+			// Restore metadata, restoring all xattrs
 			rtest.OK(t, NodeRestoreMetadata(&test, nodePath, func(msg string) { rtest.OK(t, fmt.Errorf("Warning triggered for path: %s: %s", nodePath, msg)) },
-				func(_ string) bool { return true } /* restore all xattrs */))
+				func(_ string) bool { return true }))
 
 			fs := &Local{}
 			meta, err := fs.OpenFile(nodePath, O_NOFOLLOW, true)

--- a/internal/fs/node_test.go
+++ b/internal/fs/node_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/test"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -216,7 +217,8 @@ func TestNodeRestoreAt(t *testing.T) {
 				nodePath = filepath.Join(tempdir, test.Name)
 			}
 			rtest.OK(t, NodeCreateAt(&test, nodePath))
-			rtest.OK(t, NodeRestoreMetadata(&test, nodePath, func(msg string) { rtest.OK(t, fmt.Errorf("Warning triggered for path: %s: %s", nodePath, msg)) }))
+			rtest.OK(t, NodeRestoreMetadata(&test, nodePath, func(msg string) { rtest.OK(t, fmt.Errorf("Warning triggered for path: %s: %s", nodePath, msg)) },
+				func(_ string) bool { return true } /* restore all xattrs */))
 
 			fs := &Local{}
 			meta, err := fs.OpenFile(nodePath, O_NOFOLLOW, true)
@@ -291,6 +293,7 @@ func TestNodeRestoreMetadataError(t *testing.T) {
 	nodePath := filepath.Join(tempdir, node.Name)
 
 	// This will fail because the target file does not exist
-	err := NodeRestoreMetadata(node, nodePath, func(msg string) { rtest.OK(t, fmt.Errorf("Warning triggered for path: %s: %s", nodePath, msg)) })
-	rtest.Assert(t, errors.Is(err, os.ErrNotExist), "failed for an unexpected reason")
+	err := NodeRestoreMetadata(node, nodePath, func(msg string) { rtest.OK(t, fmt.Errorf("Warning triggered for path: %s: %s", nodePath, msg)) },
+		func(_ string) bool { return true })
+	test.Assert(t, errors.Is(err, os.ErrNotExist), "failed for an unexpected reason")
 }

--- a/internal/fs/node_windows_test.go
+++ b/internal/fs/node_windows_test.go
@@ -218,7 +218,7 @@ func restoreAndGetNode(t *testing.T, tempDir string, testNode *restic.Node, warn
 			// If warning is not expected, this code should not get triggered.
 			test.OK(t, fmt.Errorf("Warning triggered for path: %s: %s", testPath, msg))
 		}
-	})
+	}, func(_ string) bool { return true })
 	test.OK(t, errors.Wrapf(err, "Failed to restore metadata for: %s", testPath))
 
 	fs := &Local{}

--- a/internal/fs/node_xattr_all_test.go
+++ b/internal/fs/node_xattr_all_test.go
@@ -26,7 +26,7 @@ func setAndVerifyXattr(t *testing.T, file string, attrs []restic.ExtendedAttribu
 		Type:               restic.NodeTypeFile,
 		ExtendedAttributes: attrs,
 	}
-	rtest.OK(t, nodeRestoreExtendedAttributes(node, file))
+	rtest.OK(t, nodeRestoreExtendedAttributes(node, file, func(_ string) bool { return true } /*restore all xattrs*/))
 
 	nodeActual := &restic.Node{
 		Type: restic.NodeTypeFile,

--- a/internal/fs/node_xattr_all_test.go
+++ b/internal/fs/node_xattr_all_test.go
@@ -26,7 +26,8 @@ func setAndVerifyXattr(t *testing.T, file string, attrs []restic.ExtendedAttribu
 		Type:               restic.NodeTypeFile,
 		ExtendedAttributes: attrs,
 	}
-	rtest.OK(t, nodeRestoreExtendedAttributes(node, file, func(_ string) bool { return true } /*restore all xattrs*/))
+	/* restore all xattrs */
+	rtest.OK(t, nodeRestoreExtendedAttributes(node, file, func(_ string) bool { return true }))
 
 	nodeActual := &restic.Node{
 		Type: restic.NodeTypeFile,

--- a/internal/fs/node_xattr_all_test.go
+++ b/internal/fs/node_xattr_all_test.go
@@ -99,10 +99,6 @@ func TestOverwriteXattr(t *testing.T) {
 			Name:  "user.foo",
 			Value: []byte("bar"),
 		},
-		{
-			Name:  "abc.test",
-			Value: []byte("testxattr"),
-		},
 	})
 
 	setAndVerifyXattr(t, file, []restic.ExtendedAttribute{

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -99,12 +99,13 @@ func (c *OverwriteBehavior) Type() string {
 // NewRestorer creates a restorer preloaded with the content from the snapshot id.
 func NewRestorer(repo restic.Repository, sn *restic.Snapshot, opts Options) *Restorer {
 	r := &Restorer{
-		repo:         repo,
-		opts:         opts,
-		fileList:     make(map[string]bool),
-		Error:        restorerAbortOnAllErrors,
-		SelectFilter: func(string, bool) (bool, bool) { return true, true },
-		sn:           sn,
+		repo:              repo,
+		opts:              opts,
+		fileList:          make(map[string]bool),
+		Error:             restorerAbortOnAllErrors,
+		SelectFilter:      func(string, bool) (bool, bool) { return true, true },
+		XattrSelectFilter: func(string) bool { return true },
+		sn:                sn,
 	}
 
 	return r

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -31,6 +31,8 @@ type Restorer struct {
 	// SelectFilter determines whether the item is selectedForRestore or whether a childMayBeSelected.
 	// selectedForRestore must not depend on isDir as `removeUnexpectedFiles` always passes false to isDir.
 	SelectFilter func(item string, isDir bool) (selectedForRestore bool, childMayBeSelected bool)
+
+	XattrSelectFilter func(xattrName string) (xattrSelectedForRestore bool)
 }
 
 var restorerAbortOnAllErrors = func(_ string, err error) error { return err }
@@ -288,7 +290,7 @@ func (res *Restorer) restoreNodeMetadataTo(node *restic.Node, target, location s
 		return nil
 	}
 	debug.Log("restoreNodeMetadata %v %v %v", node.Name, target, location)
-	err := fs.NodeRestoreMetadata(node, target, res.Warn)
+	err := fs.NodeRestoreMetadata(node, target, res.Warn, res.XattrSelectFilter)
 	if err != nil {
 		debug.Log("node.RestoreMetadata(%s) error %v", target, err)
 	}


### PR DESCRIPTION
- also allows including xattrs
- default if no flags are passed include only xattrs in the user namespace (xattrs starting with user.*)

For: https://github.com/restic/restic/issues/5089

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This introduces new command line flags for restic restore:  `--exclude-xattr` and `--include-xattr`.  These are mutually exclusive, similar to --exclude and --include.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes https://github.com/restic/restic/issues/5089

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
