### PR TITLE
Mark HTTP Error 507 as permanent

### DIFF
--- a/changelog/unreleased/issue-5429
+++ b/changelog/unreleased/issue-5429
@@ -1,0 +1,8 @@
+Bugfix: do not retry if rest-server runs out of space
+
+Rest-server return error `507 Insufficient Storage` if no more storage
+capacity is available at the server. Restic now no longer retries uploads
+in this case.
+
+https://github.com/restic/restic/issues/5429
+https://github.com/restic/restic/pull/5452

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -182,7 +182,7 @@ func (b *Backend) IsPermanentError(err error) bool {
 
 	var rerr *restError
 	if errors.As(err, &rerr) {
-		if rerr.StatusCode == http.StatusRequestedRangeNotSatisfiable || rerr.StatusCode == http.StatusUnauthorized || rerr.StatusCode == http.StatusForbidden {
+		if rerr.StatusCode == http.StatusRequestedRangeNotSatisfiable || rerr.StatusCode == http.StatusUnauthorized || rerr.StatusCode == http.StatusForbidden || rerr.StatusCode == http.StatusInsufficientStorage {
 			return true
 		}
 	}


### PR DESCRIPTION
This change classifies HTTP error 507 (Insufficient Storage) as a permanent error that should not be retried. I keep running into this once in a while and there is literally no point in retrying when the server is full.

Fixes #5429
