### PR TITLE
Add snapshot filtering --older-than and --newer-than

### DIFF
--- a/changelog/unreleased/issue-5136
+++ b/changelog/unreleased/issue-5136
@@ -1,0 +1,10 @@
+Enhancement: Add snapshot filtering options --older-than and --newer-than
+
+Restic subcommands which work on a set of snapshots (``copy``,
+``find``, ``forget``, ``snapshots``, ``tag`` and more) can now filter
+on the absolute age of the snapshots specified as a duration, e.g.,
+``--newer-than 1d12h`` to only operate on snapshots created less than
+36 hours ago, or ``--older-than 90d`` to operate on snapshots older
+than three months.
+
+https://github.com/restic/restic/issues/5136

--- a/cmd/restic/find.go
+++ b/cmd/restic/find.go
@@ -17,6 +17,8 @@ func initMultiSnapshotFilter(flags *pflag.FlagSet, filt *restic.SnapshotFilter, 
 	}
 	flags.StringArrayVarP(&filt.Hosts, "host", hostShorthand, nil, "only consider snapshots for this `host` (can be specified multiple times) (default: $RESTIC_HOST)")
 	flags.Var(&filt.Tags, "tag", "only consider snapshots including `tag[,tag,...]` (can be specified multiple times)")
+	flags.Var(&filt.OlderThan, "older-than", "only consider snapshots made more than `duration` time ago")
+	flags.Var(&filt.NewerThan, "newer-than", "only consider snapshots made less than `duration` time ago")
 	flags.StringArrayVar(&filt.Paths, "path", nil, "only consider snapshots including this (absolute) `path` (can be specified multiple times, snapshots must include all specified paths)")
 
 	// set default based on env if set

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -34,6 +34,9 @@ size of the contained files at the time when the snapshot was created.
     590c8fc8  2015-05-08 21:47:38  kazik          /srv             580.200MiB
     9f0bc19e  2015-05-08 21:46:11  luigi          /srv             572.180MiB
 
+If you have many snapshots, you can restrict it to only snapshots made
+the last week, using ``-newer-than 7d``.
+
 You can filter the listing by directory path:
 
 .. code-block:: console

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -353,7 +353,9 @@ Since restic 0.17.0, it is possible to delete all snapshots for a specific
 host, tag or path using the ``--unsafe-allow-remove-all`` option. The option
 must always be combined with a snapshot filter (by host, path or tag).
 For example the command ``forget --tag example --unsafe-allow-remove-all``
-removes all snapshots with tag ``example``.
+removes all snapshots with tag ``example``.  Since restic 0.17.4, this
+can be combined with an option like ``--older-than 1y`` to implement
+a hard maximum retention for snapshots.
 
 
 Security considerations in append-only mode

--- a/internal/restic/duration.go
+++ b/internal/restic/duration.go
@@ -127,7 +127,7 @@ func (d *Duration) Set(s string) error {
 	return nil
 }
 
