### PR TITLE
docu: Add possible pack file padding to repository design

### DIFF
--- a/doc/design.rst
+++ b/doc/design.rst
@@ -267,6 +267,7 @@ of a JSON document like the following:
       "packs": [
         {
           "id": "73d04e6125cf3c28a299cc2f3cca3b78ceac396e4fcf9575e34536b26782413c",
+          "padding": 12354,
           "blobs": [
             {
               "id": "3ec79977ef0cf5de7b08cd12b874cd0f62bbaf7f07f3497a5b1bbcc8cb39b1ce",
@@ -301,6 +302,9 @@ corresponds to ``Length(encrypted_blob)`` in the pack file header.
 Field ``uncompressed_length`` is only present for compressed blobs and
 therefore is never present in version 1 of the repository format. It is
 set to the value of ``Length(blob)``.
+The field ``padding`` is optional and describes the number of bytes used
+as padding in the pack file. If it is not present or ``0``, no padding is
+used.
 
 The field ``supersedes`` lists the storage IDs of index files that have
 been replaced with the current index file. This happens when index files

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -158,7 +158,7 @@ A Pack's structure is as follows:
 
 ::
 
-    EncryptedBlob1 || ... || EncryptedBlobN || EncryptedHeader || Header_Length
+    EncryptedBlob1 || ... || EncryptedBlobN || Random bytes padding || EncryptedHeader || Header_Length
 
 At the end of the Pack file is a header, which describes the content.
 The header is encrypted and authenticated. ``Header_Length`` is the
@@ -176,6 +176,11 @@ it also allows efficient indexing, for only the header needs to be read
 in order to find out which Blobs are contained in the Pack. Since the
 header is authenticated, authenticity of the header can be checked
 without having to read the complete Pack.
+
+After the encrypted blobs an arbitrary number of random bytes can be
+added for padding. This allows to effectively remidy attacks which are
+based on guessing sizes of blobs stored in a repository. Note that zero
+random bytes are totally valid but may targeted by such attacks.
 
 After decryption, a Pack's header consists of the following elements:
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Enhances the repository format to support padding in order to tackle length guessing attacks, see
#5291.
May close #5328.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Yes, see #5291 or #5328

Checklist
---------

- [N/A] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)). -> Not necessary, may follow with an implementation of the specification
- [x] I'm done! This pull request is ready for review.
