### PR TITLE
docs: clarify ** wildcard must me between path separators

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -346,9 +346,10 @@ A trailing ``/`` is ignored, a leading ``/`` anchors the pattern at the root dir
 This means, ``/bin`` matches ``/bin/bash`` but does not match ``/usr/bin/restic``.
 
 Regular wildcards cannot be used to match over the directory separator ``/``,
-e.g. ``b*ash`` matches ``/bin/bash`` but does not match ``/bin/ash``. For this,
-the special wildcard ``**`` can be used to match arbitrary sub-directories: The
-pattern ``foo/**/bar`` matches:
+e.g. ``b*ash`` matches ``/bin/bash`` but does not match ``/bin/ash``. To match
+across an arbitrary number of subdirectories, use the special ``**`` wildcard.
+The ``**`` must be positioned between path separators. The pattern 
+``foo/**/bar`` matches:
 
 * ``/dir1/foo/dir2/bar/file``
 * ``/foo/bar/file``


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Clarify ** wildcard needs to be placed between path separators.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
[How do I specify a wildcard string for the end/trailing of a folder - Getting Help - restic forum](https://forum.restic.net/t/how-do-i-specify-a-wildcard-string-for-the-end-trailing-of-a-folder/9710/10?u=unequal8761)

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
