### PR TITLE
Enhanced snapshot summary

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -156,9 +156,6 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 
 var backupFSTestHook func(fs fs.FS) fs.FS
 
-// ErrInvalidSourceData is used to report an incomplete backup
-var ErrInvalidSourceData = errors.New("at least one source file could not be read")
-
 // filterExisting returns a slice of all existing items, or an error if no
 // items exist at all.
 func filterExisting(items []string) (result []string, err error) {
@@ -688,7 +685,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 	// Report finished execution
 	progressReporter.Finish(id, summary, opts.DryRun)
 	if !success {
-		return ErrInvalidSourceData
+		return restic.ErrInvalidSourceData
 	}
 
 	// Return error if any

--- a/cmd/restic/cmd_backup_integration_test.go
+++ b/cmd/restic/cmd_backup_integration_test.go
@@ -413,7 +413,7 @@ func TestBackupErrors(t *testing.T) {
 	opts := BackupOptions{}
 	err := testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"testdata"}, opts, env.gopts)
 	rtest.Assert(t, err != nil, "Assumed failure, but no error occurred.")
-	rtest.Assert(t, err == ErrInvalidSourceData, "Wrong error returned")
+	rtest.Assert(t, err == restic.ErrInvalidSourceData, "Wrong error returned")
 	testListSnapshots(t, env.gopts, 1)
 }
 

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -62,9 +62,6 @@ Exit status is 12 if the password is incorrect.
 
 type ForgetPolicyCount int
 
-var ErrNegativePolicyCount = errors.New("negative values not allowed, use 'unlimited' instead")
-var ErrFailedToRemoveOneOrMoreSnapshots = errors.New("failed to remove one or more snapshots")
-
 func (c *ForgetPolicyCount) Set(s string) error {
 	switch s {
 	case "unlimited":
@@ -75,7 +72,7 @@ func (c *ForgetPolicyCount) Set(s string) error {
 			return err
 		}
 		if val < 0 {
-			return ErrNegativePolicyCount
+			return restic.ErrNegativePolicyCount
 		}
 		*c = ForgetPolicyCount(val)
 	}
@@ -338,7 +335,7 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 	}
 
 	if len(failedSnIDs) > 0 {
-		return ErrFailedToRemoveOneOrMoreSnapshots
+		return restic.ErrFailedToRemoveOneOrMoreSnapshots
 	}
 
 	if len(removeSnIDs) > 0 && opts.Prune {

--- a/cmd/restic/cmd_forget_test.go
+++ b/cmd/restic/cmd_forget_test.go
@@ -18,7 +18,7 @@ func TestForgetPolicyValues(t *testing.T) {
 		{"1", ForgetPolicyCount(1), ""},
 		{"unlimited", ForgetPolicyCount(-1), ""},
 		{"", ForgetPolicyCount(0), "strconv.ParseInt: parsing \"\": invalid syntax"},
-		{"-1", ForgetPolicyCount(0), ErrNegativePolicyCount.Error()},
+		{"-1", ForgetPolicyCount(0), restic.ErrNegativePolicyCount.Error()},
 		{"abc", ForgetPolicyCount(0), "strconv.ParseInt: parsing \"abc\": invalid syntax"},
 	}
 	for _, testCase := range testCases {

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -204,7 +204,7 @@ func runMount(ctx context.Context, opts MountOptions, gopts GlobalOptions, args 
 			Warnf("unable to umount (maybe already umounted or still in use?): %v\n", err)
 		}
 
-		return ErrOK
+		return restic.ErrOK
 	case <-done:
 		// clean shutdown, nothing to do
 	}

--- a/cmd/restic/cmd_prune_integration_test.go
+++ b/cmd/restic/cmd_prune_integration_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/backend"
-	"github.com/restic/restic/internal/repository"
 	rtest "github.com/restic/restic/internal/test"
 	"github.com/restic/restic/internal/ui/termstatus"
 )
@@ -158,7 +158,7 @@ func TestPruneWithDamagedRepository(t *testing.T) {
 		env.gopts.backendTestHook = oldHook
 	}()
 	// prune should fail
