### PR TITLE
Implement `backup --add-auto-tags` flag

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -103,6 +103,7 @@ type BackupOptions struct {
 	ReadConcurrency   uint
 	NoScan            bool
 	SkipIfUnchanged   bool
+	AddAutoTags       bool
 }
 
 func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
@@ -143,6 +144,7 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 		f.BoolVar(&opts.ExcludeCloudFiles, "exclude-cloud-files", false, "excludes online-only cloud files (such as OneDrive Files On-Demand)")
 	}
 	f.BoolVar(&opts.SkipIfUnchanged, "skip-if-unchanged", false, "skip snapshot creation if identical to parent snapshot")
+	f.BoolVar(&opts.AddAutoTags, "add-auto-tags", false, "add tags to snapshots to record various runtime conditions (ex. \"__auto:restic:errors:archiver\" for archiver errors)")
 
 	// parse read concurrency from env, on error the default value will be used
 	readConcurrency, _ := strconv.ParseUint(os.Getenv("RESTIC_READ_CONCURRENCY"), 10, 32)
@@ -667,6 +669,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 		ParentSnapshot:  parentSnapshot,
 		ProgramVersion:  "restic " + version,
 		SkipIfUnchanged: opts.SkipIfUnchanged,
+		AddAutoTags:     opts.AddAutoTags,
 	}
 
 	if !gopts.JSON {

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -96,6 +96,7 @@ type Archiver struct {
 	Select       SelectFunc
 	FS           fs.FS
 	Options      Options
+	AutoTags     map[string]bool
 
 	blobSaver *blobSaver
 	fileSaver *fileSaver
@@ -192,6 +193,7 @@ func New(repo archiverRepo, filesystem fs.FS, opts Options) *Archiver {
 		Select:       func(_ string, _ *fs.ExtendedFileInfo, _ fs.FS) bool { return true },
 		FS:           filesystem,
 		Options:      opts.ApplyDefaults(),
+		AutoTags:     make(map[string]bool),
 
 		CompleteItem: func(string, *restic.Node, *restic.Node, ItemStats, time.Duration) {},
 		StartFile:    func(string) {},
@@ -219,6 +221,7 @@ func (arch *Archiver) error(item string, err error) error {
 	errf := arch.Error(item, err)
 	if err != errf {
 		debug.Log("item %v: error was filtered by handler, before: %q, after: %v", item, err, errf)
+		arch.AutoTags["__auto:restic:errors:archiver"] = true
 	}
 	return errf
 }
@@ -798,6 +801,8 @@ type SnapshotOptions struct {
 	ProgramVersion string
 	// SkipIfUnchanged omits the snapshot creation if it is identical to the parent snapshot.
 	SkipIfUnchanged bool
+	// AddAutoTags creates tags on snapshots upon various conditions, such as Archiver errors.
+	AddAutoTags bool
 }
 
 // loadParentTree loads a tree referenced by snapshot id. If id is null, nil is returned.
@@ -948,6 +953,14 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 		DataAddedPacked:     arch.summary.ItemStats.DataSizeInRepo + arch.summary.ItemStats.TreeSizeInRepo,
 		TotalFilesProcessed: arch.summary.Files.New + arch.summary.Files.Changed + arch.summary.Files.Unchanged,
 		TotalBytesProcessed: arch.summary.ProcessedBytes,
+	}
+
+	if opts.AddAutoTags && arch.AutoTags != nil {
+		for tag, isset := range arch.AutoTags {
+			if isset {
+				sn.AddTags([]string{tag})
+			}
+		}
 	}
 
 	id, err := restic.SaveSnapshot(ctx, arch.Repo, sn)


### PR DESCRIPTION
When set, this causes snapshots created during a `backup` operation to be tagged with a "__auto:restic:errors:archiver" tag in case there were any handled errors during the operation, such as unreadable or disappearing files.

This should make it easier to filter for potentially incomplete backups with the `snapshots` command.

If the concept and proposed implementation is found to be useful, more detailed auto-added tags could be introduced later under the `__auto:restic:` tag prefix.


What does this PR change? What problem does it solve?
-----------------------------------------------------

This is a first attempt at implementing the request from issue #5135, which wishes for a way to identify snapshots with(out) missing files based on tags set upon snapshot creation.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

I am not aware of any forum threads discussing a feature like this, but several issues are requesting something like it.

Closes #5135 


Checklist
---------

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.

