### PR TITLE
repository/pack: Pad packs to further mitigate chunking attack

### DIFF
--- a/internal/repository/pack/pack_internal_test.go
+++ b/internal/repository/pack/pack_internal_test.go
@@ -207,7 +207,7 @@ func TestUnpackedVerification(t *testing.T) {
 		{damageCiphertext, "ciphertext verification failed"},
 		{damageLength, "header decoding failed"},
 	} {
-		header, err := makeHeader(blobs)
+		header, err := makeHeader(blobs, true)
 		rtest.OK(t, err)
 
 		if test.damage == damageData {

--- a/internal/repository/pack/pack_test.go
+++ b/internal/repository/pack/pack_test.go
@@ -35,7 +35,7 @@ func newPack(t testing.TB, k *crypto.Key, lengths []int) ([]Buf, []byte, uint) {
 		rtest.OK(t, err)
 	}
 
-	err := p.Finalize()
+	err := p.Finalize(false)
 	rtest.OK(t, err)
 
 	return bufs, buf.Bytes(), p.Size()
@@ -172,7 +172,7 @@ func TestPackMerge(t *testing.T) {
 
 	err := packer1.Merge(packer2, &buf2)
 	rtest.OK(t, err)
-	err = packer1.Finalize()
+	err = packer1.Finalize(false)
 	rtest.OK(t, err)
 
 	// Verify all blobs are present in the merged pack

--- a/internal/repository/pack/padding.go
+++ b/internal/repository/pack/padding.go
@@ -1,0 +1,41 @@
+package pack
+
+import (
+	"encoding/binary"
+	"math/bits"
+)
+
+// Computes a padding size using the Padmé algorithm from
+// https://lbarman.ch/blog/padme/.
+func padmé(size uint) uint {
+	if size <= 0 {
+		return size
+	}
+
+	n := uint64(size)
+	log := 64 - bits.LeadingZeros64(n) - 1
+	loglog := bits.UintSize - bits.LeadingZeros(uint(log))
+	last := log - loglog
+	mask := uint64(1)<<last - 1
+	padded := uint64(n+mask) &^ mask
+	return uint(padded - n)
+}
+
+// Returns a skippable zstd frame of the desired size.
+// A skippable frame represents the empty blob.
+// The size is exact except that sizes >0, <8 are mapped to 8.
+func skippableFrame(size uint32) []byte {
+	if size == 0 {
+		return nil
+	}
+
+	const headerSize = 4 + 4
+	size = max(size, headerSize)
+
+	// https://www.rfc-editor.org/rfc/rfc8878.pdf#name-skippable-frames
+	const magic = 0x184D2A50
+	p := make([]byte, size)
+	binary.LittleEndian.PutUint32(p[:4], magic)
+	binary.LittleEndian.PutUint32(p[4:], size-headerSize)
+	return p
+}

--- a/internal/repository/pack/padding_test.go
+++ b/internal/repository/pack/padding_test.go
@@ -1,0 +1,64 @@
+package pack
+
+import (
+	"testing"
+
+	"github.com/klauspost/compress/zstd"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestPadmé(t *testing.T) {
+	for _, c := range []struct {
+		size, exp uint
+	}{
+		{0, 0},
+		{1, 0},
+		// Expected sizes computed using the Python reference implementation.
+		{2, 0},
+		{3, 0},
+		{4, 0},
+		{5, 0},
+		{7, 0},
+		{8, 0},
+		{9, 1},
+		{10, 0},
+		{11, 1},
+		{15, 1},
+		{16, 0},
+		{17, 1},
+		{19, 1},
+		{100, 4},
+		{1000, 24},
+		{1024, 0},
+		{12345, 455},
+		{31337, 407},
+		{65536, 0},
+		{65537, 2047},
+		{16777215, 1},
+		{16777216, 0},
+		{16777217, 524287},
+		{16777218, 524286},
+		{16777219, 524285},
+		{16777316, 524188},
+		{33554432, 0},
+		{33554433, 1048575},
+		{33554435, 1048573},
+		{4294967295, 1},
+		//{1099511627676, 100},
+	} {
+		rtest.Equals(t, c.exp, padmé(c.size))
+	}
+}
+
+func TestSkippableFrame(t *testing.T) {
+	dec, err := zstd.NewReader(nil)
+	rtest.OK(t, err)
+
+	for _, size := range []uint32{0, 1, 3, 6, 8, 9, 20, 100, 1<<16 - 3, 1<<18 + 4} {
+		f := skippableFrame(size)
+		p, err := dec.DecodeAll(f, nil)
+		rtest.OK(t, err)
+		rtest.Equals(t, 0, len(p))
+	}
+}

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -220,7 +220,7 @@ func (r *packerManager) newPacker() (pck *packer, err error) {
 // savePacker stores p in the backend.
 func (r *Repository) savePacker(ctx context.Context, t restic.BlobType, p *packer) error {
 	debug.Log("save packer for %v with %d blobs (%d bytes)\n", t, p.Packer.Count(), p.Packer.Size())
-	err := p.Packer.Finalize()
+	err := p.Packer.Finalize(r.cfg.Version >= 2)
 	if err != nil {
 		return err
 	}

--- a/internal/repository/packer_manager_test.go
+++ b/internal/repository/packer_manager_test.go
@@ -64,7 +64,7 @@ func testPackerManager(t testing.TB) int64 {
 
 	savedBytes := 0
 	pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, DefaultPackSize, defaultPackerCount, func(ctx context.Context, tp restic.BlobType, p *packer) error {
-		err := p.Finalize()
+		err := p.Finalize(true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This is a backwards compatible way of introducing padding of packs. For each new pack, we determine if it needs padding with [Padmé](https://lbarman.ch/blog/padme/). If so, it adds a zero-length data blob that includes a skippable zstd frame. The user-visible result, aside from padding, is many copies of the empty blob.

Still to do is to teach prune about this change, because right now it will just try to remove those copies, then add them back in when uploading new packs. Also, because the empty blob is always a data blob, we get mixed packs. Maybe we should use a minimal tree blob with a skippable frame for padding tree packs.

I think we should document clearly that pruning a repo with padding with an old version of restic will destroy the padding.

Also, this needs some more fine-tuning, as the padding calculation does not take into account the increased header size.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

For #5328.

Checklist
---------

- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
