### PR TITLE
doc: fix various typos

### DIFF
--- a/changelog/unreleased/pull-5170
+++ b/changelog/unreleased/pull-5170
@@ -3,7 +3,7 @@ Bugfix: Prevent Windows VSS event log 8194 warnings for backup with fs snapshot
 When running `restic backup` with `--use-fs-snapshot` flag in Windows with admin rights, event logs like
 ```
 Volume Shadow Copy Service error: Unexpected error querying for the IVssWriterCallback interface.  hr = 0x80070005, Access is denied.
-. This is often caused by incorrect security settings in either the writer or requestor process. 
+. This is often caused by incorrect security settings in either the writer or requester process. 
 
 Operation:
    Gathering Writer Data

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -43,7 +43,7 @@ import (
 	"golang.org/x/term"
 )
 
-// ErrNoRepository is used to report if opening a repsitory failed due
+// ErrNoRepository is used to report if opening a repository failed due
 // to a missing backend storage location or config file
 var ErrNoRepository = errors.New("repository does not exist")
 

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -174,7 +174,7 @@ func main() {
 	if err == nil {
 		err = ctx.Err()
 	} else if err == ErrOK {
-		// ErrOK overwrites context cancelation errors
+		// ErrOK overwrites context cancellation errors
 		err = nil
 	}
 

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -148,7 +148,7 @@ options will be deleted. For example, the command
 would only delete files within ``/tmp/restore-work/foo``.
 
 When using ``--target / --delete`` then the ``restore`` command only works if either an ``--include``
-or ``--exclude`` option is also specified. This ensures that one cannot accidentaly delete
+or ``--exclude`` option is also specified. This ensures that one cannot accidentally delete
 the whole system.
 
 Dry run

--- a/internal/backend/retry/backend_retry_test.go
+++ b/internal/backend/retry/backend_retry_test.go
@@ -374,7 +374,7 @@ func TestBackendLoadCircuitBreakerCancel(t *testing.T) {
 	err := retryBackend.Load(cctx, backend.Handle{Name: "other"}, 0, 0, nilRd)
 	test.Equals(t, context.Canceled, err, "unexpected error")
 
-	// reset context and check that the cirucit breaker does not return an error
+	// reset context and check that the circuit breaker does not return an error
 	cctx, cancel = context.WithCancel(context.Background())
 	defer cancel()
 	err = retryBackend.Load(cctx, backend.Handle{Name: "other"}, 0, 0, nilRd)

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -359,7 +359,7 @@ func (r *fileRestorer) downloadBlobs(ctx context.Context, packID restic.ID,
 			}
 			for file, offsets := range blob.files {
 				for _, offset := range offsets {
-					// avoid long cancelation delays for frequently used blobs
+					// avoid long cancellation delays for frequently used blobs
 					if ctx.Err() != nil {
 						return ctx.Err()
 					}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Fixes various user-facing and non-user-facing typos.  
Typos were found via `codespell -q 3 -L atleast,iinclude,ist,programm,reenable,ser,uptodate`


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No, it wasn't

Checklist
---------

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.
