### PR TITLE
build: improve GoVersion comparison logic

### DIFF
--- a/build.go
+++ b/build.go
@@ -298,19 +298,21 @@ func (v GoVersion) AtLeast(other GoVersion) bool {
 		return true
 	}
 
+	if v.Major > other.Major {
+		return true
+	}
 	if v.Major < other.Major {
 		return false
 	}
 
+	if v.Minor > other.Minor {
+		return true
+	}
 	if v.Minor < other.Minor {
 		return false
 	}
 
-	if v.Patch < other.Patch {
-		return false
-	}
-
-	return true
+	return v.Patch >= other.Patch
 }
 
 func (v GoVersion) String() string {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR fixes a logical flaw in the GoVersion.AtLeast() function in build.go that was causing incorrect version comparisons. The current implementation checks each version component (Major, Minor, Patch) independently without respecting the version hierarchy, which leads to incorrect results in many common cases.
For example, with the current implementation:
- Version 2.1.0 would be incorrectly considered "not at least" version 1.5.5
- Version 1.18.0 would be incorrectly considered "not at least" version 1.17.5

The fix implements proper semantic versioning comparison by:
1. Checking major version first and returning early if different
2. Only then comparing minor versions if major versions are equal
3. Only comparing patch versions if both major and minor versions are equal
This ensures that higher versions are correctly identified as being "at least" as new as lower versions, regardless of individual component values.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Yes, this was reported in issue #5269 where the incorrect behavior was identified and a fix was proposed.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in changelog/unreleased/ that describes the changes for our users (see template).
- [x] I'm done! This pull request is ready for review.
