### PR TITLE
list integration test: error scanning 'restic list blobs'

### DIFF
--- a/cmd/restic/cmd_list_integration_test.go
+++ b/cmd/restic/cmd_list_integration_test.go
@@ -4,10 +4,14 @@ import (
 	"bufio"
 	"context"
 	"io"
+	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/ui"
 )
 
 func testRunList(t testing.TB, gopts GlobalOptions, tpe string) restic.IDs {
@@ -24,13 +28,24 @@ func parseIDsFromReader(t testing.TB, rd io.Reader) restic.IDs {
 	sc := bufio.NewScanner(rd)
 
 	for sc.Scan() {
-		id, err := restic.ParseID(sc.Text())
-		if err != nil {
-			t.Logf("parse id %v: %v", sc.Text(), err)
-			continue
+		if len(sc.Text()) == 64 {
+			id, err := restic.ParseID(sc.Text())
+			if err != nil {
+				t.Logf("parse id %v: %v", sc.Text(), err)
+				continue
+			}
+			IDs = append(IDs, id)
+		} else {
+			// 'list blobs' is different because it lists the blobs together with the blob type
+			// e.g. "tree ac08ce34ba4f8123618661bef2425f7028ffb9ac740578a3ee88684d2523fee8"
+			parts := strings.Split(sc.Text(), " ")
+			id, err := restic.ParseID(parts[len(parts)-1])
+			if err != nil {
+				t.Logf("parse id %v: %v", sc.Text(), err)
+				continue
+			}
+			IDs = append(IDs, id)
 		}
-
-		IDs = append(IDs, id)
 	}
 
 	return IDs
@@ -41,4 +56,55 @@ func testListSnapshots(t testing.TB, gopts GlobalOptions, expected int) restic.I
 	snapshotIDs := testRunList(t, gopts, "snapshots")
 	rtest.Assert(t, len(snapshotIDs) == expected, "expected %v snapshot, got %v", expected, snapshotIDs)
 	return snapshotIDs
+}
+
+// extract blob set from repository index
+func testListBlobs(t testing.TB, gopts GlobalOptions, env *testEnvironment) (blobSetFromIndex restic.IDSet) {
+
+	// open repository in read mode, no lock
+	var repo *repository.Repository
+	var unlock func()
+	var err error
+	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		_, repo, unlock, err = openWithReadLock(ctx, gopts, false, printer)
+		rtest.OK(t, err)
+		defer unlock()
+
+		return err
+	})
+	rtest.OK(t, err)
+
+	blobSetFromIndex = restic.NewIDSet()
+	// make sure the index is loaded
+	rtest.OK(t, repo.LoadIndex(context.TODO(), nil))
+
+	// get blobs from index
+	rtest.OK(t, repo.ListBlobs(context.TODO(), func(blob restic.PackedBlob) {
+		blobSetFromIndex.Insert(blob.ID)
+	}))
+
+	return blobSetFromIndex
+}
+
+func TestListBlobs(t *testing.T) {
+
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+
+	// first backup
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9")}, opts, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+
+	// run the `list blobs` command
+	resticIDs := testRunList(t, env.gopts, "blobs")
+
+	// convert to set
+	testIDSet := restic.NewIDSet(resticIDs...)
+	blobSetFromIndex := testListBlobs(t, env.gopts, env)
+
+	rtest.Assert(t, blobSetFromIndex.Equals(testIDSet), "the set of restic.ID s should be equal")
 }


### PR DESCRIPTION
func parseIDsFromReader does now scans the output from 'restic list blobs' correctly. 'list blobs' produces the blob type as well as the blob ID.

The test 'TestListBlobs' verifies the modified functionality. Since 'testListSnapshots' is used universally, there is no extra new test for the existing functionality.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR fixes a problem when using `restic list blobs` in the test environment. The output of `restic list blobs` contains currently 2 word, the blob type and the blob ID itself.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [X] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.
