### PR TITLE
restore: reflink identical files on extraction

### DIFF
--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -71,6 +71,7 @@ type RestoreOptions struct {
 	Verify              bool
 	Overwrite           restorer.OverwriteBehavior
 	Delete              bool
+	Reflinks            bool
 	ExcludeXattrPattern []string
 	IncludeXattrPattern []string
 	OwnershipByName     bool
@@ -91,6 +92,7 @@ func (opts *RestoreOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.Verify, "verify", false, "verify restored files content")
 	f.Var(&opts.Overwrite, "overwrite", "overwrite behavior, one of (always|if-changed|if-newer|never)")
 	f.BoolVar(&opts.Delete, "delete", false, "delete files from target directory if they do not exist in snapshot. Use '--dry-run -vv' to check what would be deleted")
+	f.BoolVar(&opts.Reflinks, "reflinks", false, "use reflinks to restore identical files")
 	if runtime.GOOS != "windows" {
 		f.BoolVar(&opts.OwnershipByName, "ownership-by-name", false, "restore file ownership by user name and group name (except POSIX ACLs)")
 	}
@@ -174,6 +176,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts global.Options,
 		Progress:        progress,
 		Overwrite:       opts.Overwrite,
 		Delete:          opts.Delete,
+		Reflinks:        opts.Reflinks,
 		OwnershipByName: opts.OwnershipByName,
 	})
 

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/pkg/profile v1.7.0
 	github.com/pkg/sftp v1.13.10
 	github.com/pkg/xattr v0.4.12
+	github.com/puzpuzpuz/xsync/v3 v3.4.0
 	github.com/restic/chunker v0.5.0
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.10
@@ -106,3 +107,5 @@ require (
 	google.golang.org/grpc v1.81.1 // indirect
 	google.golang.org/protobuf v1.36.11 // indirect
 )
+
+replace github.com/puzpuzpuz/xsync/v3 => github.com/intelfx/xsync/v3 v3.5.1-0.20250127082852-044f32c1f889

--- a/go.sum
+++ b/go.sum
@@ -129,6 +129,8 @@ github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyf
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/intelfx/xsync/v3 v3.5.1-0.20250127082852-044f32c1f889 h1:ysiXnPMU0xyr4CYc4PSoD5SCLZgrPr7l17lTnvT5hfQ=
+github.com/intelfx/xsync/v3 v3.5.1-0.20250127082852-044f32c1f889/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
 github.com/keybase/go-keychain v0.0.1 h1:way+bWYa6lDppZoZcgMbYsvC7GxljxrskdNInRtuthU=
 github.com/keybase/go-keychain v0.0.1/go.mod h1:PdEILRW3i9D8JcdM+FmY6RwkHGnhHxXwkPPMeUgOK1k=
 github.com/klauspost/compress v1.18.6 h1:2jupLlAwFm95+YDR+NwD2MEfFO9d4z4Prjl1XXDjuao=

--- a/internal/data/hardlinks_index.go
+++ b/internal/data/hardlinks_index.go
@@ -4,25 +4,26 @@ import (
 	"sync"
 )
 
-// hardlinkKey is a composed key for finding inodes on a specific device.
+// hardlinkKey is a composite key that identifies a unique inode on a device.
 type hardlinkKey struct {
 	Inode, Device uint64
 }
 
-// HardlinkIndex maps inodes on devices to associated values.
+// HardlinkIndex maps unique inodes (hardlink targets) to arbitrary data,
+// e.g. known names of those inodes.
 type HardlinkIndex[T any] struct {
 	m     sync.Mutex
 	index map[hardlinkKey]T
 }
 
-// NewHardlinkIndex create a new index for hard links
+// NewHardlinkIndex create a new HardlinkIndex for a given value type.
 func NewHardlinkIndex[T any]() *HardlinkIndex[T] {
 	return &HardlinkIndex[T]{
 		index: make(map[hardlinkKey]T),
 	}
 }
 
