### PR TITLE
Issue: 4942: cmd_rewrite: add snapshot summary data to an existing snapshot.

### DIFF
--- a/changelog/unreleased/issue-4942
+++ b/changelog/unreleased/issue-4942
@@ -1,17 +1,11 @@
-Enhancement: create snapshot summary statistics for old snapshots
+Enhancement: support creating snapshot summary statistics for old snapshots
 
-When `restic rewrite` is used with the `--snapshot-summary` option,
-a new snapshot is created containing statistics summary data. The new data tree
-is identical to the original data tree.
+When `rewrite` is used with the `--snapshot-summary` option, a new snapshot is
+created containing statistics summary data. Only two fields in the summary will
+be non-zero: `TotalFilesProcessed` and `TotalBytesProcessed`.
 
-When `restic rewrite` is called with one of the `--exclude` variants,
-a new snapshot summary will be created.
-
-When `restic rewrite` is used with `--new-host` or `--new-time` only, NO snapshot
-summary will be produced. The new data tree is identical to the original data tree.
-
-If new snapshot produces a new snapshot summary, only two fields will be non-zero:
-`TotalFilesProcessed` and `TotalBytesProcessed`.
+When rewrite is called with one of the `--exclude` options, `TotalFilesProcessed`
+and `TotalBytesProcessed` will be updated in the snapshot summary.
 
 https://github.com/restic/restic/issues/4942
 https://github.com/restic/restic/pull/5185

--- a/changelog/unreleased/issue-4942
+++ b/changelog/unreleased/issue-4942
@@ -1,10 +1,8 @@
 Enhancement: create snapshot summary statistics for snapshots which don't have them
 
-When restic rewrite is used with the --snapshot-summary [-s] option,
+When restic rewrite is used with the --snapshot-summary option,
 a new snapshot is created containing statistics summary data. Only two fields
 will be non-zero: TotalFilesProcessed and TotalBytesProcessed.
 
-There is a logic change in cmd_rewrite: statistics data will always be attached,
-even if the old snapshot(s) did not contain summary data.
-
 https://github.com/restic/restic/issues/4942
+https://github.com/restic/restic/pull/5185

--- a/changelog/unreleased/issue-4942
+++ b/changelog/unreleased/issue-4942
@@ -1,8 +1,17 @@
-Enhancement: create snapshot summary statistics for snapshots which don't have them
+Enhancement: create snapshot summary statistics for old snapshots
 
-When restic rewrite is used with the --snapshot-summary option,
-a new snapshot is created containing statistics summary data. Only two fields
-will be non-zero: TotalFilesProcessed and TotalBytesProcessed.
+When `restic rewrite` is used with the `--snapshot-summary` option,
+a new snapshot is created containing statistics summary data. The new data tree
+is identical to the original data tree.
+
+When `restic rewrite` is called with one of the `--exclude` variants,
+a new snapshot summary will be created.
+
+When `restic rewrite` is used with `--new-host` or `--new-time` only, NO snapshot
+summary will be produced. The new data tree is identical to the original data tree.
+
+If new snapshot produces a new snapshot summary, only two fields will be non-zero:
+`TotalFilesProcessed` and `TotalBytesProcessed`.
 
 https://github.com/restic/restic/issues/4942
 https://github.com/restic/restic/pull/5185

--- a/changelog/unreleased/issue-4942
+++ b/changelog/unreleased/issue-4942
@@ -1,0 +1,10 @@
+Enhancement: create snapshot summary statistics for snapshots which don't have them
+
+When restic rewrite is used with the --snapshot-summary [-s] option,
+a new snapshot is created containing statistics summary data. Only two fields
+will be non-zero: TotalFilesProcessed and TotalBytesProcessed.
+
+There is a logic change in cmd_rewrite: statistics data will always be attached,
+even if the old snapshot(s) did not contain summary data.
+
+https://github.com/restic/restic/issues/4942

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -122,19 +122,19 @@ func runRepairSnapshots(ctx context.Context, gopts GlobalOptions, opts RepairOpt
 			node.Size = newSize
 			return node
 		},
