### PR TITLE
backup: add current and avg. data processed rate

### DIFF
--- a/changelog/unreleased/issue-5387
+++ b/changelog/unreleased/issue-5387
@@ -1,0 +1,13 @@
+Enhancement: Show data transfer speed in backup progress
+
+The backup progress display previously showed only the amount of data processed
+but did not indicate the current transfer speed, making it difficult to assess
+performance in real-time or optimize backup operations.
+
+Restic now displays the data transfer speed (in MB/s) during backup operations.
+Both the current speed (calculated over the last 15 seconds) and the overall
+average speed are shown in the progress output, allowing users to monitor
+backup performance and identify bottlenecks.
+
+https://github.com/restic/restic/issues/5387
+https://github.com/restic/restic/issues/1581

--- a/internal/ui/backup/json.go
+++ b/internal/ui/backup/json.go
@@ -39,7 +39,7 @@ func (b *JSONProgress) error(status interface{}) {
 }
 
 // Update updates the status lines.
-func (b *JSONProgress) Update(total, processed Counter, errors uint, currentFiles map[string]struct{}, start time.Time, secs uint64) {
+func (b *JSONProgress) Update(total, processed Counter, errors uint, currentFiles map[string]struct{}, start time.Time, secs uint64, currentRate, overallRate float64) {
 	status := statusUpdate{
 		MessageType:      "status",
 		SecondsElapsed:   uint64(time.Since(start) / time.Second),
@@ -49,6 +49,8 @@ func (b *JSONProgress) Update(total, processed Counter, errors uint, currentFile
 		TotalBytes:       total.Bytes,
 		BytesDone:        processed.Bytes,
 		ErrorCount:       errors,
+		CurrentRate:      currentRate,
+		OverallRate:      overallRate,
 	}
 
 	if total.Bytes > 0 {
@@ -200,6 +202,8 @@ type statusUpdate struct {
 	SecondsElapsed   uint64   `json:"seconds_elapsed,omitempty"`
 	SecondsRemaining uint64   `json:"seconds_remaining,omitempty"`
 	PercentDone      float64  `json:"percent_done"`
+	CurrentRate      float64  `json:"current_rate,omitempty"`
+	OverallRate      float64  `json:"overall_rate,omitempty"`
 	TotalFiles       uint64   `json:"total_files,omitempty"`
 	FilesDone        uint64   `json:"files_done,omitempty"`
 	TotalBytes       uint64   `json:"total_bytes,omitempty"`

--- a/internal/ui/backup/progress_test.go
+++ b/internal/ui/backup/progress_test.go
@@ -18,7 +18,7 @@ type mockPrinter struct {
 	id                    restic.ID
 }
 
-func (p *mockPrinter) Update(_, _ Counter, _ uint, _ map[string]struct{}, _ time.Time, _ uint64) {
+func (p *mockPrinter) Update(_, _ Counter, _ uint, _ map[string]struct{}, _ time.Time, _ uint64, _, _ float64) {
 }
 func (p *mockPrinter) Error(_ string, err error) error        { return err }
 func (p *mockPrinter) ScannerError(_ string, err error) error { return err }

--- a/internal/ui/backup/rates.go
+++ b/internal/ui/backup/rates.go
@@ -1,0 +1,122 @@
+package backup
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// DefaultRateWindow is the default time window in seconds over which
+// to calculate the current transfer rate
+const DefaultRateWindow = 15
+
+// GetRateWindow returns the configured rate window in seconds from the
+// environment variable RESTIC_RATE_WINDOW or the default value
+func GetRateWindow() time.Duration {
+	windowStr := os.Getenv("RESTIC_RATE_WINDOW")
+	if windowStr == "" {
+		return DefaultRateWindow * time.Second
+	}
+
+	window, err := strconv.Atoi(windowStr)
+	if err != nil || window <= 0 {
+		return DefaultRateWindow * time.Second
+	}
+
+	return time.Duration(window) * time.Second
+}
+
+// FormatRate formats a rate in bytes per second in a human-readable way
+func FormatRate(bytesPerSecond float64) string {
+	if bytesPerSecond <= 0 {
+		return "0 B/s"
+	}
+
+	units := []string{"B/s", "KiB/s", "MiB/s", "GiB/s", "TiB/s"}
+	value := bytesPerSecond
+
+	var unitIndex int
+	for unitIndex = 0; value >= 1024 && unitIndex < len(units)-1; unitIndex++ {
+		value /= 1024
+	}
+
+	// Format with appropriate precision based on size
+	var formattedValue string
+	if value >= 100 {
+		formattedValue = fmt.Sprintf("%.0f", value)
+	} else if value >= 10 {
+		formattedValue = fmt.Sprintf("%.1f", value)
+	} else {
+		formattedValue = fmt.Sprintf("%.2f", value)
+	}
+
+	// Trim trailing zeros and decimal point if needed
+	formattedValue = strings.TrimRight(strings.TrimRight(formattedValue, "0"), ".")
+
+	return fmt.Sprintf("%s %s", formattedValue, units[unitIndex])
+}
+
+// GetCurrentRate returns the current transfer rate over the specified time window
+func (r *rateEstimator) GetCurrentRate(now time.Time, window time.Duration) float64 {
+	// If window is less than or equal to zero, use the default window
+	if window <= 0 {
+		window = DefaultRateWindow * time.Second
+	}
+
+	if r.buckets.Len() == 0 {
+		return 0
+	}
+
+	windowStart := now.Add(-window)
+	var bytesInWindow uint64
+	var oldestInWindow time.Time
+
+	found := false
+	for e := r.buckets.Back(); e != nil; e = e.Prev() {
+		b := e.Value.(*rateBucket)
+		bucketStart := b.end.Add(-bucketWidth)
+
+		if bucketStart.Before(windowStart) {
+			// This bucket starts before our window
+			if !found {
+				// If we didn't find any buckets completely in our window,
+				// use a partial count from this bucket
+				ratio := now.Sub(windowStart).Seconds() / bucketWidth.Seconds()
+				if ratio > 1 {
+					ratio = 1
+				}
+				bytesInWindow = uint64(float64(b.totalBytes) * ratio)
+				oldestInWindow = windowStart
+			}
+			break
+		}
+
+		bytesInWindow += b.totalBytes
+		if !found {
+			oldestInWindow = bucketStart
+			found = true
+		}
+	}
+
+	if !found {
+		return 0
+	}
+
+	elapsed := now.Sub(oldestInWindow).Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+
+	return float64(bytesInWindow) / elapsed
+}
+
+// CalculateOverallRate calculates the overall transfer rate since the start time
+func CalculateOverallRate(processedBytes uint64, start time.Time) float64 {
+	elapsed := time.Since(start).Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+	return float64(processedBytes) / elapsed
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Add current and average data processed rate for the `backup` command.

* `current_rate` is calculated over a sliding time window configurable through the environment variable `RESTIC_RATE_WINDOW`. `DefaultRateWindow` is `15 seconds`
* `overall_rate` is the average data processing rate from the beginning of the backup operation.

Disclaimer: I have used an AI code editor (Cursor) to help me with some parts of this PR, like the unit tests. 

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
#5387 #1581 

Checklist
---------
- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
