### PR TITLE
feat(backends/s3): add warmup support for check command

### DIFF
--- a/changelog/unreleased/issue-3202
+++ b/changelog/unreleased/issue-3202
@@ -1,0 +1,8 @@
+Enhancement: Add warmup support for check command on S3 backend
+
+Like the other cold storage features, warmup support for the `check` command
+remains experimental and gated behind the "s3-restore" feature flag.
+
+https://github.com/restic/restic/pull/5248
+https://github.com/restic/restic/issues/3202
+https://github.com/restic/restic/issues/2504

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -389,10 +389,9 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 	}
 
 	if readDataFilter != nil {
-		p := printer.NewCounter("packs")
 		errChan := make(chan error)
 
-		go chkr.ReadPacks(ctx, readDataFilter, p, errChan)
+		go chkr.ReadPacks(ctx, readDataFilter, printer, errChan)
 
 		for err := range errChan {
 			errorsFound = true
@@ -402,7 +401,6 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 				salvagePacks.Insert(err.PackID)
 			}
 		}
-		p.Done()
 	}
 
 	if len(salvagePacks) > 0 {

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -291,6 +291,7 @@ Archive** storage classes is available:
 - Currently, only the following commands are known to work:
 
   - ``backup``
+  - ``check``
   - ``copy``
   - ``prune``
   - ``restore``

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -292,10 +292,10 @@ func (c *Checker) UnusedBlobs(ctx context.Context) (blobs restic.BlobHandles, er
 // with an unmodified parameter list
 // Otherwise it calculates the packfiles needed, gets their sizes from the full
 // packfile set and submits them to repository.ReadPacks()
-func (c *Checker) ReadPacks(ctx context.Context, filter func(packs map[restic.ID]int64) map[restic.ID]int64, p restic.Counter, errChan chan<- error) {
+func (c *Checker) ReadPacks(ctx context.Context, filter func(packs map[restic.ID]int64) map[restic.ID]int64, printer restic.Printer, errChan chan<- error) {
 	// no snapshot filtering, pass through
 	if !c.IsFiltered() {
-		c.Checker.ReadPacks(ctx, filter, p, errChan)
+		c.Checker.ReadPacks(ctx, filter, printer, errChan)
 		return
 	}
 
@@ -314,5 +314,5 @@ func (c *Checker) ReadPacks(ctx context.Context, filter func(packs map[restic.ID
 		return filter(filteredPacks)
 	}
 
-	c.Checker.ReadPacks(ctx, packfileFilter, p, errChan)
+	c.Checker.ReadPacks(ctx, packfileFilter, printer, errChan)
 }

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -58,7 +58,7 @@ func checkData(chkr *checker.Checker) []error {
 		func(ctx context.Context, errCh chan<- error) {
 			chkr.ReadPacks(ctx, func(packs map[restic.ID]int64) map[restic.ID]int64 {
 				return packs
-			}, restic.NoopCounter, errCh)
+			}, restic.NewNoopPrinter(), errCh)
 		},
 	)
 }

--- a/internal/checker/testing.go
+++ b/internal/checker/testing.go
@@ -55,7 +55,7 @@ func TestCheckRepo(t testing.TB, repo checkerRepository) {
 	errChan = make(chan error)
 	go chkr.ReadPacks(context.TODO(), func(packs map[restic.ID]int64) map[restic.ID]int64 {
 		return packs
-	}, restic.NoopCounter, errChan)
+	}, restic.NewNoopPrinter(), errChan)
 
 	for err := range errChan {
 		t.Error(err)

--- a/internal/repository/checker.go
+++ b/internal/repository/checker.go
@@ -12,6 +12,7 @@ import (
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/feature"
 	"github.com/restic/restic/internal/repository/hashing"
 	"github.com/restic/restic/internal/repository/index"
 	"github.com/restic/restic/internal/repository/pack"
@@ -243,7 +244,7 @@ func (c *Checker) Packs(ctx context.Context, errChan chan<- error) {
 }
 
 // ReadPacks loads data from specified packs and checks the integrity.
-func (c *Checker) ReadPacks(ctx context.Context, filter func(packs map[restic.ID]int64) map[restic.ID]int64, p restic.Counter, errChan chan<- error) {
+func (c *Checker) ReadPacks(ctx context.Context, filter func(packs map[restic.ID]int64) map[restic.ID]int64, printer restic.Printer, errChan chan<- error) {
 	defer close(errChan)
 
 	// compute pack size using index entries
@@ -253,7 +254,30 @@ func (c *Checker) ReadPacks(ctx context.Context, filter func(packs map[restic.ID
 		return
 	}
 	packs = filter(packs)
+
+	p := printer.NewCounter("packs")
 	p.SetMax(uint64(len(packs)))
+	defer p.Done()
+
+	packSet := restic.NewIDSet()
+	for pack := range packs {
+		packSet.Insert(pack)
+	}
+
+	if feature.Flag.Enabled(feature.S3Restore) {
+		job, err := c.repo.StartWarmup(ctx, packSet)
+		if err != nil {
+			errChan <- err
+			return
+		}
+		if job.HandleCount() != 0 {
+			printer.P("warming up %d packs from cold storage, this may take a while...", job.HandleCount())
+			if err := job.Wait(ctx); err != nil {
+				errChan <- err
+				return
+			}
+		}
+	}
 
 	g, ctx := errgroup.WithContext(ctx)
 	type checkTask struct {
@@ -300,11 +324,6 @@ func (c *Checker) ReadPacks(ctx context.Context, filter func(packs map[restic.ID
 				}
 			}
 		})
-	}
-
-	packSet := restic.NewIDSet()
-	for pack := range packs {
-		packSet.Insert(pack)
 	}
 
 	// push packs to ch

--- a/internal/repository/checker_test.go
+++ b/internal/repository/checker_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/feature"
 	"github.com/restic/restic/internal/repository/pack"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
@@ -91,7 +92,7 @@ func runReadPacks(chkr *Checker) []error {
 		func(ctx context.Context, errCh chan<- error) {
 			chkr.ReadPacks(ctx, func(packs map[restic.ID]int64) map[restic.ID]int64 {
 				return packs
-			}, restic.NoopCounter, errCh)
+			}, restic.NewNoopPrinter(), errCh)
 		})
 }
 
@@ -223,4 +224,37 @@ func TestCheckPackPartialDownloadError(t *testing.T) {
 		rtest.Assert(t, errors.As(err, &packErr),
 			"partial read must produce ErrPackData, got: %T %v", err, err)
 	}
+}
+
+// warmupBackend simulates a backend where all handles needs to be warmed up.
+type warmupBackend struct {
+	backend.Backend
+	handlesToWarmup []backend.Handle
+	handlesAwaited  []backend.Handle
+}
+
+func (be *warmupBackend) Warmup(_ context.Context, h []backend.Handle) ([]backend.Handle, error) {
+	be.handlesToWarmup = append(be.handlesToWarmup, h...)
+	return h, nil
+}
+
+func (be *warmupBackend) WarmupWait(_ context.Context, h []backend.Handle) error {
+	be.handlesAwaited = append(be.handlesAwaited, h...)
+	return nil
+}
+
+func TestCheckerWarmup(t *testing.T) {
+	defer feature.TestSetFlag(t, feature.Flag, feature.S3Restore, true)()
+
+	var wBackend *warmupBackend
+	chkr := setupChecker(t, func(be backend.Backend) backend.Backend {
+		wBackend = &warmupBackend{Backend: be}
+		return wBackend
+	})
+
+	errs := runReadPacks(chkr)
+	rtest.Assert(t, len(errs) == 0, "expected no data error, got %v: %v", len(errs), errs)
+
+	rtest.Assert(t, len(wBackend.handlesToWarmup) > 0, "found no handles to warmup")
+	rtest.Equals(t, wBackend.handlesToWarmup, wBackend.handlesAwaited, "expected to wait for all cold handles")
 }

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -189,7 +189,7 @@ func TestCheckRepo(t testing.TB, repo *Repository) {
 	errChan = make(chan error)
 	go chkr.ReadPacks(context.TODO(), func(packs map[restic.ID]int64) map[restic.ID]int64 {
 		return packs
-	}, restic.NoopCounter, errChan)
+	}, restic.NewNoopPrinter(), errChan)
 
 	for err := range errChan {
 		t.Error(err)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Follow-up from https://github.com/restic/restic/pull/5173, implements warmup support from cold storage in `check` command.

See also https://github.com/restic/restic/issues/3202

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

No, but it follows closely what has been done in https://github.com/restic/restic/pull/5173 .

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
  - ➡️ ~~Testing this change requires mocking the `Repository` struct in `checker`. It looks like a lot of work to test a mock… WDYT? Is there a better way?~~
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
  - ➡️ ~~I've edited the existing changelog because it is not released yet, but if there's a release before this PR gets merged, then I'll create a new one.~~
- [x] I'm done! This pull request is ready for review.
