### PR TITLE
Readd feature flags removed too soon

### DIFF
--- a/changelog/unreleased/pull-5162
+++ b/changelog/unreleased/pull-5162
@@ -1,7 +1,8 @@
 Change: Promote feature flags
 
-The `explicit-s3-anonymous-auth` and `safe-forget-keep-tags` features are
-now stable and can no longer be disabled. These corresponding feature flags
+The `deprecate-legacy-index`, `deprecate-s3-legacy-layout`,
+`explicit-s3-anonymous-auth` and `safe-forget-keep-tags` features are
+now stable and can no longer be disabled. The corresponding feature flags
 will be removed in restic 0.19.0.
 
 https://github.com/restic/restic/pull/5162

--- a/internal/feature/registry.go
+++ b/internal/feature/registry.go
@@ -6,6 +6,8 @@ var Flag = New()
 // flag names are written in kebab-case
 const (
 	BackendErrorRedesign    FlagName = "backend-error-redesign"
+	DeprecateLegacyIndex    FlagName = "deprecate-legacy-index"
+	DeprecateS3LegacyLayout FlagName = "deprecate-s3-legacy-layout"
 	DeviceIDForHardlinks    FlagName = "device-id-for-hardlinks"
 	ExplicitS3AnonymousAuth FlagName = "explicit-s3-anonymous-auth"
 	SafeForgetKeepTags      FlagName = "safe-forget-keep-tags"
@@ -15,6 +17,8 @@ const (
 func init() {
 	Flag.SetFlags(map[FlagName]FlagDesc{
 		BackendErrorRedesign:    {Type: Beta, Description: "enforce timeouts for stuck HTTP requests and use new backend error handling design."},
+		DeprecateLegacyIndex:    {Type: Stable, Description: "disable support for index format used by restic 0.1.0. Use `restic repair index` to update the index if necessary."},
+		DeprecateS3LegacyLayout: {Type: Stable, Description: "disable support for S3 legacy layout used up to restic 0.7.0. Use restic 0.17.3 to migrate if necessary."},
 		DeviceIDForHardlinks:    {Type: Alpha, Description: "store deviceID only for hardlinks to reduce metadata changes for example when using btrfs subvolumes. Will be removed in a future restic version after repository format 3 is available"},
 		ExplicitS3AnonymousAuth: {Type: Stable, Description: "forbid anonymous S3 authentication unless `-o s3.unsafe-anonymous-auth=true` is set"},
 		SafeForgetKeepTags:      {Type: Stable, Description: "prevent deleting all snapshots if the tag passed to `forget --keep-tags tagname` does not exist"},


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Feature flags should remain as stable for one release.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Extends https://github.com/restic/restic/pull/5162
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
