### PR TITLE
sftp: improve error messages

### DIFF
--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -420,14 +420,14 @@ func (r *SFTP) Load(ctx context.Context, h backend.Handle, length int, offset in
 func (r *SFTP) openReader(_ context.Context, h backend.Handle, length int, offset int64) (io.ReadCloser, error) {
 	f, err := r.c.Open(r.Filename(h))
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "Open %v", r.Filename(h))
 	}
 
 	if offset > 0 {
 		_, err = f.Seek(offset, 0)
 		if err != nil {
 			_ = f.Close()
-			return nil, err
+			return nil, errors.Wrapf(err, "Seek %v", r.Filename(h))
 		}
 	}
 
@@ -566,7 +566,7 @@ func (r *SFTP) deleteRecursive(ctx context.Context, name string) error {
 		if fi.IsDir() {
 			err := r.deleteRecursive(ctx, itemName)
 			if err != nil {
-				return errors.Wrap(err, "ReadDir")
+				return err
 			}
 
 			err = r.c.RemoveDirectory(itemName)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Hopefully wrap all error messages and include the operation name and path there.

```
./restic -r sftp:michael@raspberrypi:/blub init          
enter password for new repository: 
enter password again: 
Fatal: create repository at sftp:michael@raspberrypi:/blub failed: Fatal: unable to open repository at sftp:michael@raspberrypi:/blub: MkdirAll /blub/data: permission denied
```
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/5261 .
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
