### PR TITLE
docs: updated installation docs for Windows

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -175,15 +175,19 @@ restic can be installed from the official repo of Solus via the ``eopkg`` packag
 Windows
 =======
 
-restic can be installed using `Scoop <https://scoop.sh/>`__:
+restic can be installed using either `Scoop <https://scoop.sh/>`__ or `WinGet <https://learn.microsoft.com/en-us/windows/package-manager/>`__.
+
+Regardless of the method, the ``restic.exe`` binary will be added to your ``PATH`` automatically, making the ``restic`` command accessible in Powershell or CMD.
 
 .. code-block:: console
 
     scoop install restic
 
-Using this installation method, ``restic.exe`` will automatically be available
-in the ``PATH``. It can be called from cmd.exe or PowerShell by typing ``restic``.
+.. code-block:: console
 
+    winget install --exact --id restic.restic --scope Machine
+
+By default, WinGet will install restic into the ``User`` scope, which is typically in your user's ``%LOCALAPPDATA%`` directory. This behavior may be undesirable for system-wide backups, so specifying ``--scope Machine`` is recommended so that restic is installed into ``%ProgramFiles%``. This requires elevation.
 
 .. _official_binaries:
 
@@ -252,13 +256,6 @@ the `restic beta download site
 <https://beta.restic.net/?sort=time&order=desc>`__. These too are pre-compiled
 and ready to run, and a new version is built every time a push is made to the
 master branch.
-
-Windows
-=======
-
-On Windows, put the `restic.exe` binary into `%SystemRoot%\\System32` to use restic
-in scripts without the need for absolute paths to the binary. This requires
-administrator rights.
 
 Docker Container
 ****************


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR updates the [installation docs](https://restic.readthedocs.io/en/stable/020_installation.html) around Windows. It makes two changes:

- Adds documentation on using WinGet to install restic, noting that `Machine` scope is likely wanted by end-users.
- Removes references to installing the restic binary into `%SystemRoot%\System32`, because it's just kind of weird (partly due to security). The Linux `%SystemRoot%\System32` equivalent is `/sbin/` (where restic should typically be installed into `/usr/bin` or `/usr/local/bin`). `%SystemRoot%\System32` just happens to be one of those paths that is included in the `SYSTEM` `PATH` by default.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Nope.

Checklist
---------

- [X] I'm done! This pull request is ready for review.
