### PR TITLE
Fix all actual typos and use .codespellrc to skip others

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,25 @@
+[codespell]
+check-filenames = true
+quiet-level = 1
+# For 'skip' the value must be a single string
+skip = .git,*.bz2,*.png,*.gz,*.ico,*.ttf
+# Ignore list allows multi-line config
+ignore-words-list =
+  # Method name in build.go comments
+  atleast,
+  # AsciiDoc bullet points using "*" (valid syntax)
+  bu,
+  # Test input in internal/ui/termstatus/status_test.go
+  fo,
+  # Legacy CLI flag name
+  iinclude,
+  # German text in tests
+  ist,
+  # Test variable in cmd/restic/cmd_backup_test.go
+  nin,
+  # German word in url
+  programm,
+  # Historical git entries
+  reenable,
+  # Test variable names (short for "serialized")
+  ser,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -614,7 +614,7 @@ restic users. The changes are ordered by importance.
    deprecated and will be removed in the next minor restic version. You can use
    `restic repair index` to update the index to the current format.
 
-   It is possible to temporarily reenable support for the legacy index format by
+   It is possible to temporarily re-enable support for the legacy index format by
    setting the environment variable `RESTIC_FEATURES=deprecate-legacy-index=false`.
    Note that this feature flag will be removed in the next minor restic version.
 
@@ -623,7 +623,7 @@ restic users. The changes are ordered by importance.
    version. You can migrate your S3 repository to the current layout using
    `RESTIC_FEATURES=deprecate-s3-legacy-layout=false restic migrate s3_layout`.
 
-   It is possible to temporarily reenable support for the `s3legacy` layout by
+   It is possible to temporarily re-enable support for the `s3legacy` layout by
    setting the environment variable
    `RESTIC_FEATURES=deprecate-s3-legacy-layout=false`. Note that this feature flag
    will be removed in the next minor restic version.

--- a/changelog/0.17.0_2024-07-26/issue-4602
+++ b/changelog/0.17.0_2024-07-26/issue-4602
@@ -4,7 +4,7 @@ Support for the legacy index format used by restic before version 0.2.0 has
 been deprecated and will be removed in the next minor restic version. You can
 use `restic repair index` to update the index to the current format.
 
-It is possible to temporarily reenable support for the legacy index format by
+It is possible to temporarily re-enable support for the legacy index format by
 setting the environment variable `RESTIC_FEATURES=deprecate-legacy-index=false`.
 Note that this feature flag will be removed in the next minor restic version.
 
@@ -13,7 +13,7 @@ restic 0.7.0 has been deprecated and will be removed in the next minor restic
 version. You can migrate your S3 repository to the current layout using
 `RESTIC_FEATURES=deprecate-s3-legacy-layout=false restic migrate s3_layout`.
 
-It is possible to temporarily reenable support for the `s3legacy` layout by
+It is possible to temporarily re-enable support for the `s3legacy` layout by
 setting the environment variable `RESTIC_FEATURES=deprecate-s3-legacy-layout=false`.
 Note that this feature flag will be removed in the next minor restic version.
 

--- a/changelog/unreleased/issue-5287
+++ b/changelog/unreleased/issue-5287
@@ -4,5 +4,5 @@ When trying to recover data from an interrupted snapshot, it was previously
 necessary to manually run `repair index` before runnning `recover`. This now
 happens automatically so that only `recover` is necessary.
 
-https://github.com/restic/restic/issues/52897
+https://github.com/restic/restic/issues/5287
 https://github.com/restic/restic/pull/5296

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -353,7 +353,7 @@ modifying the repository. Instead restic will only print the actions it would
 perform.
 
 .. note:: The ``rewrite`` command verifies that it does not modify snapshots in
-    unexpected ways and fails with an ``cannot encode tree at "[...]" without loosing information``
+    unexpected ways and fails with an ``cannot encode tree at "[...]" without losing information``
     error otherwise. This can occur when rewriting a snapshot created by a newer
     version of restic or some third-party implementation.
 