-// Has checks whether the link already exist in the index.
+// Has checks whether a given inode already exists in the index.
 func (idx *HardlinkIndex[T]) Has(inode uint64, device uint64) bool {
 	idx.m.Lock()
 	defer idx.m.Unlock()
@@ -31,7 +32,8 @@ func (idx *HardlinkIndex[T]) Has(inode uint64, device uint64) bool {
 	return ok
 }
 
-// Add adds a link to the index.
+// Add adds a new inode with its accompanying data to the index, if one did not
+// exist before.
 func (idx *HardlinkIndex[T]) Add(inode uint64, device uint64, value T) {
 	idx.m.Lock()
 	defer idx.m.Unlock()
@@ -42,14 +44,14 @@ func (idx *HardlinkIndex[T]) Add(inode uint64, device uint64, value T) {
 	}
 }
 
-// Value obtains the filename from the index.
+// Value looks up the associated data for a given inode.
 func (idx *HardlinkIndex[T]) Value(inode uint64, device uint64) T {
 	idx.m.Lock()
 	defer idx.m.Unlock()
 	return idx.index[hardlinkKey{inode, device}]
 }
 
-// Remove removes a link from the index.
+// Remove removes an inode from the index.
 func (idx *HardlinkIndex[T]) Remove(inode uint64, device uint64) {
 	idx.m.Lock()
 	defer idx.m.Unlock()

--- a/internal/data/hardlinks_index.go
+++ b/internal/data/hardlinks_index.go
@@ -44,11 +44,13 @@ func (idx *HardlinkIndex[T]) Add(inode uint64, device uint64, value T) {
 	}
 }
 
-// Value looks up the associated data for a given inode.
-func (idx *HardlinkIndex[T]) Value(inode uint64, device uint64) T {
+// Value looks up the associated data for a given inode, and returns that data
+// plus a flag indicating whether the inode exists in the index.
+func (idx *HardlinkIndex[T]) Value(inode uint64, device uint64) (T, bool) {
 	idx.m.Lock()
 	defer idx.m.Unlock()
-	return idx.index[hardlinkKey{inode, device}]
+	v, ok := idx.index[hardlinkKey{inode, device}]
+	return v, ok
 }
 
 // Remove removes an inode from the index.

--- a/internal/data/hardlinks_index_test.go
+++ b/internal/data/hardlinks_index_test.go
@@ -15,10 +15,12 @@ func TestHardLinks(t *testing.T) {
 	idx.Add(1, 2, "inode1-file1-on-device2")
 	idx.Add(2, 3, "inode2-file2-on-device3")
 
-	sresult := idx.Value(1, 2)
+	sresult, ok := idx.Value(1, 2)
+	rtest.Equals(t, ok, true)
 	rtest.Equals(t, sresult, "inode1-file1-on-device2")
 
-	sresult = idx.Value(2, 3)
+	sresult, ok = idx.Value(2, 3)
+	rtest.Equals(t, ok, true)
 	rtest.Equals(t, sresult, "inode2-file2-on-device3")
 
 	bresult := idx.Has(1, 2)

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -151,5 +151,6 @@ func Clone(srcName, destName string) (cloned bool, err error) {
 		_ = dest.Close()
 	}()
 
+	_ = src.Sync()
 	return doClone(src, dest)
 }

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -2,8 +2,35 @@ package fs
 
 import (
 	"fmt"
+	"io"
 	"os"
+	"reflect"
+	"runtime"
+	"sync"
+
+	"github.com/restic/restic/internal/errors"
 )
+
+type cloneMethod func(src, dst *os.File) error
+
+var (
+	mCloneMethods = &sync.Mutex{}
+	cloneMethods  = make([]cloneMethod, 0, 1)
+)
+
+func registerCloneMethod(method cloneMethod) {
+	mCloneMethods.Lock()
+	defer mCloneMethods.Unlock()
+
+	cloneMethods = append(cloneMethods, method)
+	if len(cloneMethods) > 1 {
+		var names []string
+		for _, m := range cloneMethods {
+			names = append(names, runtime.FuncForPC(reflect.ValueOf(m).Pointer()).Name())
+		}
+		fmt.Fprintf(os.Stderr, "warning: more than one clone method: %v\n", names)
+	}
+}
 
 // MkdirAll creates a directory named path, along with any necessary parents,
 // and returns nil, or else returns an error. The permission bits perm are used
@@ -84,4 +111,45 @@ func Readdirnames(filesystem FS, dir string, flags int) ([]string, error) {
 	}
 
 	return entries, nil
+}
+
+func doCloneCopy(src, dest *os.File) error {
+	srcInfo, err := src.Stat()
+	if err != nil {
+		return err
+	}
+	n, err := io.Copy(dest, src)
+	if n > 0 && n != srcInfo.Size() {
+		return errors.Wrapf(err, "io.Copy() wrote %d of %d bytes", n, srcInfo.Size())
+	}
+	return err
+}
+
+func doClone(src, dest *os.File) (cloned bool, err error) {
+	for _, fn := range cloneMethods {
+		return true, fn(src, dest)
+	}
+	return false, doCloneCopy(src, dest)
+}
+
+// Clone performs a local possibly accelerated copy of srcName to destName.
+// The cloned flag reports whether an accelerated copy (reflink) was performed.
+func Clone(srcName, destName string) (cloned bool, err error) {
+	src, err := OpenFile(srcName, O_RDONLY|O_NOFOLLOW, 0)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_ = src.Close()
+	}()
+
+	dest, err := OpenFile(destName, O_CREATE|O_WRONLY|O_NOFOLLOW, 0600)
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		_ = dest.Close()
+	}()
+
+	return doClone(src, dest)
 }

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 
 	"github.com/restic/restic/internal/errors"
+	"golang.org/x/sys/unix"
 )
 
 type cloneMethod func(src, dst *os.File) error
@@ -125,19 +126,10 @@ func doCloneCopy(src, dest *os.File) error {
 	return err
 }
 
