### PR TITLE
forget: return exit code 3 on partial removal of snapshots

### DIFF
--- a/changelog/unreleased/issue-5233
+++ b/changelog/unreleased/issue-5233
@@ -1,0 +1,8 @@
+Bugfix: forget command returns exit code 3 on partial removal of snapshots
+
+The `forget` command now returns exit code 3 when it fails to remove one or
+more snapshots. Previously, it returned exit code 0, which could lead to
+confusion if the command was used in a script.
+
+https://github.com/restic/restic/issues/5233
+https://github.com/restic/restic/pull/5322

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -41,6 +41,7 @@ EXIT STATUS
 
 Exit status is 0 if the command was successful.
 Exit status is 1 if there was any error.
+Exit status is 3 if there was an error removing one or more snapshots.
 Exit status is 10 if the repository does not exist.
 Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
@@ -62,6 +63,7 @@ Exit status is 12 if the password is incorrect.
 type ForgetPolicyCount int
 
 var ErrNegativePolicyCount = errors.New("negative values not allowed, use 'unlimited' instead")
+var ErrFailedToRemoveOneOrMoreSnapshots = errors.New("failed to remove one or more snapshots")
 
 func (c *ForgetPolicyCount) Set(s string) error {
 	switch s {
@@ -304,12 +306,15 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 		return ctx.Err()
 	}
 
+	// these are the snapshots that failed to be removed
+	failedSnIDs := restic.NewIDSet()
 	if len(removeSnIDs) > 0 {
 		if !opts.DryRun {
 			bar := printer.NewCounter("files deleted")
 			err := restic.ParallelRemove(ctx, repo, removeSnIDs, restic.WriteableSnapshotFile, func(id restic.ID, err error) error {
 				if err != nil {
 					printer.E("unable to remove %v/%v from the repository\n", restic.SnapshotFile, id)
+					failedSnIDs.Insert(id)
 				} else {
 					printer.VV("removed %v/%v\n", restic.SnapshotFile, id)
 				}
@@ -329,6 +334,10 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 		if err != nil {
 			return err
 		}
+	}
+
+	if len(failedSnIDs) > 0 {
+		return ErrFailedToRemoveOneOrMoreSnapshots
 	}
 
 	if len(removeSnIDs) > 0 && opts.Prune {

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -206,6 +206,8 @@ func main() {
 		exitCode = 0
 	case err == ErrInvalidSourceData:
 		exitCode = 3
+	case errors.Is(err, ErrFailedToRemoveOneOrMoreSnapshots):
+		exitCode = 3
 	case errors.Is(err, ErrNoRepository):
 		exitCode = 10
 	case restic.IsAlreadyLocked(err):


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Before this change, `forget` command returns exit code of 0 even if it's not able to remove all the selected snapshots, when using it with the `--prune` flag.

With this change, the `forget` command will return an exit code of 3 if it's not able to remove all the selected snapshots.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #5233 

Also, discussed in #5140, #5254 

Checklist
---------
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
