### PR TITLE
remove duplicate imports

### DIFF
--- a/internal/fs/node_test.go
+++ b/internal/fs/node_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
-	"github.com/restic/restic/internal/test"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -293,5 +292,5 @@ func TestNodeRestoreMetadataError(t *testing.T) {
 
 	// This will fail because the target file does not exist
 	err := NodeRestoreMetadata(node, nodePath, func(msg string) { rtest.OK(t, fmt.Errorf("Warning triggered for path: %s: %s", nodePath, msg)) })
-	test.Assert(t, errors.Is(err, os.ErrNotExist), "failed for an unexpected reason")
+	rtest.Assert(t, errors.Is(err, os.ErrNotExist), "failed for an unexpected reason")
 }

--- a/internal/repository/lock_test.go
+++ b/internal/repository/lock_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/restic/restic/internal/backend/mem"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/restic"
-	"github.com/restic/restic/internal/test"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -36,8 +35,8 @@ func openLockTestRepo(t *testing.T, wrapper backendWrapper) (*Repository, backen
 
 func checkedLockRepo(ctx context.Context, t *testing.T, repo *Repository, lockerInst *locker, retryLock time.Duration) (*Unlocker, context.Context) {
 	lock, wrappedCtx, err := lockerInst.Lock(ctx, repo, false, retryLock, func(msg string) {}, func(format string, args ...interface{}) {})
-	test.OK(t, err)
-	test.OK(t, wrappedCtx.Err())
+	rtest.OK(t, err)
+	rtest.OK(t, wrappedCtx.Err())
 	if lock.info.lock.Stale() {
 		t.Fatal("lock returned stale lock")
 	}
@@ -77,13 +76,13 @@ func TestLockConflict(t *testing.T) {
 	repo2 := TestOpenBackend(t, be)
 
 	lock, _, err := Lock(context.Background(), repo, true, 0, func(msg string) {}, func(format string, args ...interface{}) {})
-	test.OK(t, err)
+	rtest.OK(t, err)
 	defer lock.Unlock()
 	_, _, err = Lock(context.Background(), repo2, false, 0, func(msg string) {}, func(format string, args ...interface{}) {})
 	if err == nil {
 		t.Fatal("second lock should have failed")
 	}
-	test.Assert(t, restic.IsAlreadyLocked(err), "unexpected error %v", err)
+	rtest.Assert(t, restic.IsAlreadyLocked(err), "unexpected error %v", err)
 }
 
 type writeOnceBackend struct {
@@ -241,7 +240,7 @@ func TestLockWaitTimeout(t *testing.T) {
 	repo, _ := openLockTestRepo(t, nil)
 
 	elock, _, err := Lock(context.TODO(), repo, true, 0, func(msg string) {}, func(format string, args ...interface{}) {})
-	test.OK(t, err)
+	rtest.OK(t, err)
 	defer elock.Unlock()
 
 	retryLock := 200 * time.Millisecond
@@ -250,11 +249,11 @@ func TestLockWaitTimeout(t *testing.T) {
 	_, _, err = Lock(context.TODO(), repo, false, retryLock, func(msg string) {}, func(format string, args ...interface{}) {})
 	duration := time.Since(start)
 
-	test.Assert(t, err != nil,
+	rtest.Assert(t, err != nil,
 		"create normal lock with exclusively locked repo didn't return an error")
-	test.Assert(t, strings.Contains(err.Error(), "repository is already locked exclusively"),
+	rtest.Assert(t, strings.Contains(err.Error(), "repository is already locked exclusively"),
 		"create normal lock with exclusively locked repo didn't return the correct error")
-	test.Assert(t, retryLock <= duration && duration < retryLock*3/2,
+	rtest.Assert(t, retryLock <= duration && duration < retryLock*3/2,
 		"create normal lock with exclusively locked repo didn't wait for the specified timeout")
 }
 
@@ -263,7 +262,7 @@ func TestLockWaitCancel(t *testing.T) {
 	repo, _ := openLockTestRepo(t, nil)
 
 	elock, _, err := Lock(context.TODO(), repo, true, 0, func(msg string) {}, func(format string, args ...interface{}) {})
-	test.OK(t, err)
+	rtest.OK(t, err)
 	defer elock.Unlock()
 
 	retryLock := 200 * time.Millisecond
@@ -276,11 +275,11 @@ func TestLockWaitCancel(t *testing.T) {
 	_, _, err = Lock(ctx, repo, false, retryLock, func(msg string) {}, func(format string, args ...interface{}) {})
 	duration := time.Since(start)
 
-	test.Assert(t, err != nil,
+	rtest.Assert(t, err != nil,
 		"create normal lock with exclusively locked repo didn't return an error")
-	test.Assert(t, strings.Contains(err.Error(), "context canceled"),
+	rtest.Assert(t, strings.Contains(err.Error(), "context canceled"),
 		"create normal lock with exclusively locked repo didn't return the correct error")
-	test.Assert(t, cancelAfter <= duration && duration < retryLock-10*time.Millisecond,
+	rtest.Assert(t, cancelAfter <= duration && duration < retryLock-10*time.Millisecond,
 		"create normal lock with exclusively locked repo didn't return in time, duration %v", duration)
 }
 
@@ -289,7 +288,7 @@ func TestLockWaitSuccess(t *testing.T) {
 	repo, _ := openLockTestRepo(t, nil)
 
 	elock, _, err := Lock(context.TODO(), repo, true, 0, func(msg string) {}, func(format string, args ...interface{}) {})
-	test.OK(t, err)
+	rtest.OK(t, err)
 
 	retryLock := 200 * time.Millisecond
 	unlockAfter := 40 * time.Millisecond
@@ -299,6 +298,6 @@ func TestLockWaitSuccess(t *testing.T) {
 	})
 
 	lock, _, err := Lock(context.TODO(), repo, false, retryLock, func(msg string) {}, func(format string, args ...interface{}) {})
-	test.OK(t, err)
+	rtest.OK(t, err)
 	lock.Unlock()
 }

--- a/internal/repository/repair_pack_test.go
+++ b/internal/repository/repair_pack_test.go
@@ -10,7 +10,6 @@ import (
 	backendtest "github.com/restic/restic/internal/backend/test"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
-	"github.com/restic/restic/internal/test"
 	rtest "github.com/restic/restic/internal/test"
 	"github.com/restic/restic/internal/ui/progress"
 )
@@ -25,10 +24,10 @@ func listBlobs(repo restic.Repository) restic.BlobSet {
 
 func replaceFile(t *testing.T, be backend.Backend, h backend.Handle, damage func([]byte) []byte) {
 	buf, err := backendtest.LoadAll(context.TODO(), be, h)
-	test.OK(t, err)
+	rtest.OK(t, err)
 	buf = damage(buf)
-	test.OK(t, be.Remove(context.TODO(), h))
-	test.OK(t, be.Save(context.TODO(), h, backend.NewByteReader(buf, be.Hasher())))
+	rtest.OK(t, be.Remove(context.TODO(), h))
+	rtest.OK(t, be.Save(context.TODO(), h, backend.NewByteReader(buf, be.Hasher())))
 }
 
 func TestRepairBrokenPack(t *testing.T) {

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/repository/index"
 	"github.com/restic/restic/internal/restic"
-	"github.com/restic/restic/internal/test"
 	rtest "github.com/restic/restic/internal/test"
 	"golang.org/x/sync/errgroup"
 )
@@ -145,7 +144,7 @@ func testLoadBlob(t *testing.T, version uint) {
 func TestLoadBlobBroken(t *testing.T) {
 	be := mem.New()
 	repo, _ := repository.TestRepositoryWithBackend(t, &damageOnceBackend{Backend: be}, restic.StableRepoVersion, repository.Options{})
-	buf := test.Random(42, 1000)
+	buf := rtest.Random(42, 1000)
 
 	var wg errgroup.Group
 	repo.StartPackUploader(context.TODO(), &wg)
@@ -421,7 +420,7 @@ func TestInvalidCompression(t *testing.T) {
 func TestListPack(t *testing.T) {
 	be := mem.New()
 	repo, _ := repository.TestRepositoryWithBackend(t, &damageOnceBackend{Backend: be}, restic.StableRepoVersion, repository.Options{})
-	buf := test.Random(42, 1000)
+	buf := rtest.Random(42, 1000)
 
 	var wg errgroup.Group
 	repo.StartPackUploader(context.TODO(), &wg)
@@ -460,12 +459,12 @@ func TestNoDoubleInit(t *testing.T) {
 	rtest.OK(t, err)
 
 	pol := r.Config().ChunkerPolynomial
-	err = repo.Init(context.TODO(), r.Config().Version, test.TestPassword, &pol)
+	err = repo.Init(context.TODO(), r.Config().Version, rtest.TestPassword, &pol)
 	rtest.Assert(t, strings.Contains(err.Error(), "repository master key and config already initialized"), "expected config exist error, got %q", err)
 
 	// must also prevent init if only keys exist
 	rtest.OK(t, be.Remove(context.TODO(), backend.Handle{Type: backend.ConfigFile}))
-	err = repo.Init(context.TODO(), r.Config().Version, test.TestPassword, &pol)
+	err = repo.Init(context.TODO(), r.Config().Version, rtest.TestPassword, &pol)
 	rtest.Assert(t, strings.Contains(err.Error(), "repository already contains keys"), "expected already contains keys error, got %q", err)
 
 	// must also prevent init if a snapshot exists and keys were deleted
@@ -475,6 +474,6 @@ func TestNoDoubleInit(t *testing.T) {
 	rtest.OK(t, be.List(context.TODO(), restic.KeyFile, func(fi backend.FileInfo) error {
 		return be.Remove(context.TODO(), backend.Handle{Type: restic.KeyFile, Name: fi.Name})
 	}))
-	err = repo.Init(context.TODO(), r.Config().Version, test.TestPassword, &pol)
+	err = repo.Init(context.TODO(), r.Config().Version, rtest.TestPassword, &pol)
 	rtest.Assert(t, strings.Contains(err.Error(), "repository already contains snapshots"), "expected already contains snapshots error, got %q", err)
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The `github.com/restic/restic/internal/test` package was imported twice in some files, once with its default name and once with the alias rtest. This PR removes the redundant import, resolving the duplication.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.
