### PR TITLE
docs: document profiling options a bit better

### DIFF
--- a/doc/090_participating.rst
+++ b/doc/090_participating.rst
@@ -71,10 +71,17 @@ The program can be built with debug support like this:
     $ go run build.go -tags debug
 
 This will make the ``restic debug <subcommand>`` available which can be used to
-inspect internal data structures. In addition, this enables profiling flags such
-as ``--cpu-profile`` and ``--mem-profile`` which can help with investigation
-performance and memory usage issues. See ``restic help`` for more details and a
-few additional ``--...-profile`` flags.
+inspect internal data structures.
+
+In addition, this enables profiling flags such as ``--cpu-profile`` and
+``--mem-profile`` which can help with investigation performance and memory usage
+issues. See ``restic help`` for more details and a few additional
+``--...-profile`` flags.
+
+Running Restic with profiling enabled generates a ``.pprof`` file such as
+``cpu.pprof``. To view a profile in a web browser, first make sure that the
+``dot`` command from `Graphviz <https://graphviz.org/>`__ is in the PATH. Then,
+run ``go tool pprof -http : cpu.pprof``.
 
 
 ************

--- a/doc/090_participating.rst
+++ b/doc/090_participating.rst
@@ -71,8 +71,10 @@ The program can be built with debug support like this:
     $ go run build.go -tags debug
 
 This will make the ``restic debug <subcommand>`` available which can be used to
-inspect internal data structures. In addition, this enables profiling support
-which can help with investigation performance and memory usage issues.
+inspect internal data structures. In addition, this enables profiling flags such
+as ``--cpu-profile`` and ``--mem-profile`` which can help with investigation
+performance and memory usage issues. See ``restic help`` for more details and a
+few additional ``--...-profile`` flags.
 
 
 ************


### PR DESCRIPTION
Previously, the docs were a bit mysterious about what "enables profiling support" means or how to take advantage of it.

I am less sure about the second commit, which explains `.pprof` files
briefly. I can get rid of it; the first commit is more important.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------

- (n/a) I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- (n/a?) There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
