### PR TITLE
fs: filehandle-based File

### DIFF
--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -264,6 +264,10 @@ func (arch *Archiver) trackItem(item string, previous, current *restic.Node, s I
 // nodeFromFileInfo returns the restic node from an os.FileInfo.
 func (arch *Archiver) nodeFromFileInfo(snPath, filename string, meta ToNoder, ignoreXattrListError bool) (*restic.Node, error) {
 	node, err := meta.ToNode(ignoreXattrListError)
+	if node == nil {
+		// do not filter error on total failure
+		return node, err
+	}
 	if !arch.WithAtime {
 		node.AccessTime = node.ModTime
 	}

--- a/internal/feature/registry.go
+++ b/internal/feature/registry.go
@@ -8,6 +8,7 @@ const (
 	BackendErrorRedesign    FlagName = "backend-error-redesign"
 	DeviceIDForHardlinks    FlagName = "device-id-for-hardlinks"
 	ExplicitS3AnonymousAuth FlagName = "explicit-s3-anonymous-auth"
+	FilehandleBasedBackup   FlagName = "filehandle-based-backup"
 	SafeForgetKeepTags      FlagName = "safe-forget-keep-tags"
 )
 
@@ -15,6 +16,7 @@ func init() {
 	Flag.SetFlags(map[FlagName]FlagDesc{
 		BackendErrorRedesign:    {Type: Beta, Description: "enforce timeouts for stuck HTTP requests and use new backend error handling design."},
 		DeviceIDForHardlinks:    {Type: Alpha, Description: "store deviceID only for hardlinks to reduce metadata changes for example when using btrfs subvolumes. Will be removed in a future restic version after repository format 3 is available"},
+		FilehandleBasedBackup:   {Type: Beta, Description: "`backup` uses filehandles to atomically collect file metadata on Linux/macOS/Windows"},
 		ExplicitS3AnonymousAuth: {Type: Beta, Description: "forbid anonymous S3 authentication unless `-o s3.unsafe-anonymous-auth=true` is set"},
 		SafeForgetKeepTags:      {Type: Beta, Description: "prevent deleting all snapshots if the tag passed to `forget --keep-tags tagname` does not exist"},
 	})

--- a/internal/fs/ea_windows.go
+++ b/internal/fs/ea_windows.go
@@ -284,14 +284,10 @@ func setFileEA(handle windows.Handle, iosb *ioStatusBlock, buf *uint8, bufLen ui
 	return
 }
 
-// pathSupportsExtendedAttributes returns true if the path supports extended attributes.
-func pathSupportsExtendedAttributes(path string) (supported bool, err error) {
+// handleSupportsExtendedAttributes returns true if the handle is on a volume that supports extended attributes.
+func handleSupportsExtendedAttributes(handle windows.Handle) (supported bool, err error) {
 	var fileSystemFlags uint32
-	utf16Path, err := windows.UTF16PtrFromString(path)
-	if err != nil {
-		return false, err
-	}
-	err = windows.GetVolumeInformation(utf16Path, nil, 0, nil, nil, &fileSystemFlags, nil, 0)
+	err = windows.GetVolumeInformationByHandle(handle, nil, 0, nil, nil, &fileSystemFlags, nil, 0)
 	if err != nil {
 		return false, err
 	}

--- a/internal/fs/ea_windows_test.go
+++ b/internal/fs/ea_windows_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"unsafe"
 
+	rtest "github.com/restic/restic/internal/test"
 	"golang.org/x/sys/windows"
 )
 
@@ -261,7 +262,9 @@ func TestPathSupportsExtendedAttributes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			supported, err := pathSupportsExtendedAttributes(tc.path)
+			handle, err := openMetadataHandle(tc.path, false)
+			rtest.OK(t, err)
+			supported, err := handleSupportsExtendedAttributes(windows.Handle(handle.Fd()))
 			if err != nil {
 				t.Fatalf("Unexpected error: %v", err)
 			}
@@ -272,8 +275,12 @@ func TestPathSupportsExtendedAttributes(t *testing.T) {
 	}
 
 	// Test with an invalid path
-	_, err := pathSupportsExtendedAttributes("Z:\\NonExistentPath-UAS664da5s4dyu56das45f5as")
+
+	handle, err := openMetadataHandle("Z:\\NonExistentPath-UAS664da5s4dyu56das45f5as", false)
+	rtest.OK(t, err)
+	_, err = handleSupportsExtendedAttributes(windows.Handle(handle.Fd()))
 	if err == nil {
 		t.Error("Expected an error for non-existent path, but got nil")
 	}
+	rtest.OK(t, handle.Close())
 }

--- a/internal/fs/ea_windows_test.go
+++ b/internal/fs/ea_windows_test.go
@@ -262,7 +262,7 @@ func TestPathSupportsExtendedAttributes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			handle, err := openMetadataHandle(tc.path, false)
+			handle, err := openMetadataHandle(tc.path, 0)
 			rtest.OK(t, err)
 			supported, err := handleSupportsExtendedAttributes(windows.Handle(handle.Fd()))
 			if err != nil {
@@ -276,7 +276,7 @@ func TestPathSupportsExtendedAttributes(t *testing.T) {
 
 	// Test with an invalid path
 
-	handle, err := openMetadataHandle("Z:\\NonExistentPath-UAS664da5s4dyu56das45f5as", false)
+	handle, err := openMetadataHandle("Z:\\NonExistentPath-UAS664da5s4dyu56das45f5as", 0)
 	rtest.OK(t, err)
 	_, err = handleSupportsExtendedAttributes(windows.Handle(handle.Fd()))
 	if err == nil {

--- a/internal/fs/file_windows.go
+++ b/internal/fs/file_windows.go
@@ -113,13 +113,10 @@ func clearAttribute(path string, attribute uint32) error {
 	return nil
 }
 
-// openHandleForEA return a file handle for file or dir for setting/getting EAs
-func openHandleForEA(path string, writeAccess bool) (handle windows.Handle, err error) {
+// openWriteHandleForEA return a file handle for a file or dir for setting EAs
+func openWriteHandleForEA(path string) (handle windows.Handle, err error) {
 	path = fixpath(path)
-	fileAccess := windows.FILE_READ_EA
-	if writeAccess {
-		fileAccess = fileAccess | windows.FILE_WRITE_EA
-	}
+	fileAccess := windows.FILE_READ_EA | windows.FILE_WRITE_EA
 
 	utf16Path := windows.StringToUTF16Ptr(path)
 	return windows.CreateFile(utf16Path, uint32(fileAccess), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)

--- a/internal/fs/file_windows.go
+++ b/internal/fs/file_windows.go
@@ -8,7 +8,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/restic/restic/internal/restic"
 	"golang.org/x/sys/windows"
 )
 
@@ -115,22 +114,13 @@ func clearAttribute(path string, attribute uint32) error {
 }
 
 // openHandleForEA return a file handle for file or dir for setting/getting EAs
-func openHandleForEA(nodeType restic.NodeType, path string, writeAccess bool) (handle windows.Handle, err error) {
+func openHandleForEA(path string, writeAccess bool) (handle windows.Handle, err error) {
 	path = fixpath(path)
 	fileAccess := windows.FILE_READ_EA
 	if writeAccess {
 		fileAccess = fileAccess | windows.FILE_WRITE_EA
 	}
 
-	switch nodeType {
-	case restic.NodeTypeFile:
-		utf16Path := windows.StringToUTF16Ptr(path)
-		handle, err = windows.CreateFile(utf16Path, uint32(fileAccess), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
-	case restic.NodeTypeDir:
-		utf16Path := windows.StringToUTF16Ptr(path)
-		handle, err = windows.CreateFile(utf16Path, uint32(fileAccess), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
-	default:
-		return 0, nil
-	}
-	return handle, err
+	utf16Path := windows.StringToUTF16Ptr(path)
+	return windows.CreateFile(utf16Path, uint32(fileAccess), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
 }

--- a/internal/fs/freadlink_darwin.go
+++ b/internal/fs/freadlink_darwin.go
@@ -1,0 +1,9 @@
+package fs
+
+import "os"
+
+// TODO macOS versions >= 13 support freadlink. Use that instead of the fallback codepath
+
+func Freadlink(fd uintptr, name string) (string, error) {
+	return os.Readlink(name)
+}

--- a/internal/fs/freadlink_linux.go
+++ b/internal/fs/freadlink_linux.go
@@ -1,0 +1,47 @@
+package fs
+
+import (
+	"os"
+	"syscall"
+
+	"golang.org/x/sys/unix"
+)
+
+// based on readlink from go/src/os/file_unix.go Go 1.23.2
+// modified to use Readlinkat syscall instead of readlink
+
+// Many functions in package syscall return a count of -1 instead of 0.
+// Using fixCount(call()) instead of call() corrects the count.
+func fixCount(n int, err error) (int, error) {
+	if n < 0 {
+		n = 0
+	}
+	return n, err
+}
+
+func Freadlink(fd uintptr, name string) (string, error) {
+	for namelen := 128; ; namelen *= 2 {
+		b := make([]byte, namelen)
+		var (
+			n int
+			e error
+		)
+		for {
+			n, e = fixCount(freadlink(int(fd), b))
+			if e != syscall.EINTR {
+				break
+			}
+		}
+		if e != nil {
+			return "", &os.PathError{Op: "readlink", Path: name, Err: e}
+		}
+		if n < namelen {
+			return string(b[0:n]), nil
+		}
+	}
+}
+
+func freadlink(fd int, buf []byte) (n int, err error) {
+	// pass empty path to process the link itself
+	return unix.Readlinkat(fd, "", buf)
+}

--- a/internal/fs/freadlink_test.go
+++ b/internal/fs/freadlink_test.go
@@ -1,0 +1,24 @@
+//go:build linux || windows || darwin
+// +build linux windows darwin
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestFreadlink(t *testing.T) {
+	tmpdir := t.TempDir()
+	link := filepath.Join(tmpdir, "link")
+	rtest.OK(t, os.Symlink("other", link))
+
+	f, err := openMetadataHandle(link, O_NOFOLLOW)
+	rtest.OK(t, err)
+	target, err := Freadlink(f.Fd(), link)
+	rtest.OK(t, err)
+	rtest.Equals(t, "other", target)
+}

--- a/internal/fs/freadlink_windows.go
+++ b/internal/fs/freadlink_windows.go
@@ -1,0 +1,138 @@
+package fs
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+
+	"golang.org/x/sys/windows"
+)
+
+func Freadlink(fd uintptr, name string) (string, error) {
+	link, err := readReparseLink(windows.Handle(fd))
+	if err != nil {
+		return "", &os.PathError{Op: "readlink", Path: name, Err: err}
+	}
+	return link, nil
+}
+
+// based on src/os/file_windows.go from Go 1.23.2
+// internally readReparseLink from the std library uses a filehandle, however,
+// the external interface is based on a path. Thus, copy everything and minimally
+// tweak it to allow passing in a file handle.
+
+// normaliseLinkPath converts absolute paths returned by
+// DeviceIoControl(h, FSCTL_GET_REPARSE_POINT, ...)
+// into paths acceptable by all Windows APIs.
+// For example, it converts
+//
+//	\??\C:\foo\bar into C:\foo\bar
+//	\??\UNC\foo\bar into \\foo\bar
+//	\??\Volume{abc}\ into \\?\Volume{abc}\
+func normaliseLinkPath(path string) (string, error) {
+	if len(path) < 4 || path[:4] != `\??\` {
+		// unexpected path, return it as is
+		return path, nil
+	}
+	// we have path that start with \??\
+	s := path[4:]
+	switch {
+	case len(s) >= 2 && s[1] == ':': // \??\C:\foo\bar
+		return s, nil
+	case len(s) >= 4 && s[:4] == `UNC\`: // \??\UNC\foo\bar
+		return `\\` + s[4:], nil
+	}
+
+	// \??\Volume{abc}\
+	return `\\?\` + path[4:], nil
+	// modified to remove the legacy codepath for winreadlinkvolume == 0
+}
+
+func readReparseLink(h windows.Handle) (string, error) {
+	rdbbuf := make([]byte, windows.MAXIMUM_REPARSE_DATA_BUFFER_SIZE)
+	var bytesReturned uint32
+	err := windows.DeviceIoControl(h, windows.FSCTL_GET_REPARSE_POINT, nil, 0, &rdbbuf[0], uint32(len(rdbbuf)), &bytesReturned, nil)
+	if err != nil {
+		return "", err
+	}
+
+	rdb := (*reparseDataBuffer)(unsafe.Pointer(&rdbbuf[0]))
+	switch rdb.ReparseTag {
+	case syscall.IO_REPARSE_TAG_SYMLINK:
+		rb := (*symbolicLinkReparseBuffer)(unsafe.Pointer(&rdb.DUMMYUNIONNAME))
+		s := rb.Path()
+		if rb.Flags&symlinkFlagRelative != 0 {
+			return s, nil
+		}
+		return normaliseLinkPath(s)
+	case windows.IO_REPARSE_TAG_MOUNT_POINT:
+		return normaliseLinkPath((*mountPointReparseBuffer)(unsafe.Pointer(&rdb.DUMMYUNIONNAME)).Path())
+	default:
+		// the path is not a symlink or junction but another type of reparse
+		// point
+		return "", syscall.ENOENT
+	}
+}
+
+// copied from src/internal/syscall/windows/reparse_windows.go from Go 1.23.0
+// renamed to not export symbols
+
+const symlinkFlagRelative = 1
+
+type reparseDataBuffer struct {
+	ReparseTag        uint32
+	ReparseDataLength uint16
+	Reserved          uint16
+	DUMMYUNIONNAME    byte
+}
+
+type symbolicLinkReparseBuffer struct {
+	// The integer that contains the offset, in bytes,
+	// of the substitute name string in the PathBuffer array,
+	// computed as an offset from byte 0 of PathBuffer. Note that
+	// this offset must be divided by 2 to get the array index.
+	SubstituteNameOffset uint16
+	// The integer that contains the length, in bytes, of the
+	// substitute name string. If this string is null-terminated,
+	// SubstituteNameLength does not include the Unicode null character.
+	SubstituteNameLength uint16
+	// PrintNameOffset is similar to SubstituteNameOffset.
+	PrintNameOffset uint16
+	// PrintNameLength is similar to SubstituteNameLength.
+	PrintNameLength uint16
+	// Flags specifies whether the substitute name is a full path name or
+	// a path name relative to the directory containing the symbolic link.
+	Flags      uint32
+	PathBuffer [1]uint16
+}
+
+// Path returns path stored in rb.
+func (rb *symbolicLinkReparseBuffer) Path() string {
+	n1 := rb.SubstituteNameOffset / 2
+	n2 := (rb.SubstituteNameOffset + rb.SubstituteNameLength) / 2
+	return syscall.UTF16ToString((*[0xffff]uint16)(unsafe.Pointer(&rb.PathBuffer[0]))[n1:n2:n2])
+}
+
+type mountPointReparseBuffer struct {
+	// The integer that contains the offset, in bytes,
+	// of the substitute name string in the PathBuffer array,
+	// computed as an offset from byte 0 of PathBuffer. Note that
+	// this offset must be divided by 2 to get the array index.
+	SubstituteNameOffset uint16
+	// The integer that contains the length, in bytes, of the
+	// substitute name string. If this string is null-terminated,
+	// SubstituteNameLength does not include the Unicode null character.
+	SubstituteNameLength uint16
+	// PrintNameOffset is similar to SubstituteNameOffset.
+	PrintNameOffset uint16
+	// PrintNameLength is similar to SubstituteNameLength.
+	PrintNameLength uint16
+	PathBuffer      [1]uint16
+}
+
+// Path returns path stored in rb.
+func (rb *mountPointReparseBuffer) Path() string {
+	n1 := rb.SubstituteNameOffset / 2
+	n2 := (rb.SubstituteNameOffset + rb.SubstituteNameLength) / 2
+	return syscall.UTF16ToString((*[0xffff]uint16)(unsafe.Pointer(&rb.PathBuffer[0]))[n1:n2:n2])
+}

--- a/internal/fs/fs_local.go
+++ b/internal/fs/fs_local.go
@@ -199,54 +199,6 @@ func (f *pathLocalFile) MakeReadable() error {
 	return nil
 }
 
-type fdLocalFile struct {
-	localFile
-	flag         int
-	metadataOnly bool
-}
-
-var _ File = &fdLocalFile{}
-
-func newFdLocalFile(name string, flag int, metadataOnly bool) (*fdLocalFile, error) {
-	var f *os.File
-	var err error
-	if metadataOnly {
-		f, err = openMetadataHandle(name, flag)
-	} else {
-		f, err = openReadHandle(name, flag)
-	}
-	if err != nil {
-		return nil, err
-	}
-	meta := newFdMetadataHandle(name, f)
-	return &fdLocalFile{
-		localFile: localFile{
-			name: name,
-			f:    f,
-			meta: meta,
-		},
-		flag:         flag,
-		metadataOnly: metadataOnly,
-	}, nil
-}
-
-func (f *fdLocalFile) MakeReadable() error {
-	if !f.metadataOnly {
-		panic("file is already readable")
-	}
-
-	newF, err := reopenMetadataHandle(f.f)
-	// old handle is no longer usable
-	f.f = nil
-	if err != nil {
-		return err
-	}
-	f.f = newF
-	f.meta = newFdMetadataHandle(f.name, newF)
-	f.metadataOnly = false
-	return nil
-}
-
 func buildLocalFile(name string, flag int, metadataOnly bool) (File, error) {
 	useFd := runtime.GOOS == "linux" || runtime.GOOS == "windows" || runtime.GOOS == "darwin"
 	useFd = useFd && feature.Flag.Enabled(feature.FilehandleBasedBackup)

--- a/internal/fs/fs_local_fd.go
+++ b/internal/fs/fs_local_fd.go
@@ -1,0 +1,53 @@
+//go:build linux || darwin || windows
+
+package fs
+
+import "os"
+
+type fdLocalFile struct {
+	localFile
+	flag         int
+	metadataOnly bool
+}
+
+var _ File = &fdLocalFile{}
+
+func newFdLocalFile(name string, flag int, metadataOnly bool) (*fdLocalFile, error) {
+	var f *os.File
+	var err error
+	if metadataOnly {
+		f, err = openMetadataHandle(name, flag)
+	} else {
+		f, err = openReadHandle(name, flag)
+	}
+	if err != nil {
+		return nil, err
+	}
+	meta := newFdMetadataHandle(name, f)
+	return &fdLocalFile{
+		localFile: localFile{
+			name: name,
+			f:    f,
+			meta: meta,
+		},
+		flag:         flag,
+		metadataOnly: metadataOnly,
+	}, nil
+}
+
+func (f *fdLocalFile) MakeReadable() error {
+	if !f.metadataOnly {
+		panic("file is already readable")
+	}
+
+	newF, err := reopenMetadataHandle(f.f)
+	// old handle is no longer usable
+	f.f = nil
+	if err != nil {
+		return err
+	}
+	f.f = newF
+	f.meta = newFdMetadataHandle(f.name, newF)
+	f.metadataOnly = false
+	return nil
+}

--- a/internal/fs/fs_local_nofd.go
+++ b/internal/fs/fs_local_nofd.go
@@ -1,0 +1,7 @@
+//go:build !linux && !darwin && !windows
+
+package fs
+
+func newFdLocalFile(name string, flag int, metadataOnly bool) (File, error) {
+	panic("not supported")
+}

--- a/internal/fs/fs_local_test.go
+++ b/internal/fs/fs_local_test.go
@@ -96,7 +96,8 @@ func checkMetadata(t *testing.T, f File, path string, follow bool, nodeType rest
 
 func assertFIEqual(t *testing.T, want os.FileInfo, got *ExtendedFileInfo) {
 	t.Helper()
-	rtest.Equals(t, want.Name(), got.Name, "Name")
+	// do not compare the name as it can differ in testcases that rename the test file
+	// a fd-based implementation will still keep the original file name
 	rtest.Equals(t, want.ModTime(), got.ModTime, "ModTime")
 	rtest.Equals(t, want.Mode(), got.Mode, "Mode")
 	rtest.Equals(t, want.Size(), got.Size, "Size")

--- a/internal/fs/fs_local_unix_test.go
+++ b/internal/fs/fs_local_unix_test.go
@@ -11,6 +11,10 @@ import (
 )
 
 func TestFSLocalMetadataUnix(t *testing.T) {
+	testHandleVariants(t, testFSLocalMetadataUnix)
+}
+
+func testFSLocalMetadataUnix(t *testing.T) {
 	for _, test := range []fsLocalMetadataTestcase{
 		{
 			name: "socket",

--- a/internal/fs/fs_local_xattr_test.go
+++ b/internal/fs/fs_local_xattr_test.go
@@ -1,0 +1,76 @@
+//go:build darwin || freebsd || linux || solaris || windows
+
+package fs
+
+import (
+	"os"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestXattrNoFollow(t *testing.T) {
+	xattrs := []restic.ExtendedAttribute{
+		{
+			Name:  "user.foo",
+			Value: []byte("bar"),
+		},
+	}
+	if runtime.GOOS == "windows" {
+		// windows seems to convert the xattr name to upper case
+		for i := range xattrs {
+			xattrs[i].Name = strings.ToUpper(xattrs[i].Name)
+		}
+	}
+
+	setXattrs := func(path string) {
+		node := &restic.Node{
+			Type:               restic.NodeTypeFile,
+			ExtendedAttributes: xattrs,
+		}
+		rtest.OK(t, nodeRestoreExtendedAttributes(node, path))
+	}
+	checkXattrs := func(expected []restic.ExtendedAttribute) func(t *testing.T, node *restic.Node) {
+		return func(t *testing.T, node *restic.Node) {
+			rtest.Equals(t, expected, node.ExtendedAttributes, "xattr mismatch for file")
+		}
+	}
+
+	setupSymlinkTest := func(t *testing.T, path string) {
+		rtest.OK(t, os.WriteFile(path+"file", []byte("example"), 0o600))
+		setXattrs(path + "file")
+		rtest.OK(t, os.Symlink(path+"file", path))
+	}
+
+	for _, test := range []fsLocalMetadataTestcase{
+		{
+			name: "file",
+			setup: func(t *testing.T, path string) {
+				rtest.OK(t, os.WriteFile(path, []byte("example"), 0o600))
+				setXattrs(path)
+			},
+			nodeType: restic.NodeTypeFile,
+			check:    checkXattrs(xattrs),
+		},
+		{
+			name:     "symlink",
+			setup:    setupSymlinkTest,
+			nodeType: restic.NodeTypeSymlink,
+			check:    checkXattrs([]restic.ExtendedAttribute{}),
+		},
+		{
+			name:     "symlink file",
+			follow:   true,
+			setup:    setupSymlinkTest,
+			nodeType: restic.NodeTypeFile,
+			check:    checkXattrs(xattrs),
+		},
+	} {
+		testHandleVariants(t, func(t *testing.T) {
+			runFSLocalTestcase(t, test)
+		})
+	}
+}

--- a/internal/fs/meta.go
+++ b/internal/fs/meta.go
@@ -1,0 +1,52 @@
+package fs
+
+import (
+	"os"
+
+	"github.com/restic/restic/internal/restic"
+)
+
+type metadataHandle interface {
+	Name() string
+	Stat() (*ExtendedFileInfo, error)
+	Readlink() (string, error)
+	Xattr(ignoreListError bool) ([]restic.ExtendedAttribute, error)
+	// windows only
+	SecurityDescriptor() (*[]byte, error)
+}
+
+type pathMetadataHandle struct {
+	name string
+	flag int
+}
+
+var _ metadataHandle = &pathMetadataHandle{}
+
+func newPathMetadataHandle(name string, flag int) *pathMetadataHandle {
+	return &pathMetadataHandle{
+		name: fixpath(name),
+		flag: flag,
+	}
+}
+
+func (p *pathMetadataHandle) Name() string {
+	return p.name
+}
+
+func (p *pathMetadataHandle) Stat() (*ExtendedFileInfo, error) {
+	var fi os.FileInfo
+	var err error
+	if p.flag&O_NOFOLLOW != 0 {
+		fi, err = os.Lstat(p.name)
+	} else {
+		fi, err = os.Stat(p.name)
+	}
+	if err != nil {
+		return nil, err
+	}
+	return extendedStat(fi), nil
+}
+
+func (p *pathMetadataHandle) Readlink() (string, error) {
+	return os.Readlink(p.name)
+}

--- a/internal/fs/meta_darwin.go
+++ b/internal/fs/meta_darwin.go
@@ -24,6 +24,15 @@ func openMetadataHandle(path string, flag int) (*os.File, error) {
 	return f, nil
 }
 
+func openReadHandle(path string, flag int) (*os.File, error) {
+	f, err := os.OpenFile(path, flag, 0)
+	if err != nil {
+		return nil, err
+	}
+	_ = setFlags(f)
+	return f, nil
+}
+
 // reopenMetadataHandle reopens a handle created by openMetadataHandle for reading.
 // The caller must no longer use the original file.
 func reopenMetadataHandle(f *os.File) (*os.File, error) {

--- a/internal/fs/meta_darwin.go
+++ b/internal/fs/meta_darwin.go
@@ -23,3 +23,9 @@ func openMetadataHandle(path string, flag int) (*os.File, error) {
 	_ = setFlags(f)
 	return f, nil
 }
+
+// reopenMetadataHandle reopens a handle created by openMetadataHandle for reading.
+// The caller must no longer use the original file.
+func reopenMetadataHandle(f *os.File) (*os.File, error) {
+	return f, nil
+}

--- a/internal/fs/meta_darwin.go
+++ b/internal/fs/meta_darwin.go
@@ -1,0 +1,25 @@
+package fs
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openMetadataHandle(path string, flag int) (*os.File, error) {
+	flags := O_RDONLY
+	if flag&O_NOFOLLOW != 0 {
+		// open symlink instead of following it
+		flags |= unix.O_SYMLINK
+	}
+	if flag&O_DIRECTORY != 0 {
+		flags |= O_DIRECTORY
+	}
+
+	f, err := os.OpenFile(path, flags, 0)
+	if err != nil {
+		return nil, err
+	}
+	_ = setFlags(f)
+	return f, nil
+}

--- a/internal/fs/meta_fd.go
+++ b/internal/fs/meta_fd.go
@@ -31,6 +31,5 @@ func (p *fdMetadataHandle) Stat() (*ExtendedFileInfo, error) {
 }
 
 func (p *fdMetadataHandle) Readlink() (string, error) {
-	// FIXME
-	return os.Readlink(fixpath(p.name))
+	return Freadlink(p.f.Fd(), fixpath(p.name))
 }

--- a/internal/fs/meta_fd.go
+++ b/internal/fs/meta_fd.go
@@ -1,0 +1,36 @@
+//go:build darwin || linux || windows
+
+package fs
+
+import "os"
+
+type fdMetadataHandle struct {
+	name string
+	f    *os.File
+}
+
+var _ metadataHandle = &fdMetadataHandle{}
+
+func newFdMetadataHandle(name string, f *os.File) *fdMetadataHandle {
+	return &fdMetadataHandle{
+		name: name,
+		f:    f,
+	}
+}
+
+func (p *fdMetadataHandle) Name() string {
+	return p.name
+}
+
+func (p *fdMetadataHandle) Stat() (*ExtendedFileInfo, error) {
+	fi, err := p.f.Stat()
+	if err != nil {
+		return nil, err
+	}
+	return extendedStat(fi), nil
+}
+
+func (p *fdMetadataHandle) Readlink() (string, error) {
+	// FIXME
+	return os.Readlink(fixpath(p.name))
+}

--- a/internal/fs/meta_fd.go
+++ b/internal/fs/meta_fd.go
@@ -23,11 +23,13 @@ func (p *fdMetadataHandle) Name() string {
 }
 
 func (p *fdMetadataHandle) Stat() (*ExtendedFileInfo, error) {
-	fi, err := p.f.Stat()
-	if err != nil {
-		return nil, err
-	}
-	return extendedStat(fi), nil
+	// localFile.cacheFI() already internally calls stat on the filehandle
+	panic("should never be called")
+	// fi, err := p.f.Stat()
+	// if err != nil {
+	// 	return nil, err
+	// }
+	// return extendedStat(fi), nil
 }
 
 func (p *fdMetadataHandle) Readlink() (string, error) {

--- a/internal/fs/meta_fd_notwindows.go
+++ b/internal/fs/meta_fd_notwindows.go
@@ -1,0 +1,14 @@
+//go:build darwin || linux
+
+package fs
+
+import "github.com/restic/restic/internal/restic"
+
+func (p *fdMetadataHandle) Xattr(ignoreListError bool) ([]restic.ExtendedAttribute, error) {
+	// FIXME
+	return xattrFromPath(p.Name(), ignoreListError)
+}
+
+func (p *fdMetadataHandle) SecurityDescriptor() (*[]byte, error) {
+	return nil, nil
+}

--- a/internal/fs/meta_fd_notwindows.go
+++ b/internal/fs/meta_fd_notwindows.go
@@ -5,8 +5,13 @@ package fs
 import "github.com/restic/restic/internal/restic"
 
 func (p *fdMetadataHandle) Xattr(ignoreListError bool) ([]restic.ExtendedAttribute, error) {
-	// FIXME
-	return xattrFromPath(p.Name(), ignoreListError)
+	path := p.Name()
+	return xattrFromPath(
+		path,
+		func() ([]string, error) { return flistxattr(p.f) },
+		func(attr string) ([]byte, error) { return fgetxattr(p.f, attr) },
+		ignoreListError,
+	)
 }
 
 func (p *fdMetadataHandle) SecurityDescriptor() (*[]byte, error) {

--- a/internal/fs/meta_linux.go
+++ b/internal/fs/meta_linux.go
@@ -1,0 +1,25 @@
+package fs
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func openMetadataHandle(path string, flag int) (*os.File, error) {
+	// O_PATH|O_NOFOLLOW is necessary to also be able to get a handle to symlinks
+	flags := unix.O_PATH
+	if flag&O_NOFOLLOW != 0 {
+		flags |= O_NOFOLLOW
+	}
+	if flag&O_DIRECTORY != 0 {
+		flags |= O_DIRECTORY
+	}
+
+	f, err := os.OpenFile(path, flags, 0)
+	if err != nil {
+		return nil, err
+	}
+	_ = setFlags(f)
+	return f, nil
+}

--- a/internal/fs/meta_linux.go
+++ b/internal/fs/meta_linux.go
@@ -2,6 +2,7 @@ package fs
 
 import (
 	"os"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
@@ -22,4 +23,31 @@ func openMetadataHandle(path string, flag int) (*os.File, error) {
 	}
 	_ = setFlags(f)
 	return f, nil
+}
+
+// reopenMetadataHandle reopens a handle created by openMetadataHandle for reading.
+// The caller must no longer use the original file.
+func reopenMetadataHandle(f *os.File) (*os.File, error) {
+	defer func() {
+		_ = f.Close()
+	}()
+
+	f2, err := os.OpenFile(linuxFdPath(f.Fd()), O_RDONLY, 0)
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		_ = f2.Close()
+	}()
+
+	// Duplicate the filehandle and use that to create a file object with the correct name.
+	// f2 will automatically close its file handle on garbage collection.
+	fd3, err := syscall.Dup(int(f2.Fd()))
+	if err != nil {
+		return nil, err
+	}
+
+	f3 := os.NewFile(uintptr(fd3), f.Name())
+	_ = setFlags(f3)
+	return f3, nil
 }

--- a/internal/fs/meta_linux.go
+++ b/internal/fs/meta_linux.go
@@ -25,6 +25,15 @@ func openMetadataHandle(path string, flag int) (*os.File, error) {
 	return f, nil
 }
 
+func openReadHandle(path string, flag int) (*os.File, error) {
+	f, err := os.OpenFile(path, flag, 0)
+	if err != nil {
+		return nil, err
+	}
+	_ = setFlags(f)
+	return f, nil
+}
+
 // reopenMetadataHandle reopens a handle created by openMetadataHandle for reading.
 // The caller must no longer use the original file.
 func reopenMetadataHandle(f *os.File) (*os.File, error) {

--- a/internal/fs/meta_noxattr.go
+++ b/internal/fs/meta_noxattr.go
@@ -1,0 +1,10 @@
+//go:build aix || dragonfly || netbsd || openbsd
+// +build aix dragonfly netbsd openbsd
+
+package fs
+
+import "github.com/restic/restic/internal/restic"
+
+func (p *pathMetadataHandle) Xattr(ignoreListError bool) ([]restic.ExtendedAttribute, error) {
+	return nil, nil
+}

--- a/internal/fs/meta_unix.go
+++ b/internal/fs/meta_unix.go
@@ -1,0 +1,8 @@
+//go:build !windows
+// +build !windows
+
+package fs
+
+func (p *pathMetadataHandle) SecurityDescriptor() (*[]byte, error) {
+	return nil, nil
+}

--- a/internal/fs/meta_windows.go
+++ b/internal/fs/meta_windows.go
@@ -11,7 +11,7 @@ import (
 )
 
 func (p *pathMetadataHandle) Xattr(_ bool) ([]restic.ExtendedAttribute, error) {
-	f, err := openMetadataHandle(p.name, false)
+	f, err := openMetadataHandle(p.name, p.flag)
 	if err != nil {
 		return nil, err
 	}
@@ -54,7 +54,7 @@ func xattrFromHandle(path string, handle windows.Handle) ([]restic.ExtendedAttri
 }
 
 func (p *pathMetadataHandle) SecurityDescriptor() (buf *[]byte, err error) {
-	f, err := openMetadataHandle(p.name, 0)
+	f, err := openMetadataHandle(p.name, p.flag)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/fs/meta_windows.go
+++ b/internal/fs/meta_windows.go
@@ -1,0 +1,47 @@
+package fs
+
+import (
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/restic"
+	"golang.org/x/sys/windows"
+)
+
+func (p *pathMetadataHandle) Xattr(_ bool) ([]restic.ExtendedAttribute, error) {
+	allowExtended, err := checkAndStoreEASupport(p.name)
+	if err != nil || !allowExtended {
+		return nil, err
+	}
+
+	var fileHandle windows.Handle
+	if fileHandle, err = openHandleForEA(p.name, false); err != nil {
+		return nil, errors.Errorf("get EA failed while opening file handle for path %v, with: %v", p.name, err)
+	}
+	defer closeFileHandle(fileHandle, p.name)
+
+	//Get the windows Extended Attributes using the file handle
+	var extAtts []extendedAttribute
+	extAtts, err = fgetEA(fileHandle)
+	debug.Log("fillExtendedAttributes(%v) %v", p.name, extAtts)
+	if err != nil {
+		return nil, errors.Errorf("get EA failed for path %v, with: %v", p.name, err)
+	}
+	if len(extAtts) == 0 {
+		return nil, nil
+	}
+
+	extendedAttrs := make([]restic.ExtendedAttribute, 0, len(extAtts))
+	for _, attr := range extAtts {
+		extendedAttr := restic.ExtendedAttribute{
+			Name:  attr.Name,
+			Value: attr.Value,
+		}
+
+		extendedAttrs = append(extendedAttrs, extendedAttr)
+	}
+	return extendedAttrs, nil
+}
+
+func (p *pathMetadataHandle) SecurityDescriptor() (*[]byte, error) {
+	return getSecurityDescriptor(p.name)
+}

--- a/internal/fs/meta_xattr.go
+++ b/internal/fs/meta_xattr.go
@@ -1,0 +1,40 @@
+//go:build darwin || freebsd || linux || solaris
+// +build darwin freebsd linux solaris
+
+package fs
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/restic"
+)
+
+func (p *pathMetadataHandle) Xattr(ignoreListError bool) ([]restic.ExtendedAttribute, error) {
+	xattrs, err := listxattr(p.name)
+	debug.Log("fillExtendedAttributes(%v) %v %v", p.name, xattrs, err)
+	if err != nil {
+		if ignoreListError && isListxattrPermissionError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	extendedAttrs := make([]restic.ExtendedAttribute, 0, len(xattrs))
+	for _, attr := range xattrs {
+		attrVal, err := getxattr(p.name, attr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "can not obtain extended attribute %v for %v:\n", attr, p.name)
+			continue
+		}
+		attr := restic.ExtendedAttribute{
+			Name:  attr,
+			Value: attrVal,
+		}
+
+		extendedAttrs = append(extendedAttrs, attr)
+	}
+
+	return extendedAttrs, nil
+}

--- a/internal/fs/meta_xattr.go
+++ b/internal/fs/meta_xattr.go
@@ -12,8 +12,12 @@ import (
 )
 
 func (p *pathMetadataHandle) Xattr(ignoreListError bool) ([]restic.ExtendedAttribute, error) {
-	xattrs, err := listxattr(p.name)
-	debug.Log("fillExtendedAttributes(%v) %v %v", p.name, xattrs, err)
+	return xattrFromPath(p.Name(), ignoreListError)
+}
+
+func xattrFromPath(path string, ignoreListError bool) ([]restic.ExtendedAttribute, error) {
+	xattrs, err := listxattr(path)
+	debug.Log("fillExtendedAttributes(%v) %v %v", path, xattrs, err)
 	if err != nil {
 		if ignoreListError && isListxattrPermissionError(err) {
 			return nil, nil
@@ -23,9 +27,9 @@ func (p *pathMetadataHandle) Xattr(ignoreListError bool) ([]restic.ExtendedAttri
 
 	extendedAttrs := make([]restic.ExtendedAttribute, 0, len(xattrs))
 	for _, attr := range xattrs {
-		attrVal, err := getxattr(p.name, attr)
+		attrVal, err := getxattr(path, attr)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "can not obtain extended attribute %v for %v:\n", attr, p.name)
+			fmt.Fprintf(os.Stderr, "can not obtain extended attribute %v for %v:\n", attr, path)
 			continue
 		}
 		attr := restic.ExtendedAttribute{

--- a/internal/fs/meta_xattr.go
+++ b/internal/fs/meta_xattr.go
@@ -15,8 +15,18 @@ func (p *pathMetadataHandle) Xattr(ignoreListError bool) ([]restic.ExtendedAttri
 	path := p.Name()
 	return xattrFromPath(
 		path,
-		func() ([]string, error) { return listxattr(path) },
-		func(attr string) ([]byte, error) { return getxattr(path, attr) },
+		func() ([]string, error) {
+			if (p.flag & O_NOFOLLOW) != 0 {
+				return llistxattr(path)
+			}
+			return listxattr(path)
+		},
+		func(attr string) ([]byte, error) {
+			if (p.flag & O_NOFOLLOW) != 0 {
+				return lgetxattr(path, attr)
+			}
+			return getxattr(path, attr)
+		},
 		ignoreListError,
 	)
 }

--- a/internal/fs/node_noxattr.go
+++ b/internal/fs/node_noxattr.go
@@ -13,6 +13,6 @@ func nodeRestoreExtendedAttributes(_ *restic.Node, _ string) error {
 }
 
 // nodeFillExtendedAttributes is a no-op
-func nodeFillExtendedAttributes(_ *restic.Node, _ string, _ bool) error {
+func nodeFillExtendedAttributes(_ *restic.Node, _ metadataHandle, _ bool) error {
 	return nil
 }

--- a/internal/fs/node_unix.go
+++ b/internal/fs/node_unix.go
@@ -19,6 +19,6 @@ func nodeRestoreGenericAttributes(node *restic.Node, _ string, warn func(msg str
 }
 
 // nodeFillGenericAttributes is a no-op.
-func nodeFillGenericAttributes(_ *restic.Node, _ string, _ *ExtendedFileInfo) error {
+func nodeFillGenericAttributes(_ *restic.Node, _ metadataHandle, _ *ExtendedFileInfo) error {
 	return nil
 }

--- a/internal/fs/node_windows_test.go
+++ b/internal/fs/node_windows_test.go
@@ -47,8 +47,11 @@ func testRestoreSecurityDescriptor(t *testing.T, sd string, tempDir string, file
 	sdByteFromRestoredNode := getWindowsAttr(t, testPath, node).SecurityDescriptor
 
 	// Get the security descriptor for the test path after the restore.
-	sdBytesFromRestoredPath, err := getSecurityDescriptor(testPath)
+	handle, err := openMetadataHandle(testPath, 0)
+	test.OK(t, err)
+	sdBytesFromRestoredPath, err := getSecurityDescriptor(windows.Handle(handle.Fd()))
 	test.OK(t, errors.Wrapf(err, "Error while getting the security descriptor for: %s", testPath))
+	test.OK(t, handle.Close())
 
 	// Compare the input SD and the SD got from the restored file.
 	compareSecurityDescriptors(t, testPath, sdInputBytes, *sdBytesFromRestoredPath)

--- a/internal/fs/node_windows_test.go
+++ b/internal/fs/node_windows_test.go
@@ -372,126 +372,100 @@ func TestPrepareVolumeName(t *testing.T) {
 	osVolumeGUIDVolume := filepath.VolumeName(osVolumeGUIDPath)
 
 	testCases := []struct {
-		name                string
-		path                string
-		expectedVolume      string
-		expectError         bool
-		expectedEASupported bool
-		isRealPath          bool
+		name           string
+		path           string
+		expectedVolume string
+		expectError    bool
 	}{
 		{
-			name:                "Network drive path",
-			path:                `Z:\Shared\Documents`,
-			expectedVolume:      `Z:`,
-			expectError:         false,
-			expectedEASupported: false,
+			name:           "Network drive path",
+			path:           `Z:\Shared\Documents`,
+			expectedVolume: `Z:`,
+			expectError:    false,
 		},
 		{
-			name:                "Subst drive path",
-			path:                `X:\Virtual\Folder`,
-			expectedVolume:      `X:`,
-			expectError:         false,
-			expectedEASupported: false,
+			name:           "Subst drive path",
+			path:           `X:\Virtual\Folder`,
+			expectedVolume: `X:`,
+			expectError:    false,
 		},
 		{
-			name:                "Windows reserved path",
-			path:                `\\.\` + os.Getenv("SystemDrive") + `\System32\drivers\etc\hosts`,
-			expectedVolume:      `\\.\` + os.Getenv("SystemDrive"),
-			expectError:         false,
-			expectedEASupported: true,
-			isRealPath:          true,
+			name:           "Windows reserved path",
+			path:           `\\.\` + os.Getenv("SystemDrive") + `\System32\drivers\etc\hosts`,
+			expectedVolume: `\\.\` + os.Getenv("SystemDrive"),
+			expectError:    false,
 		},
 		{
-			name:                "Long UNC path",
-			path:                `\\?\UNC\LongServerName\VeryLongShareName\DeepPath\File.txt`,
-			expectedVolume:      `\\LongServerName\VeryLongShareName`,
-			expectError:         false,
-			expectedEASupported: false,
+			name:           "Long UNC path",
+			path:           `\\?\UNC\LongServerName\VeryLongShareName\DeepPath\File.txt`,
+			expectedVolume: `\\LongServerName\VeryLongShareName`,
+			expectError:    false,
 		},
 		{
-			name:                "Volume GUID path",
-			path:                osVolumeGUIDPath,
-			expectedVolume:      osVolumeGUIDVolume,
-			expectError:         false,
-			expectedEASupported: true,
-			isRealPath:          true,
+			name:           "Volume GUID path",
+			path:           osVolumeGUIDPath,
+			expectedVolume: osVolumeGUIDVolume,
+			expectError:    false,
 		},
 		{
-			name:                "Volume GUID path with subfolder",
-			path:                osVolumeGUIDPath + `\Windows`,
-			expectedVolume:      osVolumeGUIDVolume,
-			expectError:         false,
-			expectedEASupported: true,
-			isRealPath:          true,
+			name:           "Volume GUID path with subfolder",
+			path:           osVolumeGUIDPath + `\Windows`,
+			expectedVolume: osVolumeGUIDVolume,
+			expectError:    false,
 		},
 		{
-			name:                "Standard path",
-			path:                os.Getenv("SystemDrive") + `\Users\`,
-			expectedVolume:      os.Getenv("SystemDrive"),
-			expectError:         false,
-			expectedEASupported: true,
-			isRealPath:          true,
+			name:           "Standard path",
+			path:           os.Getenv("SystemDrive") + `\Users\`,
+			expectedVolume: os.Getenv("SystemDrive"),
+			expectError:    false,
 		},
 		{
-			name:                "Extended length path",
-			path:                longFilePath,
-			expectedVolume:      tempDirVolume,
-			expectError:         false,
-			expectedEASupported: true,
-			isRealPath:          true,
+			name:           "Extended length path",
+			path:           longFilePath,
+			expectedVolume: tempDirVolume,
+			expectError:    false,
 		},
 		{
-			name:                "UNC path",
-			path:                `\\server\share\folder`,
-			expectedVolume:      `\\server\share`,
-			expectError:         false,
-			expectedEASupported: false,
+			name:           "UNC path",
+			path:           `\\server\share\folder`,
+			expectedVolume: `\\server\share`,
+			expectError:    false,
 		},
 		{
-			name:                "Extended UNC path",
-			path:                `\\?\UNC\server\share\folder`,
-			expectedVolume:      `\\server\share`,
-			expectError:         false,
-			expectedEASupported: false,
+			name:           "Extended UNC path",
+			path:           `\\?\UNC\server\share\folder`,
+			expectedVolume: `\\server\share`,
+			expectError:    false,
 		},
 		{
-			name:                "Volume Shadow Copy root",
-			path:                `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy5555`,
-			expectedVolume:      `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy5555`,
-			expectError:         false,
-			expectedEASupported: false,
+			name:           "Volume Shadow Copy root",
+			path:           `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy5555`,
+			expectedVolume: `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy5555`,
+			expectError:    false,
 		},
 		{
-			name:                "Volume Shadow Copy path",
-			path:                `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy5555\Users\test`,
-			expectedVolume:      `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy5555`,
-			expectError:         false,
-			expectedEASupported: false,
+			name:           "Volume Shadow Copy path",
+			path:           `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy5555\Users\test`,
+			expectedVolume: `\\?\GLOBALROOT\Device\HarddiskVolumeShadowCopy5555`,
+			expectError:    false,
 		},
 		{
 			name: "Relative path",
 			path: `folder\subfolder`,
 
-			expectedVolume:      currentVolume, // Get current volume
-			expectError:         false,
-			expectedEASupported: true,
+			expectedVolume: currentVolume, // Get current volume
+			expectError:    false,
 		},
 		{
-			name:                "Empty path",
-			path:                ``,
-			expectedVolume:      currentVolume,
-			expectError:         false,
-			expectedEASupported: true,
-			isRealPath:          false,
+			name:           "Empty path",
+			path:           ``,
+			expectedVolume: currentVolume,
+			expectError:    false,
 		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			isEASupported, err := checkAndStoreEASupport(tc.path)
-			test.OK(t, err)
-			test.Equals(t, tc.expectedEASupported, isEASupported)
-
 			volume, err := prepareVolumeName(tc.path)
 
 			if tc.expectError {
@@ -500,18 +474,6 @@ func TestPrepareVolumeName(t *testing.T) {
 				test.OK(t, err)
 			}
 			test.Equals(t, tc.expectedVolume, volume)
-
-			if tc.isRealPath {
-				isEASupportedVolume, err := pathSupportsExtendedAttributes(volume + `\`)
-				// If the prepared volume name is not valid, we will next fetch the actual volume name.
-				test.OK(t, err)
-
-				test.Equals(t, tc.expectedEASupported, isEASupportedVolume)
-
-				actualVolume, err := getVolumePathName(tc.path)
-				test.OK(t, err)
-				test.Equals(t, tc.expectedVolume, actualVolume)
-			}
 		})
 	}
 }
@@ -535,47 +497,4 @@ func getOSVolumeGUIDPath(t *testing.T) string {
 	}
 
 	return windows.UTF16ToString(volumeGUID[:])
-}
-
-func TestGetVolumePathName(t *testing.T) {
-	tempDirVolume := filepath.VolumeName(os.TempDir())
-	testCases := []struct {
-		name           string
-		path           string
-		expectedPrefix string
-	}{
-		{
-			name:           "Root directory",
-			path:           os.Getenv("SystemDrive") + `\`,
-			expectedPrefix: os.Getenv("SystemDrive"),
-		},
-		{
-			name:           "Nested directory",
-			path:           os.Getenv("SystemDrive") + `\Windows\System32`,
-			expectedPrefix: os.Getenv("SystemDrive"),
-		},
-		{
-			name:           "Temp directory",
-			path:           os.TempDir() + `\`,
-			expectedPrefix: tempDirVolume,
-		},
-	}
-
-	for _, tc := range testCases {
-		t.Run(tc.name, func(t *testing.T) {
-			volumeName, err := getVolumePathName(tc.path)
-			if err != nil {
-				t.Fatalf("Unexpected error: %v", err)
-			}
-			if !strings.HasPrefix(volumeName, tc.expectedPrefix) {
-				t.Errorf("Expected volume name to start with %s, but got %s", tc.expectedPrefix, volumeName)
-			}
-		})
-	}
-
-	// Test with an invalid path
-	_, err := getVolumePathName("Z:\\NonExistentPath")
-	if err == nil {
-		t.Error("Expected an error for non-existent path, but got nil")
-	}
 }

--- a/internal/fs/node_xattr.go
+++ b/internal/fs/node_xattr.go
@@ -4,11 +4,9 @@
 package fs
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 
-	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
 
@@ -92,30 +90,8 @@ func nodeRestoreExtendedAttributes(node *restic.Node, path string) error {
 	return nil
 }
 
-func nodeFillExtendedAttributes(node *restic.Node, path string, ignoreListError bool) error {
-	xattrs, err := listxattr(path)
-	debug.Log("fillExtendedAttributes(%v) %v %v", path, xattrs, err)
-	if err != nil {
-		if ignoreListError && isListxattrPermissionError(err) {
-			return nil
-		}
-		return err
-	}
-
-	node.ExtendedAttributes = make([]restic.ExtendedAttribute, 0, len(xattrs))
-	for _, attr := range xattrs {
-		attrVal, err := getxattr(path, attr)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "can not obtain extended attribute %v for %v:\n", attr, path)
-			continue
-		}
-		attr := restic.ExtendedAttribute{
-			Name:  attr,
-			Value: attrVal,
-		}
-
-		node.ExtendedAttributes = append(node.ExtendedAttributes, attr)
-	}
-
-	return nil
+func nodeFillExtendedAttributes(node *restic.Node, meta metadataHandle, ignoreListError bool) error {
+	var err error
+	node.ExtendedAttributes, err = meta.Xattr(ignoreListError)
+	return err
 }

--- a/internal/fs/node_xattr.go
+++ b/internal/fs/node_xattr.go
@@ -51,6 +51,12 @@ func fgetxattr(f *os.File, name string) (b []byte, err error) {
 
 // getxattr retrieves extended attribute data associated with path.
 func getxattr(path string, name string) (b []byte, err error) {
+	b, err = xattr.Get(path, name)
+	return b, handleXattrErr(err)
+}
+
+// lgetxattr retrieves extended attribute data associated with path.
+func lgetxattr(path string, name string) (b []byte, err error) {
 	b, err = xattr.LGet(path, name)
 	return b, handleXattrErr(err)
 }
@@ -70,6 +76,13 @@ func flistxattr(f *os.File) (l []string, err error) {
 // listxattr retrieves a list of names of extended attributes associated with the
 // given path in the file system.
 func listxattr(path string) ([]string, error) {
+	l, err := xattr.List(path)
+	return l, handleXattrErr(err)
+}
+
+// llistxattr retrieves a list of names of extended attributes associated with the
+// given path in the file system.
+func llistxattr(path string) ([]string, error) {
 	l, err := xattr.LList(path)
 	return l, handleXattrErr(err)
 }

--- a/internal/fs/node_xattr_all_test.go
+++ b/internal/fs/node_xattr_all_test.go
@@ -31,7 +31,8 @@ func setAndVerifyXattr(t *testing.T, file string, attrs []restic.ExtendedAttribu
 	nodeActual := &restic.Node{
 		Type: restic.NodeTypeFile,
 	}
-	rtest.OK(t, nodeFillExtendedAttributes(nodeActual, file, false))
+	meta := newPathMetadataHandle(file, 0)
+	rtest.OK(t, nodeFillExtendedAttributes(nodeActual, meta, false))
 
 	rtest.Assert(t, nodeActual.Equals(*node), "xattr mismatch got %v expected %v", nodeActual.ExtendedAttributes, node.ExtendedAttributes)
 }

--- a/internal/fs/sd_windows_test.go
+++ b/internal/fs/sd_windows_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/test"
+	"golang.org/x/sys/windows"
 )
 
 func TestSetGetFileSecurityDescriptors(t *testing.T) {
@@ -51,9 +52,12 @@ func testSecurityDescriptors(t *testing.T, testSDs []string, testPath string) {
 		err = setSecurityDescriptor(testPath, &sdInputBytes)
 		test.OK(t, errors.Wrapf(err, "Error setting file security descriptor for: %s", testPath))
 
+		handle, err := openMetadataHandle(testPath, 0)
+		test.OK(t, err)
 		var sdOutputBytes *[]byte
-		sdOutputBytes, err = getSecurityDescriptor(testPath)
+		sdOutputBytes, err = getSecurityDescriptor(windows.Handle(handle.Fd()))
 		test.OK(t, errors.Wrapf(err, "Error getting file security descriptor for: %s", testPath))
+		test.OK(t, handle.Close())
 
 		compareSecurityDescriptors(t, testPath, sdInputBytes, *sdOutputBytes)
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Currently the archiver collects metadata and the file content in multiple steps during which a file could disappear or be renamed. The underlying reason for this is that files are currently access in multiple steps (stat, xattrs etc.) using their filepath. This PR introduces a new code path that instead opens a filehandle once and uses that to collect metadata and file content. This ensures that the file cannot disappear in the middle of the operation and ensures that the metadata actually belongs to the intended file.

The implementation turned out to be far more complicated than I've expected. Unfortunately, there is no standardized way across operating systems to open filehandles for arbitrary filetypes (well, reading all required metadata from a filehandle is also much more complex than it should be). In particular, symlinks turned out to be a major problem. Each filesystem API is broken or weird in its own way:

- Linux: the only option is to open the symlink using the `O_PATH|O_NOFOLLOW` flags. However, this filehandle cannot be used to retrieve xattrs. Luckily there is a workaround: read the xattrs from `/proc/self/fd/%d`. Reading the file content requires atomically reopening the file, this is possible by opening the just mentioned procfs filepath. Linux before 3.6 does not support the required syscalls (fstat on a file handle opened using O_PATH)
- Windows: most file operations are already filehandle based, making the implementation rather straightforward. According to the Windows docs, a cloud file is usually not downloaded when opening a metadata-only filehandle. To read from this filehandle later on, it must be reopened, which seems to be possible using `ReOpenFile`. Symlinks are relatively straightforward to handle by specifying `OPEN_REPARSE_POINT` where necessary.
- macOS: Symlinks can be opened using the `O_SYMLINK` flag. There is no concept of a metadata-only filehandle, so the file has always be opened for reading. This could become a problem if restic is not allowed to do that. However, this case has already resulted in an error in the past. xattrs can be read from this filehandle. In contrast, reading the symlink target from a filehandle is only possible since macOS 13, but is not exposed in Go, therefore requiring a fallback.
- Other BSDs: This is a total mess. Not all BSDs can even open a filehandle to a symlink (looking at you OpenBSD) and those that do use various different solutions. Thus to keep my sanity, there's no support for a filehandle based archiver on those OSes.

This leads to a few requirements.
- filehandle versus path-based (the existing variant) implementation must be selectable at runtime
- A metadata-only filehandle must be openable for arbitary filetype
- A read filehandle must be supported for file/directories
- Atomically reopening a metadata-only filehandle must be possible for files/directories. (the filehandle must refer to the same file before and afterwards)

For this purpose, the implementation introduces an new `metadataHandle` which is used by `nodeFromFileInfo` to collect all metadata. The interface is implemented by `fdMetadataHandle` (the just describe `filehandle` approach) and `pathMetadataHandle`. The active implementation can be selected at runtime.
`fs.Local` internally used a `localFile` type. It is now wrapped by either `fdLocalFile` or `pathLocalFile`. Those two structs implement the open and reopen lifecycle described in the requirements.

The PR copies a lot of code for `freadlink` from the Go standard library as it unfortunately only exposes a path based interface, whereas this PR absolutely require filehandles.

As a drive-by bugfix, the PR fixes xattr retrieval if a component of the backup source paths is a symlink. For example if `/test` is a symlink to `/example` which context `/example/file`. Then a backup of `/test/file` should retrieve all metadata for `/test` from `/example`. However, only basic metadata was collected from `/example` whereas the xattrs were read from `/test`.

Remaining TODOs
- [ ] Add runtime check for Linux <3.6
- [ ] Fix test failures
- [ ] Manually test whether ReopenHandle on Windows works for non-NTFS filesystems.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Part of https://github.com/restic/restic/issues/5021
Builds upon https://github.com/restic/restic/pull/5143

Fixes https://github.com/restic/restic/issues/3098
Fixes https://github.com/restic/restic/issues/2165
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