-func doClone(src, dest *os.File) (cloned bool, err error) {
-	for _, fn := range cloneMethods {
-		return true, fn(src, dest)
-	}
-	return false, doCloneCopy(src, dest)
-}
-
-// Clone performs a local possibly accelerated copy of srcName to destName.
-// The cloned flag reports whether an accelerated copy (reflink) was performed.
-func Clone(srcName, destName string) (cloned bool, err error) {
+func doClone(srcName, destName string, method cloneMethod) error {
 	src, err := OpenFile(srcName, O_RDONLY|O_NOFOLLOW, 0)
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer func() {
 		_ = src.Close()
@@ -145,12 +137,28 @@ func Clone(srcName, destName string) (cloned bool, err error) {
 
 	dest, err := OpenFile(destName, O_CREATE|O_TRUNC|O_WRONLY|O_NOFOLLOW, 0600)
 	if err != nil {
-		return false, err
+		return err
 	}
 	defer func() {
 		_ = dest.Close()
 	}()
 
 	_ = src.Sync()
-	return doClone(src, dest)
+	return method(src, dest)
+}
+
+// Clone performs a local possibly accelerated copy of srcName to destName.
+// The cloned flag reports whether an accelerated copy (reflink) was performed.
+func Clone(srcName, destName string) (cloned bool, err error) {
+	for _, fn := range cloneMethods {
+		err = doClone(srcName, destName, fn)
+		// if a particular method is not supported, or we hit the cross-device limitation,
+		// "eat" the error and go to the next method or the fallback
+		if errors.Is(err, unix.EXDEV) || errors.Is(err, unix.ENOTSUP) {
+			continue
+		}
+		return true, err
+	}
+
+	return false, doClone(srcName, destName, doCloneCopy)
 }

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -12,7 +12,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-type cloneMethod func(src, dst *os.File) error
+type cloneMethod func(src, dst *os.File) (cloned bool, err error)
 
 var (
 	mCloneMethods = &sync.Mutex{}
@@ -114,22 +114,22 @@ func Readdirnames(filesystem FS, dir string, flags int) ([]string, error) {
 	return entries, nil
 }
 
-func doCloneCopy(src, dest *os.File) error {
+func doCloneCopy(src, dest *os.File) (cloned bool, err error) {
 	srcInfo, err := src.Stat()
 	if err != nil {
-		return err
+		return false, err
 	}
 	n, err := io.Copy(dest, src)
 	if n > 0 && n != srcInfo.Size() {
-		return errors.Wrapf(err, "io.Copy() wrote %d of %d bytes", n, srcInfo.Size())
+		return false, errors.Wrapf(err, "io.Copy() wrote %d of %d bytes", n, srcInfo.Size())
 	}
-	return err
+	return false, err
 }
 
-func doClone(srcName, destName string, method cloneMethod) error {
+func doClone(srcName, destName string, method cloneMethod) (cloned bool, err error) {
 	src, err := OpenFile(srcName, O_RDONLY|O_NOFOLLOW, 0)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() {
 		_ = src.Close()
@@ -137,7 +137,7 @@ func doClone(srcName, destName string, method cloneMethod) error {
 
 	dest, err := OpenFile(destName, O_CREATE|O_TRUNC|O_WRONLY|O_NOFOLLOW, 0600)
 	if err != nil {
-		return err
+		return false, err
 	}
 	defer func() {
 		_ = dest.Close()
@@ -151,14 +151,14 @@ func doClone(srcName, destName string, method cloneMethod) error {
 // The cloned flag reports whether an accelerated copy (reflink) was performed.
 func Clone(srcName, destName string) (cloned bool, err error) {
 	for _, fn := range cloneMethods {
-		err = doClone(srcName, destName, fn)
+		cloned, err = doClone(srcName, destName, fn)
 		// if a particular method is not supported, or we hit the cross-device limitation,
 		// "eat" the error and go to the next method or the fallback
 		if errors.Is(err, unix.EXDEV) || errors.Is(err, unix.ENOTSUP) {
 			continue
 		}
-		return true, err
+		return cloned, err
 	}
 
-	return false, doClone(srcName, destName, doCloneCopy)
+	return doClone(srcName, destName, doCloneCopy)
 }

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -149,16 +149,20 @@ func doClone(srcName, destName string, method cloneMethod) (cloned bool, err err
 
 // Clone performs a local possibly accelerated copy of srcName to destName.
 // The cloned flag reports whether an accelerated copy (reflink) was performed.
-func Clone(srcName, destName string) (cloned bool, err error) {
+// The cloneErr value specifies the last non-fatal error during attempted
+// accelerated copy.
+func Clone(srcName, destName string) (cloned bool, err error, cloneErr error) {
 	for _, fn := range cloneMethods {
 		cloned, err = doClone(srcName, destName, fn)
 		// if a particular method is not supported, or we hit the cross-device limitation,
 		// "eat" the error and go to the next method or the fallback
 		if errors.Is(err, unix.EXDEV) || errors.Is(err, unix.ENOTSUP) {
+			cloneErr = err
 			continue
 		}
-		return cloned, err
+		return cloned, err, cloneErr
 	}
 
-	return doClone(srcName, destName, doCloneCopy)
+	cloned, err = doClone(srcName, destName, doCloneCopy)
+	return cloned, err, cloneErr
 }

--- a/internal/fs/file.go
+++ b/internal/fs/file.go
@@ -143,7 +143,7 @@ func Clone(srcName, destName string) (cloned bool, err error) {
 		_ = src.Close()
 	}()
 
-	dest, err := OpenFile(destName, O_CREATE|O_WRONLY|O_NOFOLLOW, 0600)
+	dest, err := OpenFile(destName, O_CREATE|O_TRUNC|O_WRONLY|O_NOFOLLOW, 0600)
 	if err != nil {
 		return false, err
 	}

--- a/internal/fs/file_linux.go
+++ b/internal/fs/file_linux.go
@@ -1,0 +1,45 @@
+//go:build linux
+// +build linux
+
+package fs
+
+import (
+	"golang.org/x/sys/unix"
+	"os"
+)
+
+func init() {
+	registerCloneMethod(doCloneIoctl)
+}
+
+func withFileDescriptors(file1, file2 *os.File, fn func(fd1, fd2 int) (int, error)) (int, error) {
+	conn1, err := file1.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	conn2, err := file2.SyscallConn()
+	if err != nil {
+		return 0, err
+	}
+	var n int
+	var err1, err2, err3 error
+	err1 = conn1.Control(func(first uintptr) {
+		err2 = conn2.Control(func(second uintptr) {
+			n, err3 = fn(int(first), int(second))
+		})
+	})
+	if err1 != nil {
+		return n, err1
+	}
+	if err2 != nil {
+		return n, err2
+	}
+	return n, err3
+}
+
+func doCloneIoctl(src, dest *os.File) (cloned bool, err error) {
+	_, err = withFileDescriptors(src, dest, func(srcFd, destFd int) (int, error) {
+		return 0, unix.IoctlFileClone(destFd, srcFd)
+	})
+	return true, err
+}

--- a/internal/restorer/progress.go
+++ b/internal/restorer/progress.go
@@ -7,6 +7,7 @@ const (
 	ActionDirRestored   ItemAction = "dir restored"
 	ActionFileRestored  ItemAction = "file restored"
 	ActionFileUpdated   ItemAction = "file updated"
+	ActionFileCloned    ItemAction = "file cloned"
 	ActionFileUnchanged ItemAction = "file unchanged"
 	ActionOtherRestored ItemAction = "other restored"
 	ActionDeleted       ItemAction = "deleted"
@@ -16,6 +17,7 @@ const (
 type ProgressReporter interface {
 	AddFile(size uint64)
 	AddProgress(name string, action ItemAction, bytesWrittenPortion, bytesTotal uint64)
+	AddClonedFile(name string, size uint64, blockCloned bool)
 	AddSkippedFile(name string, size uint64)
 	ReportDeletion(name string)
 }
@@ -27,6 +29,7 @@ var _ ProgressReporter = (*noopProgressReporter)(nil)
 func (noopProgressReporter) AddFile(uint64) {}
 func (noopProgressReporter) AddProgress(string, ItemAction, uint64, uint64) {
 }
+func (noopProgressReporter) AddClonedFile(name string, size uint64, blockCloned bool) {}
 func (noopProgressReporter) AddSkippedFile(string, uint64) {}
 func (noopProgressReporter) ReportDeletion(string)         {}
 

--- a/internal/restorer/reflinks_index.go
+++ b/internal/restorer/reflinks_index.go
@@ -1,0 +1,97 @@
+package restorer
+
+import (
+	"github.com/puzpuzpuz/xsync/v3"
+	"github.com/restic/restic/internal/restic"
+)
+
+// ReflinkKey is a composite key that identifies a unique file content.
+type ReflinkKey struct {
+	Content restic.IDs
+}
+
+// ReflinkItem is a structure that describes a specific file in the snapshot.
+type ReflinkItem struct {
+	Name string
+}
+
+// ReflinkValue is a structure describing all known files with the same content
+// that are being extracted.
+type ReflinkValue struct {
+	entry ReflinkItem
+	//m       xsync.RBMutex
+	//entries []ReflinkItem
+}
+
+// ReflinkIndex is an index of all unique file contents to the files that have
+// this content, for the purposes of reflink tracking.
+// For now, this structure only tracks the first file with given content, as we
+// will only attempt to extract one file and clone all others from it.
+type ReflinkIndex struct {
+	Index *xsync.MapOf[ReflinkKey, ReflinkValue]
+}
+
+// idHasher is the generated hasher function for a single blob ID.
+var idHasher func(restic.ID, uint64) uint64
+
+func init() {
+	idHasher = xsync.Hasher[restic.ID]()
+}
+
+// reflinkKeyHasher is the hashing function for a given ReflinkKey, implemented
+// by chain-hashing all blob IDs. This is needed because Go cannot hash slices.
+func reflinkKeyHasher(key ReflinkKey, seed uint64) uint64 {
+	h := seed
+	for _, i := range key.Content {
+		h = idHasher(i, h)
+	}
+	return h
+}
+
+// reflinkKeyCmp is the comparator function for a given ReflinkKey.
+// This is needed because Go cannot compare slices.
+func reflinkKeyCmp(a ReflinkKey, b ReflinkKey) bool {
+	if a.Content.Len() != b.Content.Len() {
+		return false
+	}
+	for i, v1 := range a.Content {
+		v2 := b.Content[i]
+		if v1 != v2 {
+			return false
+		}
+	}
+	return true
+}
+
+// NewReflinkIndex creates a new ReflinkIndex with fixed key and value types.
+func NewReflinkIndex() *ReflinkIndex {
+	return &ReflinkIndex{
+		Index: xsync.NewMapOfWithMethods[ReflinkKey, ReflinkValue](
+			reflinkKeyHasher,
+			reflinkKeyCmp,
+		),
+	}
+}
+
+// Put inserts a new mapping from file content to its name. A mapping is only
+// created if given content is not yet known, causing ReflinkIndex to track
+// names of the files considered "originals" for any given content.
+// The name of  the "original" is returned, along with the flag indicating
+// whether _this_ invocation has inserted an original.
+func (idx *ReflinkIndex) Put(name string, ids restic.IDs) (orig string, isOrig bool) {
+	v, loaded := idx.Index.LoadOrStore(
+		ReflinkKey{ids},
+		ReflinkValue{ReflinkItem{name}},
+	)
+	return v.entry.Name, !loaded
+}
+
+// Get looks up the associated file name that is "original" for a given content,
+// and returns that file name plus a flag indicating whether the original exists
+// in the index.
+func (idx *ReflinkIndex) Get(ids restic.IDs) (orig string, hasOrig bool) {
+	v, loaded := idx.Index.Load(
+		ReflinkKey{ids},
+	)
+	return v.entry.Name, loaded
+}

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -320,6 +320,24 @@ func (res *Restorer) restoreHardlinkAt(node *data.Node, target, path, location s
 	return res.restoreNodeMetadataTo(node, path, location)
 }
 
+func (res *Restorer) restoreReflink(node *data.Node, target, path, location string) error {
+	cloned := true
+	if !res.opts.DryRun {
+		var err error
+		if err = fs.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return errors.Wrap(err, "RemoveNode")
+		}
+		cloned, err = fs.Clone(target, path)
+		if err != nil {
+			return errors.WithStack(err)
+		}
+	}
+
+	res.opts.Progress.AddProgress(location, ActionFileRestored, node.Size, node.Size)
+	// reflinked files *do* have separate metadata
+	return res.restoreNodeMetadataTo(node, path, location)
+}
+
 func (res *Restorer) ensureDir(target string) error {
 	if res.opts.DryRun {
 		return nil
@@ -362,6 +380,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) (uint64, error) 
 	}
 
 	idx := data.NewHardlinkIndex[string]()
+	refIdx := NewReflinkIndex()
 	filerestorer := newFileRestorer(dst, res.repo.LoadBlobsFromPack, res.repo.LookupBlob,
 		res.repo.Connections(), res.opts.Sparse, res.opts.Delete, res.repo.StartWarmup, res.opts.Progress,
 		res.repo.ChunkerFactory().ZeroChunk())
@@ -400,6 +419,16 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) (uint64, error) 
 					return nil
 				}
 				idx.Add(node.Inode, node.DeviceID, location)
+			}
+
+			// do not bother reflinking empty files
+			if res.opts.Reflinks && node.Size > 0 {
+				refOrig, refIsOrig := refIdx.Put(location, node.Content)
+				if !refIsOrig {
+					debug.Log("reflink (deferring): orig=%s, link=%s", refOrig, location)
+					res.opts.Progress.AddFile(node.Size)
+					return nil
+				}
 			}
 
 			buf, err = res.withOverwriteCheck(ctx, node, target, location, false, buf, func(updateMetadataOnly bool, matches *fileState) error {
@@ -456,6 +485,16 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) (uint64, error) 
 					return res.restoreHardlinkAt(node, filerestorer.targetPath(orig), target, location)
 				})
 				return err
+			}
+
+			if res.opts.Reflinks && node.Size > 0 {
+				if orig, hasOrig := refIdx.Get(node.Content); hasOrig && orig != location {
+					debug.Log("reflink (restoring): orig=%s, link=%s", orig, location)
+					_, err := res.withOverwriteCheck(ctx, node, target, location, false, nil, func(_ bool, _ *fileState) error {
+						return res.restoreReflink(node, filerestorer.targetPath(orig), target, location)
+					})
+					return err
+				}
 			}
 
 			if _, ok := res.hasRestoredFile(location); ok {

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -155,7 +155,7 @@ func (res *Restorer) traverseTree(ctx context.Context, target string, treeID res
 }
 
 func (res *Restorer) traverseTreeInner(ctx context.Context, target, location string, treeID restic.ID, visitor treeVisitor) (filenames []string, hasRestored bool, err error) {
-	debug.Log("%v %v %v", target, location, treeID)
+	//debug.Log("%v %v %v", target, location, treeID)
 	tree, err := data.LoadTree(ctx, res.repo, treeID)
 	if err != nil {
 		debug.Log("error loading tree %v: %v", treeID, err)
@@ -216,7 +216,7 @@ func (res *Restorer) traverseTreeInner(ctx context.Context, target, location str
 		}
 
 		selectedForRestore, childMayBeSelected := res.SelectFilter(nodeLocation, node.Type == data.NodeTypeDir)
-		debug.Log("SelectFilter returned %v %v for %q", selectedForRestore, childMayBeSelected, nodeLocation)
+		//debug.Log("SelectFilter returned %v %v for %q", selectedForRestore, childMayBeSelected, nodeLocation)
 
 		if selectedForRestore {
 			hasRestored = true
@@ -394,7 +394,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) (uint64, error) 
 	// first tree pass: create directories and collect all files to restore
 	err = res.traverseTree(ctx, dst, *res.sn.Tree, treeVisitor{
 		enterDir: func(_ *data.Node, target, location string) error {
-			debug.Log("first pass, enterDir: mkdir %q, leaveDir should restore metadata", location)
+			//debug.Log("first pass, enterDir: mkdir %q, leaveDir should restore metadata", location)
 			if location != string(filepath.Separator) {
 				res.opts.Progress.AddFile(0)
 			}
@@ -402,7 +402,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) (uint64, error) 
 		},
 
 		visitNode: func(node *data.Node, target, location string) error {
-			debug.Log("first pass, visitNode: mkdir %q, leaveDir on second pass should restore metadata", location)
+			//debug.Log("first pass, visitNode: mkdir %q, leaveDir on second pass should restore metadata", location)
 			if err := res.ensureDir(filepath.Dir(target)); err != nil {
 				return err
 			}
@@ -472,7 +472,7 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) (uint64, error) 
 	// second tree pass: restore special files and filesystem metadata
 	err = res.traverseTree(ctx, dst, *res.sn.Tree, treeVisitor{
 		visitNode: func(node *data.Node, target, location string) error {
-			debug.Log("second pass, visitNode: restore node %q", location)
+			//debug.Log("second pass, visitNode: restore node %q", location)
 			if node.Type != data.NodeTypeFile {
 				_, err := res.withOverwriteCheck(ctx, node, target, location, false, nil, func(_ bool, _ *fileState) error {
 					return res.restoreNodeTo(node, target, location)

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -322,18 +322,23 @@ func (res *Restorer) restoreHardlinkAt(node *data.Node, target, path, location s
 
 func (res *Restorer) restoreReflink(node *data.Node, target, path, location string) error {
 	cloned := true
+	var cloneErr error
 	if !res.opts.DryRun {
 		var err error
 		if err = fs.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
 			return errors.Wrap(err, "RemoveNode")
 		}
-		cloned, err = fs.Clone(target, path)
+		cloned, err, cloneErr = fs.Clone(target, path)
 		if err != nil {
 			return errors.WithStack(err)
 		}
 	}
 
 	res.opts.Progress.AddClonedFile(location, node.Size, cloned)
+	if !cloned {
+		fmt.Fprintf(os.Stderr, "warning: could not reflink %v to %v: %v\n", target, path, cloneErr)
+	}
+
 	// reflinked files *do* have separate metadata
 	return res.restoreNodeMetadataTo(node, path, location)
 }

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -43,6 +43,7 @@ type Options struct {
 	Progress        ProgressReporter
 	Overwrite       OverwriteBehavior
 	Delete          bool
+	Reflinks        bool
 	OwnershipByName bool
 }
 

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -450,9 +450,9 @@ func (res *Restorer) RestoreTo(ctx context.Context, dst string) (uint64, error) 
 				return err
 			}
 
-			if idx.Has(node.Inode, node.DeviceID) && idx.Value(node.Inode, node.DeviceID) != location {
+			if orig, hasOrig := idx.Value(node.Inode, node.DeviceID); hasOrig && orig != location {
 				_, err := res.withOverwriteCheck(ctx, node, target, location, true, nil, func(_ bool, _ *fileState) error {
-					return res.restoreHardlinkAt(node, filerestorer.targetPath(idx.Value(node.Inode, node.DeviceID)), target, location)
+					return res.restoreHardlinkAt(node, filerestorer.targetPath(orig), target, location)
 				})
 				return err
 			}

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -333,7 +333,7 @@ func (res *Restorer) restoreReflink(node *data.Node, target, path, location stri
 		}
 	}
 
-	res.opts.Progress.AddProgress(location, ActionFileRestored, node.Size, node.Size)
+	res.opts.Progress.AddClonedFile(location, node.Size, cloned)
 	// reflinked files *do* have separate metadata
 	return res.restoreNodeMetadataTo(node, path, location)
 }

--- a/internal/ui/restore/json.go
+++ b/internal/ui/restore/json.go
@@ -40,9 +40,13 @@ func (t *jsonPrinter) Update(p State, duration time.Duration) {
 		FilesRestored:  p.FilesFinished,
 		FilesSkipped:   p.FilesSkipped,
 		FilesDeleted:   p.FilesDeleted,
+		FilesCloned:    p.FilesCloned,
+		FilesCopied:    p.FilesCopied,
 		TotalBytes:     p.AllBytesTotal,
 		BytesRestored:  p.AllBytesWritten,
 		BytesSkipped:   p.AllBytesSkipped,
+		BytesCloned:    p.AllBytesCloned,
+		BytesCopied:    p.AllBytesCopied,
 	}
 
 	if p.AllBytesTotal > 0 {
@@ -77,6 +81,8 @@ func (t *jsonPrinter) CompleteItem(messageType restorer.ItemAction, item string,
 		action = "restored"
 	case restorer.ActionFileUpdated:
 		action = "updated"
+	case restorer.ActionFileCloned:
+		action = "cloned"
 	case restorer.ActionFileUnchanged:
 		action = "unchanged"
 	case restorer.ActionDeleted:
@@ -102,9 +108,13 @@ func (t *jsonPrinter) Finish(p State, duration time.Duration) {
 		FilesRestored:  p.FilesFinished,
 		FilesSkipped:   p.FilesSkipped,
 		FilesDeleted:   p.FilesDeleted,
+		FilesCloned:    p.FilesCloned,
+		FilesCopied:    p.FilesCopied,
 		TotalBytes:     p.AllBytesTotal,
 		BytesRestored:  p.AllBytesWritten,
 		BytesSkipped:   p.AllBytesSkipped,
+		BytesCloned:    p.AllBytesCloned,
+		BytesCopied:    p.AllBytesCopied,
 	}
 	t.print(status)
 }
@@ -117,9 +127,13 @@ type statusUpdate struct {
 	FilesRestored  uint64  `json:"files_restored,omitempty"`
 	FilesSkipped   uint64  `json:"files_skipped,omitempty"`
 	FilesDeleted   uint64  `json:"files_deleted,omitempty"`
+	FilesCloned    uint64  `json:"files_cloned,omitempty"`
+	FilesCopied    uint64  `json:"files_copied,omitempty"`
 	TotalBytes     uint64  `json:"total_bytes,omitempty"`
 	BytesRestored  uint64  `json:"bytes_restored,omitempty"`
 	BytesSkipped   uint64  `json:"bytes_skipped,omitempty"`
+	BytesCloned    uint64  `json:"bytes_cloned,omitempty"`
+	BytesCopied    uint64  `json:"bytes_copied,omitempty"`
 }
 
 type errorObject struct {
@@ -147,7 +161,11 @@ type summaryOutput struct {
 	FilesRestored  uint64 `json:"files_restored,omitempty"`
 	FilesSkipped   uint64 `json:"files_skipped,omitempty"`
 	FilesDeleted   uint64 `json:"files_deleted,omitempty"`
+	FilesCloned    uint64 `json:"files_cloned,omitempty"`
+	FilesCopied    uint64 `json:"files_copied,omitempty"`
 	TotalBytes     uint64 `json:"total_bytes,omitempty"`
 	BytesRestored  uint64 `json:"bytes_restored,omitempty"`
 	BytesSkipped   uint64 `json:"bytes_skipped,omitempty"`
+	BytesCloned    uint64 `json:"bytes_cloned,omitempty"`
+	BytesCopied    uint64 `json:"bytes_copied,omitempty"`
 }

--- a/internal/ui/restore/json_test.go
+++ b/internal/ui/restore/json_test.go
@@ -18,31 +18,31 @@ func createJSONProgress() (*ui.MockTerminal, ProgressPrinter) {
 
 func TestJSONPrintUpdate(t *testing.T) {
 	term, printer := createJSONProgress()
-	printer.Update(State{3, 11, 0, 0, 29, 47, 0}, 5*time.Second)
+	printer.Update(State{3, 11, 0, 0, 0, 0, 29, 47, 0, 0, 0}, 5*time.Second)
 	test.Equals(t, []string{"{\"message_type\":\"status\",\"seconds_elapsed\":5,\"percent_done\":0.6170212765957447,\"total_files\":11,\"files_restored\":3,\"total_bytes\":47,\"bytes_restored\":29}\n"}, term.Output)
 }
 
 func TestJSONPrintUpdateWithSkipped(t *testing.T) {
 	term, printer := createJSONProgress()
-	printer.Update(State{3, 11, 2, 0, 29, 47, 59}, 5*time.Second)
+	printer.Update(State{3, 11, 2, 0, 0, 0, 29, 47, 59, 0, 0}, 5*time.Second)
 	test.Equals(t, []string{"{\"message_type\":\"status\",\"seconds_elapsed\":5,\"percent_done\":0.6170212765957447,\"total_files\":11,\"files_restored\":3,\"files_skipped\":2,\"total_bytes\":47,\"bytes_restored\":29,\"bytes_skipped\":59}\n"}, term.Output)
 }
 
 func TestJSONPrintSummaryOnSuccess(t *testing.T) {
 	term, printer := createJSONProgress()
-	printer.Finish(State{11, 11, 0, 0, 47, 47, 0}, 5*time.Second)
+	printer.Finish(State{11, 11, 0, 0, 0, 0, 47, 47, 0, 0, 0}, 5*time.Second)
 	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_restored\":11,\"total_bytes\":47,\"bytes_restored\":47}\n"}, term.Output)
 }
 
 func TestJSONPrintSummaryOnErrors(t *testing.T) {
 	term, printer := createJSONProgress()
-	printer.Finish(State{3, 11, 0, 0, 29, 47, 0}, 5*time.Second)
+	printer.Finish(State{3, 11, 0, 0, 0, 0, 29, 47, 0, 0, 0}, 5*time.Second)
 	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_restored\":3,\"total_bytes\":47,\"bytes_restored\":29}\n"}, term.Output)
 }
 
 func TestJSONPrintSummaryOnSuccessWithSkipped(t *testing.T) {
 	term, printer := createJSONProgress()
-	printer.Finish(State{11, 11, 2, 0, 47, 47, 59}, 5*time.Second)
+	printer.Finish(State{11, 11, 2, 0, 0, 0, 47, 47, 59, 0, 0}, 5*time.Second)
 	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":5,\"total_files\":11,\"files_restored\":11,\"files_skipped\":2,\"total_bytes\":47,\"bytes_restored\":47,\"bytes_skipped\":59}\n"}, term.Output)
 }
 

--- a/internal/ui/restore/progress.go
+++ b/internal/ui/restore/progress.go
@@ -14,9 +14,13 @@ type State struct {
 	FilesTotal      uint64
 	FilesSkipped    uint64
 	FilesDeleted    uint64
+	FilesCloned     uint64
+	FilesCopied     uint64
 	AllBytesWritten uint64
 	AllBytesTotal   uint64
 	AllBytesSkipped uint64
+	AllBytesCloned  uint64
+	AllBytesCopied  uint64
 }
 
 type Progress struct {
@@ -45,7 +49,6 @@ type ProgressPrinter interface {
 	restic.Printer
 }
 
-var _ restorer.ProgressReporter = (*Progress)(nil)
 
 func NewProgress(printer ProgressPrinter, quiet, json, canUpdateStatus bool) *Progress {
 	return newProgress(printer, progress.CalculateProgressInterval(!quiet, json, canUpdateStatus))
@@ -108,6 +111,32 @@ func (p *Progress) AddProgress(name string, action restorer.ItemAction, bytesWri
 
 		p.printer.CompleteItem(action, name, bytesTotal)
 	}
+}
+
+// AddClonedFile records progress for a locally copied/cloned file. It is assumed
+// that a file is never partially copied/cloned. The blockCloned flag describes
+// whether the file was cloned using filesystem-specific block cloning facilities
+// (i.e. "reflinks", leading to storage deduplication), or merely copied.
+func (p *Progress) AddClonedFile(name string, size uint64, blockCloned bool) {
+	if p == nil {
+		return
+	}
+
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	p.s.AllBytesWritten += size
+	p.s.FilesFinished++
+
+	if blockCloned {
+		p.s.AllBytesCloned += size
+		p.s.FilesCloned++
+	} else {
+		p.s.AllBytesCopied += size
+		p.s.FilesCopied++
+	}
+
+	p.printer.CompleteItem(restorer.ActionFileCloned, name, size)
 }
 
 func (p *Progress) AddSkippedFile(name string, size uint64) {

--- a/internal/ui/restore/progress_test.go
+++ b/internal/ui/restore/progress_test.go
@@ -75,7 +75,7 @@ func TestNew(t *testing.T) {
 		return false
 	})
 	test.Equals(t, printerTrace{
-		printerTraceEntry{State{0, 0, 0, 0, 0, 0, 0}, 0, false},
+		printerTraceEntry{State{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}, 0, false},
 	}, result)
 	test.Equals(t, itemTrace{}, items)
 }
@@ -88,7 +88,7 @@ func TestAddFile(t *testing.T) {
 		return false
 	})
 	test.Equals(t, printerTrace{
-		printerTraceEntry{State{0, 1, 0, 0, 0, fileSize, 0}, 0, false},
+		printerTraceEntry{State{0, 1, 0, 0, 0, 0, 0, fileSize, 0, 0, 0}, 0, false},
 	}, result)
 	test.Equals(t, itemTrace{}, items)
 }
@@ -103,7 +103,7 @@ func TestFirstProgressOnAFile(t *testing.T) {
 		return false
 	})
 	test.Equals(t, printerTrace{
-		printerTraceEntry{State{0, 1, 0, 0, expectedBytesWritten, expectedBytesTotal, 0}, 0, false},
+		printerTraceEntry{State{0, 1, 0, 0, 0, 0, expectedBytesWritten, expectedBytesTotal, 0, 0, 0}, 0, false},
 	}, result)
 	test.Equals(t, itemTrace{}, items)
 }
@@ -119,7 +119,7 @@ func TestLastProgressOnAFile(t *testing.T) {
 		return false
 	})
 	test.Equals(t, printerTrace{
-		printerTraceEntry{State{1, 1, 0, 0, fileSize, fileSize, 0}, 0, false},
+		printerTraceEntry{State{1, 1, 0, 0, 0, 0, fileSize, fileSize, 0, 0, 0}, 0, false},
 	}, result)
 	test.Equals(t, itemTrace{
 		itemTraceEntry{action: restorer.ActionFileUpdated, item: "test", size: fileSize},
@@ -138,7 +138,7 @@ func TestLastProgressOnLastFile(t *testing.T) {
 		return false
 	})
 	test.Equals(t, printerTrace{
-		printerTraceEntry{State{2, 2, 0, 0, 50 + fileSize, 50 + fileSize, 0}, 0, false},
+		printerTraceEntry{State{2, 2, 0, 0, 0, 0, 50 + fileSize, 50 + fileSize, 0, 0, 0}, 0, false},
 	}, result)
 	test.Equals(t, itemTrace{
 		itemTraceEntry{action: restorer.ActionFileUpdated, item: "test1", size: 50},
@@ -157,7 +157,7 @@ func TestSummaryOnSuccess(t *testing.T) {
 		return true
 	})
 	test.Equals(t, printerTrace{
-		printerTraceEntry{State{2, 2, 0, 0, 50 + fileSize, 50 + fileSize, 0}, mockFinishDuration, true},
+		printerTraceEntry{State{2, 2, 0, 0, 0, 0, 50 + fileSize, 50 + fileSize, 0, 0, 0}, mockFinishDuration, true},
 	}, result)
 }
 
@@ -172,7 +172,7 @@ func TestSummaryOnErrors(t *testing.T) {
 		return true
 	})
 	test.Equals(t, printerTrace{
-		printerTraceEntry{State{1, 2, 0, 0, 50 + fileSize/2, 50 + fileSize, 0}, mockFinishDuration, true},
+		printerTraceEntry{State{1, 2, 0, 0, 0, 0, 50 + fileSize/2, 50 + fileSize, 0, 0, 0}, mockFinishDuration, true},
 	}, result)
 }
 
@@ -184,7 +184,7 @@ func TestSkipFile(t *testing.T) {
 		return true
 	})
 	test.Equals(t, printerTrace{
-		printerTraceEntry{State{0, 0, 1, 0, 0, 0, fileSize}, mockFinishDuration, true},
+		printerTraceEntry{State{0, 0, 1, 0, 0, 0, 0, 0, fileSize, 0, 0}, mockFinishDuration, true},
 	}, result)
 	test.Equals(t, itemTrace{
 		itemTraceEntry{restorer.ActionFileUnchanged, "test", fileSize},

--- a/internal/ui/restore/text.go
+++ b/internal/ui/restore/text.go
@@ -28,10 +28,10 @@ func (t *textPrinter) Update(p State, duration time.Duration) {
 	formattedAllBytesWritten := ui.FormatBytes(p.AllBytesWritten)
 	formattedAllBytesTotal := ui.FormatBytes(p.AllBytesTotal)
 	allPercent := ui.FormatPercent(p.AllBytesWritten, p.AllBytesTotal)
-	progress := fmt.Sprintf("[%s] %s  %v files/dirs %s, total %v files/dirs %v",
+	progress := fmt.Sprintf("[%s] %s  %v files/dirs %s, total %v files/dirs %s",
 		timeLeft, allPercent, p.FilesFinished, formattedAllBytesWritten, p.FilesTotal, formattedAllBytesTotal)
 	if p.FilesSkipped > 0 {
-		progress += fmt.Sprintf(", skipped %v files/dirs %v", p.FilesSkipped, ui.FormatBytes(p.AllBytesSkipped))
+		progress += fmt.Sprintf(", skipped %v files/dirs %s", p.FilesSkipped, ui.FormatBytes(p.AllBytesSkipped))
 	}
 	if p.FilesDeleted > 0 {
 		progress += fmt.Sprintf(", deleted %v files/dirs", p.FilesDeleted)
@@ -86,7 +86,7 @@ func (t *textPrinter) Finish(p State, duration time.Duration) {
 			p.FilesFinished, p.FilesTotal, formattedAllBytesWritten, formattedAllBytesTotal, timeLeft)
 	}
 	if p.FilesSkipped > 0 {
-		summary += fmt.Sprintf(", skipped %v files/dirs %v", p.FilesSkipped, ui.FormatBytes(p.AllBytesSkipped))
+		summary += fmt.Sprintf(", skipped %v files/dirs (%s)", p.FilesSkipped, ui.FormatBytes(p.AllBytesSkipped))
 	}
 	if p.FilesDeleted > 0 {
 		summary += fmt.Sprintf(", deleted %v files/dirs", p.FilesDeleted)

--- a/internal/ui/restore/text.go
+++ b/internal/ui/restore/text.go
@@ -36,6 +36,12 @@ func (t *textPrinter) Update(p State, duration time.Duration) {
 	if p.FilesDeleted > 0 {
 		progress += fmt.Sprintf(", deleted %v files/dirs", p.FilesDeleted)
 	}
+	if p.FilesCloned > 0 {
+		progress += fmt.Sprintf(", cloned %v files %s", p.FilesCloned, ui.FormatBytes(p.AllBytesCloned))
+	}
+	if p.FilesCopied > 0 {
+		progress += fmt.Sprintf(", copied %v files %s", p.FilesCopied, ui.FormatBytes(p.AllBytesCopied))
+	}
 
 	t.terminal.SetStatus([]string{progress})
 }
@@ -54,6 +60,8 @@ func (t *textPrinter) CompleteItem(messageType restorer.ItemAction, item string,
 		action = "restored"
 	case restorer.ActionOtherRestored:
 		action = "restored"
+	case restorer.ActionFileCloned:
+		action = "cloned"
 	case restorer.ActionFileUpdated:
 		action = "updated"
 	case restorer.ActionFileUnchanged:
@@ -90,6 +98,12 @@ func (t *textPrinter) Finish(p State, duration time.Duration) {
 	}
 	if p.FilesDeleted > 0 {
 		summary += fmt.Sprintf(", deleted %v files/dirs", p.FilesDeleted)
+	}
+	if p.FilesCloned > 0 {
+		summary += fmt.Sprintf(", cloned %v files (%s)", p.FilesCloned, ui.FormatBytes(p.AllBytesCloned))
+	}
+	if p.FilesCopied > 0 {
+		summary += fmt.Sprintf(", copied %v files (%s)", p.FilesCopied, ui.FormatBytes(p.AllBytesCopied))
 	}
 
 	t.terminal.Print(summary)

--- a/internal/ui/restore/text_test.go
+++ b/internal/ui/restore/text_test.go
@@ -18,31 +18,31 @@ func createTextProgress() (*ui.MockTerminal, ProgressPrinter) {
 
 func TestPrintUpdate(t *testing.T) {
 	term, printer := createTextProgress()
-	printer.Update(State{3, 11, 0, 0, 29, 47, 0}, 5*time.Second)
+	printer.Update(State{3, 11, 0, 0, 0, 0, 29, 47, 0, 0, 0}, 5*time.Second)
 	test.Equals(t, []string{"[0:05] 61.70%  3 files/dirs 29 B, total 11 files/dirs 47 B"}, term.Output)
 }
 
 func TestPrintUpdateWithSkipped(t *testing.T) {
 	term, printer := createTextProgress()
-	printer.Update(State{3, 11, 2, 0, 29, 47, 59}, 5*time.Second)
+	printer.Update(State{3, 11, 2, 0, 0, 0, 29, 47, 59, 0, 0}, 5*time.Second)
 	test.Equals(t, []string{"[0:05] 61.70%  3 files/dirs 29 B, total 11 files/dirs 47 B, skipped 2 files/dirs 59 B"}, term.Output)
 }
 
 func TestPrintSummaryOnSuccess(t *testing.T) {
 	term, printer := createTextProgress()
-	printer.Finish(State{11, 11, 0, 0, 47, 47, 0}, 5*time.Second)
+	printer.Finish(State{11, 11, 0, 0, 0, 0, 47, 47, 0, 0, 0}, 5*time.Second)
 	test.Equals(t, []string{"Summary: Restored 11 files/dirs (47 B) in 0:05"}, term.Output)
 }
 
 func TestPrintSummaryOnErrors(t *testing.T) {
 	term, printer := createTextProgress()
-	printer.Finish(State{3, 11, 0, 0, 29, 47, 0}, 5*time.Second)
+	printer.Finish(State{3, 11, 0, 0, 0, 0, 29, 47, 0, 0, 0}, 5*time.Second)
 	test.Equals(t, []string{"Summary: Restored 3 / 11 files/dirs (29 B / 47 B) in 0:05"}, term.Output)
 }
 
 func TestPrintSummaryOnSuccessWithSkipped(t *testing.T) {
 	term, printer := createTextProgress()
-	printer.Finish(State{11, 11, 2, 0, 47, 47, 59}, 5*time.Second)
+	printer.Finish(State{11, 11, 2, 0, 0, 0, 47, 47, 59, 0, 0}, 5*time.Second)
 	test.Equals(t, []string{"Summary: Restored 11 files/dirs (47 B) in 0:05, skipped 2 files/dirs (59 B)"}, term.Output)
 }
 

--- a/internal/ui/restore/text_test.go
+++ b/internal/ui/restore/text_test.go
@@ -43,7 +43,7 @@ func TestPrintSummaryOnErrors(t *testing.T) {
 func TestPrintSummaryOnSuccessWithSkipped(t *testing.T) {
 	term, printer := createTextProgress()
 	printer.Finish(State{11, 11, 2, 0, 47, 47, 59}, 5*time.Second)
-	test.Equals(t, []string{"Summary: Restored 11 files/dirs (47 B) in 0:05, skipped 2 files/dirs 59 B"}, term.Output)
+	test.Equals(t, []string{"Summary: Restored 11 files/dirs (47 B) in 0:05, skipped 2 files/dirs (59 B)"}, term.Output)
 }
 
 func TestPrintCompleteItem(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR teaches `restic restore` to detect identical files in the restored set
and reflink them together transparently to the user, instead of writing each
file all over.

Reflinks are a type of on-demand data deduplication implemented by certain
modern (usually copy-on-write) filesystems such as btrfs, zfs or bcachefs
(out of classic filesystems, xfs notably implements reflinks as well).

Unlike other types of links such as hardlinks / symlinks, which cause changes to
one of the linked paths to "bleed through" to other paths, the blocks shared via
reflinks are automatically unshared whenever one of the reflinked files (ranges)
is modified, making it completely safe to use transparently.

If reflinking is not possible (which might be the case if the filesystem does
not support reflinks, or if parts of the restored set are being extracted onto
different mountpoints), a fallback to plain copy is included.

This feature is controlled by the `--reflinks` flag to `restic restore`.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

IRC.

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.

Notes
-----

This is an RFC for early review. I'm using a personal fork of a third party
library as a hash map for non-comparable types (to track the blob IDs), a bunch
of ideas are unimplemented (such as graceful handling of situations where some
reflink operations fail and some don't, such as when extracting onto different
mountpoints), and there's less fallbacks in place than I'd like.
