### PR TITLE
feat: add integrated nice and ionice options for docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 !/*.go
 !/go.*
 !/cmd/*
+!/docker/entrypoint.sh
 !/internal/*
 !/helpers/*
 !/VERSION

--- a/changelog/unreleased/pull-5448
+++ b/changelog/unreleased/pull-5448
@@ -1,0 +1,11 @@
+Enhancement: Allow nice and ionice configuration for restic containers
+
+The official restic docker now supports the following environment variables:
+
+`NICE`: set the desired nice scheduling.  See `man nice`.
+`IONICE_CLASS`: set the desired I/O scheduling class.  See `man ionice`.  Note that real time support requires the invoker to manually add the `SYS_ADMIN` capability.
+`IONICE_PRIORITY`: set the prioritization for ionice in the given `IONICE_CLASS`.  This does nothing without `IONICE_CLASS`, but defaults to `4` (no priority, no penalties).
+
+See https://restic.readthedocs.io/en/stable/020_installation.html#docker-container for further details.
+
+https://github.com/restic/restic/pull/5448

--- a/changelog/unreleased/pull-5448
+++ b/changelog/unreleased/pull-5448
@@ -3,7 +3,7 @@ Enhancement: Allow nice and ionice configuration for restic containers
 The official restic docker now supports the following environment variables:
 
 `NICE`: set the desired nice scheduling.  See `man nice`.
-`IONICE_CLASS`: set the desired I/O scheduling class.  See `man ionice`.  Note that real time support requires the invoker to manually add the `SYS_ADMIN` capability.
+`IONICE_CLASS`: set the desired I/O scheduling class.  See `man ionice`.  Note that real time support requires the invoker to manually add the `SYS_NICE` capability.
 `IONICE_PRIORITY`: set the prioritization for ionice in the given `IONICE_CLASS`.  This does nothing without `IONICE_CLASS`, but defaults to `4` (no priority, no penalties).
 
 See https://restic.readthedocs.io/en/stable/020_installation.html#docker-container for further details.

--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -289,6 +289,23 @@ Restic relies on the hostname for various operations. Make sure to set a static
 hostname using `--hostname` when creating a Docker container, otherwise Docker
 will assign a random hostname each time.
 
+The container additionally honors traditional ``nice`` `(man page) <https://man7.org/linux/man-pages/man1/nice.1.html>`__ and ``ionice`` `(man page) <https://man7.org/linux/man-pages/man1/ionice.1.html#OPTIONS>`__ directives via the following environment variables.
+This allows restic to be scheduled as a background process to reduce latency for the system while running.
+
+* ``NICE``: If set, this adjusts the CPU prioritization via ``nice -n``. This defaults to no adjustment- standard CPU priority.
+* ``IONICE_CLASS``: If set, this adjusts the IO prioritization of the restic process via ``ionice -c`` for the available classes.
+  Note: if you attempt to set `real-time`, you *will* have to add the ``SYS_NICE`` capability (`see capabilities manpage <https://man7.org/linux/man-pages/man7/capabilities.7.html#DESCRIPTION>`__) to allow assuming this IO class.
+* ``IONICE_PRIORITY``: this defaults to 4 (no prioritization or penalties); this is the prioritization within the given ``IONICE_CLASS``.
+
+The following example runs restic such that other CPU and IO requests have higher priority. This effectively perturbs the system as minimally as possible while ``restic`` runs.
+
+.. code-block:: console
+
+    # docker run -e NICE=20 -e IONICE_CLASS=2 -e IONICE_PRIORITY=7 ghcr.io/restic/restic
+
+*Remember* that this invocation is explicitly telling your CPU and IO scheduler to deprioritize restic.  This typically will result in a longer runtime.  For a system with heavy load, this can be drastically longer.
+
+
 From Source
 ***********
 

--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -292,10 +292,10 @@ will assign a random hostname each time.
 The container additionally honors traditional ``nice`` `(man page) <https://man7.org/linux/man-pages/man1/nice.1.html>`__ and ``ionice`` `(man page) <https://man7.org/linux/man-pages/man1/ionice.1.html#OPTIONS>`__ directives via the following environment variables.
 This allows restic to be scheduled as a background process to reduce latency for the system while running.
 
-* ``NICE``: If set, this adjusts the CPU prioritization via ``nice -n``. This defaults to no adjustment- standard CPU priority.
+* ``NICE``: If set, this adjusts the CPU prioritization via ``nice -n``. This defaults to no adjustment - standard CPU priority.
 * ``IONICE_CLASS``: If set, this adjusts the IO prioritization of the restic process via ``ionice -c`` for the available classes.
-  Note: if you attempt to set `real-time`, you *will* have to add the ``SYS_NICE`` capability (`see capabilities manpage <https://man7.org/linux/man-pages/man7/capabilities.7.html#DESCRIPTION>`__) to allow assuming this IO class.
-* ``IONICE_PRIORITY``: this defaults to 4 (no prioritization or penalties); this is the prioritization within the given ``IONICE_CLASS``.
+  Note: if you attempt to set `real-time`, you *will* have to add the ``SYS_NICE`` capability (`see capabilities manpage <https://man7.org/linux/man-pages/man7/capabilities.7.html#DESCRIPTION>`__) to allow using this IO class.
+* ``IONICE_PRIORITY``: This defaults to 4 (no prioritization or penalties); this is the prioritization within the given ``IONICE_CLASS``.
 
 The following example runs restic such that other CPU and IO requests have higher priority. This effectively perturbs the system as minimally as possible while ``restic`` runs.
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,11 +8,17 @@ RUN go mod download
 
 COPY . .
 RUN go run build.go
-
 FROM alpine:latest AS restic
-
 RUN apk add --no-cache ca-certificates fuse openssh-client tzdata jq
 
 COPY --from=builder /go/src/github.com/restic/restic/restic /usr/bin
+COPY ./docker/entrypoint.sh /entrypoint.sh
 
-ENTRYPOINT ["/usr/bin/restic"]
+# IO class default is "none"- 0, however busybox reject ionice `-c0 -n<something>`
+# since priority has no meaning for no scheduler.
+# Thus the set logic below is necessary.
+ENV IONICE_CLASS=
+ENV IONICE_PRIORITY=4
+ENV NICE=0
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,7 +16,7 @@ COPY ./docker/entrypoint.sh /entrypoint.sh
 
 # IO class default is "none"- 0, however busybox reject ionice `-c0 -n<something>`
 # since priority has no meaning for no scheduler.
-# Thus the set logic below is necessary.
+# Thus the entrypoint script below is necessary
 ENV IONICE_CLASS=
 ENV IONICE_PRIORITY=4
 ENV NICE=0

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -1,6 +1,6 @@
 # the official binaries are cross-built from Linux running on an AMD64 host
 # other architectures also seem to generate identical binaries but stay on the safe side
-FROM --platform=linux/amd64 restic/builder:latest as helper
+FROM --platform=linux/amd64 restic/builder:latest AS helper
 
 ARG TARGETOS
 ARG TARGETARCH
@@ -19,6 +19,15 @@ LABEL org.opencontainers.image.documentation="https://restic.readthedocs.io"
 LABEL org.opencontainers.image.source="https://github.com/restic/restic"
 
 COPY --from=helper /output/restic /usr/bin
+COPY ./docker/entrypoint.sh /entrypoint.sh
 RUN apk add --no-cache ca-certificates fuse openssh-client tzdata jq
 
-ENTRYPOINT ["/usr/bin/restic"]
+
+# IO class default is "none"- 0, however busybox ionice `-c0 -n<something>`
+# since priority has no meaning for no scheduler.
+# Thus the set logic below is necessary.
+ENV IONICE_CLASS=
+ENV IONICE_PRIORITY=4
+ENV NICE=0
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -22,10 +22,9 @@ COPY --from=helper /output/restic /usr/bin
 COPY ./docker/entrypoint.sh /entrypoint.sh
 RUN apk add --no-cache ca-certificates fuse openssh-client tzdata jq
 
-
-# IO class default is "none"- 0, however busybox ionice `-c0 -n<something>`
+# IO class default is "none"- 0, however busybox rejects ionice `-c0 -n<something>`
 # since priority has no meaning for no scheduler.
-# Thus the set logic below is necessary.
+# Thus the entrypoint script below is necessary.
 ENV IONICE_CLASS=
 ENV IONICE_PRIORITY=4
 ENV NICE=0

--- a/docker/build.sh
+++ b/docker/build.sh
@@ -1,4 +1,6 @@
 #!/bin/sh
+root="$(readlink -f "$0")"
+root="$(dirname "$(dirname "${root}")")"
 
 set -e
 
@@ -8,6 +10,6 @@ echo "Build docker image restic/restic:latest"
 docker build \
   --rm \
   --pull \
-  --file docker/Dockerfile \
+  --file "${root}"/docker/Dockerfile \
   --tag restic/restic:latest \
-  .
+  "${root}" "$@"

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/sh -e
 
-# This must be tested against busybox sh, since there are quirks in it's
+# This must be tested against busybox sh, since there are quirks in its
 # implementation of tooling.  Busybox rejects `ionice -c0 -n<something>` for example.
 set -- /usr/bin/restic "$@"
 if [ -n "${IONICE_CLASS}" ]; then

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -1,0 +1,10 @@
+#!/bin/sh -e
+
+# This must be tested against busybox sh, since there are quirks in it's
+# implementation of tooling.  Busybox rejects `ionice -c0 -n<something>` for example.
+set -- /usr/bin/restic "$@"
+if [ -n "${IONICE_CLASS}" ]; then
+	set -- ionice -c "${IONICE_CLASS}" -n "${IONICE_PRIORITY:-4}" "$@"
+fi
+
+exec nice -n "${NICE:-0}"  "$@"


### PR DESCRIPTION
The intended usage here is to basically kick restic as a background "do it, but don't bother my normal load" process.

This allows passing the following environment variables in to influence scheduling:

- NICE: usual CPU nice.  Defaults to 0.
- IONICE_CLASS: usual ionice class.  Note that setting realtime requires CAP_SYS_ADMIN.  Also note the actual ionice default is "none".
- IONICE_PRIORITY: set the priority within the given class.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This simplifies setting CPU and IO priority, doing it directly via the container.  The expectation is any user of this- as I wished- want to kick restic into the background.

This is possible already with the given containers, however this requires entrypoint override, or manipulating docker CLI args (or k8s args) to achieve it.  It's doable, but if the common case is just "do it in the background", providing environment variables to do it is the lowest friction for user.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

This integrates 3 environment variables, described above.  Further detail:

- NICE: this is always passed into the `nice` command, but defaulted to 0- no change.
- IONICE_CLASS: this is more complex; it's unset.  If set, it must be a valid `ionice` class.  Realtime is not supported without the user adding the SYS_NICE capability.  I consider that an exceptional case rather than the expected common case of "just background restic".  Note also that if the value is unset, we *must not touch the class*.  The default class for processes is "none", but busybox ionice refuses `ionice -c0 -nN` since a priority for no class makes no sense.
- IONICE_PRIORITY: if a class is given, this value is honored as an argument to `ionice`.  It defaults to 4- which should be the default priority for any given class.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

The `nice` suggestion has appeared in multiple tickets where the end users CPU scheduler was making non-optimal choices; I don't think I've seen the `ionice` suggestion however.

To my knowledge, there is no explicit asking for integrating controllable `nice` or `ionice` however.


Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
