### PR TITLE
restic list pack snapshotID - create lists of packfiles for a given snapshot as text 

### DIFF
--- a/changelog/unreleased/issue-5372
+++ b/changelog/unreleased/issue-5372
@@ -1,0 +1,8 @@
+Enhancement: command to list packfiles belonging to a snapshot
+
+This enhancement creates a new option `packfiles` for command `restore`. It shows the
+packfiles which are related to a snapshot or a set of snapshots. Output is either
+plain text or JSON. Different levels of details can be activated.
+
+https://github.com/restic/restic/issues/5372
+https://github.com/restic/restic/pull/5396

--- a/changelog/unreleased/issue-5372
+++ b/changelog/unreleased/issue-5372
@@ -1,8 +1,8 @@
-Enhancement: command to list packfiles belonging to a snapshot
+Enhancement: list packfiles belonging to a snapshot
 
-This enhancement creates a new option `packfiles` for command `restore`. It shows the
-packfiles which are related to a snapshot or a set of snapshots. Output is either
-plain text or JSON. Different levels of details can be activated.
+This enhancement uses command ``list packs snapshotID`` to show the packfiles
+belonging to the given snapshot. It can be use to apply S3 object lock
+to all packs of the given snapshot.
 
 https://github.com/restic/restic/issues/5372
 https://github.com/restic/restic/pull/5396

--- a/changelog/unreleased/issue-5372
+++ b/changelog/unreleased/issue-5372
@@ -1,8 +1,7 @@
-Enhancement: list packfiles belonging to a snapshot
+Enhancement: Add command to list packfiles belonging to a snapshot
 
-This enhancement uses command ``list packs snapshotID`` to show the packfiles
-belonging to the given snapshot. It can be use to apply S3 object lock
-to all packs of the given snapshot.
+This enhancement adds command `list packs snapshotID` to show the packfiles
+belonging to the given snapshot.
 
 https://github.com/restic/restic/issues/5372
 https://github.com/restic/restic/pull/5396

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -98,15 +98,10 @@ func runList(ctx context.Context, gopts global.Options, args []string, term ui.T
 }
 
 // packfileLIst runs the list packs <snapshotID>
