### PR TITLE
Return error if AZURE_ACCOUNT_NAME not set

### DIFF
--- a/changelog/unreleased/pull-5141
+++ b/changelog/unreleased/pull-5141
@@ -1,0 +1,7 @@
+Enhancement: Provide clear error message if AZURE_ACCOUNT_NAME is not set
+
+If AZURE_ACCOUNT_NAME is not set, any command related to an Azure repository
+would result in a misleading networking error. Restic will now detect this and
+provide a clear warning that the variable is not defined.
+
+https://github.com/restic/restic/pull/5141

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -62,6 +62,11 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 	} else {
 		endpointSuffix = "core.windows.net"
 	}
+
+	if cfg.AccountName == "" {
+		return nil, errors.Fatalf("unable to open Azure backend: Account name ($AZURE_ACCOUNT_NAME) is empty")
+	}
+
 	url := fmt.Sprintf("https://%s.blob.%s/%s", cfg.AccountName, endpointSuffix, cfg.Container)
 	opts := &azContainer.ClientOptions{
 		ClientOptions: azcore.ClientOptions{


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Due to `AZURE_ACCOUNT_NAME` not being set, this error can occur when trying to reach a repository:
```
$ restic -r azure:repo:/ stats
Fatal: unable to open config file: blob.GetProperties: Head "https://.blob.core.windows.net/repo/config": dial tcp: lookup .blob.core.windows.net: no such host
Is there a repository at the following location?
azure:repo:/
```

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

This is not tied to a previous issue, as it is a simple fix. An explicit check is added which now produces a message like this:
```
Fatal: unable to open repository at azure:repo:/: Fatal: unable to open Azure backend: Account name ($AZURE_ACCOUNT_NAME) is empty
```

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