--- a/internal/backend/cache/dir_test.go
+++ b/internal/backend/cache/dir_test.go
@@ -12,7 +12,7 @@ func TestCacheDirEnv(t *testing.T) {
 	cachedir := os.Getenv("RESTIC_CACHE_DIR")
 
 	if cachedir == "" {
-		cachedir = "/doesnt/exist"
+		cachedir = "/does/not/exist"
 		err := os.Setenv("RESTIC_CACHE_DIR", cachedir)
 		if err != nil {
 			t.Fatal(err)

--- a/internal/repository/prune_test.go
+++ b/internal/repository/prune_test.go
@@ -137,7 +137,7 @@ func TestPruneSmall(t *testing.T) {
 	var wg errgroup.Group
 	repo.StartPackUploader(context.TODO(), &wg)
 	keep := restic.NewBlobSet()
-	// we need a minum of 11 packfiles, each packfile will be about 5 Mb long
+	// we need a minimum of 11 packfiles, each packfile will be about 5 Mb long
 	for i := 0; i < numBlobsCreated; i++ {
 		buf := make([]byte, blobSize)
 		random.Read(buf)

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -126,7 +126,7 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 	packs := make(map[restic.ID]*packInfo) // all packs
 	// Process packs in order of first access. While this cannot guarantee
 	// that file chunks are restored sequentially, it offers a good enough
-	// approximation to shorten restore times by up to 19% in some test.
+	// approximation to shorten restore times by up to 19% in some tests.
 	var packOrder restic.IDs
 
 	// create packInfo from fileInfo
@@ -185,7 +185,8 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 			file.sparse = false
 		}
 
-		// empty file or one with already uptodate content. Make sure that the file size is correct
+		// empty file or one with already up-to-date content
+		// make sure that the file size is correct
 		if !restoredBlobs {
 			err := r.truncateFileToSize(file.location, file.size)
 			if errFile := r.sanitizeError(file, err); errFile != nil {


### PR DESCRIPTION
Fix all spelling errors found by codespell[1] version 2.4.1:

    ./CHANGELOG.md:617: reenable ==> re-enable
    ./CHANGELOG.md:626: reenable ==> re-enable
    ./build.go:294: AtLeast ==> at least
    ./build.go:295: AtLeast ==> at least
    ./build.go:325: AtLeast ==> at least
    ./internal/restic/node_test.go:71: ser ==> set
    ./internal/restic/node_test.go:74: ser ==> set
    ./internal/restic/node_test.go:76: ser ==> set
    ./internal/restic/node_test.go:84: ser ==> set
    ./internal/restic/node_test.go:91: ser ==> set
    ./internal/crypto/crypto_int_test.go:76: ist ==> is, it, its, it's, sit, list
    ./internal/filter/filter_test.go:237: ser ==> set
    ./internal/filter/include.go:23: iinclude ==> include
    ./internal/restorer/filerestorer.go:188: uptodate ==> up-to-date
    ./internal/ui/termstatus/status_test.go:97: fo ==> of, for, to, do, go
    ./internal/backend/cache/dir_test.go:15: doesnt ==> doesn't, does not
    ./internal/repository/prune_test.go:219: minum ==> minimum
    ./doc/110_talks.rst:29: programm ==> program, programme
    ./doc/045_working_with_repos.rst:356: loosing ==> losing
    ./doc/man/restic-diff.1:21: bu ==> by, be, but, bug, bun, bud, buy, bum
    ./doc/man/restic-diff.1:23: bu ==> by, be, but, bug, bun, bud, buy, bum
    ./doc/man/restic-diff.1:25: bu ==> by, be, but, bug, bun, bud, buy, bum
    ./doc/man/restic-diff.1:27: bu ==> by, be, but, bug, bun, bud, buy, bum
    ./doc/man/restic-diff.1:29: bu ==> by, be, but, bug, bun, bud, buy, bum
    ./doc/man/restic-diff.1:31: bu ==> by, be, but, bug, bun, bud, buy, bum
    ./doc/man/restic-stats.1:32: bu ==> by, be, but, bug, bun, bud, buy, bum
    ./doc/man/restic-stats.1:34: bu ==> by, be, but, bug, bun, bud, buy, bum
    ./doc/man/restic-stats.1:37: bu ==> by, be, but, bug, bun, bud, buy, bum
    ./doc/man/restic-stats.1:40: bu ==> by, be, but, bug, bun, bud, buy, bum
    ./cmd/restic/cmd_backup_test.go:83: nin ==> inn, min, bin, nine
    ./changelog/unreleased/issue-5109:1: configureable ==> configurable
    ./changelog/unreleased/issue-5287:4: runnning ==> running
    ./changelog/0.17.0_2024-07-26/issue-4602:7: reenable ==> re-enable
    ./changelog/0.17.0_2024-07-26/issue-4602:16: reenable ==> re-enable

Also fix typo in issue number (#52897 -> #5287).

[1] https://github.com/codespell-project/codespell/

This change has not been discussed before and there is no open issue about it.

If you choose to merge this, you may start running `codespell` in the CI to prevent future small typos.

Checklist
---------

- [not needed] I have added tests for all code changes.
- [not needed] I have added documentation for relevant changes (in the manual).
- [not needed] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
