### PR TITLE
bugfix: fatal errors do not keep underlying error

### DIFF
--- a/changelog/unreleased/issue-5258
+++ b/changelog/unreleased/issue-5258
@@ -1,0 +1,7 @@
+Bugfix: Exit with correct code on SIGINT
+
+Restic previously returned exit code 1 on SIGINT, which is incorrect. 
+Restic now returns 130 on SIGINT.
+
+https://github.com/restic/restic/issues/5258
+https://github.com/restic/restic/pull/5363

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -250,7 +250,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 	)
 	bar.Done()
 	if err != nil {
-		return errors.Fatal(err.Error())
+		return errors.Fatalf("%s", err)
 	}
 	return nil
 }

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -72,7 +72,7 @@ func (opts *DiffOptions) AddFlags(f *pflag.FlagSet) {
 func loadSnapshot(ctx context.Context, be restic.Lister, repo restic.LoaderUnpacked, desc string) (*restic.Snapshot, string, error) {
 	sn, subfolder, err := restic.FindSnapshot(ctx, be, repo, desc)
 	if err != nil {
-		return nil, "", errors.Fatal(err.Error())
+		return nil, "", errors.Fatalf("%s", err)
 	}
 	return sn, subfolder, err
 }

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -101,7 +101,7 @@ func runInit(ctx context.Context, opts InitOptions, gopts GlobalOptions, args []
 		PackSize:    gopts.PackSize * 1024 * 1024,
 	})
 	if err != nil {
-		return errors.Fatal(err.Error())
+		return errors.Fatalf("%s", err)
 	}
 
 	err = s.Init(ctx, version, gopts.password, chunkerPolynomial)

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -486,7 +486,7 @@ func OpenRepository(ctx context.Context, opts GlobalOptions) (*repository.Reposi
 		NoExtraVerify: opts.NoExtraVerify,
 	})
 	if err != nil {
-		return nil, errors.Fatal(err.Error())
+		return nil, errors.Fatalf("%s", err)
 	}
 
 	passwordTriesLeft := 1
@@ -613,7 +613,7 @@ func innerOpen(ctx context.Context, s string, gopts GlobalOptions, opts options.
 
 	rt, err := backend.Transport(globalOptions.TransportOptions)
 	if err != nil {
-		return nil, errors.Fatal(err.Error())
+		return nil, errors.Fatalf("%s", err)
 	}
 
 	// wrap the transport so that the throughput via HTTP is limited

--- a/internal/errors/fatal.go
+++ b/internal/errors/fatal.go
@@ -7,25 +7,48 @@ import (
 
 // fatalError is an error that should be printed to the user, then the program
 // should exit with an error code.
-type fatalError string
+type fatalError struct {
+	msg string
+	err error // Underlying error
+}
 
-func (e fatalError) Error() string {
-	return string(e)
+func (e *fatalError) Error() string {
+	return e.msg
+}
+
+func (e *fatalError) Unwrap() error {
+	return e.err
 }
 
 // IsFatal returns true if err is a fatal message that should be printed to the
 // user. Then, the program should exit.
 func IsFatal(err error) bool {
-	var fatal fatalError
+	var fatal *fatalError
 	return errors.As(err, &fatal)
 }
 
 // Fatal returns an error that is marked fatal.
 func Fatal(s string) error {
-	return Wrap(fatalError(s), "Fatal")
+	return Wrap(&fatalError{msg: s}, "Fatal")
 }
 
-// Fatalf returns an error that is marked fatal.
+// Fatalf returns an error that is marked fatal, preserving an underlying error if passed.
 func Fatalf(s string, data ...interface{}) error {
-	return Wrap(fatalError(fmt.Sprintf(s, data...)), "Fatal")
+	// Use the last error found.
+	var underlyingErr error
+	for i := len(data) - 1; i >= 0; i-- {
+		if err, ok := data[i].(error); ok {
+			underlyingErr = err
+			break
+		}
+	}
+
+	msg := fmt.Sprintf(s, data...)
+
+	fatal := &fatalError{
+		msg: msg,
+		err: underlyingErr,
+	}
+
+	return Wrap(fatal, "Fatal")
 }

--- a/internal/errors/fatal_test.go
+++ b/internal/errors/fatal_test.go
@@ -20,3 +20,23 @@ func TestFatal(t *testing.T) {
 		}
 	}
 }
+
+func TestFatalErrorWrapping(t *testing.T) {
+	underlying := errors.New("underlying error")
+	fatal := errors.Fatalf("fatal error: %v", underlying)
+
+	// Test that the fatal error message is preserved
+	if fatal.Error() != "Fatal: fatal error: underlying error" {
+		t.Errorf("unexpected error message: %v", fatal.Error())
+	}
+
+	// Test that we can unwrap to get the underlying error
+	if !errors.Is(fatal, underlying) {
+		t.Error("fatal error should wrap the underlying error")
+	}
+
+	// Test that the error is marked as fatal
+	if !errors.IsFatal(fatal) {
+		t.Error("error should be marked as fatal")
+	}
+}

--- a/internal/repository/prune.go
+++ b/internal/repository/prune.go
@@ -567,7 +567,7 @@ func (plan *PrunePlan) Execute(ctx context.Context, printer progress.Printer) er
 		_, err := Repack(ctx, repo, repo, plan.repackPacks, plan.keepBlobs, bar, printer.P)
 		bar.Done()
 		if err != nil {
-			return errors.Fatal(err.Error())
+			return errors.Fatalf("%s", err)
 		}
 
 		// Also remove repacked packs


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
* Modified the fatal errors struct to preserve the underlying error. 
* Added `Unwrap` method to help `errors.Is` and `errors.As` comparisons.
* Added tests to check if the `fatal` error preserves the underlying errors

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #5258 

Checklist
---------
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
