### PR TITLE
Enhancement: `restic rewrite`: allow include filters in command

### DIFF
--- a/changelog/unreleased/issue-4278
+++ b/changelog/unreleased/issue-4278
@@ -1,0 +1,12 @@
+Enhancement: Support include filters in `rewrite` command
+
+The enhancement enables the standard include filter options
+      --iinclude pattern     same as --include pattern but ignores the casing of filenames
+      --iinclude-file file   same as --include-file but ignores casing of filenames in patterns
+  -i, --include pattern      include a pattern (can be specified multiple times)
+      --include-file file    read include patterns from a file (can be specified multiple times)
+
+The exclusion or inclusion of filter parameters is exclusive, as in other commands.
+
+https://github.com/restic/restic/issues/4278
+https://github.com/restic/restic/pull/5191

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -151,7 +151,7 @@ func runRepairSnapshots(ctx context.Context, gopts global.Options, opts RepairOp
 			func(ctx context.Context, sn *data.Snapshot, uploader restic.BlobSaver) (restic.ID, *data.SnapshotSummary, error) {
 				id, err := rewriter.RewriteTree(ctx, repo, uploader, "/", *sn.Tree)
 				return id, nil, err
-			}, opts.DryRun, opts.Forget, nil, "repaired", printer)
+			}, opts.DryRun, opts.Forget, nil, "repaired", printer, false)
 		if err != nil {
 			return errors.Fatalf("unable to rewrite snapshot ID %q: %v", sn.ID().Str(), err)
 		}

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -30,6 +30,9 @@ The "rewrite" command excludes files from existing snapshots. It creates new
 snapshots containing the same data as the original ones, but without the files
 you specify to exclude. All metadata (time, host, tags) will be preserved.
 
+Alternatively you can use one of the --include variants to only include files
+in the new snapshot which you want to preserve.
+
 The snapshots to rewrite are specified using the --host, --tag and --path options,
 or by providing a list of snapshot IDs. Please note that specifying neither any of
 these options nor a snapshot ID will cause the command to rewrite all snapshots.
@@ -46,8 +49,8 @@ When rewrite is used with the --snapshot-summary option, a new snapshot is
 created containing statistics summary data. Only two fields in the summary will
 be non-zero: TotalFilesProcessed and TotalBytesProcessed.
 
-When rewrite is called with one of the --exclude options, TotalFilesProcessed
-and TotalBytesProcessed will be updated in the snapshot summary.
+When rewrite is called with one of the --exclude or --include options,
+TotalFilesProcessed and TotalBytesProcessed will be updated in the snapshot summary.
 
 EXIT STATUS
 ===========
@@ -109,6 +112,7 @@ type RewriteOptions struct {
 	Metadata snapshotMetadataArgs
 	data.SnapshotFilter
 	filter.ExcludePatternOptions
+	filter.IncludePatternOptions
 }
 
 func (opts *RewriteOptions) AddFlags(f *pflag.FlagSet) {
@@ -120,6 +124,7 @@ func (opts *RewriteOptions) AddFlags(f *pflag.FlagSet) {
 
 	initMultiSnapshotFilter(f, &opts.SnapshotFilter, true)
 	opts.ExcludePatternOptions.Add(f)
+	opts.IncludePatternOptions.Add(f)
 }
 
 // rewriteFilterFunc returns the filtered tree ID or an error. If a snapshot summary is returned, the snapshot will
@@ -136,33 +141,32 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *data.
 		return false, err
 	}
 
+	includeByNameFuncs, err := opts.IncludePatternOptions.CollectPatterns(printer.E)
+	if err != nil {
+		return false, err
+	}
+
 	metadata, err := opts.Metadata.convert()
 
 	if err != nil {
 		return false, err
 	}
 
+	condInclude := len(includeByNameFuncs) > 0
+	condExclude := len(rejectByNameFuncs) > 0 || opts.SnapshotSummary
 	var filter rewriteFilterFunc
+	var rewriteNode walker.NodeRewriteFunc
+	var keepEmptyDirectoryFunc walker.NodeKeepEmptyDirectoryFunc
 
