### PR TITLE
EOPNOTSUPP can be returned if the filesystem does not support xattrs

### DIFF
--- a/changelog/unreleased/issue-5344
+++ b/changelog/unreleased/issue-5344
@@ -1,0 +1,7 @@
+Bugfix: Ignore EOPNOTSUPP as an error for xattr
+
+Restic 0.18.0 added xattr support for NetBSD 10+, but not all NetBSD
+filesystems support xattrs.  Other BSD systems can likewise return
+EOPNOTSUPP, so restic now simply ignores EOPNOTSUPP errors for xattrs.
+
+https://github.com/restic/restic/issues/5344

--- a/internal/fs/node_xattr.go
+++ b/internal/fs/node_xattr.go
@@ -53,8 +53,7 @@ func handleXattrErr(err error) error {
 
 	case *xattr.Error:
 		// On Linux, xattr calls on files in an SMB/CIFS mount can return
-		// ENOATTR instead of ENOTSUP.  Ignore "Operation not supported"
-		// as well.
+		// ENOATTR instead of ENOTSUP.  BSD can return EOPNOTSUPP.
 		switch e.Err {
 		case syscall.ENOTSUP, syscall.EOPNOTSUPP, xattr.ENOATTR:
 			return nil

--- a/internal/fs/node_xattr.go
+++ b/internal/fs/node_xattr.go
@@ -54,8 +54,7 @@ func handleXattrErr(err error) error {
 	case *xattr.Error:
 		// On Linux, xattr calls on files in an SMB/CIFS mount can return
 		// ENOATTR instead of ENOTSUP.  BSD can return EOPNOTSUPP.
-		switch e.Err {
-		case syscall.ENOTSUP, syscall.EOPNOTSUPP, xattr.ENOATTR:
+		if e.Err == syscall.ENOTSUP || e.Err == syscall.EOPNOTSUPP || e.Err == xattr.ENOATTR {
 			return nil
 		}
 		return errors.WithStack(e)

--- a/internal/fs/node_xattr.go
+++ b/internal/fs/node_xattr.go
@@ -53,9 +53,10 @@ func handleXattrErr(err error) error {
 
 	case *xattr.Error:
 		// On Linux, xattr calls on files in an SMB/CIFS mount can return
-		// ENOATTR instead of ENOTSUP.
+		// ENOATTR instead of ENOTSUP.  Ignore "Operation not supported"
+		// as well.
 		switch e.Err {
-		case syscall.ENOTSUP, xattr.ENOATTR:
+		case syscall.ENOTSUP, syscall.EOPNOTSUPP, xattr.ENOATTR:
 			return nil
 		}
 		return errors.WithStack(e)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
EOPNOTSUPP is returned on NetBSD on non-FFSv2ea filesystems, and possibly on other OSes with filesystems which do not support xattrs.  This patch ignores EOPNOTSUPP as an error for xattr.


<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://github.com/restic/restic/issues/5341
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
