### PR TITLE
Windows Backup Privilege Tweaks

### DIFF
--- a/changelog/unreleased/pull-5424
+++ b/changelog/unreleased/pull-5424
@@ -1,6 +1,6 @@
-Enhancement: Enable file system privileges before access
+Enhancement: Enable file system privileges on Windows before access
 
-Restic attempted to enable (Windows) file system privileges when
+Restic attempted to enable Windows file system privileges when
 reading or writing security descriptors - after potentially being wholly
 denied access to previous items. It also read file extended attributes without
 using the privilege, possibly missing them and producing errors.

--- a/changelog/unreleased/pull-5424
+++ b/changelog/unreleased/pull-5424
@@ -1,0 +1,11 @@
+Enhancement: Enable file system privileges before access
+
+Restic attempted to enable (Windows) file system privileges when
+reading or writing security descriptors - after potentially being wholly
+denied access to previous items. It also read file extended attributes without
+using the privilege, possibly missing them and producing errors.
+
+Restic now attempts to enable all file system privileges before any file
+access. It also requests extended attribute reads use the backup privilege.
+
+https://github.com/restic/restic/pull/5424

--- a/internal/fs/file_windows.go
+++ b/internal/fs/file_windows.go
@@ -123,10 +123,7 @@ func openHandleForEA(nodeType data.NodeType, path string, writeAccess bool) (han
 	}
 
 	switch nodeType {
-	case data.NodeTypeFile:
-		utf16Path := windows.StringToUTF16Ptr(path)
-		handle, err = windows.CreateFile(utf16Path, uint32(fileAccess), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
-	case data.NodeTypeDir:
+	case data.NodeTypeFile, data.NodeTypeDir:
 		utf16Path := windows.StringToUTF16Ptr(path)
 		handle, err = windows.CreateFile(utf16Path, uint32(fileAccess), 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
 	default:

--- a/internal/fs/fs_local.go
+++ b/internal/fs/fs_local.go
@@ -5,7 +5,14 @@ import (
 	"path/filepath"
 
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/debug"
 )
+
+func init() {
+	if err := enableProcessPrivileges(); err != nil {
+		debug.Log("error enabling privileges: %v", err)
+	}
+}
 
 // Local is the local file system. Most methods are just passed on to the stdlib.
 type Local struct{}

--- a/internal/fs/node_windows_test.go
+++ b/internal/fs/node_windows_test.go
@@ -302,9 +302,7 @@ func TestRestoreExtendedAttributes(t *testing.T) {
 		var handle windows.Handle
 		var err error
 		utf16Path := windows.StringToUTF16Ptr(testPath)
-		if node.Type == data.NodeTypeFile {
-			handle, err = windows.CreateFile(utf16Path, windows.FILE_READ_EA, 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL, 0)
-		} else if node.Type == data.NodeTypeDir {
+		if node.Type == data.NodeTypeFile || node.Type == data.NodeTypeDir {
 			handle, err = windows.CreateFile(utf16Path, windows.FILE_READ_EA, 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
 		}
 		test.OK(t, errors.Wrapf(err, "Error opening file/directory for: %s", testPath))

--- a/internal/fs/priv.go
+++ b/internal/fs/priv.go
@@ -1,0 +1,9 @@
+//go:build !windows
+// +build !windows
+
+package fs
+
+// enableProcessPrivileges enables additional file system privileges for the current process.
+func enableProcessPrivileges() error {
+	return nil
+}

--- a/internal/fs/priv_windows.go
+++ b/internal/fs/priv_windows.go
@@ -1,0 +1,33 @@
+//go:build windows
+// +build windows
+
+package fs
+
+import (
+	"github.com/Microsoft/go-winio"
+	"github.com/restic/restic/internal/errors"
+)
+
+var processPrivileges = []string{
+	// seBackupPrivilege allows the application to bypass file and directory ACLs to back up files and directories.
+	"SeBackupPrivilege",
+	// seRestorePrivilege allows the application to bypass file and directory ACLs to restore files and directories.
+	"SeRestorePrivilege",
+	// seSecurityPrivilege allows read and write access to all SACLs.
+	"SeSecurityPrivilege",
+	// seTakeOwnershipPrivilege allows the application to take ownership of files and directories, regardless of the permissions set on them.
+	"SeTakeOwnershipPrivilege",
+}
+
+// enableProcessPrivileges enables additional file system privileges for the current process.
+func enableProcessPrivileges() error {
+	var errs []error
+
+	// EnableProcessPrivileges may enable some but not all requested privileges, yet its error lists all requested.
+	// Request one at a time to return what actually fails.
+	for _, p := range processPrivileges {
+		errs = append(errs, winio.EnableProcessPrivileges([]string{p}))
+	}
+
+	return errors.Join(errs...)
+}

--- a/internal/fs/priv_windows_test.go
+++ b/internal/fs/priv_windows_test.go
@@ -1,0 +1,61 @@
+//go:build windows
+// +build windows
+
+package fs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/test"
+	"golang.org/x/sys/windows"
+)
+
+func TestBackupPrivilegeBypassACL(t *testing.T) {
+	testPath := testGetRestrictedFilePath(t)
+
+	// Read-only Open/OpenFile should automatically use FILE_FLAG_BACKUP_SEMANTICS since Go v1.20.
+	testfile, err := os.Open(testPath)
+	test.OK(t, errors.Wrapf(err, "failed to open file for reading: %s", testPath))
+	test.OK(t, testfile.Close())
+}
+
+func TestRestorePrivilegeBypassACL(t *testing.T) {
+	testPath := testGetRestrictedFilePath(t)
+
+	// Writable OpenFile needs explicit FILE_FLAG_BACKUP_SEMANTICS.
+	// Go with issue #73676 merged would allow: os.OpenFile(testPath, os.O_WRONLY|windows.O_FILE_FLAG_BACKUP_SEMANTICS, 0)
+	utf16Path := windows.StringToUTF16Ptr(testPath)
+	handle, err := windows.CreateFile(utf16Path, windows.GENERIC_WRITE, 0, nil, windows.OPEN_EXISTING, windows.FILE_ATTRIBUTE_NORMAL|windows.FILE_FLAG_BACKUP_SEMANTICS, 0)
+	test.OK(t, errors.Wrapf(err, "failed to open file for writing: %s", testPath))
+	test.OK(t, windows.Close(handle))
+}
+
+func testGetRestrictedFilePath(t *testing.T) string {
+	// Non-admin is unlikely to have needed privileges.
+	isAdmin, err := isAdmin()
+	test.OK(t, errors.Wrap(err, "failed to check if user is admin"))
+	if !isAdmin {
+		t.Skip("not running with administrator access, skipping")
+	}
+
+	// Create temporary file.
+	tempDir := t.TempDir()
+	testPath := filepath.Join(tempDir, "testfile.txt")
+
+	testfile, err := os.Create(testPath)
+	test.OK(t, errors.Wrapf(err, "failed to create temporary file: %s", testPath))
+	test.OK(t, testfile.Close())
+
+	// Set restricted permissions.
+	sd, err := windows.SecurityDescriptorFromString("D:PAI(D;;FRFWFX;;;WD)(A;;SD;;;WD)")
+	test.OK(t, errors.Wrap(err, "failed to parse SDDL: %s"))
+	dacl, _, err := sd.DACL()
+	test.OK(t, errors.Wrap(err, "failed to extract SD DACL"))
+	err = windows.SetNamedSecurityInfo(testPath, windows.SE_FILE_OBJECT, windows.DACL_SECURITY_INFORMATION|windows.PROTECTED_DACL_SECURITY_INFORMATION, nil, nil, dacl, nil)
+	test.OK(t, errors.Wrapf(err, "failed to set SD: %s", testPath))
+
+	return testPath
+}

--- a/internal/fs/priv_windows_test.go
+++ b/internal/fs/priv_windows_test.go
@@ -50,6 +50,7 @@ func testGetRestrictedFilePath(t *testing.T) string {
 	test.OK(t, testfile.Close())
 
 	// Set restricted permissions.
+	// Deny file read/write/execute to "Everyone" (all accounts); allow delete to "Everyone".
 	sd, err := windows.SecurityDescriptorFromString("D:PAI(D;;FRFWFX;;;WD)(A;;SD;;;WD)")
 	test.OK(t, errors.Wrap(err, "failed to parse SDDL: %s"))
 	dacl, _, err := sd.DACL()


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR enables backup semantics for file EA opens and attempts to enable `SeBackupPrivilege` when first beginning a backup.

When enabled, `SeBackupPrivilege` allows read-only opening that bypasses ACLs; this can permit a restricted account with the proper privilege to back up all users' files without changing file-system permissions. Go supports backup semantics for read-only opens since [405275 / v1.20](<https://go-review.googlesource.com/c/go/+/405275>) and restic currently enables the privilege to backup security descriptors, so such backups _mostly_ work already, with two issues:
1. Reading extended attributes fails for files when `SeBackupPrivilege` allows access which would have been denied without the privilege.
   This is because `windows.CreateFile` is used directly without the appropriate flag.
   (Directories already have the flag as they require it to get a handle at all.)
2. `SeBackupPrivilege` is only enabled upon reading the first security descriptor; accesses before this are subject to normal ACLs and may fail. This always affects the scanner, and the actual backup will error & skip initial items until one has permissive enough ACLs.

An example of both issues:
```console
> rem Running in cmd.exe as Administrator
> set RESTIC_PASSWORD=0000
> restic init -r ".\repo"
> mkdir ".\data"

> rem Create directory "b" accessible only to the SYSTEM account
> mkdir ".\data\b" && echo Test > ".\data\b\b.txt" && icacls ".\data\b" /inheritance:r /grant SYSTEM:F

> restic backup -r ".\repo" -nvv ".\data\b"
open repository
repository 5403b32f opened (version 2, compression level auto)
no parent snapshot found, will read all files
load index files
[0:00]          0 index files loaded
start scan on [.\data\b]
start backup on [.\data\b]
scan: openfile for readdirnames failed: open \\?\D:\Test\data\b: Access is denied.
scan finished in 0.003s: 0 files, 0 B
error: incomplete metadata for data\b\b.txt: get EA failed while opening file handle for path data\b\b.txt, with: Access is denied.
new       /data/b/b.txt, saved in 0.003s (8 B added)
new       /data/b/, saved in 0.004s (0 B added, 0 B stored, 412 B metadata)
new       /data/, saved in 0.007s (0 B added, 0 B stored, 429 B metadata)

Files:           1 new,     0 changed,     0 unmodified
Dirs:            2 new,     0 changed,     0 unmodified
Data Blobs:      1 new
Tree Blobs:      3 new
Would add to the repository: 1.778 KiB (1.380 KiB stored)

processed 1 files, 8 B in 0:00
Warning: at least one source file could not be read

> cd ".\data" && restic backup -r "..\repo" -nvv "b"
open repository
repository 5403b32f opened (version 2, compression level auto)
no parent snapshot found, will read all files
load index files
[0:00]          0 index files loaded
start scan on [b]
start backup on [b]
scan: openfile for readdirnames failed: open \\?\D:\Test\data\b: Access is denied.
scan finished in 0.001s: 0 files, 0 B
error: openfile for readdirnames failed: open \\?\D:\Test\data\b: Access is denied.
Fatal: unable to save snapshot: snapshot is empty
```


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.


Checklist
---------

- [x] I have added tests.
- ~[ ] I have added documentation for relevant changes (in the manual).~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
