### PR TITLE
PR retired: git prune - prune more aggresively - issue 5293

### DIFF
--- a/changelog/unreleased/issue-5293
+++ b/changelog/unreleased/issue-5293
@@ -9,4 +9,4 @@ marked as deprecated.
 
 https://github.com/restic/restic/issues/5293
 https://github.com/restic/restic/pull/5183
-https://github.com/restic/restic/pull/new
+https://github.com/restic/restic/pull/5359

--- a/changelog/unreleased/issue-5293
+++ b/changelog/unreleased/issue-5293
@@ -1,0 +1,12 @@
+Enhancement: prune small packfiles more aggressively
+
+prune reads all packfiles and their sizes, sorts them by ascending size order.
+It picks the first percentile value from the sorted list of packfile sizes and
+applies the scale factor of 80% to it and uses it for its prune decisions.
+
+As a consequence, the option `--repack-small` is not longer needed and has been
+marked as deprecated.
+
+https://github.com/restic/restic/issues/5293
+https://github.com/restic/restic/pull/5183
+https://github.com/restic/restic/pull/new

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -85,6 +85,11 @@ func (opts *PruneOptions) AddLimitedFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.RepackSmall, "repack-small", false, "repack pack files below 80% of target pack size")
 	f.BoolVar(&opts.RepackUncompressed, "repack-uncompressed", false, "repack all uncompressed data")
 	f.StringVar(&opts.SmallPackSize, "repack-smaller-than", "", "pack `below-limit` packfiles (allowed suffixes: k/K, m/M)")
+	err := f.MarkDeprecated("repack-small", "not used at all")
+	if err != nil {
+		// MarkDeprecated only returns an error when the flag is not found
+		panic(err)
+	}
 }
 
 func verifyPruneOptions(opts *PruneOptions) error {
@@ -149,7 +154,6 @@ func verifyPruneOptions(opts *PruneOptions) error {
 			return errors.Fatalf("invalid number of bytes %q for --repack-smaller-than: %v", opts.SmallPackSize, err)
 		}
 		opts.SmallPackBytes = uint64(size)
-		opts.RepackSmall = true
 	}
 
 	return nil
@@ -210,7 +214,6 @@ func runPruneWithRepo(ctx context.Context, opts PruneOptions, gopts GlobalOption
 		SmallPackBytes: opts.SmallPackBytes,
 
 		RepackCacheableOnly: opts.RepackCacheableOnly,
-		RepackSmall:         opts.RepackSmall,
 		RepackUncompressed:  opts.RepackUncompressed,
 	}
 

--- a/internal/repository/prune.go
+++ b/internal/repository/prune.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"slices"
 	"sort"
 
 	"github.com/restic/restic/internal/errors"
@@ -27,7 +28,6 @@ type PruneOptions struct {
 	SmallPackBytes uint64
 
 	RepackCacheableOnly bool
-	RepackSmall         bool
 	RepackUncompressed  bool
 }
 
@@ -332,22 +332,38 @@ func decidePackAction(ctx context.Context, opts PruneOptions, repo *Repository, 
 	targetPackSize := repo.packSize() / 25
 	if opts.SmallPackBytes > 0 {
 		targetPackSize = uint(opts.SmallPackBytes)
-	} else if opts.RepackSmall {
-		// consider files with at least 80% of the target size as large enough
-		targetPackSize = repo.packSize() / 5 * 4
 	}
 
 	// loop over all packs and decide what to do
 	bar := printer.NewCounter("packs processed")
 	bar.SetMax(uint64(len(indexPack)))
+
+	packsFromPackfiles := map[restic.ID]int64{}
 	err := repo.List(ctx, restic.PackFile, func(id restic.ID, packSize int64) error {
+		packsFromPackfiles[id] = packSize
+		bar.Add(1)
+		return nil
+	})
+	bar.Done()
+	if err != nil {
+		return PrunePlan{}, err
+	}
+	percentIndex := 0 // zero based
+	rightmost := true
+	scaleFactor := 0.8
+	fPercent := smallSizeEvaluation(packsFromPackfiles, percentIndex, rightmost, scaleFactor)
+	if fPercent > targetPackSize {
+		targetPackSize = fPercent
+	}
+
+	for id, packSize := range packsFromPackfiles {
 		p, ok := indexPack[id]
 		if !ok {
 			// Pack was not referenced in index and is not used  => immediately remove!
 			printer.V("will remove pack %v as it is unused and not indexed\n", id.Str())
 			removePacksFirst.Insert(id)
 			stats.Size.Unref += uint64(packSize)
-			return nil
+			continue
 		}
 
 		if p.unusedSize+p.usedSize != uint64(packSize) && p.usedBlobs != 0 {
@@ -356,7 +372,7 @@ func decidePackAction(ctx context.Context, opts PruneOptions, repo *Repository, 
 			// and will be simply removed, see below.
 			printer.E("pack %s: calculated size %d does not match real size %d\nRun 'restic repair index'.\n",
 				id.Str(), p.unusedSize+p.usedSize, packSize)
-			return ErrSizeNotMatching
+			return PrunePlan{}, ErrSizeNotMatching
 		}
 
 		// statistics
@@ -405,13 +421,6 @@ func decidePackAction(ctx context.Context, opts PruneOptions, repo *Repository, 
 		}
 
 		delete(indexPack, id)
-		bar.Add(1)
-		return nil
-	})
-
-	bar.Done()
-	if err != nil {
-		return PrunePlan{}, err
 	}
 
 	// At this point indexPacks contains only missing packs!
@@ -645,4 +654,24 @@ func deleteFiles(ctx context.Context, ignoreError bool, repo restic.RemoverUnpac
 		printer.VV("removed %v/%v\n", fileType, id)
 		return nil
 	}, bar)