-	if len(rejectByNameFuncs) > 0 || opts.SnapshotSummary {
-		selectByName := func(nodepath string) bool {
-			for _, reject := range rejectByNameFuncs {
-				if reject(nodepath) {
-					return false
-				}
-			}
-			return true
+	if condInclude || condExclude {
+		if condInclude {
+			rewriteNode, keepEmptyDirectoryFunc = gatherIncludeFilters(includeByNameFuncs, printer)
+		} else {
+			rewriteNode = gatherExcludeFilters(rejectByNameFuncs, printer)
+			keepEmptyDirectoryFunc = nil
 		}
 
-		rewriteNode := func(node *data.Node, path string) *data.Node {
-			if selectByName(path) {
-				return node
-			}
-			printer.P("excluding %s", path)
-			return nil
-		}
-
-		rewriter, querySize := walker.NewSnapshotSizeRewriter(rewriteNode)
+		rewriter, querySize := walker.NewSnapshotSizeRewriter(rewriteNode, keepEmptyDirectoryFunc)
 
 		filter = func(ctx context.Context, sn *data.Snapshot, uploader restic.BlobSaver) (restic.ID, *data.SnapshotSummary, error) {
 			id, err := rewriter.RewriteTree(ctx, repo, uploader, "/", *sn.Tree)
@@ -186,11 +190,12 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *data.
 	}
 
 	return filterAndReplaceSnapshot(ctx, repo, sn,
-		filter, opts.DryRun, opts.Forget, metadata, "rewrite", printer)
+		filter, opts.DryRun, opts.Forget, metadata, "rewrite", printer, len(includeByNameFuncs) > 0)
 }
 
 func filterAndReplaceSnapshot(ctx context.Context, repo restic.Repository, sn *data.Snapshot,
-	filter rewriteFilterFunc, dryRun bool, forget bool, newMetadata *snapshotMetadata, addTag string, printer progress.Printer) (bool, error) {
+	filter rewriteFilterFunc, dryRun bool, forget bool, newMetadata *snapshotMetadata, addTag string, printer progress.Printer,
+	keepEmptySnapshot bool) (bool, error) {
 
 	var filteredTree restic.ID
 	var summary *data.SnapshotSummary
@@ -204,6 +209,10 @@ func filterAndReplaceSnapshot(ctx context.Context, repo restic.Repository, sn *d
 	}
 
 	if filteredTree.IsNull() {
+		if keepEmptySnapshot {
+			debug.Log("Snapshot %v not modified", sn)
+			return false, nil
+		}
 		if dryRun {
 			printer.P("would delete empty snapshot")
 		} else {
@@ -284,8 +293,12 @@ func filterAndReplaceSnapshot(ctx context.Context, repo restic.Repository, sn *d
 }
 
 func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, args []string, term ui.Terminal) error {
-	if !opts.SnapshotSummary && opts.ExcludePatternOptions.Empty() && opts.Metadata.empty() {
-		return errors.Fatal("Nothing to do: no excludes provided and no new metadata provided")
+	hasExcludes := !opts.ExcludePatternOptions.Empty()
+	hasIncludes := !opts.IncludePatternOptions.Empty()
+	if !opts.SnapshotSummary && !hasExcludes && !hasIncludes && opts.Metadata.empty() {
+		return errors.Fatal("Nothing to do: no excludes/includes provided and no new metadata provided")
+	} else if hasExcludes && hasIncludes {
+		return errors.Fatal("exclude and include patterns are mutually exclusive")
 	}
 
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
@@ -347,4 +360,72 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, 
 	}
 
 	return nil
+}
+
+func gatherIncludeFilters(includeByNameFuncs []filter.IncludeByNameFunc, printer progress.Printer) (rewriteNode walker.NodeRewriteFunc, keepEmptyDirectory walker.NodeKeepEmptyDirectoryFunc) {
+	inSelectByName := func(nodepath string, node *data.Node) bool {
+		for _, include := range includeByNameFuncs {
+			if node.Type == data.NodeTypeDir {
+				// always include directories
+				return true
+			}
+			matched, childMayMatch := include(nodepath)
+			if matched && childMayMatch {
+				return matched && childMayMatch
+			}
+		}
+		return false
+	}
+
+	rewriteNode = func(node *data.Node, path string) *data.Node {
+		if inSelectByName(path, node) {
+			if node.Type != data.NodeTypeDir {
+				printer.VV("including %q\n", path)
+			}
+			return node
+		}
+		return nil
+	}
+
+	inSelectByNameDir := func(nodepath string) bool {
+		for _, include := range includeByNameFuncs {
+			matched, _ := include(nodepath)
+			if matched {
+				return matched
+			}
+		}
+		return false
+	}
+
+	keepEmptyDirectory = func(path string) bool {
+		keep := inSelectByNameDir(path)
+		if keep {
+			printer.VV("including directoty %q\n", path)
+		}
+		return keep
+	}
+
+	return rewriteNode, keepEmptyDirectory
+}
+
+func gatherExcludeFilters(excludeByNameFuncs []filter.RejectByNameFunc, printer progress.Printer) (rewriteNode walker.NodeRewriteFunc) {
+	exSelectByName := func(nodepath string) bool {
+		for _, reject := range excludeByNameFuncs {
+			if reject(nodepath) {
+				return false
+			}
+		}
+		return true
+	}
+
+	rewriteNode = func(node *data.Node, path string) *data.Node {
+		if exSelectByName(path) {
+			return node
+		}
+
+		printer.VV("excluding %q\n", path)
+		return nil
+	}
+
+	return rewriteNode
 }

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -364,12 +364,13 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, 
 func gatherIncludeFilters(includeByNameFuncs []filter.IncludeByNameFunc, printer progress.Printer) (rewriteNode walker.NodeRewriteFunc, keepEmptyDirectory walker.NodeKeepEmptyDirectoryFunc) {
 	inSelectByName := func(nodepath string, node *data.Node) bool {
 		for _, include := range includeByNameFuncs {
-			if node.Type == data.NodeTypeDir {
-				// always include directories
-				return true
-			}
 			matched, childMayMatch := include(nodepath)
-			if matched && childMayMatch {
+			if node.Type == data.NodeTypeDir {
+				// include directories if they or some of their children may be included
+				if matched || childMayMatch {
+					return true
+				}
+			} else if matched {
 				return true
 			}
 		}

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -153,17 +153,16 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *data.
 	}
 
 	condInclude := len(includeByNameFuncs) > 0
-	condExclude := len(rejectByNameFuncs) > 0 || opts.SnapshotSummary
+	condExclude := len(rejectByNameFuncs) > 0
 	var filter rewriteFilterFunc
-	var rewriteNode walker.NodeRewriteFunc
-	var keepEmptyDirectoryFunc walker.NodeKeepEmptyDirectoryFunc
 
-	if condInclude || condExclude {
+	if condInclude || condExclude || opts.SnapshotSummary {
+		var rewriteNode walker.NodeRewriteFunc
+		var keepEmptyDirectoryFunc walker.NodeKeepEmptyDirectoryFunc
 		if condInclude {
 			rewriteNode, keepEmptyDirectoryFunc = gatherIncludeFilters(includeByNameFuncs, printer)
 		} else {
 			rewriteNode = gatherExcludeFilters(rejectByNameFuncs, printer)
-			keepEmptyDirectoryFunc = nil
 		}
 
 		rewriter, querySize := walker.NewSnapshotSizeRewriter(rewriteNode, keepEmptyDirectoryFunc)
@@ -371,7 +370,7 @@ func gatherIncludeFilters(includeByNameFuncs []filter.IncludeByNameFunc, printer
 			}
 			matched, childMayMatch := include(nodepath)
 			if matched && childMayMatch {
-				return matched && childMayMatch
+				return true
 			}
 		}
 		return false
@@ -400,7 +399,7 @@ func gatherIncludeFilters(includeByNameFuncs []filter.IncludeByNameFunc, printer
 	keepEmptyDirectory = func(path string) bool {
 		keep := inSelectByNameDir(path)
 		if keep {
-			printer.VV("including directoty %q\n", path)
+			printer.VV("including directory %q\n", path)
 		}
 		return keep
 	}

--- a/cmd/restic/cmd_rewrite_integration_test.go
+++ b/cmd/restic/cmd_rewrite_integration_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"context"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/restic/restic/internal/data"
@@ -27,6 +29,13 @@ func testRunRewriteExclude(t testing.TB, gopts global.Options, excludes []string
 	}))
 }
 
+func testRunRewriteWithOpts(t testing.TB, opts RewriteOptions, gopts global.Options, args []string) error {
+	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		return runRewrite(context.TODO(), opts, gopts, args, gopts.Term)
+	}))
+	return nil
+}
+
 func createBasicRewriteRepo(t testing.TB, env *testEnvironment) restic.ID {
 	testSetupBackupData(t, env)
 
@@ -35,6 +44,20 @@ func createBasicRewriteRepo(t testing.TB, env *testEnvironment) restic.ID {
 	snapshotIDs := testRunList(t, env.gopts, "snapshots")
 	rtest.Assert(t, len(snapshotIDs) == 1, "expected one snapshot, got %v", snapshotIDs)
 	testRunCheck(t, env.gopts)
+
+	return snapshotIDs[0]
+}
+
+func createBasicRewriteRepoWithEmptyDirectory(t testing.TB, env *testEnvironment) restic.ID {
+	testSetupBackupData(t, env)
+
+	// make an empty directory named "empty-directory"
+	rtest.OK(t, os.Mkdir(filepath.Join(env.testdata, "/0/tests", "empty-directory"), 0755))
+
+	// create backup
+	testRunBackup(t, filepath.Dir(env.testdata), []string{"testdata"}, BackupOptions{}, env.gopts)
+	snapshotIDs := testRunList(t, env.gopts, "snapshots")
+	rtest.Assert(t, len(snapshotIDs) == 1, "expected one snapshot, got %v", snapshotIDs)
 
 	return snapshotIDs[0]
 }
@@ -194,4 +217,170 @@ func TestRewriteSnaphotSummary(t *testing.T) {
 	rtest.Assert(t, newSn.Summary != nil, "snapshot should have summary attached")
 	rtest.Equals(t, oldSummary.TotalBytesProcessed, newSn.Summary.TotalBytesProcessed, "unexpected TotalBytesProcessed value")
 	rtest.Equals(t, oldSummary.TotalFilesProcessed, newSn.Summary.TotalFilesProcessed, "unexpected TotalFilesProcessed value")
+}
+
+func TestRewriteIncludeFiles(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	// opens repo, creates one backup of the whole lot of 'testdata'
+	createBasicRewriteRepo(t, env)
+	snapshots := testListSnapshots(t, env.gopts, 1)
+
+	// include txt files
+	err := testRunRewriteWithOpts(t,
+		RewriteOptions{
+			Forget:                true,
+			IncludePatternOptions: filter.IncludePatternOptions{Includes: []string{"*.txt"}},
+		},
+		env.gopts,
+		[]string{"latest"})
+	rtest.OK(t, err)
+	newSnapshots := testListSnapshots(t, env.gopts, 1)
+	rtest.Assert(t, snapshots[0] != newSnapshots[0], "snapshot id should have changed")
+
+	// read restic ls output and count .txt files
+	count := 0
+	out := testRunLsWithOpts(t, env.gopts, LsOptions{}, []string{"latest"})
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, ".txt") {
+			count++
+		}
+	}
+	rtest.Assert(t, count == 2, "expected two txt files, but got %d files", count)
+
+	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
+		_, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
+		rtest.OK(t, err)
+		defer unlock()
+
+		sn, err := data.LoadSnapshot(context.TODO(), repo, newSnapshots[0])
+		rtest.OK(t, err)
+
+		rtest.Assert(t, sn.Summary != nil, "snapshot should have a summary attached")
+		rtest.Assert(t, sn.Summary.TotalFilesProcessed == 2,
+			"there should be 2 files in the snapshot, but there are %d files", sn.Summary.TotalFilesProcessed)
+		return nil
+	})
+	rtest.OK(t, err)
+}
+
+func TestRewriteExcludeFiles(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	createBasicRewriteRepo(t, env)
+	snapshots := testListSnapshots(t, env.gopts, 1)
+
+	// exclude txt files
+	err := testRunRewriteWithOpts(t,
+		RewriteOptions{
+			Forget:                true,
+			ExcludePatternOptions: filter.ExcludePatternOptions{Excludes: []string{"*.txt"}},
+		},
+		env.gopts,
+		[]string{"latest"})
+	rtest.OK(t, err)
+	newSnapshots := testListSnapshots(t, env.gopts, 1)
+	rtest.Assert(t, snapshots[0] != newSnapshots[0], "snapshot id should have changed")
+
+	// read restic ls output and count .txt files
+	count := 0
+	out := testRunLsWithOpts(t, env.gopts, LsOptions{}, []string{"latest"})
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, ".txt") {
+			count++
+		}
+	}
+	rtest.Assert(t, count == 0, "expected 0 txt files, but got %d files", count)
+}
+
+func TestRewriteExcludeIncludeContradiction(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	createBasicRewriteRepo(t, env)
+	testListSnapshots(t, env.gopts, 1)
+
+	// test contradiction
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
+		return runRewrite(ctx,
+			RewriteOptions{
+				ExcludePatternOptions: filter.ExcludePatternOptions{Excludes: []string{"nonsense"}},
+				IncludePatternOptions: filter.IncludePatternOptions{Includes: []string{"not allowed"}},
+			},
+			gopts, []string{"quack"}, env.gopts.Term)
+	})
+	rtest.Assert(t, err != nil, `expected to fail command with message "exclude and include patterns are mutually exclusive"`)
+}
+
+func TestRewriteIncludeEmptyDirectory(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	snapIDEmpty := createBasicRewriteRepoWithEmptyDirectory(t, env)
+
+	// restic rewrite <snapshots[0]> -i empty-directory --forget
+	// exclude txt files
+	err := testRunRewriteWithOpts(t,
+		RewriteOptions{
+			Forget:                true,
+			IncludePatternOptions: filter.IncludePatternOptions{Includes: []string{"empty-directory"}},
+		},
+		env.gopts,
+		[]string{"latest"})
+	rtest.OK(t, err)
+	newSnapshots := testListSnapshots(t, env.gopts, 1)
+	rtest.Assert(t, snapIDEmpty != newSnapshots[0], "snapshot id should have changed")
+
+	// read restic ls output and count lines with "empty-directory"
+	count := 0
+	out := testRunLsWithOpts(t, env.gopts, LsOptions{}, []string{"latest"})
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, "empty-directory") {
+			count++
+		}
+	}
+	rtest.Assert(t, count == 1, "expected 1 empty directory, but got %d entries", count)
+}
+
+// TestRewriteIncludeNothing makes sure when nothing is included, the original snapshot stays untouched
+func TestRewriteIncludeNothing(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	createBasicRewriteRepo(t, env)
+	snapsBefore := testListSnapshots(t, env.gopts, 1)
+
+	// restic rewrite latest -i nothing-whatsoever --forget
+	err := testRunRewriteWithOpts(t,
+		RewriteOptions{
+			Forget:                true,
+			ExcludePatternOptions: filter.ExcludePatternOptions{Excludes: []string{"nothing-whatsoever"}},
+		},
+		env.gopts,
+		[]string{"latest"})
+	rtest.OK(t, err)
+
+	snapsAfter := testListSnapshots(t, env.gopts, 1)
+	rtest.Assert(t, snapsBefore[0] == snapsAfter[0], "snapshots should be identical but are %s and %s",
+		snapsBefore[0].Str(), snapsAfter[0].Str())
+}
+
+// TestRewriteExcludeNothing makes sure when nothing is excluded, the original snapshot stays untouched
+// and no new (unchanged) snapshot would be created
+func TestRewriteExcludeNothing(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	createBasicRewriteRepo(t, env)
+	snapsBefore := testListSnapshots(t, env.gopts, 1)
+
+	// restic rewrite latest -e 'nothing-whatsoever' --forget
+	err := testRunRewriteWithOpts(t,
+		RewriteOptions{
+			Forget:                true,
+			ExcludePatternOptions: filter.ExcludePatternOptions{Excludes: []string{"nothing-whatsoever"}},
+		},
+		env.gopts,
+		[]string{"latest"})
+	rtest.OK(t, err)
+	snapsAfter := testListSnapshots(t, env.gopts, 1)
+	rtest.Assert(t, snapsBefore[0] == snapsAfter[0], "snapshots should be identical but are %s and %s",
+		snapsBefore[0].String(), snapsAfter[0].String())
 }

