### PR TITLE
Update passwords section of faq

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -110,9 +110,8 @@ How can I specify encryption passwords automatically?
 When you run ``restic backup``, you need to enter the passphrase on
 the console. This is not very convenient for automated backups, so you
 can also provide the password through the ``--password-file`` option, or one of
-the environment variables ``RESTIC_PASSWORD`` or ``RESTIC_PASSWORD_FILE``.
-A discussion is in progress over implementing unattended backups happens in
-:issue:`533`.
+the environment variables: ``RESTIC_PASSWORD``, ``RESTIC_PASSWORD_FILE``,
+or ``RESTIC_PASSWORD_COMMAND``.
 
 .. important:: Be careful how you set the environment; using the env
                command, a `system()` call or using inline shell
@@ -124,9 +123,32 @@ A discussion is in progress over implementing unattended backups happens in
                `accessible only to that user`_. Please make sure that
                the permissions on the files where the password is
                eventually stored are safe (e.g. `0600` and owned by
-               root).
+               root). Note also that ``RESTIC_PASSWORD_COMMAND`` is
+               safe because it does not export the password itself to
+               the environment.
 
 .. _accessible only to that user: https://security.stackexchange.com/questions/14000/environment-variable-accessibility-in-linux/14009#14009
+
+On platforms with an available keychain, keyring or similar secret store, a
+user can add and then dynamically retrieve passwords, cloud credentials,
+repository paths, or any other data deemed sensitive. Here's an example of
+part of a shell script using the `built-in`_ ``security`` command on macOS
+to retrieve credentials from the system's Keychain before running various
+``restic`` commands:
+
+.. _built-in: https://ss64.com/mac/security.html
+
+::
+
+    export GOOGLE_PROJECT_ID=$(security find-generic-password -a resticGCS -s restic_project_ID -w)
+
+    export GOOGLE_APPLICATION_CREDENTIALS=$(security find-generic-password -a resticGCS -s restic_key -w)
+
+    export RESTIC_REPOSITORY=$(security find-generic-password -a resticGCS -s restic_repo_path -w)
+
+    export RESTIC_PASSWORD_COMMAND='security find-generic-password -a resticGCS -s restic_pwd -w' 
+
+
 
 How to prioritize restic's IO and CPU time
 ------------------------------------------


### PR DESCRIPTION

What does this PR change? What problem does it solve?
-----------------------------------------------------
This section was out of date: it contained a dead link to an old issue, and did not mention the RESTIC_PASSWORD_COMMAND variable. 

I also added some basic info on using built-in keyring/keychains to store and retrieve env variables, including passwords.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Yes, it was discussed here, concluding with the suggestion that I try to update this faq:
https://forum.restic.net/t/why-cant-restic-save-credentials-directly-to-keychain-keyring/9637/8


Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
_No code changed, just docs_
- [X] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.

I think it's ready to review, but I've never done this before, so please be patient with me