### PR TITLE
PR closed - wrong email: restic check - enable --read-data-* with snapshot filter

### DIFF
--- a/changelog/unreleased/issue-3326
+++ b/changelog/unreleased/issue-3326
@@ -1,0 +1,8 @@
+check: enable --read-data-subset and --read-data for specified snapshot(s)
+
+When snapshots are specified on the command line, the metadata for these
+snapshots will be read and a set of packfiles will be created representing the data
+parts of these snapshots.
+
+https://github.com/restic/restic/issues/3326
+https://github.com/restic/restic/pull/5213

--- a/changelog/unreleased/issue-3326
+++ b/changelog/unreleased/issue-3326
@@ -1,8 +1,8 @@
-check: enable --read-data-subset and --read-data for specified snapshot(s)
+Enhancement: enable --read-data-subset and --read-data for specified snapshot(s)
 
-When snapshots are specified on the command line, the metadata for these
-snapshots will be read and a set of packfiles will be created representing the data
-parts of these snapshots.
+Snapshots can now be specified on the command line via the standard snapshot filter,
+(`--tag`, `--host`, `--path` or specifying snapshot IDs directly) and will be used
+for checking the packfiles used by these snapshots.
 
 https://github.com/restic/restic/issues/3326
 https://github.com/restic/restic/pull/5213

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -35,6 +35,9 @@ finds. It can also be used to read all data and therefore simulate a restore.
 By default, the "check" command will always load all data directly from the
 repository and not use a local cache.
 
+The "check" command can now check packfiles for specific snapshots. The snapshots
+are filtered via the standard SnapshotFilter.
+
 EXIT STATUS
 ===========
 
@@ -265,7 +268,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 			return summary, err
 		}
 		if len(selectedTrees) == 0 {
-			return summary, errors.Fatal("snapshotfilter active but no snapshot selected.")
+			return summary, errors.New("snapshotfilter active but no snapshot selected")
 		}
 	}
 

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -264,6 +264,9 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 		if err != nil {
 			return err
 		}
+		if len(selectedTrees) == 0 {
+			return errors.Fatal("snapshotfilter active but no snapshot selected.")
+		}
 	}
 
 	chkr := checker.New(repo, opts.CheckUnused)

--- a/doc/077_troubleshooting.rst
+++ b/doc/077_troubleshooting.rst
@@ -82,6 +82,12 @@ If ``check`` detects damaged pack files, it will show instructions on how to rep
 them using the ``repair pack`` command. Use that command instead of the "Repair the
 index" section in this guide.
 
+If you are interested to check the repository via snapshots, you can now
+use the standard snapshot filter method specifying ``--host``, ``--path``, ``--tag`` or
+alternatively naming snapshot ID(s) explicitely. The selected subset of packfiles
+will then be read to disk and checked for consistency
+when either ``--read-data`` or ``--read-data-subset`` is given.
+
 
 2. Backup the repository
 ************************

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -522,11 +522,12 @@ func (c *Checker) ReadPacks(ctx context.Context, packs map[restic.ID]int64, p *p
 	}
 }
 