-// it creates a sorted list of packfiles belonging to this snapshot
+// it prints a sorted list of packfiles belonging to this snapshot
 func packfileLIst(ctx context.Context, repo restic.Repository, snapshotID string, printer progress.Printer) error {
 
-	snapshotLister, err := restic.MemorizeList(ctx, repo, restic.SnapshotFile)
-	if err != nil {
-		return err
-	}
-
-	sn, _, err := (&data.SnapshotFilter{}).FindLatest(ctx, snapshotLister, repo, snapshotID)
+	sn, _, err := (&data.SnapshotFilter{}).FindLatest(ctx, repo, repo, snapshotID)
 	if err != nil {
 		return fmt.Errorf("required snapshot ID %q not found", snapshotID)
 	}

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -125,7 +125,7 @@ func packfileLIst(ctx context.Context, repo restic.Repository, snapshotID string
 
 	snapPacks := restic.NewIDSet()
 	for bh := range usedBlobs.Keys() {
-		for _, blob := range repo.LookupBlob(bh.Type, bh.ID) {
+		for _, blob := range repo.LookupBlob(bh) {
 			snapPacks.Insert(blob.PackID())
 		}
 	}

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -21,11 +21,11 @@ func newListCommand(globalOptions *global.Options) *cobra.Command {
 	var listAllowedArgsUseString = strings.Join(listAllowedArgs, "|")
 
 	cmd := &cobra.Command{
-		Use:   "list [flags] [" + listAllowedArgsUseString + "] or list packs snapshotID",
+		Use:   "list [flags] [" + listAllowedArgsUseString + "|packs snapshotID]",
 		Short: "List objects in the repository",
 		Long: `
 The "list" command allows listing objects in the repository based on type.
-The "list packs snapshotID" accepts one snapshotID and lists all packfiles
+The "list packs snapshotID" variant accepts one snapshotID and lists all packfiles
 used by this snapshot.
 
 EXIT STATUS
@@ -47,9 +47,7 @@ Exit status is 12 if the password is incorrect.
 	return cmd
 }
 
-func runList(ctx context.Context, gopts global.Options, args []string, term ui.Terminal,
-	listAllowedArgsUseString string,
-) error {
+func runList(ctx context.Context, gopts global.Options, args []string, term ui.Terminal, listAllowedArgsUseString string) error {
 	printer := progress.NewTerminalPrinter(false, gopts.Verbosity, term)
 
 	if len(args) == 0 || (args[0] == "packs" && len(args) > 2) || (args[0] != "packs" && len(args) != 1) {
@@ -68,7 +66,7 @@ func runList(ctx context.Context, gopts global.Options, args []string, term ui.T
 		t = restic.PackFile
 		if len(args) == 2 {
 			// args[1] needs to be a snapshotID
-			return packfileLIst(ctx, repo, args[1], printer)
+			return packfileList(ctx, repo, args[1], printer)
 		}
 	case "index":
 		t = restic.IndexFile
@@ -96,10 +94,9 @@ func runList(ctx context.Context, gopts global.Options, args []string, term ui.T
 	})
 }
 
-// packfileLIst runs the list packs <snapshotID>
-// it prints a sorted list of packfiles belonging to this snapshot
-func packfileLIst(ctx context.Context, repo restic.Repository, snapshotID string, printer progress.Printer) error {
-
+// packfileList handles the list packs <snapshotID> variant.
+// It prints a sorted list of packfiles belonging to this snapshot.
+func packfileList(ctx context.Context, repo restic.Repository, snapshotID string, printer progress.Printer) error {
 	sn, _, err := (&data.SnapshotFilter{}).FindLatest(ctx, repo, repo, snapshotID)
 	if err != nil {
 		return fmt.Errorf("required snapshot ID %q not found", snapshotID)

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
+	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
@@ -19,10 +21,12 @@ func newListCommand(globalOptions *global.Options) *cobra.Command {
 	var listAllowedArgsUseString = strings.Join(listAllowedArgs, "|")
 
 	cmd := &cobra.Command{
-		Use:   "list [flags] [" + listAllowedArgsUseString + "]",
+		Use:   "list [flags] [" + listAllowedArgsUseString + "] or list packs snapshotID",
 		Short: "List objects in the repository",
 		Long: `
 The "list" command allows listing objects in the repository based on type.
+The "list packs snapshotID" accepts one snapshotID and lists all packfiles
+used by this snapshot.
 
 EXIT STATUS
 ===========
@@ -36,18 +40,20 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		GroupID:           cmdGroupDefault,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), *globalOptions, args, globalOptions.Term)
+			return runList(cmd.Context(), *globalOptions, args, globalOptions.Term, listAllowedArgsUseString)
 		},
 		ValidArgs: listAllowedArgs,
-		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
 	}
 	return cmd
 }
 