-// ParseTime returns past point in time where this duration is relative to time t.  If t is not given, use time.Now().
+// PastTime returns past point in time where this duration is relative to time t.  If t is not given, use time.Now().
 func (d Duration) PastTime(t ...time.Time) time.Time {
 	var reftime time.Time
 	if t == nil {

--- a/internal/restic/duration.go
+++ b/internal/restic/duration.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 
 	"github.com/restic/restic/internal/errors"
@@ -124,6 +125,18 @@ func (d *Duration) Set(s string) error {
 
 	*d = v
 	return nil
+}
+
+// Subtract duration from t to return past point in time.  If t is not given, use time.Now().
+func (d Duration) PastTime(t ...time.Time) time.Time {
+	var reftime time.Time
+	if t == nil {
+		reftime = time.Now()
+	} else {
+		reftime = t[0]
+	}
+
+	return reftime.AddDate(-d.Years, -d.Months, -d.Days).Add(-time.Duration(d.Hours) * time.Hour)
 }
 
 // Type returns the type of Duration, usable within github.com/spf13/pflag and

--- a/internal/restic/duration.go
+++ b/internal/restic/duration.go
@@ -127,7 +127,7 @@ func (d *Duration) Set(s string) error {
 	return nil
 }
 
-// Subtract duration from t to return past point in time.  If t is not given, use time.Now().
+// ParseTime returns past point in time where this duration is relative to time t.  If t is not given, use time.Now().
 func (d Duration) PastTime(t ...time.Time) time.Time {
 	var reftime time.Time
 	if t == nil {

--- a/internal/restic/duration_test.go
+++ b/internal/restic/duration_test.go
@@ -2,6 +2,7 @@ package restic
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
@@ -103,4 +104,19 @@ func TestParseDuration(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPastTime(t *testing.T) {
+	t.Run("", func(t *testing.T) {
+		d, err := ParseDuration("1y2m3d4h")
+		if err != nil {
+			t.Fatal(err)
+		}
+		reftime, err := time.Parse(time.DateTime, "1999-12-30 15:16:17")
+		expected := "1998-10-27 11:16:17"
+		result := d.PastTime(reftime).Format(time.DateTime)
+		if result != expected {
+			t.Errorf("unexpected return of PastTime, wanted %q, got %q", expected, result)
+		}
+	})
 }

--- a/internal/restic/duration_test.go
+++ b/internal/restic/duration_test.go
@@ -112,7 +112,7 @@ func TestPastTime(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		reftime, err := time.Parse(time.DateTime, "1999-12-30 15:16:17")
+		reftime, _ := time.Parse(time.DateTime, "1999-12-30 15:16:17")
 		expected := "1998-10-27 11:16:17"
 		result := d.PastTime(reftime).Format(time.DateTime)
 		if result != expected {

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -248,6 +248,22 @@ func (sn *Snapshot) HasHostname(hostnames []string) bool {
 	return false
 }
 
+// HasTimeBetween returns false if either
+// - start is given and Time is before start, or
+// - stop is given and Time is after stop
+// Otherwise return true
+// start is the value closest in time, ie. the shortest duration value.
+func (sn *Snapshot) HasTimeBetween(start Duration, stop Duration) bool {
+	if !start.Zero() && sn.Time.After(start.PastTime()) {
+		return false
+	}
+	if !stop.Zero() && sn.Time.Before(stop.PastTime()) {
+		return false
+	}
+
+	return true
+}
+
 // Snapshots is a list of snapshots.
 type Snapshots []*Snapshot
 

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -20,8 +20,12 @@ type SnapshotFilter struct {
 	Hosts []string
 	Tags  TagLists
 	Paths []string
-	// Match snapshots from before this timestamp. Zero for no limit.
+	// Match snapshots from before this timestamp. Zero for no limit.  Only used to find parent.
 	TimestampLimit time.Time
+	// Match snapshots from before this timestamp. Zero for no limit.
+	NewerThan Duration
+	// Match snapshots from after this timestamp. Zero for no limit.
+	OlderThan Duration
 }
 
 func (f *SnapshotFilter) Empty() bool {
@@ -29,7 +33,7 @@ func (f *SnapshotFilter) Empty() bool {
 }
 
 func (f *SnapshotFilter) matches(sn *Snapshot) bool {
-	return sn.HasHostname(f.Hosts) && sn.HasTagList(f.Tags) && sn.HasPaths(f.Paths)
+	return sn.HasHostname(f.Hosts) && sn.HasTagList(f.Tags) && sn.HasPaths(f.Paths) && sn.HasTimeBetween(f.OlderThan, f.NewerThan)
 }
 
 // findLatest finds the latest snapshot with optional target/directory,

--- a/internal/restic/snapshot_find.go
+++ b/internal/restic/snapshot_find.go
@@ -29,7 +29,7 @@ type SnapshotFilter struct {
 }
 
 func (f *SnapshotFilter) Empty() bool {
-	return len(f.Hosts)+len(f.Tags)+len(f.Paths) == 0
+	return len(f.Hosts)+len(f.Tags)+len(f.Paths) == 0 && f.NewerThan.Zero() && f.OlderThan.Zero()
 }
 
 func (f *SnapshotFilter) matches(sn *Snapshot) bool {


### PR DESCRIPTION
This patch adds generic options for filtering snapshots for commands which work on a set of snapshots, like `restic snapshots` and `restic forget`.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

The output of `snapshots` can be overwhelming, and it can be useful to only list this day's backups using `--newer-than 1d` for instance.

This functionality can also be used to forget all snapshots within a time period, e.g.,

`restic forget --older-than 90d --unsafe-allow-remove-all`

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Yes, this closes #5136.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
