### PR TITLE
Native/parallel backup of block devices

### DIFF
--- a/changelog/unreleased/pull-5250
+++ b/changelog/unreleased/pull-5250
@@ -1,0 +1,12 @@
+Enhancement: Support native/parallel backup of block devices
+
+Backing up large block devices used to take a long time because Restic
+had no native support for it and required passing the content of the device
+to stdin, which meant that reading was performed linearly. It now supports
+the --read-special flag, which reads the content of block devices and
+follows symlinks pointing to them, and the --block-size option, which
+divides each file into blocks of the specified size in gigabytes,
+allowing them to be read in parallel.
+
+https://github.com/restic/restic/pull/5250
+https://forum.restic.net/t/native-parallel-backup-of-block-devices/8641

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -103,6 +103,7 @@ type BackupOptions struct {
 	ReadConcurrency   uint
 	NoScan            bool
 	SkipIfUnchanged   bool
+	ReadSpecial       bool
 }
 
 func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
@@ -143,6 +144,9 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 		f.BoolVar(&opts.ExcludeCloudFiles, "exclude-cloud-files", false, "excludes online-only cloud files (such as OneDrive Files On-Demand)")
 	}
 	f.BoolVar(&opts.SkipIfUnchanged, "skip-if-unchanged", false, "skip snapshot creation if identical to parent snapshot")
+	if runtime.GOOS == "linux" {
+		f.BoolVar(&opts.ReadSpecial, "read-special", false, "backup block devices as well as follow symlinks pointing to block devices")
+	}
 
 	// parse read concurrency from env, on error the default value will be used
 	readConcurrency, _ := strconv.ParseUint(os.Getenv("RESTIC_READ_CONCURRENCY"), 10, 32)
@@ -634,6 +638,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 	arch.SelectByName = selectByNameFilter
 	arch.Select = selectFilter
 	arch.WithAtime = opts.WithAtime