-	rtest.Equals(t, repository.ErrPacksMissing, withTermStatus(env.gopts, func(ctx context.Context, term *termstatus.Terminal) error {
+	rtest.Equals(t, restic.ErrPacksMissing, withTermStatus(env.gopts, func(ctx context.Context, term *termstatus.Terminal) error {
 		return runPrune(context.TODO(), pruneDefaultOptions, env.gopts, term)
 	}), "prune should have reported index not complete error")
 }

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -42,10 +42,6 @@ import (
 	"golang.org/x/term"
 )
 
-// ErrNoRepository is used to report if opening a repository failed due
-// to a missing backend storage location or config file
-var ErrNoRepository = errors.New("repository does not exist")
-
 var version = "0.18.0-dev (compiled manually)"
 
 // TimeFormat is the format used for all timestamps printed by restic.
@@ -514,7 +510,7 @@ func OpenRepository(ctx context.Context, opts GlobalOptions) (*repository.Reposi
 		}
 	}
 	if err != nil {
-		if errors.IsFatal(err) || errors.Is(err, repository.ErrNoKeyFound) {
+		if errors.IsFatal(err) || errors.Is(err, restic.ErrNoKeyFound) {
 			return nil, err
 		}
 		return nil, errors.Fatalf("%s", err)
@@ -632,8 +628,8 @@ func innerOpen(ctx context.Context, s string, gopts GlobalOptions, opts options.
 		be, err = factory.Open(ctx, cfg, rt, lim)
 	}
 
-	if errors.Is(err, backend.ErrNoRepository) {
-		return nil, fmt.Errorf("Fatal: %w at %v: %v", ErrNoRepository, location.StripPassword(gopts.backends, s), err)
+	if errors.Is(err, restic.ErrNoRepository) {
+		return nil, fmt.Errorf("Fatal: %w at %v: %v", restic.ErrNoRepository, location.StripPassword(gopts.backends, s), err)
 	}
 	if err != nil {
 		return nil, errors.Fatalf("unable to open repository at %v: %v", location.StripPassword(gopts.backends, s), err)
@@ -683,7 +679,7 @@ func open(ctx context.Context, s string, gopts GlobalOptions, opts options.Optio
 	// check if config is there
 	fi, err := be.Stat(ctx, backend.Handle{Type: restic.ConfigFile})
 	if be.IsNotExist(err) {
-		return nil, fmt.Errorf("Fatal: %w: unable to open config file: %v\nIs there a repository at the following location?\n%v", ErrNoRepository, err, location.StripPassword(gopts.backends, s))
+		return nil, fmt.Errorf("Fatal: %w: unable to open config file: %v\nIs there a repository at the following location?\n%v", restic.ErrNoRepository, err, location.StripPassword(gopts.backends, s))
 	}
 	if err != nil {
 		return nil, errors.Fatalf("unable to open config file: %v\nIs there a repository at the following location?\n%v", err, location.StripPassword(gopts.backends, s))

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -53,7 +53,6 @@ type Summary struct {
 	BackupEnd      time.Time
 	Files, Dirs    ChangeStats
 	ProcessedBytes uint64
-	Errors         uint64
 	ErrorsHandled  uint64
 	ItemStats
 }
@@ -221,10 +220,6 @@ func (arch *Archiver) error(item string, err error) error {
 
 	arch.mu.Lock()
 	defer arch.mu.Unlock()
-
-	if arch.summary != nil {
-		arch.summary.Errors++
-	}
 
 	errf := arch.Error(item, err)
 	if err != errf {
@@ -961,7 +956,6 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 		DataAddedPacked:       arch.summary.ItemStats.DataSizeInRepo + arch.summary.ItemStats.TreeSizeInRepo,
 		TotalFilesProcessed:   arch.summary.Files.New + arch.summary.Files.Changed + arch.summary.Files.Unchanged,
 		TotalBytesProcessed:   arch.summary.ProcessedBytes,
-		ArchiverErrors:        arch.summary.Errors,
 		ArchiverErrorsHandled: arch.summary.ErrorsHandled,
 	}
 

--- a/internal/backend/b2/b2.go
+++ b/internal/backend/b2/b2.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/layout"
 	"github.com/restic/restic/internal/backend/location"
@@ -101,7 +102,7 @@ func Open(ctx context.Context, cfg Config, rt http.RoundTripper) (backend.Backen
 
 	bucket, err := client.Bucket(ctx, cfg.Bucket)
 	if b2.IsNotExist(err) {
-		return nil, backend.ErrNoRepository
+		return nil, restic.ErrNoRepository
 	} else if err != nil {
 		return nil, errors.Wrap(err, "Bucket")
 	}

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -2,12 +2,9 @@ package backend
 
 import (
 	"context"
-	"fmt"
 	"hash"
 	"io"
 )
-
-var ErrNoRepository = fmt.Errorf("repository does not exist")
 
 // Backend is used to store and access data.
 //

--- a/internal/repository/prune.go
+++ b/internal/repository/prune.go
@@ -6,16 +6,12 @@ import (
 	"math"
 	"sort"
 
+	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository/index"
 	"github.com/restic/restic/internal/repository/pack"
-	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui/progress"
 )
-
-var ErrIndexIncomplete = errors.Fatal("index is not complete")
-var ErrPacksMissing = errors.Fatal("packs from index missing in repo")
-var ErrSizeNotMatching = errors.Fatal("pack size does not match calculated size from index")
 
 // PruneOptions collects all options for the cleanup command.
 type PruneOptions struct {
@@ -189,7 +185,7 @@ func packInfoFromIndex(ctx context.Context, idx restic.ListBlobser, usedBlobs *i
 			"Will not start prune to prevent (additional) data loss!\n"+
 			"Please report this error (along with the output of the 'prune' run) at\n"+
 			"https://github.com/restic/restic/issues/new/choose\n", missingBlobs)
-		return nil, nil, ErrIndexIncomplete
+		return nil, nil, restic.ErrIndexIncomplete
 	}
 
 	indexPack := make(map[restic.ID]packInfo)
@@ -356,7 +352,7 @@ func decidePackAction(ctx context.Context, opts PruneOptions, repo *Repository, 
 			// and will be simply removed, see below.
 			printer.E("pack %s: calculated size %d does not match real size %d\nRun 'restic repair index'.\n",
 				id.Str(), p.unusedSize+p.usedSize, packSize)
-			return ErrSizeNotMatching
+			return restic.ErrSizeNotMatching
 		}
 
 		// statistics
@@ -432,7 +428,7 @@ func decidePackAction(ctx context.Context, opts PruneOptions, repo *Repository, 
 		for id := range indexPack {
 			printer.E("  %v\n", id)
 		}
-		return PrunePlan{}, ErrPacksMissing
+		return PrunePlan{}, restic.ErrPacksMissing
 	}
 	if len(ignorePacks) != 0 {
 		printer.E("Missing but unneeded pack files are referenced in the index, will be repaired\n")

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -5,13 +5,9 @@ import (
 
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/crypto"
-	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/ui/progress"
 	"golang.org/x/sync/errgroup"
 )
-
-// ErrInvalidData is used to report that a file is corrupted
-var ErrInvalidData = errors.New("invalid data returned")
 
 // Repository stores data in a backend. It provides high-level functions and
 // transparently encrypts/decrypts data.

--- a/internal/restic/restic_error_codes.go
+++ b/internal/restic/restic_error_codes.go
@@ -1,0 +1,54 @@
+package restic
+
+import (
+	"context"
+	// "fmt"
+
+	"github.com/restic/restic/internal/errors"
+)
+
+var ErrOK = errors.New("ok")
+
+var ErrInvalidData = errors.New("invalid data returned")
+
+var ErrIndexIncomplete = errors.Fatal("index is not complete")
+
+var ErrPacksMissing = errors.Fatal("packs from index missing in repo")
+
+var ErrSizeNotMatching = errors.Fatal("pack size does not match calculated size from index")
+
+// ErrNoRepository is used to report if opening a repository failed due
+// to a missing backend storage location or config file
+var ErrNoRepository = errors.New("repository does not exist")
+
+// ErrInvalidSourceData is used to report an incomplete backup
+var ErrInvalidSourceData = errors.New("at least one source file could not be read")
+
+var ErrNegativePolicyCount = errors.New("negative values not allowed, use 'unlimited' instead")
+
+var ErrFailedToRemoveOneOrMoreSnapshots = errors.New("failed to remove one or more snapshots")
+
+var ErrNoKeyFound = errors.New("wrong password or no key found")
+
+func ComputeExitCode(err error) int {
+	var exitCode int
+	switch {
+	case err == nil:
+		exitCode = 0
+	case err == ErrInvalidSourceData:
+		exitCode = 3
+	case errors.Is(err, ErrFailedToRemoveOneOrMoreSnapshots):
+		exitCode = 3
+	case errors.Is(err, ErrNoRepository):
+		exitCode = 10
+	case IsAlreadyLocked(err):
+		exitCode = 11
+	case errors.Is(err, ErrNoKeyFound):
+		exitCode = 12
+	case errors.Is(err, context.Canceled):
+		exitCode = 130
+	default:
+		exitCode = 1
+	}
+	return exitCode
+}

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -36,18 +36,20 @@ type SnapshotSummary struct {
 	BackupEnd   time.Time `json:"backup_end"`
 
 	// statistics from the backup json output
-	FilesNew            uint   `json:"files_new"`
-	FilesChanged        uint   `json:"files_changed"`
-	FilesUnmodified     uint   `json:"files_unmodified"`
-	DirsNew             uint   `json:"dirs_new"`
-	DirsChanged         uint   `json:"dirs_changed"`
-	DirsUnmodified      uint   `json:"dirs_unmodified"`
-	DataBlobs           int    `json:"data_blobs"`
-	TreeBlobs           int    `json:"tree_blobs"`
-	DataAdded           uint64 `json:"data_added"`
-	DataAddedPacked     uint64 `json:"data_added_packed"`
-	TotalFilesProcessed uint   `json:"total_files_processed"`
-	TotalBytesProcessed uint64 `json:"total_bytes_processed"`
+	FilesNew              uint   `json:"files_new"`
+	FilesChanged          uint   `json:"files_changed"`
+	FilesUnmodified       uint   `json:"files_unmodified"`
+	DirsNew               uint   `json:"dirs_new"`
+	DirsChanged           uint   `json:"dirs_changed"`
+	DirsUnmodified        uint   `json:"dirs_unmodified"`
+	DataBlobs             int    `json:"data_blobs"`
+	TreeBlobs             int    `json:"tree_blobs"`
+	DataAdded             uint64 `json:"data_added"`
+	DataAddedPacked       uint64 `json:"data_added_packed"`
+	TotalFilesProcessed   uint   `json:"total_files_processed"`
+	TotalBytesProcessed   uint64 `json:"total_bytes_processed"`
+	ArchiverErrors        uint64 `json:"errors_archiver"`
+	ArchiverErrorsHandled uint64 `json:"errors_archiver_handled"`
 }
 
 // NewSnapshot returns an initialized snapshot struct for the current user and

--- a/internal/restic/snapshot.go
+++ b/internal/restic/snapshot.go
@@ -48,7 +48,6 @@ type SnapshotSummary struct {
 	DataAddedPacked       uint64 `json:"data_added_packed"`
 	TotalFilesProcessed   uint   `json:"total_files_processed"`
 	TotalBytesProcessed   uint64 `json:"total_bytes_processed"`
-	ArchiverErrors        uint64 `json:"errors_archiver"`
 	ArchiverErrorsHandled uint64 `json:"errors_archiver_handled"`
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR adds statistics for Archiver errors encountered during the creation of a snapshot into that snapshot's summary. It also reorganizes all Err* values/codes that restic can throw around in a new file in the `restic` package, which should make it easier to understand the codebase and maybe do more fine-grained bookkeeping of errors in the future (which I intend to think about more, if this PR gets merged).
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
I touched briefly upon this on IRC (planning to record the exit code of restic in these stats), with @MichaelEischer suggesting that keeping track of error counts would make more sense, which I agree with. The inspiration of tracking this stat in snapshot summaries originally came from #5135.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
