### PR TITLE
Add support for additional compression levels `fastest` and `better`

### DIFF
--- a/changelog/unreleased/issue-4728
+++ b/changelog/unreleased/issue-4728
@@ -1,0 +1,7 @@
+Enhancement: Added support for zstd compression levels `fastest` and `better`
+
+Restic now supports the zstd compression modes `fastest` and `better`. Set the
+environment variable `RESTIC_COMPRESSION` to `fastest` or `better` to use these
+compression levels. This can also be set with the `--compression` flag.
+
+https://github.com/restic/restic/issues/4728

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -114,7 +114,7 @@ func (opts *GlobalOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.InsecureNoPassword, "insecure-no-password", false, "use an empty password for the repository, must be passed to every restic command (insecure)")
 	f.BoolVar(&opts.InsecureTLS, "insecure-tls", false, "skip TLS certificate verification when connecting to the repository (insecure)")
 	f.BoolVar(&opts.CleanupCache, "cleanup-cache", false, "auto remove old cache directories")
-	f.Var(&opts.Compression, "compression", "compression mode (only available for repository format version 2), one of (auto|off|max|fastest|better) (default: $RESTIC_COMPRESSION)")
+	f.Var(&opts.Compression, "compression", "compression mode (only available for repository format version 2), one of (auto|off|fastest|better|max) (default: $RESTIC_COMPRESSION)")
 	f.BoolVar(&opts.NoExtraVerify, "no-extra-verify", false, "skip additional verification of data before upload (see documentation)")
 	f.IntVar(&opts.Limits.UploadKb, "limit-upload", 0, "limits uploads to a maximum `rate` in KiB/s. (default: unlimited)")
 	f.IntVar(&opts.Limits.DownloadKb, "limit-download", 0, "limits downloads to a maximum `rate` in KiB/s. (default: unlimited)")

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -114,7 +114,7 @@ func (opts *GlobalOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.InsecureNoPassword, "insecure-no-password", false, "use an empty password for the repository, must be passed to every restic command (insecure)")
 	f.BoolVar(&opts.InsecureTLS, "insecure-tls", false, "skip TLS certificate verification when connecting to the repository (insecure)")
 	f.BoolVar(&opts.CleanupCache, "cleanup-cache", false, "auto remove old cache directories")
-	f.Var(&opts.Compression, "compression", "compression mode (only available for repository format version 2), one of (auto|off|max) (default: $RESTIC_COMPRESSION)")
+	f.Var(&opts.Compression, "compression", "compression mode (only available for repository format version 2), one of (auto|off|max|fastest|better) (default: $RESTIC_COMPRESSION)")
 	f.BoolVar(&opts.NoExtraVerify, "no-extra-verify", false, "skip additional verification of data before upload (see documentation)")
 	f.IntVar(&opts.Limits.UploadKb, "limit-upload", 0, "limits uploads to a maximum `rate` in KiB/s. (default: unlimited)")
 	f.IntVar(&opts.Limits.DownloadKb, "limit-download", 0, "limits downloads to a maximum `rate` in KiB/s. (default: unlimited)")

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -73,7 +73,9 @@ const (
 	CompressionAuto    CompressionMode = 0
 	CompressionOff     CompressionMode = 1
 	CompressionMax     CompressionMode = 2
-	CompressionInvalid CompressionMode = 3
+	CompressionFastest CompressionMode = 3
+	CompressionBetter  CompressionMode = 4
+	CompressionInvalid CompressionMode = 5
 )
 
 // Set implements the method needed for pflag command flag parsing.
@@ -85,9 +87,13 @@ func (c *CompressionMode) Set(s string) error {
 		*c = CompressionOff
 	case "max":
 		*c = CompressionMax
+	case "fastest":
+		*c = CompressionFastest
+	case "better":
+		*c = CompressionBetter
 	default:
 		*c = CompressionInvalid
-		return fmt.Errorf("invalid compression mode %q, must be one of (auto|off|max)", s)
+		return fmt.Errorf("invalid compression mode %q, must be one of (auto|off|max|fastest|better)", s)
 	}
 
 	return nil
@@ -101,6 +107,10 @@ func (c *CompressionMode) String() string {
 		return "off"
 	case CompressionMax:
 		return "max"
+	case CompressionFastest:
+		return "fastest"
+	case CompressionBetter:
+		return "better"
 	default:
 		return "invalid"
 	}
@@ -306,8 +316,16 @@ func (r *Repository) loadBlob(ctx context.Context, blobs []restic.PackedBlob, bu
 func (r *Repository) getZstdEncoder() *zstd.Encoder {
 	r.allocEnc.Do(func() {
 		level := zstd.SpeedDefault
-		if r.opts.Compression == CompressionMax {
+
+		switch r.opts.Compression {
+		case CompressionFastest:
+			level = zstd.SpeedFastest
+		case CompressionBetter:
+			level = zstd.SpeedBetterCompression
+		case CompressionMax:
 			level = zstd.SpeedBestCompression
+		default:
+			level = zstd.SpeedDefault
 		}
 
 		opts := []zstd.EOption{

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -315,8 +315,8 @@ func (r *Repository) loadBlob(ctx context.Context, blobs []restic.PackedBlob, bu
 
 func (r *Repository) getZstdEncoder() *zstd.Encoder {
 	r.allocEnc.Do(func() {
-		level := zstd.SpeedDefault
 
+		var level zstd.EncoderLevel
 		switch r.opts.Compression {
 		case CompressionFastest:
 			level = zstd.SpeedFastest

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -93,7 +93,7 @@ func (c *CompressionMode) Set(s string) error {
 		*c = CompressionBetter
 	default:
 		*c = CompressionInvalid
-		return fmt.Errorf("invalid compression mode %q, must be one of (auto|off|max|fastest|better)", s)
+		return fmt.Errorf("invalid compression mode %q, must be one of (auto|off|fastest|better|max)", s)
 	}
 
 	return nil


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Added support for `fastest` and `better` compression levels exposed by klaupost/compress library.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #4728 

Checklist
---------

- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
