### PR TITLE
repository/pack: Pad packs to further mitigate chunking attack

### DIFF
--- a/internal/repository/pack/pack.go
+++ b/internal/repository/pack/pack.go
@@ -9,11 +9,10 @@ import (
 	"math/bits"
 	"sync"
 
+	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/restic"
-
-	"github.com/restic/restic/internal/crypto"
 )
 
 // Packer is used to create a new Pack.
@@ -86,8 +85,8 @@ func (p *Packer) Finalize() error {
 	// in a compatible way by inserting a blob of all zeros. This only works,
 	// and probably only matters, for data packs.
 
-	padding := padmé(p.bytes)
-	if p.blobs[0].Type == restic.DataBlob && padding > 0 {
+	if p.blobs[0].Type == restic.DataBlob {
+		padding := padmé(p.bytes)
 		padding -= int(plainEntrySize)
 		padding = max(padding, 0)
 

--- a/internal/repository/pack/pack.go
+++ b/internal/repository/pack/pack.go
@@ -6,6 +6,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"io"
+	"math/bits"
 	"sync"
 
 	"github.com/restic/restic/internal/debug"
@@ -37,8 +38,11 @@ func (p *Packer) Add(t restic.BlobType, id restic.ID, data []byte, uncompressedL
 	p.m.Lock()
 	defer p.m.Unlock()
 
-	c := restic.Blob{BlobHandle: restic.BlobHandle{Type: t, ID: id}}
+	return p.addLocked(t, id, data, uncompressedLength)
+}
 
+func (p *Packer) addLocked(t restic.BlobType, id restic.ID, data []byte, uncompressedLength int) (int, error) {
+	c := restic.Blob{BlobHandle: restic.BlobHandle{Type: t, ID: id}}
 	n, err := p.wr.Write(data)
 	c.Length = uint(n)
 	c.Offset = p.bytes
@@ -75,15 +79,31 @@ func (p *Packer) Finalize() error {
 	p.m.Lock()
 	defer p.m.Unlock()
 
+	// Add some padding to mitigate an attack that looks for a known file
+	// by checking the lengths of blobs.
+	//
+	// The pack format was not designed with padding in mind, so we add it
+	// in a compatible way by inserting a blob of all zeros. This only works,
+	// and probably only matters, for data packs.
+
+	padding := padmé(p.bytes)
+	if p.blobs[0].Type == restic.DataBlob && padding > 0 {
+		padding -= int(plainEntrySize)
+		padding = max(padding, 0)
+
+		zeros := make([]byte, padding)
+		_, err := p.addLocked(restic.DataBlob, restic.Hash(zeros), p.encrypt(zeros), 0)
+		if err != nil {
+			return err
+		}
+	}
+
 	header, err := makeHeader(p.blobs)
 	if err != nil {
 		return err
 	}
 
-	encryptedHeader := make([]byte, 0, crypto.CiphertextLength(len(header)))
-	nonce := crypto.NewRandomNonce()
-	encryptedHeader = append(encryptedHeader, nonce...)
-	encryptedHeader = p.k.Seal(encryptedHeader, nonce, header, nil)
+	encryptedHeader := p.encrypt(header)
 	encryptedHeader = binary.LittleEndian.AppendUint32(encryptedHeader, uint32(len(encryptedHeader)))
 
 	if err := verifyHeader(p.k, encryptedHeader, p.blobs); err != nil {
@@ -103,6 +123,31 @@ func (p *Packer) Finalize() error {
 	p.bytes += uint(len(encryptedHeader))
 
 	return nil
+}
+
+func (p *Packer) encrypt(data []byte) []byte {
+	nonce := crypto.NewRandomNonce()
+	ciphertext := make([]byte, 0, crypto.CiphertextLength(len(data)))
+	ciphertext = append(ciphertext, nonce...)
+	return p.k.Seal(ciphertext, nonce, data, nil)
+}
+
+// Computes a padding size using the Padmé algorithm from
+// https://lbarman.ch/blog/padme/.
+//
+// Note that this returns the size of the padding, not the total padded size.
+func padmé(size uint) int {
+	if size == 0 {
+		return 0
+	}
+
+	n := uint64(size)
+	log := 64 - bits.LeadingZeros64(n) - 1
+	loglog := bits.UintSize - bits.LeadingZeros(uint(log))
+	last := log - loglog
+	mask := uint64(1)<<last - 1
+	padded := uint64(n+mask) &^ mask
+	return int(padded - n)
 }
 
 func verifyHeader(k *crypto.Key, header []byte, expected []restic.Blob) error {

--- a/internal/repository/pack/pack_internal_test.go
+++ b/internal/repository/pack/pack_internal_test.go
@@ -12,6 +12,50 @@ import (
 	rtest "github.com/restic/restic/internal/test"
 )
 
+func TestPadmé(t *testing.T) {
+	for _, c := range []struct {
+		size uint
+		exp  int
+	}{
+		{0, 0},
+		{1, 0},
+		// Expected sizes computed using the Python reference implementation.
+		{2, 0},
+		{3, 0},
+		{4, 0},
+		{5, 0},
+		{7, 0},
+		{8, 0},
+		{9, 1},
+		{10, 0},
+		{11, 1},
+		{15, 1},
+		{16, 0},
+		{17, 1},
+		{19, 1},
+		{100, 4},
+		{1000, 24},
+		{1024, 0},
+		{12345, 455},
+		{31337, 407},
+		{65536, 0},
+		{65537, 2047},
+		{16777215, 1},
+		{16777216, 0},
+		{16777217, 524287},
+		{16777218, 524286},
+		{16777219, 524285},
+		{16777316, 524188},
+		{33554432, 0},
+		{33554433, 1048575},
+		{33554435, 1048573},
+		{4294967295, 1},
+		//{1099511627676, 100},
+	} {
+		rtest.Equals(t, c.exp, padmé(c.size))
+	}
+}
+
 func TestParseHeaderEntry(t *testing.T) {
 	h := headerEntry{
 		Type:   0, // Blob

--- a/internal/repository/pack/pack_test.go
+++ b/internal/repository/pack/pack_test.go
@@ -31,7 +31,7 @@ func newPack(t testing.TB, k *crypto.Key, lengths []int) ([]Buf, []byte, uint) {
 	var buf bytes.Buffer
 	p := pack.NewPacker(k, &buf)
 	for _, b := range bufs {
-		_, err := p.Add(restic.TreeBlob, b.id, b.data, 2*len(b.data))
+		_, err := p.Add(restic.DataBlob, b.id, b.data, 2*len(b.data))
 		rtest.OK(t, err)
 	}
 
@@ -161,14 +161,14 @@ func TestPackMerge(t *testing.T) {
 	var buf1 bytes.Buffer
 	packer1 := pack.NewPacker(k, &buf1)
 	for _, b := range bufs[:splitAt] {
-		_, err := packer1.Add(restic.TreeBlob, b.id, b.data, 2*len(b.data))
+		_, err := packer1.Add(restic.DataBlob, b.id, b.data, 2*len(b.data))
 		rtest.OK(t, err)
 	}
 
 	var buf2 bytes.Buffer
 	packer2 := pack.NewPacker(k, &buf2)
 	for _, b := range bufs[splitAt:] {
-		_, err := packer2.Add(restic.DataBlob, b.id, b.data, 2*len(b.data))
+		_, err := packer2.Add(restic.TreeBlob, b.id, b.data, 2*len(b.data))
 		rtest.OK(t, err)
 	}
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This is a backwards compatible way of introducing padding of packs. For each new pack, we determine if it needs padding with [Padmé](https://lbarman.ch/blog/padme/). If so, we add a data blob of all zeros. The user-visible result, aside from bigger pack files, is that restic cat will find these all-zero blobs.

Still to do is to teach prune about this change, because right now it will just try to remove those unused blobs, then add them back in when uploading new packs.

I think we should document clearly that pruning a repo with padding with an old version of restic will destroy the padding.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

For #5328. Replaces #5407.

Checklist
---------

- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
