### PR TITLE
fix: Windows VSS Event ID 8194

### DIFF
--- a/changelog/unreleased/pull-5170
+++ b/changelog/unreleased/pull-5170
@@ -1,6 +1,22 @@
-BugFix: Prevent Windows VSS event log 8194
+Bugfix: Prevent Windows VSS event log 8194 from being created with `restic backup --use-fs-snapshot`
 
-Initialize VSS security to prevent VSS 8194 event logs occurring when running `restic backup` with `--use-fs-snapshot` flag in Windows.
+When running `restic backup` with `--use-fs-snapshot` flag in Windows with admin right, event logs like
+```
+Volume Shadow Copy Service error: Unexpected error querying for the IVssWriterCallback interface.  hr = 0x80070005, Access is denied.
+. This is often caused by incorrect security settings in either the writer or requestor process. 
+
+Operation:
+   Gathering Writer Data
+
+Context:
+   Writer Class Id: {e8132975-6f93-4464-a53e-1050253ae220}
+   Writer Name: System Writer
+   Writer Instance ID: {54b151ac-d27d-4628-9cb0-2bc40959f50f}
+```
+are created several times(the backup itself succeeds).
+To resolve this, initialize VSS security by calling `CoInitializeSecurity` following the approach from
+https://github.com/microsoft/Windows-classic-samples/blob/main/Samples/VShadowVolumeShadowCopy/cpp/vssclient.cpp#L52-L63 
+before initializing VSS instance in Windows.
 
 https://github.com/restic/restic/issues/5169
 https://github.com/restic/restic/pull/5170

--- a/changelog/unreleased/pull-5170
+++ b/changelog/unreleased/pull-5170
@@ -1,0 +1,7 @@
+BugFix: Prevent Windows VSS event log 8194
+
+Initialize VSS security to prevent VSS 8194 event logs occurring when running `restic backup` with `--use-fs-snapshot` flag in Windows.
+
+https://github.com/restic/restic/issues/5169
+https://github.com/restic/restic/pull/5170
+https://forum.restic.net/t/windows-shadow-copy-snapshot-vss-unexpected-provider-error/3674/2

--- a/changelog/unreleased/pull-5170
+++ b/changelog/unreleased/pull-5170
@@ -1,6 +1,6 @@
-Bugfix: Prevent Windows VSS event log 8194 from being created with `restic backup --use-fs-snapshot`
+Bugfix: Prevent Windows VSS event log 8194 warnings for backup with fs snapshot
 
-When running `restic backup` with `--use-fs-snapshot` flag in Windows with admin right, event logs like
+When running `restic backup` with `--use-fs-snapshot` flag in Windows with admin rights, event logs like
 ```
 Volume Shadow Copy Service error: Unexpected error querying for the IVssWriterCallback interface.  hr = 0x80070005, Access is denied.
 . This is often caused by incorrect security settings in either the writer or requestor process. 
@@ -13,10 +13,8 @@ Context:
    Writer Name: System Writer
    Writer Instance ID: {54b151ac-d27d-4628-9cb0-2bc40959f50f}
 ```
-are created several times(the backup itself succeeds).
-To resolve this, initialize VSS security by calling `CoInitializeSecurity` following the approach from
-https://github.com/microsoft/Windows-classic-samples/blob/main/Samples/VShadowVolumeShadowCopy/cpp/vssclient.cpp#L52-L63 
-before initializing VSS instance in Windows.
+are created several times(the backup itself succeeds). Prevent this from occurring.
+
 
 https://github.com/restic/restic/issues/5169
 https://github.com/restic/restic/pull/5170

--- a/internal/fs/vss_windows.go
+++ b/internal/fs/vss_windows.go
@@ -810,6 +810,17 @@ func initializeVssCOMInterface() (*ole.IUnknown, error) {
 		}
 	}
 
+	// initialize COM security for VSS, this can't be called more then once
+	if err = ole.CoInitializeSecurity(
+		-1,   // Allow *all* VSS writers to communicate back!
+		5,    // RPC_C_AUTHN_LEVEL_PKT_INTEGRITY
+		3,    // RPC_C_IMP_LEVEL_IMPERSONATE
+		0x40, // EOAC_DYNAMIC_CLOAKING
+	); err != nil {
+		// TODO: warn for expected events for VSS failure event
+		fmt.Printf("VSS warning")
+	}
+
 	var oleIUnknown *ole.IUnknown
 	result, _, _ := vssInstance.Call(uintptr(unsafe.Pointer(&oleIUnknown)))
 	hresult := HRESULT(result)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->
Prevent Windows event 8194 log occurring when doing a backup with --use-fs-snapshot flag.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
Closes #5169 

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

~~- [ ] I have added tests for all code changes.~~
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
