### PR TITLE
Fix tty capture when started in background

### DIFF
--- a/changelog/unreleased/issue-5354
+++ b/changelog/unreleased/issue-5354
@@ -1,0 +1,12 @@
+Bugfix: Allow use of rclone/sftp backend when running restic in background
+
+When starting restic in the background, this could result in unexpected behavior
+when using the rclone or sftp backend.
+
+For example running `restic -r rclone:./example --insecure-no-password init &`
+could cause the calling `bash` shell to exit unexpectedly.
+
+This has been fixed.
+
+https://github.com/restic/restic/issues/5354
+https://github.com/restic/restic/pull/5358


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

The rclone and sftp backends require starting a child process. It is first moved into the foreground and back into the background after the initial startup is done.

However, this behavior is also active if restic itself is started in the background. In this case, restic changing the foreground process may confuse the shell and in case of bash causes it to exit. Thus, disable modification of the controlling process group of the tty if restic is run in the background.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/5354
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
