### PR TITLE
docs: fix unit for S3 restore timeout

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -253,7 +253,7 @@ Archive** storage classes is available:
 .. code-block:: console
 
    $ restic backup -o s3.storage-class=GLACIER somedir/
-   $ RESTIC_FEATURES=s3-restore restic restore -o s3.enable-restore=1 -o s3.restore-days=7 -o s3.restore-timeout=1d latest
+   $ RESTIC_FEATURES=s3-restore restic restore -o s3.enable-restore=1 -o s3.restore-days=7 -o s3.restore-timeout=24h latest
 
 **Notes:**
 

--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -26,7 +26,7 @@ type Config struct {
 
 	EnableRestore  bool          `option:"enable-restore" help:"restore objects from GLACIER or DEEP_ARCHIVE storage classes (default: false, requires \"s3-restore\" feature flag)"`
 	RestoreDays    int           `option:"restore-days" help:"lifetime in days of restored object (default: 7)"`
-	RestoreTimeout time.Duration `option:"restore-timeout" help:"maximum time to wait for objects transition (default: 1d)"`
+	RestoreTimeout time.Duration `option:"restore-timeout" help:"maximum time to wait for objects transition (default: 24h)"`
 	RestoreTier    string        `option:"restore-tier" help:"Retrieval tier at which the restore will be processed. (Standard, Bulk or Expedited) (default: Standard)"`
 
 	Connections         uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`


### PR DESCRIPTION

What does this PR change? What problem does it solve?
-----------------------------------------------------

"d" is not a valid unit for duration. Sorry.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

- [ ] I have added tests for all code changes.
  - not relevant
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
  - no changelog entry needed IMO
- [x] I'm done! This pull request is ready for review.