-// process snapshot IDs from command line
+// CheckWithSnapshots will process snapshot IDs from command line and
+// madify c.packs so it contains only the selected packfiles via snapshotFilter
 func (c *Checker) CheckWithSnapshots(ctx context.Context, repo *repository.Repository, args []string, snapshotFilter *restic.SnapshotFilter) (bool, error) {
 
 	selectedTrees := []restic.ID{}
-	err := snapshotFilter.FindAll(ctx, c.snapshots, repo, args, func(id string, sn *restic.Snapshot, err error) error {
+	err := snapshotFilter.FindAll(ctx, c.snapshots, repo, args, func(_ string, sn *restic.Snapshot, err error) error {
 		if err != nil {
 			return err
 		} else if ctx.Err() != nil {

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -525,6 +525,9 @@ func (c *Checker) ReadPacks(ctx context.Context, packs map[restic.ID]int64, p *p
 // CheckWithSnapshots will process snapshot IDs from 'selectedTrees' and
 // add to snapPacks so it contains only the selected packfiles.
 func (c *Checker) CheckWithSnapshots(ctx context.Context, selectedTrees []restic.ID) error {
+	if len(selectedTrees) == 0 {
+		return errors.New("no IDs given")
+	}
 
 	// gather used blobs from all trees
 	usedBlobs := restic.NewBlobSet()

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -522,8 +522,8 @@ func (c *Checker) ReadPacks(ctx context.Context, packs map[restic.ID]int64, p *p
 	}
 }
 
-// CheckWithSnapshots will process snapshot IDs from command line and
-// add to snapPacks so it contains only the selected packfiles via snapshotFilter
+// CheckWithSnapshots will process snapshot IDs from 'selectedTrees' and
+// add to snapPacks so it contains only the selected packfiles.
 func (c *Checker) CheckWithSnapshots(ctx context.Context, selectedTrees []restic.ID) error {
 
 	// gather used blobs from all trees
@@ -541,6 +541,10 @@ func (c *Checker) CheckWithSnapshots(ctx context.Context, selectedTrees []restic
 		}
 	}
 
-	c.packs = snapPacks
+	if len(snapPacks) > 0 {
+		c.packs = snapPacks
+	} else {
+		return errors.Fatal("no packfiles found for given snapshot trees")
+	}
 	return nil
 }

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -582,86 +582,56 @@ func TestCheckRepoSnapshot(t *testing.T) {
 
 	chkr := checker.New(repo, false)
 	_, errs := chkr.LoadIndex(context.TODO(), nil)
-	if len(errs) > 0 {
-		t.Fatalf("expected no errors, got %v: %v", len(errs), errs)
-	}
+	test.OKs(t, errs)
 
 	test.OKs(t, checkPacks(chkr))
 	test.OKs(t, checkStruct(chkr))
 
 	snID := restic.TestParseID("f7d83db709977178c9d1a09e4009355e534cde1a135b8186b8b118a3fc4fcd41")
 	sn1, err := restic.LoadSnapshot(context.TODO(), repo, snID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	test.OK(t, err)
 	selectedTrees := []restic.ID{*sn1.Tree}
 	test.OK(t, chkr.CheckWithSnapshots(context.TODO(), selectedTrees))
-
-	// size of packs (1)
 	lenPacks := chkr.CountPacks()
-	if lenPacks != 1 {
-		t.Fatalf("expected 1 packfile, got %v", lenPacks)
-	}
+	test.Assert(t, lenPacks == uint64(1), "expected 1 packfile, got %v", lenPacks)
 
+	// index needs reloading every time
 	_, errs = chkr.LoadIndex(context.TODO(), nil)
-	if len(errs) > 0 {
-		t.Fatalf("expected no errors, got %v: %v", len(errs), errs)
-	}
+	test.Assert(t, len(errs) == 0, "expected no errors, got %v: %v", len(errs), errs)
+
 	snID = restic.TestParseID("c2b53c5e6a16db92fbb9aa08bd2794c58b379d8724d661ee30d20898bdfdff22")
 	sn2, err := restic.LoadSnapshot(context.TODO(), repo, snID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	test.OK(t, err)
 	selectedTrees = []restic.ID{*sn2.Tree}
 	test.OK(t, chkr.CheckWithSnapshots(context.TODO(), selectedTrees))
-
-	// size of packs (2)
 	lenPacks = chkr.CountPacks()
-	if lenPacks != 2 {
-		t.Fatalf("expected 2 packfiles, got %v", lenPacks)
-	}
+	test.Assert(t, lenPacks == 2, "expected 2 packfiles, got %v", lenPacks)
 
 	_, errs = chkr.LoadIndex(context.TODO(), nil)
-	if len(errs) > 0 {
-		t.Fatalf("expected no errors, got %v: %v", len(errs), errs)
-	}
+	test.Assert(t, len(errs) == 0, "expected no errors, got %v: %v", len(errs), errs)
+
 	snID = restic.TestParseID("a13c11e582b77a693dd75ab4e3a3ba96538a056594a4b9076e4cacebe6e06d43")
 	sn3, err := restic.LoadSnapshot(context.TODO(), repo, snID)
-	if err != nil {
-		t.Fatal(err)
-	}
+	test.OK(t, err)
 	selectedTrees = []restic.ID{*sn3.Tree}
 	test.OK(t, chkr.CheckWithSnapshots(context.TODO(), selectedTrees))
-
-	// size of packs (3)
 	lenPacks = chkr.CountPacks()
-	if lenPacks != 2 {
-		t.Fatalf("expected 2 packfiles, got %v", lenPacks)
-	}
+	test.Assert(t, lenPacks == 2, "expected 2 packfiles, got %v", lenPacks)
 
-	// size of packs (4)
 	_, errs = chkr.LoadIndex(context.TODO(), nil)
-	if len(errs) > 0 {
-		t.Fatalf("expected no errors, got %v: %v", len(errs), errs)
-	}
+	test.Assert(t, len(errs) == 0, "expected no errors, got %v: %v", len(errs), errs)
+
 	selectedTrees = []restic.ID{*sn1.Tree, *sn3.Tree}
 	test.OK(t, chkr.CheckWithSnapshots(context.TODO(), selectedTrees))
 	lenPacks = chkr.CountPacks()
-	if lenPacks != 3 {
-		t.Fatalf("expected 3 packfiles, got %v", lenPacks)
-	}
+	test.Assert(t, lenPacks == 3, "expected 3 packfiles, got %v", lenPacks)
 
-	// size of packs (5): unmodified - filter empty
 	_, errs = chkr.LoadIndex(context.TODO(), nil)
-	if len(errs) > 0 {
-		t.Fatalf("expected no errors, got %v: %v", len(errs), errs)
-	}
+	test.Assert(t, len(errs) == 0, "expected no errors, got %v: %v", len(errs), errs)
 
 	selectedTrees = []restic.ID{}
 	err = chkr.CheckWithSnapshots(context.TODO(), selectedTrees)
-	if err == nil {
-		t.Fatalf("expected an error, got no error")
-	}
+	test.Assert(t, err != nil && err.Error() == "no IDs given", "expected specific error, got %v", err)
 }
 
 func loadBenchRepository(t *testing.B) (*checker.Checker, restic.Repository, func()) {


### PR DESCRIPTION
Enable restic check based on snapshots. The standard snapshot filtering routine  "FindFilteredSnapshots" is used for snapshots selection. However if no snapshots are specified, the subcommand behaves as before.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The PR solves issue 3326. 
<!--
Describe the changes and their purpose here, as detailed as needed.
-->
Add standard snapshot filtering to subcommand.
Add code to cmd/restic/cmd_check.go to detect snapshot filtering 
Add code to internal/checker/checker.go to collect data blobs based on tree visitor. The functions CountPacks() and GetPacks() have been modified, so that snapshot filtering creates a subset of packfiles on which all size calculations will be based.

When snapshot filtering is activated, the complete tree for this snapshot is read and the data blobs - and their packfiles - are extracted.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://github.com/restic/restic/issues/3326

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
Closes #3326

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
