### PR TITLE
Prevent creation of oversized indexes and automatically rewrite them.

### DIFF
--- a/changelog/unreleased/pull-5249
+++ b/changelog/unreleased/pull-5249
@@ -1,0 +1,10 @@
+Bugfix: Fix creation of oversized indexes by `repair index --read-all-packs`
+
+Since restic 0.17.0, the new index created by `repair index --read-all-packs` was
+written as a single large index. This significantly increases memory usage while
+loading the index.
+
+The index is now correctly split into multiple smaller indexes. `repair index` now
+also automatically splits oversized indexes.
+
+https://github.com/restic/restic/pull/5249

--- a/internal/repository/index/associated_data_test.go
+++ b/internal/repository/index/associated_data_test.go
@@ -35,8 +35,8 @@ func TestAssociatedSet(t *testing.T) {
 	bh, blob := makeFakePackedBlob()
 
 	mi := NewMasterIndex()
-	mi.StorePack(blob.PackID, []restic.Blob{blob.Blob})
-	test.OK(t, mi.SaveIndex(context.TODO(), &noopSaver{}))
+	test.OK(t, mi.StorePack(context.TODO(), blob.PackID, []restic.Blob{blob.Blob}, &noopSaver{}))
+	test.OK(t, mi.Flush(context.TODO(), &noopSaver{}))
 
 	bs := NewAssociatedSet[uint8](mi)
 	test.Equals(t, bs.Len(), 0)
@@ -118,15 +118,15 @@ func TestAssociatedSetWithExtendedIndex(t *testing.T) {
 	_, blob := makeFakePackedBlob()
 
 	mi := NewMasterIndex()
-	mi.StorePack(blob.PackID, []restic.Blob{blob.Blob})
-	test.OK(t, mi.SaveIndex(context.TODO(), &noopSaver{}))
+	test.OK(t, mi.StorePack(context.TODO(), blob.PackID, []restic.Blob{blob.Blob}, &noopSaver{}))
+	test.OK(t, mi.Flush(context.TODO(), &noopSaver{}))
 
 	bs := NewAssociatedSet[uint8](mi)
 
 	// add new blobs to index after building the set
 	of, blob2 := makeFakePackedBlob()
-	mi.StorePack(blob2.PackID, []restic.Blob{blob2.Blob})
-	test.OK(t, mi.SaveIndex(context.TODO(), &noopSaver{}))
+	test.OK(t, mi.StorePack(context.TODO(), blob2.PackID, []restic.Blob{blob2.Blob}, &noopSaver{}))
+	test.OK(t, mi.Flush(context.TODO(), &noopSaver{}))
 
 	// non-existent
 	test.Equals(t, false, bs.Has(of))

--- a/internal/repository/index/index_internal_test.go
+++ b/internal/repository/index/index_internal_test.go
@@ -1,0 +1,40 @@
+package index
+
+import (
+	"testing"
+
+	"github.com/restic/restic/internal/repository/pack"
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestIndexOversized(t *testing.T) {
+	idx := NewIndex()
+
+	// Add blobs up to indexMaxBlobs + pack.MaxHeaderEntries - 1
+	packID := idx.addToPacks(restic.NewRandomID())
+	for i := uint(0); i < indexMaxBlobs+pack.MaxHeaderEntries-1; i++ {
+		idx.store(packID, restic.Blob{
+			BlobHandle: restic.BlobHandle{
+				Type: restic.DataBlob,
+				ID:   restic.NewRandomID(),
+			},
+			Length: 100,
+			Offset: uint(i) * 100,
+		})
+	}
+
+	rtest.Assert(t, !IndexOversized(idx), "index should not be considered oversized")
+
+	// Add one more blob to exceed the limit
+	idx.store(packID, restic.Blob{
+		BlobHandle: restic.BlobHandle{
+			Type: restic.DataBlob,
+			ID:   restic.NewRandomID(),
+		},
+		Length: 100,
+		Offset: uint(indexMaxBlobs+pack.MaxHeaderEntries) * 100,
+	})
+
+	rtest.Assert(t, IndexOversized(idx), "index should be considered oversized")
+}

--- a/internal/repository/index/master_index.go
+++ b/internal/repository/index/master_index.go
@@ -153,7 +153,12 @@ func (mi *MasterIndex) Insert(idx *Index) {
 }
 
 // StorePack remembers the id and pack in the index.
-func (mi *MasterIndex) StorePack(id restic.ID, blobs []restic.Blob) {
+func (mi *MasterIndex) StorePack(ctx context.Context, id restic.ID, blobs []restic.Blob, r restic.SaverUnpacked[restic.FileType]) error {
+	mi.storePack(id, blobs)
+	return mi.saveFullIndex(ctx, r)
+}
+
+func (mi *MasterIndex) storePack(id restic.ID, blobs []restic.Blob) {
 	mi.idxMutex.Lock()
 	defer mi.idxMutex.Unlock()
 
@@ -589,13 +594,13 @@ func (mi *MasterIndex) saveIndex(ctx context.Context, r restic.SaverUnpacked[res
 	return mi.MergeFinalIndexes()
 }
 
-// SaveIndex saves all new indexes in the backend.
-func (mi *MasterIndex) SaveIndex(ctx context.Context, r restic.SaverUnpacked[restic.FileType]) error {
+// Flush saves all new indexes in the backend.
+func (mi *MasterIndex) Flush(ctx context.Context, r restic.SaverUnpacked[restic.FileType]) error {
 	return mi.saveIndex(ctx, r, mi.finalizeNotFinalIndexes()...)
 }
 
-// SaveFullIndex saves all full indexes in the backend.
-func (mi *MasterIndex) SaveFullIndex(ctx context.Context, r restic.SaverUnpacked[restic.FileType]) error {
+// saveFullIndex saves all full indexes in the backend.
+func (mi *MasterIndex) saveFullIndex(ctx context.Context, r restic.SaverUnpacked[restic.FileType]) error {
 	return mi.saveIndex(ctx, r, mi.finalizeFullIndexes()...)
 }
 

--- a/internal/repository/index/master_index.go
+++ b/internal/repository/index/master_index.go
@@ -419,7 +419,7 @@ func (mi *MasterIndex) Rewrite(ctx context.Context, repo restic.Unpacked[restic.
 		newIndex := NewIndex()
 		for task := range rewriteCh {
 			// always rewrite indexes that include a pack that must be removed or that are not full
-			if len(task.idx.Packs().Intersect(excludePacks)) == 0 && IndexFull(task.idx) {
+			if len(task.idx.Packs().Intersect(excludePacks)) == 0 && IndexFull(task.idx) && !IndexOversized(task.idx) {
 				// make sure that each pack is only stored exactly once in the index
 				excludePacks.Merge(task.idx.Packs())
 				// index is already up to date

--- a/internal/repository/pack/pack.go
+++ b/internal/repository/pack/pack.go
@@ -215,6 +215,11 @@ const (
 	eagerEntries = 15
 )
 
+var (
+	// MaxHeaderEntries is the number of entries a pack file can contain at most
+	MaxHeaderEntries = (MaxHeaderSize - headerSize) / entrySize
+)
+
 // readRecords reads up to bufsize bytes from the underlying ReaderAt, returning
 // the raw header, the total number of bytes in the header, and any error.
 // If the header contains fewer than bufsize bytes, the header is truncated to

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -187,8 +187,5 @@ func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *packe
 
 	// update blobs in the index
 	debug.Log("  updating blobs %v to pack %v", p.Packer.Blobs(), id)
-	r.idx.StorePack(id, p.Packer.Blobs())
-
-	// Save index if full
-	return r.idx.SaveFullIndex(ctx, &internalRepository{r})
+	return r.idx.StorePack(ctx, id, p.Packer.Blobs(), &internalRepository{r})
 }

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -542,7 +542,7 @@ func (r *Repository) Flush(ctx context.Context) error {
 		return err
 	}
 
-	return r.idx.SaveIndex(ctx, &internalRepository{r})
+	return r.idx.Flush(ctx, &internalRepository{r})
 }
 
 func (r *Repository) StartPackUploader(ctx context.Context, wg *errgroup.Group) {
@@ -701,7 +701,9 @@ func (r *Repository) createIndexFromPacks(ctx context.Context, packsize map[rest
 				invalid = append(invalid, fi.ID)
 				m.Unlock()
 			}
-			r.idx.StorePack(fi.ID, entries)
+			if err := r.idx.StorePack(ctx, fi.ID, entries, &internalRepository{r}); err != nil {
+				return err
+			}
 			p.Add(1)
 		}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Since restic 0.17.0, `restic repair index --read-all-packs` creates a single large index, which significantly increases memory consumption. The PR changes the `MasterIndex.StorePack` method signature to prevent incorrect usages (aka. not immediately uploading full indexes).

In addition, `restic repair index` now automatically rewrites such oversized indexes.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://forum.restic.net/t/fix-broken-snapshot/9051
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
