### PR TITLE
Fix lock pass by value and handle error from Release().

### DIFF
--- a/internal/restic/lock_windows.go
+++ b/internal/restic/lock_windows.go
@@ -14,12 +14,15 @@ func uidGidInt(_ *user.User) (uid, gid uint32, err error) {
 
 // checkProcess will check if the process retaining the lock exists.
 // Returns true if the process exists.
-func (l Lock) processExists() bool {
+func (l *Lock) processExists() bool {
 	proc, err := os.FindProcess(l.PID)
 	if err != nil {
 		debug.Log("error searching for process %d: %v\n", l.PID, err)
 		return false
 	}
-	proc.Release()
+	err = proc.Release()
+	if err != nil {
+		debug.Log("error releasing process %d: %v\n", l.PID, err)
+	}
 	return true
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Cleanup fixing a lock being passed by value in lock_windows.go.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No. Small change and should not affect semantics.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [X] I have added tests for all code changes. No behaviour changes.
- [X] I have added documentation for relevant changes (in the manual). Not user visible
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)). Trivial cleanup.
- [X] I'm done! This pull request is ready for review.
