### PR TITLE
 restic copy - add more status counters - issue #5175

### DIFF
--- a/changelog/unreleased/pull-5319
+++ b/changelog/unreleased/pull-5319
@@ -2,7 +2,8 @@ Enhancement: add more status counters to `restic copy`
 
 `restic copy` now produces more status counters in text format. The new counters
 are the number of blobs to copy, their size on disk and the number of packfiles
-used from the source repository.
+used from the source repository. The additional statistics is only produced when
+the `--verbose` option is apecified.
 
 https://github.com/restic/restic/issues/5175
 https://github.com/restic/restic/pull/5319

--- a/changelog/unreleased/pull-5319
+++ b/changelog/unreleased/pull-5319
@@ -1,0 +1,8 @@
+Enhancement: add more status counters to `restic copy`
+
+`restic copy` now produces more status counters in text format. The new counters
+are the number of tree/data blobs, their sizes and the number of packfiles
+they are attachedc to.
+
+https://github.com/restic/restic/issues/5175
+https://github.com/restic/restic/pull/5319

--- a/changelog/unreleased/pull-5319
+++ b/changelog/unreleased/pull-5319
@@ -1,8 +1,8 @@
 Enhancement: add more status counters to `restic copy`
 
 `restic copy` now produces more status counters in text format. The new counters
-are the number of tree/data blobs, their sizes and the number of packfiles
-they are attachedc to.
+are the number of blobs to copy, their size on disk and the number of packfiles
+used from the source repository.
 
 https://github.com/restic/restic/issues/5175
 https://github.com/restic/restic/pull/5319

--- a/changelog/unreleased/pull-5319
+++ b/changelog/unreleased/pull-5319
@@ -3,7 +3,7 @@ Enhancement: add more status counters to `restic copy`
 `restic copy` now produces more status counters in text format. The new counters
 are the number of blobs to copy, their size on disk and the number of packfiles
 used from the source repository. The additional statistics is only produced when
-the `--verbose` option is apecified.
+the `--verbose` option is specified.
 
 https://github.com/restic/restic/issues/5175
 https://github.com/restic/restic/pull/5319

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -251,7 +251,9 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 	return nil
 }
 
+// copyStats: print statistics for the blobs to be copied
 func copyStats(srcRepo restic.Repository, copyBlobs restic.BlobSet, packList restic.IDSet, printer progress.Printer) {
+
 	// count and size
 	countBlobs := 0
 	sizeBlobs := uint64(0)
@@ -259,10 +261,10 @@ func copyStats(srcRepo restic.Repository, copyBlobs restic.BlobSet, packList res
 		for _, blob := range srcRepo.LookupBlob(blob.Type, blob.ID) {
 			countBlobs++
 			sizeBlobs += uint64(blob.Length)
+			break
 		}
-		break
 	}
 
-	printer.V("  %7d all  blobs with a size %11s in %7d packfiles\n",
+	printer.V("  copy %d blobs with disk size %s in %d packfiles\n",
 		countBlobs, ui.FormatBytes(uint64(sizeBlobs)), len(packList))
 }


### PR DESCRIPTION
'copyTree()' now counts and sizes the blobs in 'copyBlobs' and prints them out via 'Verbosef()'.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR addresses the issue raised in https://github.com/restic/restic/issues/5175


<!--
Describe the changes and their purpose here, as detailed as needed.
-->
code has been added to count and size the changes collected in copyBlobs. These counts are printed out via Verbosef().

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
closes https://github.com/restic/restic/issues/5175

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.
