### PR TITLE
Enable xattr support, on NetBSD 10+

### DIFF
--- a/changelog/unreleased/issue-5174
+++ b/changelog/unreleased/issue-5174
@@ -1,0 +1,6 @@
+Enhancement: Enable xattr support, on NetBSD 10+
+
+Restic now supports backing up, and restoring extended attributes, on systems running NetBSD 10, or later.
+
+https://github.com/restic/restic/issues/5174
+https://github.com/restic/restic/pull/5180

--- a/internal/fs/node_noxattr.go
+++ b/internal/fs/node_noxattr.go
@@ -1,5 +1,5 @@
-//go:build aix || dragonfly || netbsd || openbsd
-// +build aix dragonfly netbsd openbsd
+//go:build aix || dragonfly || openbsd
+// +build aix dragonfly openbsd
 
 package fs
 

--- a/internal/fs/node_xattr.go
+++ b/internal/fs/node_xattr.go
@@ -1,5 +1,5 @@
-//go:build darwin || freebsd || linux || solaris
-// +build darwin freebsd linux solaris
+//go:build darwin || freebsd || netbsd || linux || solaris
+// +build darwin freebsd netbsd linux solaris
 
 package fs
 

--- a/internal/fs/node_xattr_all_test.go
+++ b/internal/fs/node_xattr_all_test.go
@@ -1,5 +1,5 @@
-//go:build darwin || freebsd || linux || solaris || windows
-// +build darwin freebsd linux solaris windows
+//go:build darwin || freebsd || netbsd || linux || solaris || windows
+// +build darwin freebsd netbsd linux solaris windows
 
 package fs
 

--- a/internal/fs/node_xattr_test.go
+++ b/internal/fs/node_xattr_test.go
@@ -1,5 +1,5 @@
-//go:build darwin || freebsd || linux || solaris
-// +build darwin freebsd linux solaris
+//go:build darwin || freebsd || netbsd || linux || solaris
+// +build darwin freebsd netbsd linux solaris
 
 package fs
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->
This change enables support for extended attributes, on NetBSD.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

This implements the desire, in https://github.com/restic/restic/issues/5174, to use the existing FreeBSD-compatible xattr API, on NetBSD, and has been successfully tested, on NetBSD 10/ARM64, with Go 1.22.7.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
