### PR TITLE
Retry temporary rclone backend errors

### DIFF
--- a/changelog/unreleased/pull-5251
+++ b/changelog/unreleased/pull-5251
@@ -1,0 +1,9 @@
+Enhancement: Improve handling of flaky rclone backends
+
+Since restic 0.17.0, the backend retry mechanisms relies on backends correctly
+reporting when a file does not exist. This is not always the case for some rclone
+backends, causing restic to stop retrying after the first failure.
+
+For rclone, failed requests are now retried up to 5 times before giving up.
+
+https://github.com/restic/restic/pull/5251

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -217,18 +217,16 @@ func (be *Backend) IsPermanentError(err error) bool {
 	return false
 }
 
-func (be *Backend) Connections() uint {
-	return be.connections
+func (be *Backend) Properties() backend.Properties {
+	return backend.Properties{
+		Connections:      be.connections,
+		HasAtomicReplace: true,
+	}
 }
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (be *Backend) Hasher() hash.Hash {
 	return md5.New()
-}
-
-// HasAtomicReplace returns whether Save() can atomically replace files
-func (be *Backend) HasAtomicReplace() bool {
-	return true
 }
 
 // Path returns the path in the bucket that is used for this backend.

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -154,18 +154,16 @@ func (be *b2Backend) SetListMaxItems(i int) {
 	be.listMaxItems = i
 }
 
-func (be *b2Backend) Connections() uint {
-	return be.cfg.Connections
+func (be *b2Backend) Properties() backend.Properties {
+	return backend.Properties{
+		Connections:      be.cfg.Connections,
+		HasAtomicReplace: true,
+	}
 }
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (be *b2Backend) Hasher() hash.Hash {
 	return nil
-}
-
-// HasAtomicReplace returns whether Save() can atomically replace files
-func (be *b2Backend) HasAtomicReplace() bool {
-	return true
 }
 
 // IsNotExist returns true if the error is caused by a non-existing file.

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -17,14 +17,11 @@ var ErrNoRepository = fmt.Errorf("repository does not exist")
 // the context package need not be wrapped, as context cancellation is checked
 // separately by the retrying logic.
 type Backend interface {
-	// Connections returns the maximum number of concurrent backend operations.
-	Connections() uint
+	// Properties returns information about the backend
+	Properties() Properties
 
 	// Hasher may return a hash function for calculating a content hash for the backend
 	Hasher() hash.Hash
-
-	// HasAtomicReplace returns whether Save() can atomically replace files
-	HasAtomicReplace() bool
 
 	// Remove removes a File described by h.
 	Remove(ctx context.Context, h Handle) error
@@ -90,6 +87,14 @@ type Backend interface {
 
 	// WarmupWait waits until all given handles are warm.
 	WarmupWait(ctx context.Context, h []Handle) error
+}
+
+type Properties struct {
+	// Connections states the maximum number of concurrent backend operations.
+	Connections uint
+
+	// HasAtomicReplace states whether Save() can atomically replace files
+	HasAtomicReplace bool
 }
 
 type Unwrapper interface {

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -95,6 +95,10 @@ type Properties struct {
 
 	// HasAtomicReplace states whether Save() can atomically replace files
 	HasAtomicReplace bool
+
+	// HasFlakyErrors states whether the backend may temporarily return errors
+	// that are considered as permanent for existing files.
+	HasFlakyErrors bool
 }
 
 type Unwrapper interface {

--- a/internal/backend/dryrun/dry_backend.go
+++ b/internal/backend/dryrun/dry_backend.go
@@ -42,8 +42,8 @@ func (be *Backend) Remove(_ context.Context, _ backend.Handle) error {
 	return nil
 }
 
-func (be *Backend) Connections() uint {
-	return be.b.Connections()
+func (be *Backend) Properties() backend.Properties {
+	return be.b.Properties()
 }
 
 // Delete removes all data in the backend.
@@ -57,10 +57,6 @@ func (be *Backend) Close() error {
 
 func (be *Backend) Hasher() hash.Hash {
 	return be.b.Hasher()
-}
-
-func (be *Backend) HasAtomicReplace() bool {
-	return be.b.HasAtomicReplace()
 }
 
 func (be *Backend) IsNotExist(err error) bool {

--- a/internal/backend/gs/gs.go
+++ b/internal/backend/gs/gs.go
@@ -186,18 +186,16 @@ func (be *Backend) IsPermanentError(err error) bool {
 	return false
 }
 
-func (be *Backend) Connections() uint {
-	return be.connections
+func (be *Backend) Properties() backend.Properties {
+	return backend.Properties{
+		Connections:      be.connections,
+		HasAtomicReplace: true,
+	}
 }
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (be *Backend) Hasher() hash.Hash {
 	return md5.New()
-}
-
-// HasAtomicReplace returns whether Save() can atomically replace files
-func (be *Backend) HasAtomicReplace() bool {
-	return true
 }
 
 // Path returns the path in the bucket that is used for this backend.

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -84,18 +84,16 @@ func Create(_ context.Context, cfg Config) (*Local, error) {
 	return be, nil
 }
 
-func (b *Local) Connections() uint {
-	return b.Config.Connections
+func (b *Local) Properties() backend.Properties {
+	return backend.Properties{
+		Connections:      b.Config.Connections,
+		HasAtomicReplace: true,
+	}
 }
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (b *Local) Hasher() hash.Hash {
 	return nil
-}
-
-// HasAtomicReplace returns whether Save() can atomically replace files
-func (b *Local) HasAtomicReplace() bool {
-	return true
 }
 
 // IsNotExist returns true if the error is caused by a non existing file.

--- a/internal/backend/mem/mem_backend.go
+++ b/internal/backend/mem/mem_backend.go
@@ -218,18 +218,16 @@ func (be *MemoryBackend) List(ctx context.Context, t backend.FileType, fn func(b
 	return ctx.Err()
 }
 
-func (be *MemoryBackend) Connections() uint {
-	return connectionCount
+func (be *MemoryBackend) Properties() backend.Properties {
+	return backend.Properties{
+		Connections:      connectionCount,
+		HasAtomicReplace: false,
+	}
 }
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (be *MemoryBackend) Hasher() hash.Hash {
 	return xxhash.New()
-}
-
-// HasAtomicReplace returns whether Save() can atomically replace files
-func (be *MemoryBackend) HasAtomicReplace() bool {
-	return false
 }
 
 // Delete removes all data in the backend.

--- a/internal/backend/mock/backend.go
+++ b/internal/backend/mock/backend.go
@@ -22,9 +22,8 @@ type Backend struct {
 	DeleteFn           func(ctx context.Context) error
 	WarmupFn           func(ctx context.Context, h []backend.Handle) ([]backend.Handle, error)
 	WarmupWaitFn       func(ctx context.Context, h []backend.Handle) error
-	ConnectionsFn      func() uint
+	PropertiesFn       func() backend.Properties
 	HasherFn           func() hash.Hash
-	HasAtomicReplaceFn func() bool
 }
 
 // NewBackend returns new mock Backend instance
@@ -42,12 +41,15 @@ func (m *Backend) Close() error {
 	return m.CloseFn()
 }
 
-func (m *Backend) Connections() uint {
-	if m.ConnectionsFn == nil {
-		return 2
+func (m *Backend) Properties() backend.Properties {
+	if m.PropertiesFn == nil {
+		return backend.Properties{
+			Connections:      2,
+			HasAtomicReplace: false,
+		}
 	}
 
-	return m.ConnectionsFn()
+	return m.PropertiesFn()
 }
 
 // Hasher may return a hash function for calculating a content hash for the backend
@@ -57,14 +59,6 @@ func (m *Backend) Hasher() hash.Hash {
 	}
 
 	return m.HasherFn()
-}
-
-// HasAtomicReplace returns whether Save() can atomically replace files
-func (m *Backend) HasAtomicReplace() bool {
-	if m.HasAtomicReplaceFn == nil {
-		return false
-	}
-	return m.HasAtomicReplaceFn()
 }
 
 // IsNotExist returns true if the error is caused by a missing file.

--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -346,9 +346,3 @@ func (be *Backend) Properties() backend.Properties {
 	properties.HasFlakyErrors = true
 	return properties
 }
-
-// Warmup not implemented
-func (be *Backend) Warmup(_ context.Context, _ []backend.Handle) ([]backend.Handle, error) {
-	return []backend.Handle{}, nil
-}
-func (be *Backend) WarmupWait(_ context.Context, _ []backend.Handle) error { return nil }

--- a/internal/backend/rclone/backend.go
+++ b/internal/backend/rclone/backend.go
@@ -341,6 +341,12 @@ func (be *Backend) Close() error {
 	return be.waitResult
 }
 
+func (be *Backend) Properties() backend.Properties {
+	properties := be.Backend.Properties()
+	properties.HasFlakyErrors = true
+	return properties
+}
+
 // Warmup not implemented
 func (be *Backend) Warmup(_ context.Context, _ []backend.Handle) ([]backend.Handle, error) {
 	return []backend.Handle{}, nil

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -116,19 +116,17 @@ func Create(ctx context.Context, cfg Config, rt http.RoundTripper) (*Backend, er
 	return be, nil
 }
 
-func (b *Backend) Connections() uint {
-	return b.connections
+func (b *Backend) Properties() backend.Properties {
+	return backend.Properties{
+		Connections: b.connections,
+		// rest-server prevents overwriting
+		HasAtomicReplace: false,
+	}
 }
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (b *Backend) Hasher() hash.Hash {
 	return nil
-}
-
-// HasAtomicReplace returns whether Save() can atomically replace files
-func (b *Backend) HasAtomicReplace() bool {
-	// rest-server prevents overwriting
-	return false
 }
 
 // Save stores data in the backend at the handle.

--- a/internal/backend/retry/backend_retry.go
+++ b/internal/backend/retry/backend_retry.go
@@ -166,7 +166,7 @@ func (be *Backend) Save(ctx context.Context, h backend.Handle, rd backend.Rewind
 			return nil
 		}
 
-		if be.Backend.HasAtomicReplace() {
+		if be.Backend.Properties().HasAtomicReplace {
 			debug.Log("Save(%v) failed with error: %v", h, err)
 			// there is no need to remove files from backends which can atomically replace files
 			// in fact if something goes wrong at the backend side the delete operation might delete the wrong instance of the file

--- a/internal/backend/retry/backend_retry_test.go
+++ b/internal/backend/retry/backend_retry_test.go
@@ -69,7 +69,12 @@ func TestBackendSaveRetryAtomic(t *testing.T) {
 			calledRemove = true
 			return nil
 		},
-		HasAtomicReplaceFn: func() bool { return true },
+		PropertiesFn: func() backend.Properties {
+			return backend.Properties{
+				Connections:      2,
+				HasAtomicReplace: true,
+			}
+		},
 	}
 
 	TestFastRetries(t)

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -261,18 +261,16 @@ func (be *Backend) IsPermanentError(err error) bool {
 	return false
 }
 
-func (be *Backend) Connections() uint {
-	return be.cfg.Connections
+func (be *Backend) Properties() backend.Properties {
+	return backend.Properties{
+		Connections:      be.cfg.Connections,
+		HasAtomicReplace: true,
+	}
 }
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (be *Backend) Hasher() hash.Hash {
 	return nil
-}
-
-// HasAtomicReplace returns whether Save() can atomically replace files
-func (be *Backend) HasAtomicReplace() bool {
-	return true
 }
 
 // Path returns the path in the bucket that is used for this backend.

--- a/internal/backend/sema/backend.go
+++ b/internal/backend/sema/backend.go
@@ -22,7 +22,7 @@ type connectionLimitedBackend struct {
 
 // NewBackend creates a backend that limits the concurrent operations on the underlying backend
 func NewBackend(be backend.Backend) backend.Backend {
-	sem, err := newSemaphore(be.Connections())
+	sem, err := newSemaphore(be.Properties().Connections)
 	if err != nil {
 		panic(err)
 	}

--- a/internal/backend/sema/backend_test.go
+++ b/internal/backend/sema/backend_test.go
@@ -106,7 +106,12 @@ func concurrencyTester(t *testing.T, setup func(m *mock.Backend), handler func(b
 
 	m := mock.NewBackend()
 	setup(m)
-	m.ConnectionsFn = func() uint { return uint(expectBlocked) }
+	m.PropertiesFn = func() backend.Properties {
+		return backend.Properties{
+			Connections:      uint(expectBlocked),
+			HasAtomicReplace: false,
+		}
+	}
 	be := sema.NewBackend(m)
 
 	var wg errgroup.Group
@@ -206,7 +211,12 @@ func TestFreeze(t *testing.T) {
 		atomic.AddInt64(&counter, 1)
 		return nil
 	}
-	m.ConnectionsFn = func() uint { return 2 }
+	m.PropertiesFn = func() backend.Properties {
+		return backend.Properties{
+			Connections:      2,
+			HasAtomicReplace: false,
+		}
+	}
 	be := sema.NewBackend(m)
 	fb := be.(backend.FreezeBackend)
 

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -264,18 +264,16 @@ func Create(ctx context.Context, cfg Config) (*SFTP, error) {
 	return open(sftp, cfg)
 }
 
-func (r *SFTP) Connections() uint {
-	return r.Config.Connections
+func (r *SFTP) Properties() backend.Properties {
+	return backend.Properties{
+		Connections:      r.Config.Connections,
+		HasAtomicReplace: r.posixRename,
+	}
 }
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (r *SFTP) Hasher() hash.Hash {
 	return nil
-}
-
-// HasAtomicReplace returns whether Save() can atomically replace files
-func (r *SFTP) HasAtomicReplace() bool {
-	return r.posixRename
 }
 
 // tempSuffix generates a random string suffix that should be sufficiently long

--- a/internal/backend/swift/swift.go
+++ b/internal/backend/swift/swift.go
@@ -111,18 +111,16 @@ func (be *beSwift) createContainer(ctx context.Context, policy string) error {
 	return be.conn.ContainerCreate(ctx, be.container, h)
 }
 
-func (be *beSwift) Connections() uint {
-	return be.connections
+func (be *beSwift) Properties() backend.Properties {
+	return backend.Properties{
+		Connections:      be.connections,
+		HasAtomicReplace: true,
+	}
 }
 
 // Hasher may return a hash function for calculating a content hash for the backend
 func (be *beSwift) Hasher() hash.Hash {
 	return md5.New()
-}
-
-// HasAtomicReplace returns whether Save() can atomically replace files
-func (be *beSwift) HasAtomicReplace() bool {
-	return true
 }
 
 // Load runs fn with a reader that yields the contents of the file at h at the

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -552,7 +552,7 @@ func (r *Repository) StartPackUploader(ctx context.Context, wg *errgroup.Group) 
 
 	innerWg, ctx := errgroup.WithContext(ctx)
 	r.packerWg = innerWg
-	r.uploader = newPackerUploader(ctx, innerWg, r, r.be.Connections())
+	r.uploader = newPackerUploader(ctx, innerWg, r, r.Connections())
 	r.treePM = newPackerManager(r.key, restic.TreeBlob, r.packSize(), r.uploader.QueuePacker)
 	r.dataPM = newPackerManager(r.key, restic.DataBlob, r.packSize(), r.uploader.QueuePacker)
 
@@ -587,7 +587,7 @@ func (r *Repository) flushPacks(ctx context.Context) error {
 }
 
 func (r *Repository) Connections() uint {
-	return r.be.Connections()
+	return r.be.Properties().Connections
 }
 
 func (r *Repository) LookupBlob(tpe restic.BlobType, id restic.ID) []restic.PackedBlob {

--- a/internal/repository/upgrade_repo.go
+++ b/internal/repository/upgrade_repo.go
@@ -33,7 +33,7 @@ func (err *upgradeRepoV2Error) Unwrap() error {
 func upgradeRepository(ctx context.Context, repo *Repository) error {
 	h := backend.Handle{Type: backend.ConfigFile}
 
-	if !repo.be.HasAtomicReplace() {
+	if !repo.be.Properties().HasAtomicReplace {
 		// remove the original file for backends which do not support atomic overwriting
 		err := repo.be.Remove(ctx, h)
 		if err != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

rclone backends apparently sometimes temporarily report a file as missing even though it actually exists. This results in problems with the backend error redesign in restic 0.17.0, which relies on accurate information about missing files. Thus this PR reintroduces a limited number of retries when using rclone as backend.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes https://forum.restic.net/t/data-does-not-exist-check-successful-on-second-attempt-but-restic-returns-non-zero-error-code/9117
Fixes https://forum.restic.net/t/fatal-repository-contains-errors-when-only-errors-are-successfully-retried-operations/8971

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
