### PR TITLE
doc: typo & minor rewording in 'Removing files from snapshots'

### DIFF
--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -297,7 +297,7 @@ Note that it is not possible to change the chunker parameters of an existing rep
 Removing files from snapshots
 =============================
 
-Snapshots sometimes turn out to include more files that intended. Instead of
+Snapshots sometimes turn out to include more files than intended. Instead of
 removing the snapshots entirely and running the corresponding backup commands
 again (which is not always practical after the fact) it is possible to remove
 the unwanted files from affected snapshots by rewriting them using the
@@ -338,8 +338,8 @@ the only fields added are ``TotalFilesProcessed`` and ``TotalBytesProcessed``.
 
 By default, the ``rewrite`` command will keep the original snapshots and create
 new ones for every snapshot which was modified during rewriting. The new
-snapshots are marked with the tag ``rewrite`` to differentiate them from the
-original, rewritten snapshots.
+snapshots are marked with the tag ``rewrite`` to distinguish them from the
+original, untouched snapshots.
 
 Alternatively, you can use the ``--forget`` option to immediately remove the
 original snapshots. In this case, no tag is added to the new snapshots. Please


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

fixed typo: that => than
better wording: differentiate => distinguish
fixed misleading adjective: rewritten => untouched (indeed the original snapshot is NOT rewritten)

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No. I think the changes are trivial and obvious.

Checklist
---------

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X ] I'm done! This pull request is ready for review.
