### PR TITLE
backend/local: ignore chmod "not supported" errors

### DIFF
--- a/changelog/unreleased/issue-5342
+++ b/changelog/unreleased/issue-5342
@@ -1,0 +1,7 @@
+Bugfix: Ignore "chmod not supported" errors when writing files
+
+Restic 0.18.0 introduced a bug that caused "chmod xxx: operation not supported"
+errors to appear when writing to a local file repository that did not support
+chmod (like CIFS or WebDAV mounted via FUSE). Restic now ignores those errors.
+
+https://github.com/restic/restic/issues/5342

--- a/internal/backend/local/local_unix.go
+++ b/internal/backend/local/local_unix.go
@@ -43,5 +43,12 @@ func isMacENOTTY(err error) bool {
 
 // set file to readonly
 func setFileReadonly(f string, mode os.FileMode) error {
-	return os.Chmod(f, mode&^0222)
+	err := os.Chmod(f, mode&^0222)
+
+	// ignore the error if the FS does not support setting this mode (e.g. CIFS with gvfs on Linux)
+	if err != nil && errors.Is(err, errors.ErrUnsupported) {
+		return nil
+	}
+
+	return err
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This fixes a regression in 0.18.0, where local filesystems that don't support chmod would throw errors during writes.

This change is the lightest touch option. But other thoughts if we wanted to go bigger:
- I'm uncertain whether the `os.IsPermission` check on the same line could be removed. Presumably the change in Go versions with 0.18.0 introduced this bug? And it was being caught with `os.IsPermission` before, in which case we could remove it?
- I see that a very similar ENOTSUP check is being done in the `chmod` wrapper in `file_unix.go`. But it felt like a bigger refactor than it was worth to try to unify the chmod-calling code points.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://github.com/restic/restic/issues/5342

Checklist
---------

- [ ] I have added tests for all code changes. (I'm a little unsure how best to test this - presumably injecting /mocking a low level error up.)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
