### PR TITLE
backup: Ignore disappeared files

### DIFF
--- a/changelog/unreleased/issue-2165
+++ b/changelog/unreleased/issue-2165
@@ -1,0 +1,16 @@
+Bugfix: Ignore disappeared backup source files
+
+If during a backup files were removed between restic listing the directory
+content and backing up the file in question, the following error could occur:
+
+```
+error: lstat /some/file/name: no such file or directory
+```
+
+The backup command now ignores this particular error and silently skips the
+removed file.
+
+https://github.com/restic/restic/issues/2165
+https://github.com/restic/restic/issues/3098
+https://github.com/restic/restic/pull/5143
+https://github.com/restic/restic/pull/5145

--- a/internal/fs/vss_windows.go
+++ b/internal/fs/vss_windows.go
@@ -171,6 +171,11 @@ func (h HRESULT) Str() string {
 	return "UNKNOWN"
 }
 
+// Error implements the error interface
+func (h HRESULT) Error() string {
+	return h.Str()
+}
+
 // VssError encapsulates errors returned from calling VSS api.
 type vssError struct {
 	text    string
@@ -193,6 +198,11 @@ func newVssErrorIfResultNotOK(text string, hresult HRESULT) error {
 // Error implements the error interface.
 func (e *vssError) Error() string {
 	return fmt.Sprintf("VSS error: %s: %s (%#x)", e.text, e.hresult.Str(), e.hresult)
+}
+
+// Unwrap returns the underlying HRESULT error
+func (e *vssError) Unwrap() error {
+	return e.hresult
 }
 
 // vssTextError encapsulates errors returned from calling VSS api.
@@ -943,10 +953,23 @@ func NewVssSnapshot(provider string,
 			"%s", volume))
 	}
 
-	snapshotSetID, err := iVssBackupComponents.StartSnapshotSet()
-	if err != nil {
-		iVssBackupComponents.Release()
-		return VssSnapshot{}, err
+	const retryStartSnapshotSetSleep = 5 * time.Second
+	var snapshotSetID ole.GUID
+	for {
+		var err error
+		snapshotSetID, err = iVssBackupComponents.StartSnapshotSet()
+		if errors.Is(err, VSS_E_SNAPSHOT_SET_IN_PROGRESS) && time.Now().Add(-retryStartSnapshotSetSleep).Before(deadline) {
+			// retry snapshot set creation while deadline is not reached
+			time.Sleep(retryStartSnapshotSetSleep)
+			continue
+		}
+
+		if err != nil {
+			iVssBackupComponents.Release()
+			return VssSnapshot{}, err
+		} else {
+			break
+		}
 	}
 
 	if err := iVssBackupComponents.AddToSnapshotSet(volume, providerID, &snapshotSetID); err != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Ignore "No such file" errors when trying to save a file in the archiver. This PR includes https://github.com/restic/restic/pull/5143 and only adds a single commit. Making the PRs independent is unfortunately not possible as it would require a reimplementation of this PR, which would soon become obsolete.

This PR only fixes the "No such file" error in regards to `lstat` (probably the most common), but not the `Listxattr` errors later on. Those require a file-handle-based implementation that has to wait for a followup PR.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes part of https://github.com/restic/restic/issues/3098
Fixes part of https://github.com/restic/restic/issues/2165
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
