### PR TITLE
mount: append the repository ID to the name of the FUSE mount

### DIFF
--- a/changelog/unreleased/issue-4868
+++ b/changelog/unreleased/issue-4868
@@ -1,0 +1,14 @@
+Enhancement: Include repository id in filesystem name used by `mount`
+
+The filesystem created by restic's `mount` command now includes the repository
+id in the filesystem name. The repository id is printed by restic when opening
+a repository or can be looked up using `restic cat config`.
+
+```
+[restic-user@hostname restic]$ df ./test-mount/
+Filesystem        1K-blocks  Used Available Use% Mounted on
+restic:d3b07384d1         0     0         0    - /mnt/my-restic-repo
+```
+
+https://github.com/restic/restic/issues/4868
+https://github.com/restic/restic/pull/5243

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -5,6 +5,7 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"time"
@@ -148,9 +149,11 @@ func runMount(ctx context.Context, opts MountOptions, gopts GlobalOptions, args 
 		return err
 	}
 
+	fuseMountName := fmt.Sprintf("restic:%s", repo.Config().ID[:10])
+
 	mountOptions := []systemFuse.MountOption{
 		systemFuse.ReadOnly(),
-		systemFuse.FSName("restic"),
+		systemFuse.FSName(fuseMountName),
 		systemFuse.MaxReadahead(128 * 1024),
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Append the repository ID to the name of the FUSE mount created using the restic `mount` command. When the user is mounting multiple repositories, this makes it easier to understand which repository is mounted where. 

[Edit]
Example output:
```
[konidev20@vm-1 restic]$ df ./test-mount/
Filesystem      1K-blocks  Used Available Use% Mounted on
restic:d3b07384d1         0     0         0    - /home/konidev20/restic/test-mount
```

In the above example the ID `d3b07384d1` is appended to the filesystem name. This is the first 10 characters of the repository ID.
[/Edited]
Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #4868 

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