-func runList(ctx context.Context, gopts global.Options, args []string, term ui.Terminal) error {
+func runList(ctx context.Context, gopts global.Options, args []string, term ui.Terminal,
+	listAllowedArgsUseString string,
+) error {
 	printer := progress.NewTerminalPrinter(false, gopts.Verbosity, term)
 
-	if len(args) != 1 {
+	if len(args) == 0 {
+		printer.E("restic list needs one of [%s] or `list packs snapshotID` as argument", listAllowedArgsUseString)
 		return errors.Fatal("type not specified")
 	}
 
@@ -61,6 +67,10 @@ func runList(ctx context.Context, gopts global.Options, args []string, term ui.T
 	switch args[0] {
 	case "packs":
 		t = restic.PackFile
+		if len(args) == 2 {
+			// args[1] needs to be a snapshotID
+			return packfileLIst(ctx, repo, args[1], printer)
+		}
 	case "index":
 		t = restic.IndexFile
 	case "snapshots":
@@ -85,4 +95,44 @@ func runList(ctx context.Context, gopts global.Options, args []string, term ui.T
 		printer.S("%s", id)
 		return nil
 	})
+}
+
+// packfileLIst runs the list packs <snapshotID>
+// it creates a sorted list of packfiles belonging to this snapshot
+func packfileLIst(ctx context.Context, repo restic.Repository, snapshotID string, printer progress.Printer) error {
+
+	snapshotLister, err := restic.MemorizeList(ctx, repo, restic.SnapshotFile)
+	if err != nil {
+		return err
+	}
+
+	sn, _, err := (&data.SnapshotFilter{}).FindLatest(ctx, snapshotLister, repo, snapshotID)
+	if err != nil {
+		return fmt.Errorf("required snapshot ID %q not found", snapshotID)
+	}
+
+	if err = repo.LoadIndex(ctx, printer); err != nil {
+		return err
+	}
+
+	usedBlobs := repo.NewAssociatedBlobSet()
+	bar := printer.NewCounter("snapshot")
+	bar.SetMax(uint64(1))
+	if err := data.FindUsedBlobs(ctx, repo, []restic.ID{*sn.Tree}, usedBlobs, bar); err != nil {
+		return err
+	}
+	bar.Done()
+
+	snapPacks := restic.NewIDSet()
+	for bh := range usedBlobs.Keys() {
+		for _, blob := range repo.LookupBlob(bh.Type, bh.ID) {
+			snapPacks.Insert(blob.PackID())
+		}
+	}
+
+	for _, packID := range snapPacks.List() {
+		printer.S("%v", packID)
+	}
+
+	return nil
 }

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -52,9 +52,8 @@ func runList(ctx context.Context, gopts global.Options, args []string, term ui.T
 ) error {
 	printer := progress.NewTerminalPrinter(false, gopts.Verbosity, term)
 
-	if len(args) == 0 {
-		printer.E("restic list needs one of [%s] or `list packs snapshotID` as argument", listAllowedArgsUseString)
-		return errors.Fatal("type not specified")
+	if len(args) == 0 || (args[0] == "packs" && len(args) > 2) || (args[0] != "packs" && len(args) != 1) {
+		return errors.Fatal(fmt.Sprintf("too many parameters or type not specified. Must be one of [%s] or 'packs snapshotID'", listAllowedArgsUseString))
 	}
 
 	ctx, repo, unlock, err := openWithReadLock(ctx, gopts, gopts.NoLock || args[0] == "locks", printer)
@@ -113,10 +112,11 @@ func packfileLIst(ctx context.Context, repo restic.Repository, snapshotID string
 	usedBlobs := repo.NewAssociatedBlobSet()
 	bar := printer.NewCounter("snapshot")
 	bar.SetMax(uint64(1))
-	if err := data.FindUsedBlobs(ctx, repo, []restic.ID{*sn.Tree}, usedBlobs, bar); err != nil {
+	err = data.FindUsedBlobs(ctx, repo, []restic.ID{*sn.Tree}, usedBlobs, bar)
+	bar.Done()
+	if err != nil {
 		return err
 	}
-	bar.Done()
 
 	snapPacks := restic.NewIDSet()
 	for bh := range usedBlobs.Keys() {

--- a/cmd/restic/cmd_list_integration_test.go
+++ b/cmd/restic/cmd_list_integration_test.go
@@ -16,7 +16,7 @@ import (
 
 func testRunList(t testing.TB, gopts global.Options, tpe string) restic.IDs {
 	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
-		return runList(ctx, gopts, []string{tpe}, gopts.Term)
+		return runList(ctx, gopts, []string{tpe}, gopts.Term, "")
 	})
 	rtest.OK(t, err)
 	return parseIDsFromReader(t, buf)
@@ -101,4 +101,51 @@ func TestListBlobs(t *testing.T) {
 	blobSetFromIndex := testListBlobs(t, env.gopts)
 
 	rtest.Assert(t, blobSetFromIndex.Equals(testIDSet), "the set of restic.ID s should be equal")
+}
+
+func testRunPackfiles(t testing.TB, gopts global.Options, args []string) []byte {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		err := runList(ctx, gopts, args, gopts.Term, "")
+		rtest.OK(t, err)
+		return nil
+	})
+	rtest.OK(t, err)
+
+	return buf.Bytes()
+}
+
+func checkPacklistOutput(output string) int {
+	numLines := 0
+	for _, line := range strings.Split(output, "\n") {
+		_, err := restic.ParseID(line)
+		if err != nil {
+			continue
+		}
+		numLines++
+	}
+
+	return numLines
+}
+
+func TestPackfileListWithSnapshot(t *testing.T) {
+	// setup
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	testSetupBackupData(t, env)
+
+	// 3 backups, single file each
+	opts := BackupOptions{}
+	testRunBackup(t, env.testdata, []string{filepath.Join(env.testdata, "0", "0", "9", "40")}, opts, env.gopts)
+	testRunBackup(t, env.testdata, []string{filepath.Join(env.testdata, "0", "0", "9", "41")}, opts, env.gopts)
+	testRunBackup(t, env.testdata, []string{filepath.Join(env.testdata, "0", "0", "9", "42")}, opts, env.gopts)
+	testListSnapshots(t, env.gopts, 3)
+
+	// run packfilelist
+	buf := testRunPackfiles(t, env.gopts, []string{"packs"})
+	numLines := checkPacklistOutput(string(buf))
+	rtest.Assert(t, numLines == 6, "expected 6 packfiles in repository, got %d", numLines)
+
+	buf = testRunPackfiles(t, env.gopts, []string{"packs", "latest"})
+	numLines = checkPacklistOutput(string(buf))
+	rtest.Assert(t, numLines == 2, "expected 2 packfiles in snapshot, got %d", numLines)
 }

--- a/cmd/restic/cmd_list_integration_test.go
+++ b/cmd/restic/cmd_list_integration_test.go
@@ -14,9 +14,9 @@ import (
 	"github.com/restic/restic/internal/ui/progress"
 )
 
-func testRunList(t testing.TB, gopts global.Options, tpe string) restic.IDs {
+func testRunList(t testing.TB, gopts global.Options, params ...string) restic.IDs {
 	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
-		return runList(ctx, gopts, []string{tpe}, gopts.Term, "")
+		return runList(ctx, gopts, params, gopts.Term, "")
 	})
 	rtest.OK(t, err)
 	return parseIDsFromReader(t, buf)
@@ -103,30 +103,6 @@ func TestListBlobs(t *testing.T) {
 	rtest.Assert(t, blobSetFromIndex.Equals(testIDSet), "the set of restic.ID s should be equal")
 }
 
-func testRunPackfiles(t testing.TB, gopts global.Options, args []string) []byte {
-	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
-		err := runList(ctx, gopts, args, gopts.Term, "")
-		rtest.OK(t, err)
-		return nil
-	})
-	rtest.OK(t, err)
-
-	return buf.Bytes()
-}
-
-func checkPacklistOutput(output string) int {
-	numLines := 0
-	for _, line := range strings.Split(output, "\n") {
-		_, err := restic.ParseID(line)
-		if err != nil {
-			continue
-		}
-		numLines++
-	}
-
-	return numLines
-}
-
 func TestPackfileListWithSnapshot(t *testing.T) {
 	// setup
 	env, cleanup := withTestEnvironment(t)
@@ -141,11 +117,9 @@ func TestPackfileListWithSnapshot(t *testing.T) {
 	testListSnapshots(t, env.gopts, 3)
 
 	// run packfilelist
-	buf := testRunPackfiles(t, env.gopts, []string{"packs"})
-	numLines := checkPacklistOutput(string(buf))
-	rtest.Assert(t, numLines == 6, "expected 6 packfiles in repository, got %d", numLines)
+	packfiles := testRunList(t, env.gopts, "packs")
+	rtest.Assert(t, len(packfiles) == 6, "expected 6 packfiles in repository, got %d", len(packfiles))
 
-	buf = testRunPackfiles(t, env.gopts, []string{"packs", "latest"})
-	numLines = checkPacklistOutput(string(buf))
-	rtest.Assert(t, numLines == 2, "expected 2 packfiles in snapshot, got %d", numLines)
+	packfiles = testRunList(t, env.gopts, "packs", "latest")
+	rtest.Assert(t, len(packfiles) == 2, "expected 2 packfiles in snapshot, got %d", len(packfiles))
 }

--- a/doc/view_repository.rst
+++ b/doc/view_repository.rst
@@ -30,7 +30,7 @@ The allowed types are (in alphabetic order):
 - :ref:`list_index`
 - :ref:`keys <list_keys_locks_packs>`
 - :ref:`locks <list_keys_locks_packs>`
-- :ref:`packs <list_keys_locks_packs>`
+- :ref:`packs <list_keys_locks_packs>` [snapshot ID]
 - :ref:`list_snapshots`
 
 
@@ -159,6 +159,18 @@ Here is an example which lists all the packs in the repository:
     $ restic -r /srv/restic-repo list packs -q
     953e5381138bdc44da23740a83065809dd4021f45ce4e351b577dc4c07f81314
     75bca8556f47d16362e58e757ea89a34b28fb96aedcc314bea35d468e5cb665c
+
+If you want to list all packfiles which participate in a snapshot, use the command
+``list packs`` and attach the snapshot ID of the snapshot you want to see.
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo list packs latest -q
+    ae92415f79c281330159ed590db2a973048c886aacfa4fabfa0eaac10b396b8f
+    dc25893d422a71af41aaaa843cd7121708cd88679bf3885f94a32900ac068e84
+
+This will give you the list of all packfiles, sorted in ID ascending order.
+
 
 .. _view-repository-objects:
 

--- a/doc/view_repository.rst
+++ b/doc/view_repository.rst
@@ -30,7 +30,8 @@ The allowed types are (in alphabetic order):
 - :ref:`list_index`
 - :ref:`keys <list_keys_locks_packs>`
 - :ref:`locks <list_keys_locks_packs>`
-- :ref:`packs <list_keys_locks_packs>` [snapshot ID]
+- :ref:`packs<list_keys_locks_packs>`
+- :ref:`packs [snapshot ID]<list_keys_locks_packs>`
 - :ref:`list_snapshots`
 
 
@@ -160,7 +161,7 @@ Here is an example which lists all the packs in the repository:
     953e5381138bdc44da23740a83065809dd4021f45ce4e351b577dc4c07f81314
     75bca8556f47d16362e58e757ea89a34b28fb96aedcc314bea35d468e5cb665c
 
-If you want to list all packfiles which participate in a snapshot, use the command
+If you want to list all packfiles which are part of a snapshot, use the command
 ``list packs`` and attach the snapshot ID of the snapshot you want to see.
 
 .. code-block:: console


### PR DESCRIPTION
Command to show packfiles which belong to a snapshot or list of snapshots.

packfilelist gathers all snapshots from the the standard restic.SnapshotFilter, collects the trees which belong to these snapshots and calls restic.FindUsedBlobs to collect all blobs participating in these snapshots. These blobs get translated to their containing packfiles and these lists are printed out either as standard text of in JSON format. The `--detail` options allows for more insights to be looked at.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR addresses issues raised in #5372.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
https://github.com/restic/restic/issues/5372
https://github.com/restic/restic/issues/5751

Closes #5372

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [X] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
