### PR TITLE
restore: improve error if timestamp fails to restore

### DIFF
--- a/internal/fs/node.go
+++ b/internal/fs/node.go
@@ -1,6 +1,7 @@
 package fs
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"strconv"
@@ -296,7 +297,7 @@ func nodeRestoreTimestamps(node *restic.Node, path string) error {
 	mtime := node.ModTime.UnixNano()
 
 	if err := utimesNano(fixpath(path), atime, mtime, node.Type); err != nil {
-		return &os.PathError{Op: "UtimesNano", Path: path, Err: err}
+		return fmt.Errorf("failed to restore timestamp of %q: %w", path, err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Improve error message when timestamp cannot be restored. Previously it was `UtimesNano /file/path: Access is denied`. This is replaced by `failed to restore timestamp of "/file/path": Access is denied`. This is just as informative for developers, but also much clearer for users.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/5133 .
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].
-->

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- [x] I have [enabled maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I have run `gofmt` on the code in all commits.
- [x] All commit messages are formatted in the same style as [the other commits in the repo](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
- [x] I'm done! This pull request is ready for review.