+}
+
+func smallSizeEvaluation(packsFromPackfiles map[restic.ID]int64, percentIndex int, rightmost bool, scaleFactor float64) uint {
+
+	i := 0
+	packSizeSlice := make([]int64, len(packsFromPackfiles))
+	for _, size := range packsFromPackfiles {
+		packSizeSlice[i] = size
+		i++
+	}
+	slices.Sort(packSizeSlice)
+	numberOfPackfiles := len(packsFromPackfiles)
+
+	chosen := numberOfPackfiles * percentIndex / 100
+	if rightmost && numberOfPackfiles >= 100 {
+		chosen += numberOfPackfiles/100 - 1
+	}
+	value := uint(float64(packSizeSlice[chosen]) * scaleFactor)
+	//fmt.Printf("ix %d smallPacksize %d\n", chosen, value)
+	return value
 }

--- a/internal/repository/prune.go
+++ b/internal/repository/prune.go
@@ -348,7 +348,13 @@ func decidePackAction(ctx context.Context, opts PruneOptions, repo *Repository, 
 	if err != nil {
 		return PrunePlan{}, err
 	}
-	percentIndex := 0 // zero based
+
+	// There are some choices which can be made here:
+	// which percentile (0 <= percentIndex < 100),
+	// left or right border of selected percentile
+	// and the scale Factor (0.0 <= scaleFactor <= 1.0)
+	// These could be made into options of `restic prune`
+	percentIndex := 1
 	rightmost := true
 	scaleFactor := 0.8
 	fPercent := smallSizeEvaluation(packsFromPackfiles, percentIndex, rightmost, scaleFactor)
@@ -657,6 +663,18 @@ func deleteFiles(ctx context.Context, ignoreError bool, repo restic.RemoverUnpac
 }
 
 func smallSizeEvaluation(packsFromPackfiles map[restic.ID]int64, percentIndex int, rightmost bool, scaleFactor float64) uint {
+
+	// do some quiet boundary checking
+	if percentIndex < 0 {
+		percentIndex = 0
+	} else if percentIndex > 99 {
+		percentIndex = 99
+	}
+	if scaleFactor < 0.0 {
+		scaleFactor = 0.0
+	} else if scaleFactor > 1.0 {
+		scaleFactor = 1.0
+	}
 
 	i := 0
 	packSizeSlice := make([]int64, len(packsFromPackfiles))


### PR DESCRIPTION
Changes: cmd_prune.go: removed option `--repack-small` and marked it deprecated.

Add changelog note.

Added code to filter out the processing of all packfiles early in the ``prune`` process, so that map can be reused for calculating a ``targetPackSize`` value based on the chosen percentile of the sorted packfiles list.

Added test to validate modified prune behaviour.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR addresses the issue https://github.com/restic/restic/issues/5293.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://github.com/restic/restic/issues/5293
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
closes #5293

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [X] I have added tests for all code changes.
~~- [ ] I have added documentation for relevant changes (in the manual).~~
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.
