### PR TITLE
backup: fix possible crash if directory disappears before metadata collection

### DIFF
--- a/changelog/unreleased/pull-5421
+++ b/changelog/unreleased/pull-5421
@@ -1,0 +1,8 @@
+Bugfix: Fix rare crash if directory is removed during backup
+
+In restic 0.18.0, the `backup` command could crash if a directory is removed
+inbetween reading its metadata and listing its directory content.
+
+This has been fixed.
+
+https://github.com/restic/restic/pull/5421

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -723,8 +723,14 @@ func (arch *Archiver) saveTree(ctx context.Context, snPath string, atree *tree, 
 			arch.trackItem(snItem, oldNode, n, is, time.Since(start))
 		})
 		if err != nil {
+			err = arch.error(join(snPath, name), err)
+			if err == nil {
+				// ignore error
+				continue
+			}
 			return futureNode{}, 0, err
 		}
+
 		nodes = append(nodes, fn)
 	}
 

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -264,6 +264,11 @@ func (arch *Archiver) trackItem(item string, previous, current *restic.Node, s I
 // nodeFromFileInfo returns the restic node from an os.FileInfo.
 func (arch *Archiver) nodeFromFileInfo(snPath, filename string, meta ToNoder, ignoreXattrListError bool) (*restic.Node, error) {
 	node, err := meta.ToNode(ignoreXattrListError)
+	// node does not exist. This prevents all further processing for this file.
+	// If an error and a node are returned, then preserve as much data as possible (see below).
+	if err != nil && node == nil {
+		return nil, err
+	}
 	if !arch.WithAtime {
 		node.AccessTime = node.ModTime
 	}

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1870,12 +1870,13 @@ func TestArchiverErrorReporting(t *testing.T) {
 	}
 
 	var tests = []struct {
-		name      string
-		src       TestDir
-		want      TestDir
-		prepare   func(t testing.TB)
-		errFn     ErrorFunc
-		mustError bool
+		name    string
+		targets []string
+		src     TestDir
+		want    TestDir
+		prepare func(t testing.TB)
+		errFn   ErrorFunc
+		errStr  string
 	}{
 		{
 			name: "no-error",
@@ -1888,8 +1889,8 @@ func TestArchiverErrorReporting(t *testing.T) {
 			src: TestDir{
 				"targetfile": TestFile{Content: "foobar"},
 			},
-			prepare:   chmodUnreadable("targetfile"),
-			mustError: true,
+			prepare: chmodUnreadable("targetfile"),
+			errStr:  "open targetfile: permission denied",
 		},
 		{
 			name: "file-unreadable-ignore-error",
@@ -1910,8 +1911,8 @@ func TestArchiverErrorReporting(t *testing.T) {
 					"targetfile": TestFile{Content: "foobar"},
 				},
 			},
-			prepare:   chmodUnreadable("subdir/targetfile"),
-			mustError: true,
+			prepare: chmodUnreadable("subdir/targetfile"),
+			errStr:  "open subdir/targetfile: permission denied",
 		},
 		{
 			name: "file-subdir-unreadable-ignore-error",
@@ -1928,6 +1929,12 @@ func TestArchiverErrorReporting(t *testing.T) {
 			},
 			prepare: chmodUnreadable("subdir/targetfile"),
 			errFn:   ignoreErrorForBasename("targetfile"),
+		},
+		{
+			name:    "parent-dir-missing",
+			targets: []string{"subdir/missing"},
+			src:     TestDir{},
+			errStr:  "stat subdir: no such file or directory",
 		},
 	}
 
@@ -1948,14 +1955,18 @@ func TestArchiverErrorReporting(t *testing.T) {
 			arch := New(repo, fs.Track{FS: fs.Local{}}, Options{})
 			arch.Error = test.errFn
 
-			_, snapshotID, _, err := arch.Snapshot(ctx, []string{"."}, SnapshotOptions{Time: time.Now()})
-			if test.mustError {
-				if err != nil {
+			target := test.targets
+			if len(target) == 0 {
+				target = []string{"."}
+			}
+			_, snapshotID, _, err := arch.Snapshot(ctx, target, SnapshotOptions{Time: time.Now()})
+			if test.errStr != "" {
+				if strings.Contains(err.Error(), test.errStr) {
 					t.Logf("found expected error (%v), skipping further checks", err)
 					return
 				}
 
-				t.Fatalf("expected error not returned by archiver")
+				t.Fatalf("expected error (%v) not returned by archiver, got (%v)", test.errStr, err)
 				return
 			}
 

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1846,8 +1846,8 @@ func TestArchiverParent(t *testing.T) {
 func TestArchiverErrorReporting(t *testing.T) {
 	ignoreErrorForBasename := func(basename string) ErrorFunc {
 		return func(item string, err error) error {
-			if filepath.Base(item) == "targetfile" {
-				t.Logf("ignoring error for targetfile: %v", err)
+			if filepath.Base(item) == basename {
+				t.Logf("ignoring error for %v: %v", basename, err)
 				return nil
 			}
 
@@ -1935,6 +1935,14 @@ func TestArchiverErrorReporting(t *testing.T) {
 			targets: []string{"subdir/missing"},
 			src:     TestDir{},
 			errStr:  "stat subdir: no such file or directory",
+		},
+		{
+			name:    "parent-dir-missing-filtered",
+			targets: []string{"targetfile", "subdir/missing"},
+			src: TestDir{
+				"targetfile": TestFile{Content: "foobar"},
+			},
+			errFn: ignoreErrorForBasename("subdir"),
 		},
 	}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Fix a crash during the backup in nodeFromFileInfo in two cases:
- if a directory is deleted between restic stating it and trying to list  its directory content.
- when restic tries to list the parent directory of a backup target, but  the parent directory has been deleted.

A backup also no longer completely fails if a parent folder becomes inaccessible during the backup. This only becomes relevant with the above crash fix as this scenario most likely results in a crash in restic 0.18.0.
The general idea is to also handle errors for parent directories of backup directories in the same way as all other file access errors during a backup.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Partially addresses https://github.com/restic/restic/issues/5391 .
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
