### PR TITLE
backup: Fix `--stdin-filename` with directory

### DIFF
--- a/changelog/unreleased/issue-5324
+++ b/changelog/unreleased/issue-5324
@@ -1,0 +1,14 @@
+Bugfix: Correctly handle `backup --stdin-filename` with directories
+
+In restic 0.18.0, the `backup` command failed if a filename that includes
+a least a directory was passed to `--stdin-filename`. For example,
+`--stdin-filename /foo/bar` resulted in the following error:
+
+```
+Fatal: unable to save snapshot: open /foo: no such file or directory
+```
+
+This has been fixed now.
+
+https://github.com/restic/restic/issues/5324
+https://github.com/restic/restic/pull/5356

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -591,12 +591,10 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 				return err
 			}
 		}
-		targetFS = &fs.Reader{
-			ModTime:    timeStamp,
-			Name:       filename,
-			Mode:       0644,
-			ReadCloser: source,
-		}
+		targetFS = fs.NewReader(filename, source, fs.ReaderOptions{
+			ModTime: timeStamp,
+			Mode:    0644,
+		})
 		targets = []string{filename}
 	}
 

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -591,10 +591,13 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 				return err
 			}
 		}
-		targetFS = fs.NewReader(filename, source, fs.ReaderOptions{
+		targetFS, err = fs.NewReader(filename, source, fs.ReaderOptions{
 			ModTime: timeStamp,
 			Mode:    0644,
 		})
+		if err != nil {
+			return fmt.Errorf("failed to backup from stdin: %w", err)
+		}
 		targets = []string{filename}
 	}
 

--- a/cmd/restic/cmd_backup_integration_test.go
+++ b/cmd/restic/cmd_backup_integration_test.go
@@ -632,12 +632,15 @@ func TestStdinFromCommand(t *testing.T) {
 
 	testSetupBackupData(t, env)
 	opts := BackupOptions{
-		StdinCommand:  true,
-		StdinFilename: "stdin",
+		StdinCommand: true,
+		// test that subdirectories are handled correctly
+		StdinFilename: "stdin/subdir/file",
 	}
 
 	testRunBackup(t, filepath.Dir(env.testdata), []string{"python", "-c", "import sys; print('something'); sys.exit(0)"}, opts, env.gopts)
-	testListSnapshots(t, env.gopts, 1)
+	snapshots := testListSnapshots(t, env.gopts, 1)
+	files := testRunLs(t, env.gopts, snapshots[0].String())
+	rtest.Assert(t, includes(files, "/stdin/subdir/file"), "file %q missing from snapshot, got %v", "stdin/subdir/file", files)
 
 	testRunCheck(t, env.gopts)
 }

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -174,10 +174,11 @@ func TestArchiverSaveFileReaderFS(t *testing.T) {
 
 			ts := time.Now()
 			filename := "xx"
-			readerFs := fs.NewReader(filename, io.NopCloser(strings.NewReader(test.Data)), fs.ReaderOptions{
+			readerFs, err := fs.NewReader(filename, io.NopCloser(strings.NewReader(test.Data)), fs.ReaderOptions{
 				ModTime: ts,
 				Mode:    0123,
 			})
+			rtest.OK(t, err)
 
 			node, stats := saveFile(t, repo, filename, readerFs)
 
@@ -286,11 +287,11 @@ func TestArchiverSaveReaderFS(t *testing.T) {
 
 			ts := time.Now()
 			filename := "xx"
-			readerFs := fs.NewReader(filename, io.NopCloser(strings.NewReader(test.Data)), fs.ReaderOptions{
+			readerFs, err := fs.NewReader(filename, io.NopCloser(strings.NewReader(test.Data)), fs.ReaderOptions{
 				ModTime: ts,
 				Mode:    0123,
 			})
-
+			rtest.OK(t, err)
 			arch := New(repo, readerFs, Options{})
 			arch.Error = func(item string, err error) error {
 				t.Errorf("archiver error for %v: %v", item, err)

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -174,12 +174,10 @@ func TestArchiverSaveFileReaderFS(t *testing.T) {
 
 			ts := time.Now()
 			filename := "xx"
-			readerFs := &fs.Reader{
-				ModTime:    ts,
-				Mode:       0123,
-				Name:       filename,
-				ReadCloser: io.NopCloser(strings.NewReader(test.Data)),
-			}
+			readerFs := fs.NewReader(filename, io.NopCloser(strings.NewReader(test.Data)), fs.ReaderOptions{
+				ModTime: ts,
+				Mode:    0123,
+			})
 
 			node, stats := saveFile(t, repo, filename, readerFs)
 
@@ -288,12 +286,10 @@ func TestArchiverSaveReaderFS(t *testing.T) {
 
 			ts := time.Now()
 			filename := "xx"
-			readerFs := &fs.Reader{
-				ModTime:    ts,
-				Mode:       0123,
-				Name:       filename,
-				ReadCloser: io.NopCloser(strings.NewReader(test.Data)),
-			}
+			readerFs := fs.NewReader(filename, io.NopCloser(strings.NewReader(test.Data)), fs.ReaderOptions{
+				ModTime: ts,
+				Mode:    0123,
+			})
 
 			arch := New(repo, readerFs, Options{})
 			arch.Error = func(item string, err error) error {

--- a/internal/fs/fs_reader.go
+++ b/internal/fs/fs_reader.go
@@ -19,35 +19,87 @@ import (
 // be opened once, all subsequent open calls return syscall.EIO. For Lstat(),
 // the provided FileInfo is returned.
 type Reader struct {
-	Name string
-	io.ReadCloser
+	items map[string]readerItem
+}
 
-	// for FileInfo
+type ReaderOptions struct {
 	Mode    os.FileMode
 	ModTime time.Time
 	Size    int64
 
 	AllowEmptyFile bool
+}
 
-	open sync.Once
+type readerItem struct {
+	open           *sync.Once
+	fi             *ExtendedFileInfo
+	rc             io.ReadCloser
+	allowEmptyFile bool
+
+	children []string
 }
 
 // statically ensure that Local implements FS.
 var _ FS = &Reader{}
 
+func NewReader(name string, r io.ReadCloser, opts ReaderOptions) *Reader {
+	items := make(map[string]readerItem)
+	name = readerCleanPath(name)
+
+	isFile := true
+	for {
+		if isFile {
+			fi := &ExtendedFileInfo{
+				Name:    path.Base(name),
+				Mode:    opts.Mode,
+				ModTime: opts.ModTime,
+				Size:    opts.Size,
+			}
+			items[name] = readerItem{
+				open:           &sync.Once{},
+				fi:             fi,
+				rc:             r,
+				allowEmptyFile: opts.AllowEmptyFile,
+			}
+			isFile = false
+		} else {
+			fi := &ExtendedFileInfo{
+				Name:    path.Base(name),
+				Mode:    os.ModeDir | 0755,
+				ModTime: time.Now(), // FIXME
+				Size:    0,
+			}
+			items[name] = readerItem{
+				fi: fi,
+				// keep the children set during the previous iteration
+				children: items[name].children,
+			}
+		}
+
+		parent := path.Dir(name)
+		if parent == name {
+			break
+		}
+		// add the current file to the children of the parent directory
+		item := items[parent]
+		item.children = append(item.children, path.Base(name))
+		items[parent] = item
+
+		name = parent
+	}
+	return &Reader{
+		items: items,
+	}
+}
+
+func readerCleanPath(name string) string {
+	return path.Clean("/" + name)
+}
+
 // VolumeName returns leading volume name, for the Reader file system it's
 // always the empty string.
 func (fs *Reader) VolumeName(_ string) string {
 	return ""
-}
-
-func (fs *Reader) fi() *ExtendedFileInfo {
-	return &ExtendedFileInfo{
-		Name:    fs.Name,
-		Mode:    fs.Mode,
-		ModTime: fs.ModTime,
-		Size:    fs.Size,
-	}
 }
 
 func (fs *Reader) OpenFile(name string, flag int, _ bool) (f File, err error) {
@@ -56,10 +108,16 @@ func (fs *Reader) OpenFile(name string, flag int, _ bool) (f File, err error) {
 			fmt.Errorf("invalid combination of flags 0x%x", flag))
 	}
 
-	switch name {
-	case fs.Name:
-		fs.open.Do(func() {
-			f = newReaderFile(fs.ReadCloser, fs.fi(), fs.AllowEmptyFile)
+	name = readerCleanPath(name)
+	item, ok := fs.items[name]
+	if !ok {
+		return nil, pathError("open", name, syscall.ENOENT)
+	}
+
+	// Check if the path matches our target file
+	if item.rc != nil {
+		item.open.Do(func() {
+			f = newReaderFile(item.rc, item.fi, item.allowEmptyFile)
 		})
 
 		if f == nil {
@@ -67,49 +125,23 @@ func (fs *Reader) OpenFile(name string, flag int, _ bool) (f File, err error) {
 		}
 
 		return f, nil
-	case "/", ".":
-		f = fakeDir{
-			entries: []string{fs.fi().Name},
-		}
-		return f, nil
 	}
 
-	return nil, pathError("open", name, syscall.ENOENT)
+	f = fakeDir{
+		entries: slices.Clone(item.children),
+	}
+	return f, nil
 }
 
 // Lstat returns the FileInfo structure describing the named file.
-// If the file is a symbolic link, the returned FileInfo
-// describes the symbolic link.  Lstat makes no attempt to follow the link.
 // If there is an error, it will be of type *os.PathError.
 func (fs *Reader) Lstat(name string) (*ExtendedFileInfo, error) {
-	getDirInfo := func(name string) *ExtendedFileInfo {
-		return &ExtendedFileInfo{
-			Name:    fs.Base(name),
-			Size:    0,
-			Mode:    os.ModeDir | 0755,
-			ModTime: time.Now(),
-		}
+	name = readerCleanPath(name)
+	item, ok := fs.items[name]
+	if !ok {
+		return nil, pathError("lstat", name, os.ErrNotExist)
 	}
-
-	switch name {
-	case fs.Name:
-		return fs.fi(), nil
-	case "/", ".":
-		return getDirInfo(name), nil
-	}
-
-	dir := fs.Dir(fs.Name)
-	for {
-		if dir == "/" || dir == "." {
-			break
-		}
-		if name == dir {
-			return getDirInfo(name), nil
-		}
-		dir = fs.Dir(dir)
-	}
-
-	return nil, pathError("lstat", name, os.ErrNotExist)
+	return item.fi, nil
 }
 
 // Join joins any number of path elements into a single path, adding a
@@ -137,7 +169,7 @@ func (fs *Reader) IsAbs(_ string) bool {
 //
 // For the Reader, all paths are absolute.
 func (fs *Reader) Abs(p string) (string, error) {
-	return path.Clean(p), nil
+	return readerCleanPath(p), nil
 }
 
 // Clean returns the cleaned path. For details, see filepath.Clean.

--- a/internal/fs/fs_reader.go
+++ b/internal/fs/fs_reader.go
@@ -128,6 +128,9 @@ func (fs *Reader) OpenFile(name string, flag int, _ bool) (f File, err error) {
 	}
 
 	f = fakeDir{
+		fakeFile: fakeFile{
+			fi: item.fi,
+		},
 		entries: slices.Clone(item.children),
 	}
 	return f, nil

--- a/internal/fs/fs_reader.go
+++ b/internal/fs/fs_reader.go
@@ -42,9 +42,12 @@ type readerItem struct {
 // statically ensure that Local implements FS.
 var _ FS = &Reader{}
 
-func NewReader(name string, r io.ReadCloser, opts ReaderOptions) *Reader {
+func NewReader(name string, r io.ReadCloser, opts ReaderOptions) (*Reader, error) {
 	items := make(map[string]readerItem)
 	name = readerCleanPath(name)
+	if name == "/" {
+		return nil, fmt.Errorf("invalid filename specified")
+	}
 
 	isFile := true
 	for {
@@ -89,7 +92,7 @@ func NewReader(name string, r io.ReadCloser, opts ReaderOptions) *Reader {
 	}
 	return &Reader{
 		items: items,
-	}
+	}, nil
 }
 
 func readerCleanPath(name string) string {

--- a/internal/fs/fs_reader.go
+++ b/internal/fs/fs_reader.go
@@ -66,7 +66,7 @@ func NewReader(name string, r io.ReadCloser, opts ReaderOptions) *Reader {
 			fi := &ExtendedFileInfo{
 				Name:    path.Base(name),
 				Mode:    os.ModeDir | 0755,
-				ModTime: time.Now(), // FIXME
+				ModTime: opts.ModTime,
 				Size:    0,
 			}
 			items[name] = readerItem{

--- a/internal/fs/fs_reader_test.go
+++ b/internal/fs/fs_reader_test.go
@@ -185,15 +185,16 @@ func TestFSReader(t *testing.T) {
 	tests = append(tests, createFileTest(filename, now, data)...)
 	tests = append(tests, createDirTest("", now)...)
 
-	for _, test := range tests {
-		fs := NewReader(filename, io.NopCloser(bytes.NewReader(data)), ReaderOptions{
+	for _, tst := range tests {
+		fs, err := NewReader(filename, io.NopCloser(bytes.NewReader(data)), ReaderOptions{
 			Mode:    0644,
 			Size:    int64(len(data)),
 			ModTime: now,
 		})
+		test.OK(t, err)
 
-		t.Run(test.name, func(t *testing.T) {
-			test.f(t, fs)
+		t.Run(tst.name, func(t *testing.T) {
+			tst.f(t, fs)
 		})
 	}
 }
@@ -211,15 +212,16 @@ func TestFSReaderNested(t *testing.T) {
 	tests = append(tests, createDirTest("foo", now)...)
 	tests = append(tests, createDirTest("foo/sub", now)...)
 
-	for _, test := range tests {
-		fs := NewReader(filename, io.NopCloser(bytes.NewReader(data)), ReaderOptions{
+	for _, tst := range tests {
+		fs, err := NewReader(filename, io.NopCloser(bytes.NewReader(data)), ReaderOptions{
 			Mode:    0644,
 			Size:    int64(len(data)),
 			ModTime: now,
 		})
+		test.OK(t, err)
 
-		t.Run(test.name, func(t *testing.T) {
-			test.f(t, fs)
+		t.Run(tst.name, func(t *testing.T) {
+			tst.f(t, fs)
 		})
 	}
 }
@@ -244,12 +246,12 @@ func TestFSReaderDir(t *testing.T) {
 
 	for _, tst := range tests {
 		t.Run(tst.name, func(t *testing.T) {
-			fs := NewReader(tst.filename, io.NopCloser(bytes.NewReader(data)), ReaderOptions{
+			fs, err := NewReader(tst.filename, io.NopCloser(bytes.NewReader(data)), ReaderOptions{
 				Mode:    0644,
 				Size:    int64(len(data)),
 				ModTime: now,
 			})
-
+			test.OK(t, err)
 			dir := path.Dir(tst.filename)
 			for {
 				if dir == "/" || dir == "." {
@@ -294,12 +296,12 @@ func TestFSReaderMinFileSize(t *testing.T) {
 
 	for _, tst := range tests {
 		t.Run(tst.name, func(t *testing.T) {
-			fs := NewReader("testfile", io.NopCloser(strings.NewReader(tst.data)), ReaderOptions{
+			fs, err := NewReader("testfile", io.NopCloser(strings.NewReader(tst.data)), ReaderOptions{
 				Mode:           0644,
 				ModTime:        time.Now(),
 				AllowEmptyFile: tst.allowEmpty,
 			})
-
+			test.OK(t, err)
 			f, err := fs.OpenFile("testfile", O_RDONLY, false)
 			test.OK(t, err)
 

--- a/internal/fs/fs_reader_test.go
+++ b/internal/fs/fs_reader_test.go
@@ -183,26 +183,36 @@ func createDirTest(fpath string, now time.Time) fsTest {
 		{
 			name: "dir/Open-slash-" + fpath,
 			f: func(t *testing.T, fs FS) {
-				fi, err := fs.Lstat("/" + fpath)
-				if err != nil {
-					t.Fatal(err)
-				}
-
+				fi := fsStatDir(t, fs, "/"+fpath)
 				checkFileInfo(t, fi, "/"+fpath, now, os.ModeDir|0755, true)
 			},
 		},
 		{
 			name: "dir/Open-current-" + fpath,
 			f: func(t *testing.T, fs FS) {
-				fi, err := fs.Lstat("./" + fpath)
-				if err != nil {
-					t.Fatal(err)
-				}
-
+				fi := fsStatDir(t, fs, "./"+fpath)
 				checkFileInfo(t, fi, "/"+fpath, now, os.ModeDir|0755, true)
 			},
 		},
 	}
+}
+
+func fsStatDir(t *testing.T, fs FS, fpath string) *ExtendedFileInfo {
+	f, err := fs.OpenFile(fpath, O_RDONLY, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fi, err := f.Stat()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = f.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+	return fi
 }
 
 func TestFSReader(t *testing.T) {

--- a/internal/fs/fs_reader_test.go
+++ b/internal/fs/fs_reader_test.go
@@ -69,7 +69,7 @@ func checkFileInfo(t testing.TB, fi *ExtendedFileInfo, filename string, modtime 
 		t.Errorf("Mode has wrong value, want 0%o, got 0%o", mode, fi.Mode)
 	}
 
-	if !modtime.Equal(time.Time{}) && !fi.ModTime.Equal(modtime) {
+	if !fi.ModTime.Equal(modtime) {
 		t.Errorf("ModTime has wrong value, want %v, got %v", modtime, fi.ModTime)
 	}
 
@@ -147,7 +147,7 @@ func createFileTest(filename string, now time.Time, data []byte) fsTest {
 	}
 }
 
-func createDirTest(fpath string) fsTest {
+func createDirTest(fpath string, now time.Time) fsTest {
 	return fsTest{
 		{
 			name: "dir/Lstat-slash-" + fpath,
@@ -157,7 +157,7 @@ func createDirTest(fpath string) fsTest {
 					t.Fatal(err)
 				}
 
-				checkFileInfo(t, fi, "/"+fpath, time.Time{}, os.ModeDir|0755, true)
+				checkFileInfo(t, fi, "/"+fpath, now, os.ModeDir|0755, true)
 			},
 		},
 		{
@@ -168,7 +168,7 @@ func createDirTest(fpath string) fsTest {
 					t.Fatal(err)
 				}
 
-				checkFileInfo(t, fi, "/"+fpath, time.Time{}, os.ModeDir|0755, true)
+				checkFileInfo(t, fi, "/"+fpath, now, os.ModeDir|0755, true)
 			},
 		},
 		{
@@ -188,7 +188,7 @@ func createDirTest(fpath string) fsTest {
 					t.Fatal(err)
 				}
 
-				checkFileInfo(t, fi, "/"+fpath, time.Time{}, os.ModeDir|0755, true)
+				checkFileInfo(t, fi, "/"+fpath, now, os.ModeDir|0755, true)
 			},
 		},
 		{
@@ -199,7 +199,7 @@ func createDirTest(fpath string) fsTest {
 					t.Fatal(err)
 				}
 
-				checkFileInfo(t, fi, "/"+fpath, time.Time{}, os.ModeDir|0755, true)
+				checkFileInfo(t, fi, "/"+fpath, now, os.ModeDir|0755, true)
 			},
 		},
 	}
@@ -212,7 +212,7 @@ func TestFSReader(t *testing.T) {
 
 	tests := createReadDirTest("", filename)
 	tests = append(tests, createFileTest(filename, now, data)...)
-	tests = append(tests, createDirTest("")...)
+	tests = append(tests, createDirTest("", now)...)
 
 	for _, test := range tests {
 		fs := NewReader(filename, io.NopCloser(bytes.NewReader(data)), ReaderOptions{
@@ -236,9 +236,9 @@ func TestFSReaderNested(t *testing.T) {
 	tests = append(tests, createReadDirTest("foo", "sub")...)
 	tests = append(tests, createReadDirTest("foo/sub", "bar")...)
 	tests = append(tests, createFileTest(filename, now, data)...)
-	tests = append(tests, createDirTest("")...)
-	tests = append(tests, createDirTest("foo")...)
-	tests = append(tests, createDirTest("foo/sub")...)
+	tests = append(tests, createDirTest("", now)...)
+	tests = append(tests, createDirTest("foo", now)...)
+	tests = append(tests, createDirTest("foo/sub", now)...)
 
 	for _, test := range tests {
 		fs := NewReader(filename, io.NopCloser(bytes.NewReader(data)), ReaderOptions{
@@ -290,7 +290,7 @@ func TestFSReaderDir(t *testing.T) {
 					t.Fatal(err)
 				}
 
-				checkFileInfo(t, fi, dir, time.Time{}, os.ModeDir|0755, true)
+				checkFileInfo(t, fi, dir, now, os.ModeDir|0755, true)
 
 				dir = path.Dir(dir)
 			}

--- a/internal/fs/fs_reader_test.go
+++ b/internal/fs/fs_reader_test.go
@@ -126,21 +126,7 @@ func createFileTest(filename string, now time.Time, data []byte) fsTest {
 		{
 			name: "file/Stat",
 			f: func(t *testing.T, fs FS) {
-				f, err := fs.OpenFile(filename, O_RDONLY, true)
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				fi, err := f.Stat()
-				if err != nil {
-					t.Fatal(err)
-				}
-
-				err = f.Close()
-				if err != nil {
-					t.Fatal(err)
-				}
-
+				fi := fsOpenAndStat(t, fs, filename, true)
 				checkFileInfo(t, fi, filename, now, 0644, false)
 			},
 		},
@@ -183,22 +169,22 @@ func createDirTest(fpath string, now time.Time) fsTest {
 		{
 			name: "dir/Open-slash-" + fpath,
 			f: func(t *testing.T, fs FS) {
-				fi := fsStatDir(t, fs, "/"+fpath)
+				fi := fsOpenAndStat(t, fs, "/"+fpath, false)
 				checkFileInfo(t, fi, "/"+fpath, now, os.ModeDir|0755, true)
 			},
 		},
 		{
 			name: "dir/Open-current-" + fpath,
 			f: func(t *testing.T, fs FS) {
-				fi := fsStatDir(t, fs, "./"+fpath)
+				fi := fsOpenAndStat(t, fs, "./"+fpath, false)
 				checkFileInfo(t, fi, "/"+fpath, now, os.ModeDir|0755, true)
 			},
 		},
 	}
 }
 
-func fsStatDir(t *testing.T, fs FS, fpath string) *ExtendedFileInfo {
-	f, err := fs.OpenFile(fpath, O_RDONLY, false)
+func fsOpenAndStat(t *testing.T, fs FS, fpath string, metadataOnly bool) *ExtendedFileInfo {
+	f, err := fs.OpenFile(fpath, O_RDONLY, metadataOnly)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/fs/fs_reader_test.go
+++ b/internal/fs/fs_reader_test.go
@@ -97,6 +97,13 @@ func createFileTest(filename string, now time.Time, data []byte) fsTest {
 			},
 		},
 		{
+			name: "file/Open-error-not-exist",
+			f: func(t *testing.T, fs FS) {
+				_, err := fs.OpenFile(filename+"/other", O_RDONLY, false)
+				test.Assert(t, errors.Is(err, os.ErrNotExist), "unexpected error, got %v, expected %v", err, os.ErrNotExist)
+			},
+		},
+		{
 			name: "file/Lstat",
 			f: func(t *testing.T, fs FS) {
 				fi, err := fs.Lstat(filename)

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -908,11 +908,9 @@ func TestRestorerSparseFiles(t *testing.T) {
 
 	var zeros [1<<20 + 13]byte
 
-	target := &fs.Reader{
-		Mode:       0600,
-		Name:       "/zeros",
-		ReadCloser: io.NopCloser(bytes.NewReader(zeros[:])),
-	}
+	target := fs.NewReader("/zeros", io.NopCloser(bytes.NewReader(zeros[:])), fs.ReaderOptions{
+		Mode: 0600,
+	})
 	sc := archiver.NewScanner(target)
 	err := sc.Scan(context.TODO(), []string{"/zeros"})
 	rtest.OK(t, err)

--- a/internal/restorer/restorer_test.go
+++ b/internal/restorer/restorer_test.go
@@ -908,11 +908,12 @@ func TestRestorerSparseFiles(t *testing.T) {
 
 	var zeros [1<<20 + 13]byte
 
-	target := fs.NewReader("/zeros", io.NopCloser(bytes.NewReader(zeros[:])), fs.ReaderOptions{
+	target, err := fs.NewReader("/zeros", io.NopCloser(bytes.NewReader(zeros[:])), fs.ReaderOptions{
 		Mode: 0600,
 	})
+	rtest.OK(t, err)
 	sc := archiver.NewScanner(target)
-	err := sc.Scan(context.TODO(), []string{"/zeros"})
+	err = sc.Scan(context.TODO(), []string{"/zeros"})
 	rtest.OK(t, err)
 
 	arch := archiver.New(repo, target, archiver.Options{})


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
In restic 0.18.0, the `backup` command failed if a filename that includes a least a directory was passed to `--stdin-filename`. For example, `--stdin-filename /foo/bar` resulted in the following error:

```
Fatal: unable to save snapshot: open /foo: no such file or directory
```

With the FS interface changes included in restic 0.18.0, it is now necessary for the `fs.Reader` struct to handle intermediate directories correctly. This is now ensured by constructing the directory right when initializing the `Reader`. Thereby, the full path handling is only necessary once. The accessor functions then just can look up the relevant directory entry.

The intermediate directories now use the same timestamp as the file. This ensures that the snapshot content is fully deterministic when the timestamp is specified. I've also added proper error handling for that case that an invalid path was specified.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/5324
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