--- a/cmd/restic/cmd_rewrite_integration_test.go
+++ b/cmd/restic/cmd_rewrite_integration_test.go
@@ -250,7 +250,7 @@ func TestRewriteIncludeFiles(t *testing.T) {
 
 	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
-		_, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
+		_, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
 		defer unlock()
 

--- a/cmd/restic/cmd_rewrite_integration_test.go
+++ b/cmd/restic/cmd_rewrite_integration_test.go
@@ -36,6 +36,20 @@ func testRunRewriteWithOpts(t testing.TB, opts RewriteOptions, gopts global.Opti
 	return nil
 }
 
+// testLsOutputContainsCount runs restic ls with the given options and asserts that
+// exactly expectedCount lines of the output contain substring.
+func testLsOutputContainsCount(t testing.TB, gopts global.Options, lsOpts LsOptions, lsArgs []string, substring string, expectedCount int) {
+	t.Helper()
+	out := testRunLsWithOpts(t, gopts, lsOpts, lsArgs)
+	count := 0
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.Contains(line, substring) {
+			count++
+		}
+	}
+	rtest.Assert(t, count == expectedCount, "expected %d lines containing %q, but got %d", expectedCount, substring, count)
+}
+
 func createBasicRewriteRepo(t testing.TB, env *testEnvironment) restic.ID {
 	testSetupBackupData(t, env)
 
@@ -238,31 +252,11 @@ func TestRewriteIncludeFiles(t *testing.T) {
 	newSnapshots := testListSnapshots(t, env.gopts, 1)
 	rtest.Assert(t, snapshots[0] != newSnapshots[0], "snapshot id should have changed")
 
-	// read restic ls output and count .txt files
-	count := 0
-	out := testRunLsWithOpts(t, env.gopts, LsOptions{}, []string{"latest"})
-	for _, line := range strings.Split(string(out), "\n") {
-		if strings.Contains(line, ".txt") {
-			count++
-		}
-	}
-	rtest.Assert(t, count == 2, "expected two txt files, but got %d files", count)
-
-	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
-		_, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
-		rtest.OK(t, err)
-		defer unlock()
-
-		sn, err := data.LoadSnapshot(context.TODO(), repo, newSnapshots[0])
-		rtest.OK(t, err)
-
-		rtest.Assert(t, sn.Summary != nil, "snapshot should have a summary attached")
-		rtest.Assert(t, sn.Summary.TotalFilesProcessed == 2,
-			"there should be 2 files in the snapshot, but there are %d files", sn.Summary.TotalFilesProcessed)
-		return nil
-	})
-	rtest.OK(t, err)
+	testLsOutputContainsCount(t, env.gopts, LsOptions{}, []string{"latest"}, ".txt", 2)
+	sn := testLoadSnapshot(t, env.gopts, newSnapshots[0])
+	rtest.Assert(t, sn.Summary != nil, "snapshot should have a summary attached")
+	rtest.Assert(t, sn.Summary.TotalFilesProcessed == 2,
+		"there should be 2 files in the snapshot, but there are %d files", sn.Summary.TotalFilesProcessed)
 }
 
 func TestRewriteExcludeFiles(t *testing.T) {
@@ -283,22 +277,13 @@ func TestRewriteExcludeFiles(t *testing.T) {
 	newSnapshots := testListSnapshots(t, env.gopts, 1)
 	rtest.Assert(t, snapshots[0] != newSnapshots[0], "snapshot id should have changed")
 
-	// read restic ls output and count .txt files
-	count := 0
-	out := testRunLsWithOpts(t, env.gopts, LsOptions{}, []string{"latest"})
-	for _, line := range strings.Split(string(out), "\n") {
-		if strings.Contains(line, ".txt") {
-			count++
-		}
-	}
-	rtest.Assert(t, count == 0, "expected 0 txt files, but got %d files", count)
+	testLsOutputContainsCount(t, env.gopts, LsOptions{}, []string{"latest"}, ".txt", 0)
 }
 
 func TestRewriteExcludeIncludeContradiction(t *testing.T) {
 	env, cleanup := withTestEnvironment(t)
 	defer cleanup()
-	createBasicRewriteRepo(t, env)
-	testListSnapshots(t, env.gopts, 1)
+	testRunInit(t, env.gopts)
 
 	// test contradiction
 	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
@@ -309,7 +294,7 @@ func TestRewriteExcludeIncludeContradiction(t *testing.T) {
 			},
 			gopts, []string{"quack"}, env.gopts.Term)
 	})
