### PR TITLE
add a test to cmd_ls_integration_test.go: test `rest ls --json`

### DIFF
--- a/changelog/unreleased/pull-5255
+++ b/changelog/unreleased/pull-5255
@@ -1,0 +1,8 @@
+Change: add a test to cmd_ls_integration_test.go: test `rest ls --json`
+
+Create backup of 0/for_cmd_ls, which contains only a few files.
+Compare first line of ls --json oytput with snapshotID coming back from
+`testRunList()`.
+Compare node.Path with expected results list.
+
+https://github.com/restic/restic/pull/5255

--- a/changelog/unreleased/pull-5255
+++ b/changelog/unreleased/pull-5255
@@ -1,8 +1,0 @@
-Change: add a test to cmd_ls_integration_test.go: test `rest ls --json`
-
-Create backup of 0/for_cmd_ls, which contains only a few files.
-Compare first line of ls --json oytput with snapshotID coming back from
-`testRunList()`.
-Compare node.Path with expected results list.
-
-https://github.com/restic/restic/pull/5255

--- a/cmd/restic/cmd_ls_integration_test.go
+++ b/cmd/restic/cmd_ls_integration_test.go
@@ -146,13 +146,13 @@ func TestRunLsJson(t *testing.T) {
 
 	// the node structure from cmd_ls
 	type lsNode struct {
-		Name        string      `json:"name"`
-		Type        string      `json:"type"`
-		Path        string      `json:"path"`
-		Permissions string      `json:"permissions,omitempty"`
-		Inode       uint64      `json:"inode,omitempty"`
-		MessageType string      `json:"message_type"` // "node"
-		StructType  string      `json:"struct_type"`  // "node", deprecated
+		Name        string `json:"name"`
+		Type        string `json:"type"`
+		Path        string `json:"path"`
+		Permissions string `json:"permissions,omitempty"`
+		Inode       uint64 `json:"inode,omitempty"`
+		MessageType string `json:"message_type"` // "node"
+		StructType  string `json:"struct_type"`  // "node", deprecated
 	}
 
 	var testNode lsNode

--- a/cmd/restic/cmd_ls_integration_test.go
+++ b/cmd/restic/cmd_ls_integration_test.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 
+	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -99,5 +101,67 @@ func TestRunLsSort(t *testing.T) {
 		out := testRunLsWithOpts(t, env.gopts, LsOptions{Sort: test.mode}, []string{"latest"})
 		fileList := strings.Split(string(out), "\n")
 		rtest.Equals(t, test.expected, fileList, fmt.Sprintf("mismatch for mode %v", test.mode))
+	}
+}
+
+// JSON lines test
+func TestRunLsJson(t *testing.T) {
+	pathList := []string{
+		"/0",
+		"/0/for_cmd_ls",
+		"/0/for_cmd_ls/file1.txt",
+		"/0/for_cmd_ls/file2.txt",
+		"/0/for_cmd_ls/python.py",
+	}
+
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+	testRunBackup(t, env.testdata, []string{"0/for_cmd_ls"}, opts, env.gopts)
+	snapshotIDs := testRunList(t, "snapshots", env.gopts)
+	rtest.Assert(t, len(snapshotIDs) == 1, "expected one snapshot, got %v", snapshotIDs)
+
+	buf, err := withCaptureStdout(func() error {
+		env.gopts.Quiet = true
+		env.gopts.JSON = true
+		return runLs(context.TODO(), LsOptions{}, env.gopts, []string{"latest"})
+	})
+	rtest.OK(t, err)
+	byteLines := bytes.Split(buf.Bytes(), []byte{'\n'})
+
+	// the snapshot structure from cmd_ls
+	type lsSnapshot struct {
+		*restic.Snapshot
+		ID          *restic.ID `json:"id"`
+		ShortID     string     `json:"short_id"`     // deprecated
+		MessageType string     `json:"message_type"` // "snapshot"
+		StructType  string     `json:"struct_type"`  // "snapshot", deprecated
+	}
+
+	var snappy lsSnapshot
+	rtest.OK(t, json.Unmarshal(byteLines[0], &snappy))
+	rtest.Equals(t, snappy.ShortID, snapshotIDs[0].Str(), "expected snap IDs to be identical")
+
+	// the node structure from cmd_ls
+	type lsNode struct {
+		Name        string      `json:"name"`
+		Type        string      `json:"type"`
+		Path        string      `json:"path"`
+		Permissions string      `json:"permissions,omitempty"`
+		Inode       uint64      `json:"inode,omitempty"`
+		MessageType string      `json:"message_type"` // "node"
+		StructType  string      `json:"struct_type"`  // "node", deprecated
+	}
+
+	var testNode lsNode
+	for i, nodeLine := range byteLines[1:] {
+		if len(nodeLine) == 0 {
+			break
+		}
+
+		rtest.OK(t, json.Unmarshal(nodeLine, &testNode))
+		rtest.Assert(t, testNode.Path == pathList[i], "expected %s actual %s", pathList[i], testNode.Path)
 	}
 }


### PR DESCRIPTION
validate that the individual JSON lines are valid JSON statements. Check for snap ID and the path names in the backup.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR adds a test to cmd_ls_integration_test.go. It checks the validity of the JSON lines output,
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [X] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.