+	arch.ReadSpecial = opts.ReadSpecial
 	success := true
 	arch.Error = func(item string, err error) error {
 		success = false

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -550,7 +550,7 @@ The characters left of the file path show what has changed for this file:
 Backing up special items and metadata
 *************************************
 
-**Symlinks** are archived as symlinks, ``restic`` does not follow them.
+In general, **symlinks** are archived as symlinks, ``restic`` does not follow them.
 When you restore, you get the same symlink again, with the same link target
 and the same timestamps.
 
@@ -559,6 +559,10 @@ If there is a **bind-mount** below a directory that is to be saved, restic desce
 **Device files** are saved and restored as device files. This means that e.g. ``/dev/sda`` is
 archived as a block device file and restored as such. This also means that the content of the
 corresponding disk is not read, at least not from the device file.
+
+However, if ``--read-special`` is set, ``restic`` will follow symlinks pointing to block
+devices and read their content, which can later be restored with the ``dump`` command.
+Currently only supported on linux.
 
 By default, restic does not save the access time (atime) for any files or other
 items, since it is not possible to reliably disable updating the access time by
@@ -578,6 +582,22 @@ particular note are:
 
 * File creation date on Unix platforms
 * Inode flags on Unix platforms
+
+Parallelizing file reading
+**************************
+
+For large files it could be beneficial to split them into blocks and read those
+blocks concurrently.
+
+In order to do that, specify the ``--block-size`` option followed by the desired
+block size in gigabytes in your ``backup`` command.  In that case, ``RESTIC_READ_CONCURRENCY``
+will correspond to the amount of threads used to read each file.
+
+.. warning::
+
+    Backing up the same file with different block sizes might not result in identical
+    backups blob-wise. This means that changing the block size could lead to additional
+    data needing to be stored.
 
 Reading data from a command
 ***************************

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -554,7 +554,7 @@ func rename(t testing.TB, oldname, newname string) {
 func nodeFromFile(t testing.TB, localFs fs.FS, filename string) *restic.Node {
 	meta, err := localFs.OpenFile(filename, fs.O_NOFOLLOW, true)
 	rtest.OK(t, err)
-	node, err := meta.ToNode(false)
+	node, err := meta.ToNode(false, false)
 	rtest.OK(t, err)
 	rtest.OK(t, meta.Close())
 
@@ -2241,9 +2241,9 @@ func (f overrideFile) MakeReadable() error {
 	return f.File.MakeReadable()
 }
 
-func (f overrideFile) ToNode(ignoreXattrListError bool) (*restic.Node, error) {
+func (f overrideFile) ToNode(ignoreXattrListError, _ bool) (*restic.Node, error) {
 	if f.ofs.overrideNode == nil {
-		return f.File.ToNode(ignoreXattrListError)
+		return f.File.ToNode(ignoreXattrListError, false)
 	}
 	return f.ofs.overrideNode, f.ofs.overrideErr
 }
@@ -2275,7 +2275,7 @@ func TestMetadataChanged(t *testing.T) {
 	localFS := &fs.Local{}
 	meta, err := localFS.OpenFile("testfile", fs.O_NOFOLLOW, true)
 	rtest.OK(t, err)
-	want, err := meta.ToNode(false)
+	want, err := meta.ToNode(false, false)
 	rtest.OK(t, err)
 	rtest.OK(t, meta.Close())
 
@@ -2409,7 +2409,7 @@ type mockToNoder struct {
 	err  error
 }
 
-func (m *mockToNoder) ToNode(_ bool) (*restic.Node, error) {
+func (m *mockToNoder) ToNode(_, _ bool) (*restic.Node, error) {
 	return m.node, m.err
 }
 

--- a/internal/archiver/file_saver.go
+++ b/internal/archiver/file_saver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"math"
 	"sync"
 
 	"github.com/restic/chunker"
@@ -29,16 +30,27 @@ type fileSaver struct {
 	CompleteBlob func(bytes uint64)
 
 	NodeFromFileInfo func(snPath, filename string, meta ToNoder, ignoreXattrListError bool) (*restic.Node, error)
+
+	perFileWorkers uint
+	blockSize      uint
 }
 
 // newFileSaver returns a new file saver. A worker pool with fileWorkers is
 // started, it is stopped when ctx is cancelled.
-func newFileSaver(ctx context.Context, wg *errgroup.Group, save saveBlobFn, pol chunker.Pol, fileWorkers, blobWorkers uint) *fileSaver {
+func newFileSaver(ctx context.Context, wg *errgroup.Group, save saveBlobFn, pol chunker.Pol, fileWorkers, blobWorkers, blockSize uint) *fileSaver {
 	ch := make(chan saveFileJob)
 
 	debug.Log("new file saver with %v file workers and %v blob workers", fileWorkers, blobWorkers)
 
 	poolSize := fileWorkers + blobWorkers
+
+	var perFileWorkers uint
+	if blockSize == 0 {
+		perFileWorkers = 1
+	} else {
+		perFileWorkers = fileWorkers
+		fileWorkers = 1
+	}
 
 	s := &fileSaver{
 		saveBlob:     save,
@@ -47,6 +59,9 @@ func newFileSaver(ctx context.Context, wg *errgroup.Group, save saveBlobFn, pol 
 		ch:           ch,
 
 		CompleteBlob: func(uint64) {},
+
+		perFileWorkers: perFileWorkers,
+		blockSize:      blockSize,
 	}
 
 	for i := uint(0); i < fileWorkers; i++ {
@@ -72,6 +87,7 @@ type fileCompleteFunc func(*restic.Node, ItemStats)
 // this will always happen before calling complete.
 func (s *fileSaver) Save(ctx context.Context, snPath string, target string, file fs.File, start func(), completeReading func(), complete fileCompleteFunc) futureNode {
 	fn, ch := newFutureNode()
+
 	job := saveFileJob{
 		snPath: snPath,
 		target: target,
@@ -106,7 +122,7 @@ type saveFileJob struct {
 }
 
 // saveFile stores the file f in the repo, then closes it.
-func (s *fileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPath string, target string, f fs.File, start func(), finishReading func(), finish func(res futureNodeResult)) {
+func (s *fileSaver) saveFile(ctx context.Context, chnkers []*chunker.Chunker, snPath string, target string, f fs.File, start func(), finishReading func(), finish func(res futureNodeResult)) {
 	start()
 
 	fnr := futureNodeResult{
@@ -114,27 +130,8 @@ func (s *fileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 		target: target,
 	}
 	var lock sync.Mutex
-	remaining := 0
 	isCompleted := false
 
-	completeBlob := func() {
-		lock.Lock()
-		defer lock.Unlock()
-
-		remaining--
-		if remaining == 0 && fnr.err == nil {
-			if isCompleted {
-				panic("completed twice")
-			}
-			for _, id := range fnr.node.Content {
-				if id.IsNull() {
-					panic("completed file with null ID")
-				}
-			}
-			isCompleted = true
-			finish(fnr)
-		}
-	}
 	completeError := func(err error) {
 		lock.Lock()
 		defer lock.Unlock()
@@ -166,65 +163,126 @@ func (s *fileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 		return
 	}
 
-	// reuse the chunker
-	chnker.Reset(f, s.pol)
+	fileSize := uint(node.Size)
 
-	node.Content = []restic.ID{}
-	node.Size = 0
-	var idx int
-	for {
-		buf := s.saveFilePool.Get()
-		chunk, err := chnker.Next(buf.Data)
-		if err == io.EOF {
-			buf.Release()
-			break
-		}
+	remaining := 0
+	var blockCount uint
+	if s.blockSize == 0 {
+		blockCount = 0
+	} else {
+		// simply an integer division but with rounding up
+		blockCount = (fileSize + s.blockSize) / s.blockSize
+	}
 
-		buf.Data = chunk.Data
-		node.Size += uint64(chunk.Length)
+	contentByBlock := make([]*[]restic.ID, 0, blockCount)
 
-		if err != nil {
-			_ = f.Close()
-			completeError(err)
-			return
-		}
-		// test if the context has been cancelled, return the error
-		if ctx.Err() != nil {
-			_ = f.Close()
-			completeError(ctx.Err())
-			return
-		}
-
-		// add a place to store the saveBlob result
-		pos := idx
-
+	completeBlob := func(blobLength, blobSize, blobSizeInRepo uint64, blobKnown bool) {
 		lock.Lock()
-		node.Content = append(node.Content, restic.ID{})
-		lock.Unlock()
+		defer lock.Unlock()
 
-		s.saveBlob(ctx, restic.DataBlob, buf, target, func(sbr saveBlobResponse) {
-			lock.Lock()
-			if !sbr.known {
-				fnr.stats.DataBlobs++
-				fnr.stats.DataSize += uint64(sbr.length)
-				fnr.stats.DataSizeInRepo += uint64(sbr.sizeInRepo)
+		fnr.node.Size += blobSize
+
+		if !blobKnown {
+			fnr.stats.DataBlobs++
+			fnr.stats.DataSize += blobLength
+			fnr.stats.DataSizeInRepo += blobSizeInRepo
+		}
+
+		remaining--
+		if remaining == 0 && fnr.err == nil {
+			if isCompleted {
+				panic("completed twice")
+			}
+			isCompleted = true
+
+			if len(contentByBlock) == 1 {
+				// don't copy the content
+				fnr.node.Content = *contentByBlock[0]
+			} else {
+				// count the total amount of blobs in order to preallocate memory
+				totalBlobs := 0
+				for _, blockContent := range contentByBlock {
+					totalBlobs += len(*blockContent)
+				}
+
+				fnr.node.Content = make([]restic.ID, 0, totalBlobs)
+				for _, blockContent := range contentByBlock {
+					fnr.node.Content = append(fnr.node.Content, *blockContent...)
+				}
 			}
 
-			node.Content[pos] = sbr.id
-			lock.Unlock()
+			for _, id := range fnr.node.Content {
+				if id.IsNull() {
+					panic("completed file with null ID")
+				}
+			}
 
-			completeBlob()
-		})
-		idx++
-
-		// test if the context has been cancelled, return the error
-		if ctx.Err() != nil {
-			_ = f.Close()
-			completeError(ctx.Err())
-			return
+			finish(fnr)
 		}
+	}
 
-		s.CompleteBlob(uint64(len(chunk.Data)))
+	// reset node size, as we're going to calculate it
+	node.Size = 0
+	fnr.node = node
+
+	jobs := make(chan processBlobJob)
+	results := make(chan int)
+	wg, wgCtx := errgroup.WithContext(ctx)
+
+	for i := 0; i < len(chnkers); i++ {
+		chnkerNum := i
+		wg.Go(func() error {
+			return s.processBlobWorker(jobs, results, chnkers[chnkerNum], wgCtx, target, f, &lock, completeBlob)
+		})
+	}
+
+	wg.Go(func() error {
+		defer close(jobs)
+
+		offsetStart := uint(0)
+		for offsetStart < fileSize || fileSize == 0 {
+			nextOffsetStart := offsetStart + s.blockSize
+			var blockSize int64
+			if nextOffsetStart < fileSize || s.blockSize == 0 {
+				blockSize = int64(s.blockSize)
+			} else {
+				// read the remains in case the file has grown in size
+				blockSize = math.MaxInt64
+			}
+
+			targetContent := make([]restic.ID, 0)
+			contentByBlock = append(contentByBlock, &targetContent)
+			select {
+			case jobs <- processBlobJob{&targetContent, int64(offsetStart), blockSize}:
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+
+			if s.blockSize == 0 || fileSize == 0 {
+				break
+			}
+			offsetStart = nextOffsetStart
+		}
+		return nil
+	})
+
+	go func() {
+		wg.Wait()
+		close(results)
+	}()
+
+	totalChunks := 0
+
+	for result := range results {
+		totalChunks += result
+	}
+
+	// at this point wg has been awaited - but we need to process errors
+	err = wg.Wait()
+	if err != nil {
+		_ = f.Close()
+		completeError(err)
+		return
 	}
 
 	err = f.Close()
@@ -233,19 +291,125 @@ func (s *fileSaver) saveFile(ctx context.Context, chnker *chunker.Chunker, snPat
 		return
 	}
 
-	fnr.node = node
 	lock.Lock()
 	// require one additional completeFuture() call to ensure that the future only completes
 	// after reaching the end of this method
-	remaining += idx + 1
+	remaining += totalChunks + 1
 	lock.Unlock()
 	finishReading()
-	completeBlob()
+	completeBlob(0, 0, 0, true)
+}
+
+type processBlobJob struct {
+	targetContent *[]restic.ID
+	offsetStart   int64
+	blockSize     int64
+}
+
+func (s *fileSaver) processBlobWorker(
+	jobs <-chan processBlobJob,
+	results chan<- int,
+	chnker *chunker.Chunker,
+	ctx context.Context,
+	target string,
+	f fs.File,
+	lock *sync.Mutex,
+	completeBlob func(uint64, uint64, uint64, bool),
+) error {
+
+	for {
+		var job processBlobJob
+		var ok bool
+		select {
+		case <-ctx.Done():
+			return nil
+		case job, ok = <-jobs:
+			if !ok {
+				return nil
+			}
+		}
+		var reader io.Reader
+		if job.blockSize == 0 {
+			// '0' indicates that we do not cut the file in parts
+			reader = f
+		} else {
+			reader = io.NewSectionReader(f, job.offsetStart, job.blockSize)
+		}
+		chunksCount, err := s.processBlobs(ctx, target, reader, lock, completeBlob, chnker, job.targetContent)
+		if err != nil {
+			return err
+		}
+		results <- chunksCount
+	}
+}
+
+func (s *fileSaver) processBlobs(
+	ctx context.Context,
+	target string,
+	f io.Reader,
+	lock *sync.Mutex,
+	completeBlob func(uint64, uint64, uint64, bool),
+	chnker *chunker.Chunker,
+	targetContent *[]restic.ID,
+) (int, error) {
+
+	var chunksCount int
+	chnker.Reset(f, s.pol)
+
+	for {
+		buf := s.saveFilePool.Get()
+		chunk, err := chnker.Next(buf.Data)
+		if err == io.EOF {
+			buf.Release()
+			break
+		}
+
+		if err != nil {
+			return 0, err
+		}
+
+		buf.Data = chunk.Data
+
+		// test if the context has been cancelled, return the error
+		if ctx.Err() != nil {
+			return 0, ctx.Err()
+		}
+
+		// redefinition of pos and on each iteration is needed as we pass it to saveBlob cb
+		pos := chunksCount
+		size := uint64(chunk.Length)
+
+		// add a place to store the saveBlob result
+		lock.Lock()
+		*targetContent = append(*targetContent, restic.ID{})
+		lock.Unlock()
+
+		s.saveBlob(ctx, restic.DataBlob, buf, target, func(sbr saveBlobResponse) {
+			lock.Lock()
+			(*targetContent)[pos] = sbr.id
+			lock.Unlock()
+
+			completeBlob(uint64(sbr.length), size, uint64(sbr.sizeInRepo), sbr.known)
+		})
+		chunksCount++
+
+		// test if the context has been cancelled, return the error
+		if ctx.Err() != nil {
+			return 0, ctx.Err()
+		}
+
+		s.CompleteBlob(uint64(len(chunk.Data)))
+	}
+	return chunksCount, nil
 }
 
 func (s *fileSaver) worker(ctx context.Context, jobs <-chan saveFileJob) {
-	// a worker has one chunker which is reused for each file (because it contains a rather large buffer)
-	chnker := chunker.New(nil, s.pol)
+	// each worker has a fixed amount of chunkers which are reused for each file (because they contain a rather large buffer)
+	chunkersAmount := int(s.perFileWorkers)
+	chnkers := make([]*chunker.Chunker, chunkersAmount)
+	for i := 0; i < chunkersAmount; i++ {
+		chnkers[i] = chunker.New(nil, s.pol)
+	}
 
 	for {
 		var job saveFileJob
@@ -259,7 +423,7 @@ func (s *fileSaver) worker(ctx context.Context, jobs <-chan saveFileJob) {
 			}
 		}
 
-		s.saveFile(ctx, chnker, job.snPath, job.target, job.file, job.start, func() {
+		s.saveFile(ctx, chnkers, job.snPath, job.target, job.file, job.start, func() {
 			if job.completeReading != nil {
 				job.completeReading()
 			}

--- a/internal/archiver/file_saver_test.go
+++ b/internal/archiver/file_saver_test.go
@@ -50,7 +50,7 @@ func startFileSaver(ctx context.Context, t testing.TB, fsInst fs.FS) (*fileSaver
 
 	s := newFileSaver(ctx, wg, saveBlob, pol, workers, workers)
 	s.NodeFromFileInfo = func(snPath, filename string, meta ToNoder, ignoreXattrListError bool) (*restic.Node, error) {
-		return meta.ToNode(ignoreXattrListError)
+		return meta.ToNode(ignoreXattrListError, false)
 	}
 
 	return s, ctx, wg

--- a/internal/fs/fs_local.go
+++ b/internal/fs/fs_local.go
@@ -163,6 +163,10 @@ func (f *localFile) Read(p []byte) (n int, err error) {
 	return f.f.Read(p)
 }
 
+func (f *localFile) ReadAt(p []byte, off int64) (n int, err error) {
+	return f.f.ReadAt(p, off)
+}
+
 func (f *localFile) Readdirnames(n int) ([]string, error) {
 	return f.f.Readdirnames(n)
 }

--- a/internal/fs/fs_local_test.go
+++ b/internal/fs/fs_local_test.go
@@ -86,7 +86,7 @@ func checkMetadata(t *testing.T, f File, path string, follow bool, nodeType rest
 	rtest.OK(t, err)
 	assertFIEqual(t, fi2, fi)
 
-	node, err := f.ToNode(false)
+	node, err := f.ToNode(false, false)
 	rtest.OK(t, err)
 
 	// ModTime is likely unique per file, thus it provides a good indication that it is from the correct file

--- a/internal/fs/fs_local_unix.go
+++ b/internal/fs/fs_local_unix.go
@@ -1,0 +1,19 @@
+//go:build !windows
+// +build !windows
+
+package fs
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func (f *localFile) GetBlockDeviceSize() (uint64, error) {
+	var sizeBytes uint64
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, f.f.Fd(), unix.BLKGETSIZE64, uintptr(unsafe.Pointer(&sizeBytes)))
+	if errno != 0 {
+		return 0, errno
+	}
+	return sizeBytes, nil
+}

--- a/internal/fs/fs_local_vss_test.go
+++ b/internal/fs/fs_local_vss_test.go
@@ -333,7 +333,7 @@ func TestVSSFS(t *testing.T) {
 	rtest.OK(t, err)
 	rtest.Equals(t, "example", string(data), "unexpected file content")
 
-	node, err := f.ToNode(false)
+	node, err := f.ToNode(false, false)
 	rtest.OK(t, err)
 	rtest.Equals(t, node.Mode, lstatFi.Mode)
 

--- a/internal/fs/fs_local_windows.go
+++ b/internal/fs/fs_local_windows.go
@@ -1,0 +1,9 @@
+package fs
+
+import (
+	"github.com/restic/restic/internal/errors"
+)
+
+func (f *localFile) GetBlockDeviceSize() (uint64, error) {
+	return 0, errors.New("Backup of block devices is not supported on Windows")
+}

--- a/internal/fs/fs_reader.go
+++ b/internal/fs/fs_reader.go
@@ -221,6 +221,10 @@ func (f fakeFile) Read(_ []byte) (int, error) {
 	return 0, pathError("read", f.name, os.ErrInvalid)
 }
 
+func (f fakeFile) ReadAt(_ []byte, _ int64) (n int, err error) {
+	return 0, pathError("readAt", f.name, os.ErrInvalid)
+}
+
 func (f fakeFile) Close() error {
 	return nil
 }

--- a/internal/fs/fs_reader.go
+++ b/internal/fs/fs_reader.go
@@ -233,7 +233,7 @@ func (f fakeFile) Stat() (*ExtendedFileInfo, error) {
 	return f.fi, nil
 }
 
-func (f fakeFile) ToNode(_ bool) (*restic.Node, error) {
+func (f fakeFile) ToNode(_, _ bool) (*restic.Node, error) {
 	node := buildBasicNode(f.name, f.fi)
 
 	// fill minimal info with current values for uid, gid

--- a/internal/fs/interface.go
+++ b/internal/fs/interface.go
@@ -41,6 +41,7 @@ type File interface {
 	MakeReadable() error
 
 	io.Reader
+	io.ReaderAt
 	io.Closer
 
 	Readdirnames(n int) ([]string, error)

--- a/internal/fs/interface.go
+++ b/internal/fs/interface.go
@@ -49,5 +49,5 @@ type File interface {
 	// ToNode returns a restic.Node for the File. The internally used os.FileInfo
 	// must be consistent with that returned by Stat(). In particular, the metadata
 	// returned by consecutive calls to Stat() and ToNode() must match.
-	ToNode(ignoreXattrListError bool) (*restic.Node, error)
+	ToNode(ignoreXattrListError, readDevice bool) (*restic.Node, error)
 }

--- a/internal/fs/node_test.go
+++ b/internal/fs/node_test.go
@@ -32,7 +32,7 @@ func BenchmarkNodeFromFileInfo(t *testing.B) {
 	t.ResetTimer()
 
 	for i := 0; i < t.N; i++ {
-		_, err := f.ToNode(false)
+		_, err := f.ToNode(false, false)
 		rtest.OK(t, err)
 	}
 
@@ -224,9 +224,9 @@ func TestNodeRestoreAt(t *testing.T) {
 			fs := &Local{}
 			meta, err := fs.OpenFile(nodePath, O_NOFOLLOW, true)
 			rtest.OK(t, err)
-			n2, err := meta.ToNode(false)
+			n2, err := meta.ToNode(false, false)
 			rtest.OK(t, err)
-			n3, err := meta.ToNode(true)
+			n3, err := meta.ToNode(true, false)
 			rtest.OK(t, err)
 			rtest.OK(t, meta.Close())
 			rtest.Assert(t, n2.Equals(*n3), "unexpected node info mismatch %v", cmp.Diff(n2, n3))

--- a/internal/fs/node_unix_test.go
+++ b/internal/fs/node_unix_test.go
@@ -117,7 +117,7 @@ func TestNodeFromFileInfo(t *testing.T) {
 			fs := &Local{}
 			meta, err := fs.OpenFile(test.filename, O_NOFOLLOW, true)
 			rtest.OK(t, err)
-			node, err := meta.ToNode(false)
+			node, err := meta.ToNode(false, false)
 			rtest.OK(t, err)
 			rtest.OK(t, meta.Close())
 

--- a/internal/fs/node_windows_test.go
+++ b/internal/fs/node_windows_test.go
@@ -224,7 +224,7 @@ func restoreAndGetNode(t *testing.T, tempDir string, testNode *restic.Node, warn
 	fs := &Local{}
 	meta, err := fs.OpenFile(testPath, O_NOFOLLOW, true)
 	test.OK(t, err)
-	nodeFromFileInfo, err := meta.ToNode(false)
+	nodeFromFileInfo, err := meta.ToNode(false, false)
 	test.OK(t, errors.Wrapf(err, "Could not get NodeFromFileInfo for path: %s", testPath))
 	test.OK(t, meta.Close())
 

--- a/internal/restic/tree_test.go
+++ b/internal/restic/tree_test.go
@@ -86,7 +86,7 @@ func TestNodeMarshal(t *testing.T) {
 func nodeForFile(t *testing.T, name string) *restic.Node {
 	f, err := (&fs.Local{}).OpenFile(name, fs.O_NOFOLLOW, true)
 	rtest.OK(t, err)
-	node, err := f.ToNode(false)
+	node, err := f.ToNode(false, false)
 	rtest.OK(t, err)
 	rtest.OK(t, f.Close())
 	return node

--- a/internal/test/helpers.go
+++ b/internal/test/helpers.go
@@ -66,7 +66,7 @@ func Equals(tb testing.TB, exp, act interface{}, msgs ...string) {
 	}
 }
 
-// Random returns size bytes of pseudo-random data derived from the seed.
+// Random returns count bytes of pseudo-random data derived from the seed.
 func Random(seed, count int) []byte {
 	p := make([]byte, count)
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR introduces two closely related features:
1) Support for backup of block devices via the `--read-special` flag. If specified, `restic backup` reads the content of each block device and follows symlinks pointing to them.
2) The `--block-size` option, which, if specified, makes `restic backup` divide each file into blocks of the designated size, and back up those blocks independently. If  `ReadConcurrency` is greater than 1, then those blocks will be read in parallel.

These changes allow for a substantially faster backup of large devices. Although initial tests showed that the bottleneck seems to be saving blobs to the repository, in case of backing up data that is already present in the repository the time for backup is inversely proportional to the number of reading workers (provided there are enough physical cores).
For instance, if the second linear backup of a file took 60 seconds, then the second backup of the file with two workers reading blocks in parallel would take approximately 30 seconds. ("Second" backup means that we have already backed up the same file previously).

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://forum.restic.net/t/native-parallel-backup-of-block-devices/8641

Design
----------------------------------------------------------------
Parallelization of file reading is implemented via distributing the work using channels inside the `saveFile` routine, resulting in nested channels (when viewed at a high level).
One viable alternative could be to pass the boundaries of the blocks to the `saveFile`function (this would require renaming it) and delegate the responsibility of tracking file completion elsewhere. This approach offers some benefits but might lead to increased complexity and a greater level of coherence, whereas the current solution provides a clearer level of abstraction.

If `--block-size` is specified, we don't read several files concurrently, but rather use the value specified by `ReadConcurrency` as the number of workers reading blocks of the same file. This method is not ideal, but it's simple, and I can't think of a use case where it would be problematic.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
     I have added tests for the parallel backup of a file, but testing --read-special is a bit tricky, as creating a block device in user space is not straightforward. Since there is no complicated logic for that feature, I decided to leave it out for now.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