-	rtest.Assert(t, err != nil, `expected to fail command with message "exclude and include patterns are mutually exclusive"`)
+	rtest.Assert(t, err != nil && strings.Contains(err.Error(), "exclude and include patterns are mutually exclusive"), `expected to fail command with message "exclude and include patterns are mutually exclusive"`)
 }
 
 func TestRewriteIncludeEmptyDirectory(t *testing.T) {
@@ -330,15 +315,7 @@ func TestRewriteIncludeEmptyDirectory(t *testing.T) {
 	newSnapshots := testListSnapshots(t, env.gopts, 1)
 	rtest.Assert(t, snapIDEmpty != newSnapshots[0], "snapshot id should have changed")
 
-	// read restic ls output and count lines with "empty-directory"
-	count := 0
-	out := testRunLsWithOpts(t, env.gopts, LsOptions{}, []string{"latest"})
-	for _, line := range strings.Split(string(out), "\n") {
-		if strings.Contains(line, "empty-directory") {
-			count++
-		}
-	}
-	rtest.Assert(t, count == 1, "expected 1 empty directory, but got %d entries", count)
+	testLsOutputContainsCount(t, env.gopts, LsOptions{}, []string{"latest"}, "empty-directory", 1)
 }
 
 // TestRewriteIncludeNothing makes sure when nothing is included, the original snapshot stays untouched
@@ -352,7 +329,7 @@ func TestRewriteIncludeNothing(t *testing.T) {
 	err := testRunRewriteWithOpts(t,
 		RewriteOptions{
 			Forget:                true,
-			ExcludePatternOptions: filter.ExcludePatternOptions{Excludes: []string{"nothing-whatsoever"}},
+			IncludePatternOptions: filter.IncludePatternOptions{Includes: []string{"nothing-whatsoever"}},
 		},
 		env.gopts,
 		[]string{"latest"})
@@ -361,26 +338,4 @@ func TestRewriteIncludeNothing(t *testing.T) {
 	snapsAfter := testListSnapshots(t, env.gopts, 1)
 	rtest.Assert(t, snapsBefore[0] == snapsAfter[0], "snapshots should be identical but are %s and %s",
 		snapsBefore[0].Str(), snapsAfter[0].Str())
-}
-
-// TestRewriteExcludeNothing makes sure when nothing is excluded, the original snapshot stays untouched
-// and no new (unchanged) snapshot would be created
-func TestRewriteExcludeNothing(t *testing.T) {
-	env, cleanup := withTestEnvironment(t)
-	defer cleanup()
-	createBasicRewriteRepo(t, env)
-	snapsBefore := testListSnapshots(t, env.gopts, 1)
-
-	// restic rewrite latest -e 'nothing-whatsoever' --forget
-	err := testRunRewriteWithOpts(t,
-		RewriteOptions{
-			Forget:                true,
-			ExcludePatternOptions: filter.ExcludePatternOptions{Excludes: []string{"nothing-whatsoever"}},
-		},
-		env.gopts,
-		[]string{"latest"})
-	rtest.OK(t, err)
-	snapsAfter := testListSnapshots(t, env.gopts, 1)
-	rtest.Assert(t, snapsBefore[0] == snapsAfter[0], "snapshots should be identical but are %s and %s",
-		snapsBefore[0].String(), snapsAfter[0].String())
 }

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -336,6 +336,13 @@ The options ``--exclude``, ``--exclude-file``, ``--iexclude`` and
 ``--iexclude-file`` are supported. They behave the same way as for the backup
 command, see :ref:`backup-excluding-files` for details.
 
+The options ``--include``, ``--include-file``, ``--iinclude`` and
+``--iinclude-file`` are supported as well.
+The ``--include`` variants allow you to reduce an existing snapshot or a set of snapshots
+to those files that you are really interested in. An example could be all pictures
+from a snapshot:
+``restic rewrite -r ... --iinclude "*.jpg" --iinclude "*.jpeg" --iinclude "*.png"``.
+
 It is possible to rewrite only a subset of snapshots by filtering them the same
 way as for the ``copy`` command, see :ref:`copy-filtering-snapshots`.
 

--- a/internal/data/tree.go
+++ b/internal/data/tree.go
@@ -225,8 +225,7 @@ func (t *TreeWriter) Finalize(ctx context.Context) (restic.ID, error) {
 
 // Count returns the number of nodes in the tree
 func (t *TreeWriter) Count() int {
-
-	return t.builder.countNodes
+	return t.builder.Count()
 }
 
 func SaveTree(ctx context.Context, saver restic.BlobSaver, nodes TreeNodeIterator) (restic.ID, error) {

--- a/internal/data/tree.go
+++ b/internal/data/tree.go
@@ -238,8 +238,9 @@ func SaveTree(ctx context.Context, saver restic.BlobSaver, nodes TreeNodeIterato
 }
 
 type TreeJSONBuilder struct {
-	buf      bytes.Buffer
-	lastName string
+	buf        bytes.Buffer
+	lastName   string
+	countNodes int
 }
 
 func NewTreeJSONBuilder() *TreeJSONBuilder {
@@ -262,6 +263,7 @@ func (builder *TreeJSONBuilder) AddNode(node *Node) error {
 		return err
 	}
 	_, _ = builder.buf.Write(val)
+	builder.countNodes++
 	return nil
 }
 
@@ -273,6 +275,11 @@ func (builder *TreeJSONBuilder) Finalize() ([]byte, error) {
 	// drop reference to buffer
 	builder.buf = bytes.Buffer{}
 	return buf, nil
+}
+
+// Count returns the number of nodes in the tree
+func (builder *TreeJSONBuilder) Count() int {
+	return builder.countNodes
 }
 
 func FindTreeDirectory(ctx context.Context, repo restic.BlobLoader, id *restic.ID, dir string) (*restic.ID, error) {

--- a/internal/data/tree.go
+++ b/internal/data/tree.go
@@ -223,6 +223,12 @@ func (t *TreeWriter) Finalize(ctx context.Context) (restic.ID, error) {
 	return id, err
 }
 
+// Count returns the number of nodes in the tree
+func (t *TreeWriter) Count() int {
+
+	return t.builder.countNodes
+}
+
 func SaveTree(ctx context.Context, saver restic.BlobSaver, nodes TreeNodeIterator) (restic.ID, error) {
 	treeWriter := NewTreeWriter(saver)
 	for item := range nodes {

--- a/internal/filter/include.go
+++ b/internal/filter/include.go
@@ -25,6 +25,10 @@ func (opts *IncludePatternOptions) Add(f *pflag.FlagSet) {
 	f.StringArrayVar(&opts.InsensitiveIncludeFiles, "iinclude-file", nil, "same as --include-file but ignores casing of `file`names in patterns")
 }
 
+func (opts *IncludePatternOptions) Empty() bool {
+	return len(opts.Includes) == 0 && len(opts.InsensitiveIncludes) == 0 && len(opts.IncludeFiles) == 0 && len(opts.InsensitiveIncludeFiles) == 0
+}
+
 func (opts IncludePatternOptions) CollectPatterns(warnf func(msg string, args ...interface{})) ([]IncludeByNameFunc, error) {
 	var fs []IncludeByNameFunc
 	if len(opts.IncludeFiles) > 0 {

--- a/internal/walker/rewriter.go
+++ b/internal/walker/rewriter.go
@@ -23,7 +23,7 @@ type SnapshotSize struct {
 type RewriteOpts struct {
 	// return nil to remove the node
 	RewriteNode        NodeRewriteFunc
-	KeepEmtpyDirectory NodeKeepEmptyDirectoryFunc
+	KeepEmptyDirectory NodeKeepEmptyDirectoryFunc
 	// decide what to do with a tree that could not be loaded. Return nil to remove the node. By default the load error is returned which causes the operation to fail.
 	RewriteFailedTree FailedTreeRewriteFunc
 
@@ -58,8 +58,8 @@ func NewTreeRewriter(opts RewriteOpts) *TreeRewriter {
 			return nil, err
 		}
 	}
-	if rw.opts.KeepEmtpyDirectory == nil {
-		rw.opts.KeepEmtpyDirectory = func(_ string) bool {
+	if rw.opts.KeepEmptyDirectory == nil {
+		rw.opts.KeepEmptyDirectory = func(_ string) bool {
 			return true
 		}
 	}
@@ -80,7 +80,7 @@ func NewSnapshotSizeRewriter(rewriteNode NodeRewriteFunc, keepEmptyDirecoryFilte
 			return node
 		},
 		DisableNodeCache:   true,
-		KeepEmtpyDirectory: keepEmptyDirecoryFilter,
+		KeepEmptyDirectory: keepEmptyDirecoryFilter,
 	})
 
 	ss := func() SnapshotSize {
@@ -181,7 +181,7 @@ func (t *TreeRewriter) RewriteTree(ctx context.Context, loader restic.BlobLoader
 	if err != nil {
 		return restic.ID{}, err
 	}
-	if tb.Count() == 0 && !t.opts.KeepEmtpyDirectory(nodepath) {
+	if tb.Count() == 0 && !t.opts.KeepEmptyDirectory(nodepath) {
 		return restic.ID{}, nil
 	}
 

--- a/internal/walker/rewriter.go
+++ b/internal/walker/rewriter.go
@@ -13,6 +13,7 @@ import (
 type NodeRewriteFunc func(node *data.Node, path string) *data.Node
 type FailedTreeRewriteFunc func(nodeID restic.ID, path string, err error) (data.TreeNodeIterator, error)
 type QueryRewrittenSizeFunc func() SnapshotSize
+type NodeKeepEmptyDirectoryFunc func(path string) bool
 
 type SnapshotSize struct {
 	FileCount uint
@@ -21,7 +22,8 @@ type SnapshotSize struct {
 
 type RewriteOpts struct {
 	// return nil to remove the node
-	RewriteNode NodeRewriteFunc
+	RewriteNode        NodeRewriteFunc
+	KeepEmtpyDirectory NodeKeepEmptyDirectoryFunc
 	// decide what to do with a tree that could not be loaded. Return nil to remove the node. By default the load error is returned which causes the operation to fail.
 	RewriteFailedTree FailedTreeRewriteFunc
 
@@ -56,10 +58,15 @@ func NewTreeRewriter(opts RewriteOpts) *TreeRewriter {
 			return nil, err
 		}
 	}
+	if rw.opts.KeepEmtpyDirectory == nil {
+		rw.opts.KeepEmtpyDirectory = func(_ string) bool {
+			return true
+		}
+	}
 	return rw
 }
 
-func NewSnapshotSizeRewriter(rewriteNode NodeRewriteFunc) (*TreeRewriter, QueryRewrittenSizeFunc) {
+func NewSnapshotSizeRewriter(rewriteNode NodeRewriteFunc, keepEmptyDirecoryFilter NodeKeepEmptyDirectoryFunc) (*TreeRewriter, QueryRewrittenSizeFunc) {
 	var count uint
 	var size uint64
 
@@ -72,7 +79,8 @@ func NewSnapshotSizeRewriter(rewriteNode NodeRewriteFunc) (*TreeRewriter, QueryR
 			}
 			return node
 		},
-		DisableNodeCache: true,
+		DisableNodeCache:   true,
+		KeepEmtpyDirectory: keepEmptyDirecoryFilter,
 	})
 
 	ss := func() SnapshotSize {
@@ -159,6 +167,8 @@ func (t *TreeRewriter) RewriteTree(ctx context.Context, loader restic.BlobLoader
 		newID, err := t.RewriteTree(ctx, loader, saver, path, subtree)
 		if err != nil {
 			return restic.ID{}, err
+		} else if err == nil && newID.IsNull() {
+			continue
 		}
 		node.Subtree = &newID
 		err = tb.AddNode(node)
@@ -170,6 +180,9 @@ func (t *TreeRewriter) RewriteTree(ctx context.Context, loader restic.BlobLoader
 	newTreeID, err := tb.Finalize(ctx)
 	if err != nil {
 		return restic.ID{}, err
+	}
+	if tb.Count() == 0 && !t.opts.KeepEmtpyDirectory(nodepath) {
+		return restic.ID{}, nil
 	}
 
 	if t.replaces != nil {

--- a/internal/walker/rewriter_test.go
+++ b/internal/walker/rewriter_test.go
@@ -329,6 +329,74 @@ func TestSnapshotSizeQuery(t *testing.T) {
 
 }
 
+func TestRewriterKeepEmptyDirectory(t *testing.T) {
+	var paths []string
+	tests := []struct {
+		name      string
+		keepEmpty NodeKeepEmptyDirectoryFunc
+		assert    func(t *testing.T, newRoot restic.ID)
+	}{
+		{
+			name:      "Keep",
+			keepEmpty: func(string) bool { return true },
+			assert: func(t *testing.T, newRoot restic.ID) {
+				_, expRoot := BuildTreeMap(TestTree{"empty": TestTree{}})
+				test.Assert(t, newRoot == expRoot, "expected empty dir kept")
+			},
+		},
+		{
+			name:      "Drop subdir only",
+			keepEmpty: func(p string) bool { return p != "/empty" },
+			assert: func(t *testing.T, newRoot restic.ID) {
+				_, expRoot := BuildTreeMap(TestTree{})
+				test.Assert(t, newRoot == expRoot, "expected empty root")
+			},
+		},
+		{
+			name:      "Drop all",
+			keepEmpty: func(string) bool { return false },
+			assert: func(t *testing.T, newRoot restic.ID) {
+				test.Assert(t, newRoot.IsNull(), "expected null root")
+			},
+		},
+		{
+			name: "Paths",
+			keepEmpty: func(p string) bool {
+				paths = append(paths, p)
+				return p != "/empty"
+			},
+			assert: func(t *testing.T, newRoot restic.ID) {
+				test.Assert(t, len(paths) >= 2, "expected at least two KeepEmptyDirectory calls")
+				var hasRoot, hasEmpty bool
+				for _, p := range paths {
+					if p == "/" {
+						hasRoot = true
+					}
+					if p == "/empty" {
+						hasEmpty = true
+					}
+				}
+				test.Assert(t, hasRoot && hasEmpty, "expected paths \"/\" and \"/empty\", got %v", paths)
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			repo, root := BuildTreeMap(TestTree{"empty": TestTree{}})
+			modrepo := data.TestWritableTreeMap{TestTreeMap: repo}
+
+			rw := NewTreeRewriter(RewriteOpts{KeepEmptyDirectory: tc.keepEmpty})
+			newRoot, err := rw.RewriteTree(ctx, modrepo, modrepo, "/", root)
+			test.OK(t, err)
+			tc.assert(t, newRoot)
+		})
+	}
+}
+
 func TestRewriterFailOnUnknownFields(t *testing.T) {
 	tm := data.TestWritableTreeMap{TestTreeMap: data.TestTreeMap{}}
 	node := []byte(`{"nodes":[{"name":"subfile","type":"file","mtime":"0001-01-01T00:00:00Z","atime":"0001-01-01T00:00:00Z","ctime":"0001-01-01T00:00:00Z","uid":0,"gid":0,"content":null,"unknown_field":42}]}`)

--- a/internal/walker/rewriter_test.go
+++ b/internal/walker/rewriter_test.go
@@ -306,7 +306,7 @@ func TestSnapshotSizeQuery(t *testing.T) {
 			}
 			return node
 		}
-		rewriter, querySize := NewSnapshotSizeRewriter(rewriteNode)
+		rewriter, querySize := NewSnapshotSizeRewriter(rewriteNode, nil)
 		newRoot, err := rewriter.RewriteTree(ctx, modrepo, modrepo, "/", root)
 		if err != nil {
 			t.Error(err)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
----------------------------------------------------- 
This enhancement enables the use of include filters for the rewrite command. Instead of using complex logic to exclude everything else bar the files and directories which the user is interested in, it can now be defined as include "all the bits I am interested in".

File internal/filter/include.go gained an "Empty() function, and file internal/walker/rewriter.go gained logic to recognize empty sub-trees and suppresses the creation for include filtering.

cmd_rewite adds code for inclusion filters. Only sub-trees which are needed will be created.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
closes https://github.com/restic/restic/issues/4278

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
