### PR TITLE
backup: return exit code 3 if not all targets are available

### DIFF
--- a/changelog/unreleased/issue-4467
+++ b/changelog/unreleased/issue-4467
@@ -1,6 +1,6 @@
 Bugfix: Exit with code 3 when some `backup` source files do not exist
 
-Restic used to exit with code 0 even when some targets did not exist. Restic 
+Restic used to exit with code 0 even when some backup sources did not exist. Restic
 would exit with code 3 only when child directories or files did not exist. This
 could cause confusion and unexpected behavior in scripts that relied on the exit
 code to determine if the backup was successful.

--- a/changelog/unreleased/issue-4467
+++ b/changelog/unreleased/issue-4467
@@ -1,0 +1,11 @@
+Bugfix: Exit with code 3 when some targets do not exist
+
+Restic used to exit with code 0 even when some targets did not exist. Restic 
+would exit with code 3 only when child directories or files did not exist. This
+could cause confusion and unexpected behavior in scripts that relied on the exit
+code to determine if the backup was successful.
+
+Restic now exits with code 3 when some targets do not exist.
+
+https://github.com/restic/restic/issues/4467
+https://github.com/restic/restic/pull/5347

--- a/changelog/unreleased/issue-4467
+++ b/changelog/unreleased/issue-4467
@@ -5,7 +5,7 @@ would exit with code 3 only when child directories or files did not exist. This
 could cause confusion and unexpected behavior in scripts that relied on the exit
 code to determine if the backup was successful.
 
-Restic now exits with code 3 when some targets do not exist.
+Restic now exits with code 3 when some backup sources do not exist.
 
 https://github.com/restic/restic/issues/4467
 https://github.com/restic/restic/pull/5347

--- a/changelog/unreleased/issue-4467
+++ b/changelog/unreleased/issue-4467
@@ -1,4 +1,4 @@
-Bugfix: Exit with code 3 when some targets do not exist
+Bugfix: Exit with code 3 when some `backup` source files do not exist
 
 Restic used to exit with code 0 even when some targets did not exist. Restic 
 would exit with code 3 only when child directories or files did not exist. This

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -157,6 +157,9 @@ var backupFSTestHook func(fs fs.FS) fs.FS
 // ErrInvalidSourceData is used to report an incomplete backup
 var ErrInvalidSourceData = errors.New("at least one source file could not be read")
 
+// ErrNoSourceData is used to report that no source data was found
+var ErrNoSourceData = errors.Fatal("all source directories/files do not exist")
+
 // filterExisting returns a slice of all existing items, or an error if no
 // items exist at all.
 func filterExisting(items []string, warnf func(msg string, args ...interface{})) (result []string, err error) {

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -160,6 +160,8 @@ var ErrInvalidSourceData = errors.New("at least one source file could not be rea
 // filterExisting returns a slice of all existing items, or an error if no
 // items exist at all.
 func filterExisting(items []string, warnf func(msg string, args ...interface{})) (result []string, err error) {
+	countTargets := len(items)
+
 	for _, item := range items {
 		_, err := fs.Lstat(item)
 		if errors.Is(err, os.ErrNotExist) {
@@ -168,6 +170,12 @@ func filterExisting(items []string, warnf func(msg string, args ...interface{}))
 		}
 
 		result = append(result, item)
+	}
+
+	countExisting := len(result)
+
+	if countExisting < countTargets {
+		return nil, ErrInvalidSourceData
 	}
 
 	if len(result) == 0 {
@@ -437,17 +445,9 @@ func collectTargets(opts BackupOptions, args []string, warnf func(msg string, ar
 		return nil, errors.Fatal("nothing to backup, please specify source files/dirs")
 	}
 
-	countTargets := len(targets)
-
 	targets, err = filterExisting(targets, warnf)
 	if err != nil {
 		return nil, err
-	}
-
-	countExisting := len(targets)
-
-	if countExisting < countTargets {
-		return nil, ErrInvalidSourceData
 	}
 
 	return targets, nil

--- a/cmd/restic/cmd_backup_integration_test.go
+++ b/cmd/restic/cmd_backup_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
@@ -271,7 +272,9 @@ func TestBackupNonExistingFile(t *testing.T) {
 
 	opts := BackupOptions{}
 
-	testRunBackup(t, "", dirs, opts, env.gopts)
+	err := testRunBackupAssumeFailure(t, "", dirs, opts, env.gopts)
+	rtest.Assert(t, err != nil, "expected error for non-existing file")
+	rtest.Assert(t, !errors.Is(err, ErrInvalidSourceData), "expected ErrInvalidSourceData; got %v", err)
 }
 
 func TestBackupSelfHealing(t *testing.T) {

--- a/cmd/restic/cmd_backup_integration_test.go
+++ b/cmd/restic/cmd_backup_integration_test.go
@@ -272,9 +272,17 @@ func TestBackupNonExistingFile(t *testing.T) {
 
 	opts := BackupOptions{}
 
+	// mix of existing and non-existing files
 	err := testRunBackupAssumeFailure(t, "", dirs, opts, env.gopts)
 	rtest.Assert(t, err != nil, "expected error for non-existing file")
-	rtest.Assert(t, !errors.Is(err, ErrInvalidSourceData), "expected ErrInvalidSourceData; got %v", err)
+	rtest.Assert(t, errors.Is(err, ErrInvalidSourceData), "expected ErrInvalidSourceData; got %v", err)
+	// only non-existing file
+	dirs = []string{
+		filepath.Join(p, "nonexisting"),
+	}
+	err = testRunBackupAssumeFailure(t, "", dirs, opts, env.gopts)
+	rtest.Assert(t, err != nil, "expected error for non-existing file")
+	rtest.Assert(t, errors.Is(err, ErrNoSourceData), "expected ErrNoSourceData; got %v", err)
 }
 
 func TestBackupSelfHealing(t *testing.T) {

--- a/cmd/restic/cmd_backup_test.go
+++ b/cmd/restic/cmd_backup_test.go
@@ -71,6 +71,9 @@ func TestCollectTargets(t *testing.T) {
 	rtest.OK(t, err)
 	sort.Strings(targets)
 	rtest.Equals(t, expect, targets)
+
+	_, err = collectTargets(opts, []string{filepath.Join(dir, "cmdline arg"), filepath.Join(dir, "non-existing-file")}, t.Logf, nil)
+	rtest.Assert(t, err == ErrInvalidSourceData, "expected error when not all targets exist")
 }
 
 func TestReadFilenamesRaw(t *testing.T) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Restic `backup` command will also exit with code 3 if any one of the targets selected for backup are inaccessible. Previously, the `backup` command would exit with code 3 only if a child directory or file was inaccessible.

I have modified the `collectTargets` function in the `cmd_backup.go` command to check if all the targets collected from command line args, `--files-from`, `--files-from-verbatim` and `--files-from-raw` are accessible. If any of the targets are inaccessible then, we return the `ErrInvalidSourceData` towards the end; this will result in a exit code `3` (partial snapshot)

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #4467 

Checklist
---------
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