-		RewriteFailedTree: func(_ restic.ID, path string, _ error) (restic.ID, *restic.SnapshotSummary, error) {
+		RewriteFailedTree: func(_ restic.ID, path string, _ error) (restic.ID, error) {
 			if path == "/" {
 				Verbosef("  dir %q: not readable\n", path)
 				// remove snapshots with invalid root node
-				return restic.ID{}, nil, nil
+				return restic.ID{}, nil
 			}
 			// If a subtree fails to load, remove it
 			Verbosef("  dir %q: replaced with empty directory\n", path)
 			emptyID, err := restic.SaveTree(ctx, repo, &restic.Tree{})
 			if err != nil {
-				return restic.ID{}, nil, err
+				return restic.ID{}, err
 			}
-			return emptyID, nil, nil
+			return emptyID, nil
 		},
 		AllowUnstableSerialization: true,
 	})
@@ -143,7 +143,7 @@ func runRepairSnapshots(ctx context.Context, gopts GlobalOptions, opts RepairOpt
 	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &opts.SnapshotFilter, args) {
 		Verbosef("\n%v\n", sn)
 		changed, err := filterAndReplaceSnapshot(ctx, repo, sn,
-			func(ctx context.Context, sn *restic.Snapshot) (restic.ID, *restic.SnapshotSummary, error) {
+			func(ctx context.Context, sn *restic.Snapshot) (restic.ID, error) {
 				return rewriter.RewriteTree(ctx, repo, "/", *sn.Tree)
 			}, opts.DryRun, opts.Forget, nil, "repaired")
 		if err != nil {

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -143,9 +143,10 @@ func runRepairSnapshots(ctx context.Context, gopts GlobalOptions, opts RepairOpt
 	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &opts.SnapshotFilter, args) {
 		Verbosef("\n%v\n", sn)
 		changed, err := filterAndReplaceSnapshot(ctx, repo, sn,
-			func(ctx context.Context, sn *restic.Snapshot) (restic.ID, error) {
-				return rewriter.RewriteTree(ctx, repo, "/", *sn.Tree)
-			}, opts.DryRun, opts.Forget, false, nil, "repaired")
+			func(ctx context.Context, sn *restic.Snapshot) (restic.ID, *restic.SnapshotSummary, error) {
+				id, err := rewriter.RewriteTree(ctx, repo, "/", *sn.Tree)
+				return id, nil, err
+			}, opts.DryRun, opts.Forget, nil, "repaired")
 		if err != nil {
 			return errors.Fatalf("unable to rewrite snapshot ID %q: %v", sn.ID().Str(), err)
 		}

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -145,7 +145,7 @@ func runRepairSnapshots(ctx context.Context, gopts GlobalOptions, opts RepairOpt
 		changed, err := filterAndReplaceSnapshot(ctx, repo, sn,
 			func(ctx context.Context, sn *restic.Snapshot) (restic.ID, error) {
 				return rewriter.RewriteTree(ctx, repo, "/", *sn.Tree)
-			}, opts.DryRun, opts.Forget, nil, "repaired")
+			}, opts.DryRun, opts.Forget, false, nil, "repaired")
 		if err != nil {
 			return errors.Fatalf("unable to rewrite snapshot ID %q: %v", sn.ID().Str(), err)
 		}

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -95,7 +95,7 @@ func (sma snapshotMetadataArgs) convert() (*snapshotMetadata, error) {
 	}
 
 	// hostname validation
-	re := regexp.MustCompile("^([A-Za-z0-9][[A-Za-z0-9-]+)$")
+	re := regexp.MustCompile("^([A-Za-z0-9][[A-Za-z0-9-]*)$")
 	result := re.FindString(sma.Hostname)
 	if result == "" {
 		return &snapshotMetadata{}, errors.Fatalf("hostname '%s' is not valid!", sma.Hostname)
@@ -220,7 +220,9 @@ func filterAndReplaceSnapshot(ctx context.Context, repo restic.Repository, sn *r
 		return false, err
 	}
 
+	// bug: do not destroy old snapshot!
 	if filteredTree.IsNull() {
+		/*
 		if dryRun {
 			Verbosef("would delete empty snapshot\n")
 		} else {
@@ -230,7 +232,8 @@ func filterAndReplaceSnapshot(ctx context.Context, repo restic.Repository, sn *r
 			debug.Log("removed empty snapshot %v", sn.ID())
 			Verbosef("removed empty snapshot %v\n", sn.ID().Str())
 		}
-		return true, nil
+		*/
+		return false, nil
 	}
 
 	if filteredTree == *sn.Tree && newMetadata == nil && summary == nil {

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -315,6 +315,10 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts GlobalOptions, a
 
 	changedCount := 0
 	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &opts.SnapshotFilter, args) {
+		if opts.SnapshotSummary && sn.Summary != nil {
+			continue
+		}
+
 		Verbosef("\n%v\n", sn)
 		changed, err := rewriteSnapshot(ctx, repo, sn, opts)
 		if err != nil {

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -172,7 +172,7 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *resti
 		}
 
 		rewriteNode := func(node *restic.Node, path string) *restic.Node {
-			return node // always include everything
+			return node
 		}
 
 		rewriter, querySize := walker.NewSnapshotSizeRewriter(rewriteNode)

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -326,11 +326,11 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts GlobalOptions, a
 
 	changedCount := 0
 	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &opts.SnapshotFilter, args) {
-		Verbosef("\n%v\n", sn)
 		if opts.SnapshotSummary && opts.ExcludePatternOptions.Empty() && opts.Metadata.empty() && sn.Summary != nil {
-			Printf("snapshot %q already has snapshot summary data\n", sn.ID().Str())
-			return nil
+			//Printf("snapshot %q already has snapshot summary data\n", sn.ID().Str())
+			continue
 		}
+		Verbosef("\n%v\n", sn)
 
 		changed, err := rewriteSnapshot(ctx, repo, sn, opts)
 		if err != nil {

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -139,9 +139,9 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *resti
 	}
 
 	var filter rewriteFilterFunc
-	var rewriteNode walker.NodeRewriteFunc
 
 	if len(rejectByNameFuncs) > 0 || opts.SnapshotSummary {
+		var rewriteNode walker.NodeRewriteFunc
 		if len(rejectByNameFuncs) > 0 {
 			selectByName := func(nodepath string) bool {
 				for _, reject := range rejectByNameFuncs {
@@ -227,7 +227,7 @@ func filterAndReplaceSnapshot(ctx context.Context, repo restic.Repository, sn *r
 		return true, nil
 	}
 
-	// failes tests TestRepairSnapshotsIntact and TestRewriteUnchanged
+	// fails tests TestRepairSnapshotsIntact and TestRewriteUnchanged when sn.Summary == nil is used
 	//if filteredTree == *sn.Tree && newMetadata == nil && sn.Summary == nil {
 	if filteredTree == *sn.Tree && newMetadata == nil {
 		debug.Log("Snapshot %v not modified", sn)

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -141,28 +141,21 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *resti
 	var filter rewriteFilterFunc
 
 	if len(rejectByNameFuncs) > 0 || opts.SnapshotSummary {
-		var rewriteNode walker.NodeRewriteFunc
-		if len(rejectByNameFuncs) > 0 {
-			selectByName := func(nodepath string) bool {
-				for _, reject := range rejectByNameFuncs {
-					if reject(nodepath) {
-						return false
-					}
+		selectByName := func(nodepath string) bool {
+			for _, reject := range rejectByNameFuncs {
+				if reject(nodepath) {
+					return false
 				}
-				return true
 			}
+			return true
+		}
 
-			rewriteNode = func(node *restic.Node, path string) *restic.Node {
-				if selectByName(path) {
-					return node
-				}
-				Verbosef("excluding %s\n", path)
-				return nil
-			}
-		} else { // if opts.SnapshotSummary
-			rewriteNode = func(node *restic.Node, _ string) *restic.Node {
+		rewriteNode := func(node *restic.Node, path string) *restic.Node {
+			if selectByName(path) {
 				return node
 			}
+			Verbosef("excluding %s\n", path)
+			return nil
 		}
 
 		rewriter, querySize := walker.NewSnapshotSizeRewriter(rewriteNode)

--- a/cmd/restic/cmd_rewrite_integration_test.go
+++ b/cmd/restic/cmd_rewrite_integration_test.go
@@ -146,11 +146,11 @@ func TestRewriteSnaphotSummary(t *testing.T) {
 
 	// rewrite --snapshot-summary <snap>
 	rtest.OK(t, runRewrite(context.TODO(), RewriteOptions{SnapshotSummary: true}, env.gopts, []string{snap.String()}))
-	// since we have attached SnapshotSummary to snap1, the call to runRewrite
-	// is a no op
+	// since we have attached SnapshotSummary to <snap>, the call to runRewrite is a no op
 	testListSnapshots(t, env.gopts, 1)
 
-	// get repo so we access
+	// get repo so we can access snapshot strcuture - this is a hackish.
+	// Is there a better way of doing it?
 	t.Helper()
 	_, repo, unlock, err := openWithReadLock(context.TODO(), env.gopts, false)
 	rtest.OK(t, err)

--- a/cmd/restic/cmd_rewrite_integration_test.go
+++ b/cmd/restic/cmd_rewrite_integration_test.go
@@ -71,9 +71,15 @@ func TestRewriteUnchanged(t *testing.T) {
 	snapshotID := createBasicRewriteRepo(t, env)
 
 	// use an exclude that will not exclude anything
-	testRunRewriteExclude(t, env.gopts, []string{"3dflkhjgdflhkjetrlkhjgfdlhkj"}, false, snapshotMetadataArgs{Hostname: "", Time: ""})
+	// this is strictly speaking possible from the command line but really does not make any sense
+
+	// since the rewrite logic has changed, this test is no longer valid, as it produces
+	// a new snapshot with no exclusion == identical tree, but different SnapshotSummaries
+	//testRunRewriteExclude(t, env.gopts, []string{"3dflkhjgdflhkjetrlkhjgfdlhkj"}, false, snapshotMetadataArgs{Hostname: "", Time: ""})
+
+	testRunRewriteExclude(t, env.gopts, []string{"3dflkhjgdflhkjetrlkhjgfdlhkj"}, false, snapshotMetadataArgs{})
 	newSnapshotIDs := testRunList(t, "snapshots", env.gopts)
-	rtest.Assert(t, len(newSnapshotIDs) == 1, "expected one snapshot, got %v", newSnapshotIDs)
+	rtest.Assert(t, len(newSnapshotIDs) == 2, "expected two snapshots, got %v", newSnapshotIDs)
 	rtest.Assert(t, snapshotID == newSnapshotIDs[0], "snapshot id changed unexpectedly")
 	testRunCheck(t, env.gopts)
 }

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -332,6 +332,12 @@ command, see :ref:`backup-excluding-files` for details.
 It is possible to rewrite only a subset of snapshots by filtering them the same
 way as for the ``copy`` command, see :ref:`copy-filtering-snapshots`.
 
+The option ``--snapshot-summary`` can be used to attach summary data to an
+existing snapshot, which does not have this inforamtion. ``--snapshot-summary`` is
+incompatible with any other option (``--exclude variants``, ``--new-host`` and
+``--new-time``). When a snapshot summary is created the only fields in use are
+``TotalFilesProcessed`` and ``TotalBytesProcessed``.
+
 By default, the ``rewrite`` command will keep the original snapshots and create
 new ones for every snapshot which was modified during rewriting. The new
 snapshots are marked with the tag ``rewrite`` to differentiate them from the

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -332,11 +332,9 @@ command, see :ref:`backup-excluding-files` for details.
 It is possible to rewrite only a subset of snapshots by filtering them the same
 way as for the ``copy`` command, see :ref:`copy-filtering-snapshots`.
 
-The option ``--snapshot-summary`` can be used to attach summary data to an
-existing snapshot, which does not have this inforamtion. ``--snapshot-summary`` is
-incompatible with any other option (``--exclude variants``, ``--new-host`` and
-``--new-time``). When a snapshot summary is created the only fields in use are
-``TotalFilesProcessed`` and ``TotalBytesProcessed``.
+The option ``--snapshot-summary`` can be used to attach summary data to existing
+snapshots that do not have this information. When a snapshot summary is created
+the only fields added are ``TotalFilesProcessed`` and ``TotalBytesProcessed``.
 
 By default, the ``rewrite`` command will keep the original snapshots and create
 new ones for every snapshot which was modified during rewriting. The new

--- a/internal/walker/rewriter.go
+++ b/internal/walker/rewriter.go
@@ -10,7 +10,7 @@ import (
 )
 
 type NodeRewriteFunc func(node *restic.Node, path string) *restic.Node
-type FailedTreeRewriteFunc func(nodeID restic.ID, path string, err error) (restic.ID, *restic.SnapshotSummary, error)
+type FailedTreeRewriteFunc func(nodeID restic.ID, path string, err error) (restic.ID, error)
 type QueryRewrittenSizeFunc func() SnapshotSize
 
 type SnapshotSize struct {
@@ -51,8 +51,8 @@ func NewTreeRewriter(opts RewriteOpts) *TreeRewriter {
 	}
 	if rw.opts.RewriteFailedTree == nil {
 		// fail with error by default
-		rw.opts.RewriteFailedTree = func(_ restic.ID, _ string, err error) (restic.ID, *restic.SnapshotSummary, error) {
-			return restic.ID{}, nil, err
+		rw.opts.RewriteFailedTree = func(_ restic.ID, _ string, err error) (restic.ID, error) {
+			return restic.ID{}, err
 		}
 	}
 	return rw
@@ -86,11 +86,11 @@ type BlobLoadSaver interface {
 	restic.BlobLoader
 }
 
-func (t *TreeRewriter) RewriteTree(ctx context.Context, repo BlobLoadSaver, nodepath string, nodeID restic.ID) (newNodeID restic.ID, summary *restic.SnapshotSummary, err error) {
+func (t *TreeRewriter) RewriteTree(ctx context.Context, repo BlobLoadSaver, nodepath string, nodeID restic.ID) (newNodeID restic.ID, err error) {
 	// check if tree was already changed
 	newID, ok := t.replaces[nodeID]
 	if ok {
-		return newID, nil, nil
+		return newID, nil
 	}
 
 	// a nil nodeID will lead to a load error
@@ -105,10 +105,10 @@ func (t *TreeRewriter) RewriteTree(ctx context.Context, repo BlobLoadSaver, node
 		// a custom UnmarshalJSON to decode trees, see also https://github.com/golang/go/issues/41144
 		testID, err := restic.SaveTree(ctx, repo, curTree)
 		if err != nil {
-			return restic.ID{}, nil, err
+			return restic.ID{}, err
 		}
 		if nodeID != testID {
-			return restic.ID{}, nil, fmt.Errorf("cannot encode tree at %q without losing information", nodepath)
+			return restic.ID{}, fmt.Errorf("cannot encode tree at %q without losing information", nodepath)
 		}
 	}
 
@@ -117,7 +117,7 @@ func (t *TreeRewriter) RewriteTree(ctx context.Context, repo BlobLoadSaver, node
 	tb := restic.NewTreeJSONBuilder()
 	for _, node := range curTree.Nodes {
 		if ctx.Err() != nil {
-			return restic.ID{}, nil, ctx.Err()
+			return restic.ID{}, ctx.Err()
 		}
 
 		path := path.Join(nodepath, node.Name)
@@ -129,7 +129,7 @@ func (t *TreeRewriter) RewriteTree(ctx context.Context, repo BlobLoadSaver, node
 		if node.Type != restic.NodeTypeDir {
 			err = tb.AddNode(node)
 			if err != nil {
-				return restic.ID{}, nil, err
+				return restic.ID{}, err
 			}
 			continue
 		}
@@ -138,20 +138,20 @@ func (t *TreeRewriter) RewriteTree(ctx context.Context, repo BlobLoadSaver, node
 		if node.Subtree != nil {
 			subtree = *node.Subtree
 		}
-		newID, _, err := t.RewriteTree(ctx, repo, path, subtree)
+		newID, err := t.RewriteTree(ctx, repo, path, subtree)
 		if err != nil {
-			return restic.ID{}, nil, err
+			return restic.ID{}, err
 		}
 		node.Subtree = &newID
 		err = tb.AddNode(node)
 		if err != nil {
-			return restic.ID{}, nil, err
+			return restic.ID{}, err
 		}
 	}
 
 	tree, err := tb.Finalize()
 	if err != nil {
-		return restic.ID{}, nil, err
+		return restic.ID{}, err
 	}
 
 	// Save new tree
@@ -162,5 +162,5 @@ func (t *TreeRewriter) RewriteTree(ctx context.Context, repo BlobLoadSaver, node
 	if !newTreeID.Equal(nodeID) {
 		debug.Log("filterTree: save new tree for %s as %v\n", nodepath, newTreeID)
 	}
-	return newTreeID, nil, err
+	return newTreeID, err
 }


### PR DESCRIPTION
cmd_rewrite: add capability to add snapshot summary data to an existing snapshot.

Add option --snapshot-summary [-s] to enable this enhancement.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This pull request add the capability of adding snapshot summary data to an existing snapshot.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://github.com/restic/restic/issues/4942
closes https://github.com/restic/restic/issues/4942
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
