### PR TITLE
restic copy --stream: run one large copy operation crossing snapshot boundaries - issue #5453

### DIFF
--- a/changelog/unreleased/issue-5453
+++ b/changelog/unreleased/issue-5453
@@ -1,12 +1,10 @@
-Enhancement: `restic copy` can now spool packfiles across muliple snapshots
+Enhancement: `copy` copies snapshots in batches
 
-When using `restic copy` used to save all newly created packfiles when finishing one snapshot,
-even when the actual packfile size was quite small. This applied particularly to
-incremental backups, when there was only small changes between individual backups.
+The `copy` command used to copy snapshots individually, even if this resulted in creating pack files
+smaller than the target pack size. In particular, this resulted in many small files
+when copying small incremental snapshots.
 
-When using the new option `--batch`, `restic copy` now creates one large request list
-which contains all blobs from all snapshots to be copied and then executes the
-copy operation.
+Now, `copy` copies multiple snapshots at once to avoid creating small files.
 
 https://github.com/restic/restic/issues/5175
 https://github.com/restic/restic/pull/5464

--- a/changelog/unreleased/issue-5453
+++ b/changelog/unreleased/issue-5453
@@ -1,0 +1,12 @@
+Enhancement: `restic copy` can now spool packfiles across muliple snapshots
+
+When using `restic copy` used to save all newly created packfiles when finishing one snapshot,
+even when the actual packfile size was quite small. This applied particularly to
+incremental backups, when there was only small changes between individual backups.
+
+When using the new option `--batch`, `restic copy` now creates one large request list
+which contains all blobs from all snapshots to be copied and then executes the
+copy operation.
+
+https://github.com/restic/restic/issues/5175
+https://github.com/restic/restic/pull/5464

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -276,9 +276,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 
 	copyStats(srcRepo, copyBlobs, packList, printer)
 	bar := printer.NewCounter("packs copied")
-	bar.SetMax(uint64(len(packList)))
 	err = repository.CopyBlobs(ctx, srcRepo, dstRepo, uploader, packList, copyBlobs, bar, printer.P)
-	bar.Done()
 	if err != nil {
 		return errors.Fatalf("%s", err)
 	}

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -225,6 +225,10 @@ func copyTreeBatched(ctx context.Context, srcRepo restic.Repository, dstRepo res
 			return err
 		}
 
+		// add a newline to separate saved snapshot messages from the other messages
+		if len(batch) > 1 {
+			printer.P("")
+		}
 		// save all the snapshots
 		for _, sn := range batch {
 			err := copySaveSnapshot(ctx, sn, dstRepo, printer)
@@ -322,6 +326,6 @@ func copySaveSnapshot(ctx context.Context, sn *data.Snapshot, dstRepo restic.Rep
 	if err != nil {
 		return err
 	}
-	printer.P("snapshot %s saved", newID.Str())
+	printer.P("snapshot %s saved, copied from source snapshot %s", newID.Str(), sn.ID().Str())
 	return nil
 }

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -85,7 +85,6 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 		if sn.Original != nil {
 			srcOriginal = *sn.Original
 		}
-
 		if originalSns, ok := dstSnapshotByOriginal[srcOriginal]; ok {
 			isCopy := false
 			for _, originalSn := range originalSns {
@@ -201,7 +200,7 @@ func copyTreeBatched(ctx context.Context, srcRepo restic.Repository, dstRepo res
 	// each snapshot to be copied or once for all snapshots
 	if opts.batch {
 		// call WithBlobUploader() once and then loop over all selectedSnapshots
-		err := dstRepo.WithBlobUploader(context.TODO(), func(ctx context.Context, uploader restic.BlobSaver) error {
+		err := dstRepo.WithBlobUploader(ctx, func(ctx context.Context, uploader restic.BlobSaver) error {
 			for _, sn := range selectedSnapshots {
 				printer.P("\n%v", sn)
 				printer.P("  copy started, this may take a while...")
@@ -230,7 +229,7 @@ func copyTreeBatched(ctx context.Context, srcRepo restic.Repository, dstRepo res
 	for _, sn := range selectedSnapshots {
 		printer.P("\n%v", sn)
 		printer.P("  copy started, this may take a while...")
-		err := dstRepo.WithBlobUploader(context.TODO(), func(ctx context.Context, uploader restic.BlobSaver) error {
+		err := dstRepo.WithBlobUploader(ctx, func(ctx context.Context, uploader restic.BlobSaver) error {
 			if err := copyTree(ctx, srcRepo, dstRepo, visitedTrees, *sn.Tree, printer, uploader); err != nil {
 				return err
 			}

--- a/cmd/restic/cmd_copy_integration_test.go
+++ b/cmd/restic/cmd_copy_integration_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
@@ -24,25 +23,6 @@ func testRunCopy(t testing.TB, srcGopts global.Options, dstGopts global.Options)
 			Password:           srcGopts.Password,
 			InsecureNoPassword: srcGopts.InsecureNoPassword,
 		},
-	}
-
-	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
-		return runCopy(context.TODO(), copyOpts, gopts, nil, gopts.Term)
-	}))
-}
-
-func testRunCopyBatched(t testing.TB, srcGopts global.Options, dstGopts global.Options) {
-	gopts := srcGopts
-	gopts.Repo = dstGopts.Repo
-	gopts.Password = dstGopts.Password
-	gopts.InsecureNoPassword = dstGopts.InsecureNoPassword
-	copyOpts := CopyOptions{
-		SecondaryRepoOptions: global.SecondaryRepoOptions{
-			Repo:               srcGopts.Repo,
-			Password:           srcGopts.Password,
-			InsecureNoPassword: srcGopts.InsecureNoPassword,
-		},
-		batch: true,
 	}
 
 	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
@@ -107,76 +87,29 @@ func TestCopy(t *testing.T) {
 	rtest.Assert(t, len(origRestores) == 0, "found not copied snapshots")
 }
 
-// packfile with size and type
-type packInfo struct {
-	Type        string
-	size        int64
-	numberBlobs int
-}
-
-// testGetUsedBlobs: call data.FindUsedBlobs for all snapshots in repositpry
-func testGetUsedBlobs(t *testing.T, repo restic.Repository) (usedBlobs restic.BlobSet) {
-	selectedTrees := make([]restic.ID, 0, 3)
-	usedBlobs = restic.NewBlobSet()
-
-	snapshotLister, err := restic.MemorizeList(context.TODO(), repo, restic.SnapshotFile)
-	rtest.OK(t, err)
-	rtest.OK(t, repo.LoadIndex(context.TODO(), nil))
-
-	// gather all snapshots
-	nullFilter := &data.SnapshotFilter{}
-	err = nullFilter.FindAll(context.TODO(), snapshotLister, repo, nil, func(_ string, sn *data.Snapshot, err error) error {
+func testPackAndBlobCounts(t testing.TB, gopts global.Options) (countTreePacks int, countDataPacks int, countBlobs int) {
+	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
+		_, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
-		selectedTrees = append(selectedTrees, *sn.Tree)
-		return nil
-	})
-	rtest.OK(t, err)
+		defer unlock()
 
-	rtest.OK(t, data.FindUsedBlobs(context.TODO(), repo, selectedTrees, usedBlobs, nil))
+		rtest.OK(t, repo.List(context.TODO(), restic.PackFile, func(id restic.ID, size int64) error {
+			blobs, _, err := repo.ListPack(context.TODO(), id, size)
+			rtest.OK(t, err)
+			rtest.Assert(t, len(blobs) > 0, "a packfile should contain at least one blob")
 
-	return usedBlobs
-}
-
-// getPackfileInfo: get packfiles, their length, type and number of blobs in packfile
-func getPackfileInfo(t *testing.T, repo restic.Repository) (packfiles map[restic.ID]packInfo) {
-	packfiles = make(map[restic.ID]packInfo)
-
-	rtest.OK(t, repo.List(context.TODO(), restic.PackFile, func(id restic.ID, size int64) error {
-		blobs, _, err := repo.ListPack(context.TODO(), id, size)
-		rtest.OK(t, err)
-		rtest.Assert(t, len(blobs) > 0, "a packfile should contain at least one blob")
-
-		Type := ""
-		if len(blobs) > 0 {
-			Type = blobs[0].Type.String()
-		}
-
-		packfiles[id] = packInfo{
-			Type:        Type,
-			size:        size,
-			numberBlobs: len(blobs),
-		}
-
+			switch blobs[0].Type {
+			case restic.TreeBlob:
+				countTreePacks++
+			case restic.DataBlob:
+				countDataPacks++
+			}
+			countBlobs += len(blobs)
+			return nil
+		}))
 		return nil
 	}))
-
-	return packfiles
-}
-
-// get various counts from the packfiles in the repository
-func getCounts(t *testing.T, repo restic.Repository) (int, int, int) {
-	countTreePacks := 0
-	countDataPacks := 0
-	countBlobs := 0
-	for _, item := range getPackfileInfo(t, repo) {
-		switch item.Type {
-		case "tree":
-			countTreePacks++
-		case "data":
-			countDataPacks++
-		}
-		countBlobs += item.numberBlobs
-	}
 
 	return countTreePacks, countDataPacks, countBlobs
 }
@@ -184,99 +117,45 @@ func getCounts(t *testing.T, repo restic.Repository) (int, int, int) {
 func TestCopyBatched(t *testing.T) {
 	env, cleanup := withTestEnvironment(t)
 	defer cleanup()
-	env3, cleanup3 := withTestEnvironment(t)
-	defer cleanup3()
+	envDst, cleanupDst := withTestEnvironment(t)
+	defer cleanupDst()
 
 	testSetupBackupData(t, env)
 	opts := BackupOptions{}
 	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9")}, opts, env.gopts)
 	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "2")}, opts, env.gopts)
 	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "3")}, opts, env.gopts)
-	testRunCheck(t, env.gopts)
 
 	// batch copy
-	testRunInit(t, env3.gopts)
-	testRunCopyBatched(t, env.gopts, env3.gopts)
+	testRunInit(t, envDst.gopts)
+	testRunCopy(t, env.gopts, envDst.gopts)
 
 	// check integrity of the copy
-	testRunCheck(t, env3.gopts)
-
-	snapshotIDs := testListSnapshots(t, env.gopts, 3)
-	copiedSnapshotIDs := testListSnapshots(t, env3.gopts, 3)
+	testRunCheck(t, envDst.gopts)
 
 	// check that the copied snapshots have the same tree contents as the old ones (= identical tree hash)
-	origRestores := make(map[string]struct{})
-	for i, snapshotID := range snapshotIDs {
-		restoredir := filepath.Join(env.base, fmt.Sprintf("restore%d", i))
-		origRestores[restoredir] = struct{}{}
-		testRunRestore(t, env.gopts, restoredir, snapshotID.String())
+	snapshotIDs := testListSnapshots(t, env.gopts, 3)
+	snapshotTrees := make(map[restic.ID]struct{})
+	for _, snapshotID := range snapshotIDs {
+		snapshot := testLoadSnapshot(t, env.gopts, snapshotID)
+		snapshotTrees[*snapshot.Tree] = struct{}{}
 	}
 
-	for i, snapshotID := range copiedSnapshotIDs {
-		restoredir := filepath.Join(env3.base, fmt.Sprintf("restore%d", i))
-		testRunRestore(t, env3.gopts, restoredir, snapshotID.String())
-		foundMatch := false
-		for cmpdir := range origRestores {
-			diff := directoriesContentsDiff(t, restoredir, cmpdir)
-			if diff == "" {
-				delete(origRestores, cmpdir)
-				foundMatch = true
-			}
-		}
-
-		rtest.Assert(t, foundMatch, "found no counterpart for snapshot %v", snapshotID)
+	copiedSnapshotIDs := testListSnapshots(t, envDst.gopts, 3)
+	copiedSnapshotTrees := make(map[restic.ID]struct{})
+	for _, snapshotID := range copiedSnapshotIDs {
+		snapshot := testLoadSnapshot(t, envDst.gopts, snapshotID)
+		copiedSnapshotTrees[*snapshot.Tree] = struct{}{}
 	}
 
-	rtest.Assert(t, len(origRestores) == 0, "found not copied snapshots")
+	rtest.Equals(t, snapshotTrees, copiedSnapshotTrees, "snapshot trees must be identical after copy")
 
-	// get access to the repositories
-	var repo1 restic.Repository
-	var unlock1 func()
-	var err error
-	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
-		_, repo1, unlock1, err = openWithReadLock(ctx, gopts, false, printer)
-		rtest.OK(t, err)
-		defer unlock1()
-		return err
-	}))
+	_, _, countBlobs := testPackAndBlobCounts(t, env.gopts)
+	countTreePacksDst, countDataPacksDst, countBlobsDst := testPackAndBlobCounts(t, envDst.gopts)
 
-	var repo3 restic.Repository
-	var unlock3 func()
-	rtest.OK(t, withTermStatus(t, env3.gopts, func(ctx context.Context, gopts global.Options) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
-		_, repo3, unlock3, err = openWithReadLock(ctx, gopts, false, printer)
-		rtest.OK(t, err)
-		defer unlock3()
-		return err
-	}))
-
-	usedBlobs1 := testGetUsedBlobs(t, repo1)
-	usedBlobs3 := testGetUsedBlobs(t, repo3)
-	rtest.Assert(t, len(usedBlobs1) == len(usedBlobs3),
-		"used blob length must be identical in both repositories, but is not: (normal) %d <=> (batched) %d",
-		len(usedBlobs1), len(usedBlobs3))
-
-	// compare usedBlobs1 <=> usedBlobs3
-	good := true
-	for bh := range usedBlobs1 {
-		if !usedBlobs3.Has(bh) {
-			good = false
-			break
-		}
-	}
-	rtest.Assert(t, good, "all blobs in both repositories should be equal but they are not")
-
-	_, _, countBlobs1 := getCounts(t, repo1)
-	countTreePacks3, countDataPacks3, countBlobs3 := getCounts(t, repo3)
-
-	rtest.Assert(t, countBlobs1 == countBlobs3,
-		"expected 1 blob count in boths repos to be equal, but got %d and %d blobs",
-		countBlobs1, countBlobs3)
-
-	rtest.Assert(t, countTreePacks3 == 1 && countDataPacks3 == 1,
-		"expected 1 data packfile and 1 tree packfile, but got %d trees and %d data packfiles",
-		countTreePacks3, countDataPacks3)
+	rtest.Equals(t, countBlobs, countBlobsDst, "expected blob count in boths repos to be equal")
+	rtest.Equals(t, countTreePacksDst, 1, "expected 1 tree packfile")
+	rtest.Equals(t, countDataPacksDst, 1, "expected 1 data packfile")
 }
 
 func TestCopyIncremental(t *testing.T) {

--- a/cmd/restic/cmd_copy_integration_test.go
+++ b/cmd/restic/cmd_copy_integration_test.go
@@ -6,8 +6,11 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/global"
+	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/ui"
 )
 
 func testRunCopy(t testing.TB, srcGopts global.Options, dstGopts global.Options) {
@@ -21,6 +24,25 @@ func testRunCopy(t testing.TB, srcGopts global.Options, dstGopts global.Options)
 			Password:           srcGopts.Password,
 			InsecureNoPassword: srcGopts.InsecureNoPassword,
 		},
+	}
+
+	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		return runCopy(context.TODO(), copyOpts, gopts, nil, gopts.Term)
+	}))
+}
+
+func testRunCopyBatched(t testing.TB, srcGopts global.Options, dstGopts global.Options) {
+	gopts := srcGopts
+	gopts.Repo = dstGopts.Repo
+	gopts.Password = dstGopts.Password
+	gopts.InsecureNoPassword = dstGopts.InsecureNoPassword
+	copyOpts := CopyOptions{
+		SecondaryRepoOptions: global.SecondaryRepoOptions{
+			Repo:               srcGopts.Repo,
+			Password:           srcGopts.Password,
+			InsecureNoPassword: srcGopts.InsecureNoPassword,
+		},
+		batch: true,
 	}
 
 	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
@@ -83,6 +105,178 @@ func TestCopy(t *testing.T) {
 	}
 
 	rtest.Assert(t, len(origRestores) == 0, "found not copied snapshots")
+}
+
+// packfile with size and type
+type packInfo struct {
+	Type        string
+	size        int64
+	numberBlobs int
+}
+
+// testGetUsedBlobs: call data.FindUsedBlobs for all snapshots in repositpry
+func testGetUsedBlobs(t *testing.T, repo restic.Repository) (usedBlobs restic.BlobSet) {
+	selectedTrees := make([]restic.ID, 0, 3)
+	usedBlobs = restic.NewBlobSet()
+
+	snapshotLister, err := restic.MemorizeList(context.TODO(), repo, restic.SnapshotFile)
+	rtest.OK(t, err)
+	rtest.OK(t, repo.LoadIndex(context.TODO(), nil))
+
+	// gather all snapshots
+	nullFilter := &data.SnapshotFilter{}
+	err = nullFilter.FindAll(context.TODO(), snapshotLister, repo, nil, func(_ string, sn *data.Snapshot, err error) error {
+		rtest.OK(t, err)
+		selectedTrees = append(selectedTrees, *sn.Tree)
+		return nil
+	})
+	rtest.OK(t, err)
+
+	rtest.OK(t, data.FindUsedBlobs(context.TODO(), repo, selectedTrees, usedBlobs, nil))
+
+	return usedBlobs
+}
+
+// getPackfileInfo: get packfiles, their length, type and number of blobs in packfile
+func getPackfileInfo(t *testing.T, repo restic.Repository) (packfiles map[restic.ID]packInfo) {
+	packfiles = make(map[restic.ID]packInfo)
+
+	rtest.OK(t, repo.List(context.TODO(), restic.PackFile, func(id restic.ID, size int64) error {
+		blobs, _, err := repo.ListPack(context.TODO(), id, size)
+		rtest.OK(t, err)
+		rtest.Assert(t, len(blobs) > 0, "a packfile should contain at least one blob")
+
+		Type := ""
+		if len(blobs) > 0 {
+			Type = blobs[0].Type.String()
+		}
+
+		packfiles[id] = packInfo{
+			Type:        Type,
+			size:        size,
+			numberBlobs: len(blobs),
+		}
+
+		return nil
+	}))
+
+	return packfiles
+}
+
+// get various counts from the packfiles in the repository
+func getCounts(t *testing.T, repo restic.Repository) (int, int, int) {
+	countTreePacks := 0
+	countDataPacks := 0
+	countBlobs := 0
+	for _, item := range getPackfileInfo(t, repo) {
+		switch item.Type {
+		case "tree":
+			countTreePacks++
+		case "data":
+			countDataPacks++
+		}
+		countBlobs += item.numberBlobs
+	}
+
+	return countTreePacks, countDataPacks, countBlobs
+}
+
+func TestCopyBatched(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	env3, cleanup3 := withTestEnvironment(t)
+	defer cleanup3()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9")}, opts, env.gopts)
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "2")}, opts, env.gopts)
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "3")}, opts, env.gopts)
+	testRunCheck(t, env.gopts)
+
+	// batch copy
+	testRunInit(t, env3.gopts)
+	testRunCopyBatched(t, env.gopts, env3.gopts)
+
+	// check integrity of the copy
+	testRunCheck(t, env3.gopts)
+
+	snapshotIDs := testListSnapshots(t, env.gopts, 3)
+	copiedSnapshotIDs := testListSnapshots(t, env3.gopts, 3)
+
+	// check that the copied snapshots have the same tree contents as the old ones (= identical tree hash)
+	origRestores := make(map[string]struct{})
+	for i, snapshotID := range snapshotIDs {
+		restoredir := filepath.Join(env.base, fmt.Sprintf("restore%d", i))
+		origRestores[restoredir] = struct{}{}
+		testRunRestore(t, env.gopts, restoredir, snapshotID.String())
+	}
+
+	for i, snapshotID := range copiedSnapshotIDs {
+		restoredir := filepath.Join(env3.base, fmt.Sprintf("restore%d", i))
+		testRunRestore(t, env3.gopts, restoredir, snapshotID.String())
+		foundMatch := false
+		for cmpdir := range origRestores {
+			diff := directoriesContentsDiff(t, restoredir, cmpdir)
+			if diff == "" {
+				delete(origRestores, cmpdir)
+				foundMatch = true
+			}
+		}
+
+		rtest.Assert(t, foundMatch, "found no counterpart for snapshot %v", snapshotID)
+	}
+
+	rtest.Assert(t, len(origRestores) == 0, "found not copied snapshots")
+
+	// get access to the repositories
+	var repo1 restic.Repository
+	var unlock1 func()
+	var err error
+	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
+		_, repo1, unlock1, err = openWithReadLock(ctx, gopts, false, printer)
+		rtest.OK(t, err)
+		defer unlock1()
+		return err
+	}))
+
+	var repo3 restic.Repository
+	var unlock3 func()
+	rtest.OK(t, withTermStatus(t, env3.gopts, func(ctx context.Context, gopts global.Options) error {
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
+		_, repo3, unlock3, err = openWithReadLock(ctx, gopts, false, printer)
+		rtest.OK(t, err)
+		defer unlock3()
+		return err
+	}))
+
+	usedBlobs1 := testGetUsedBlobs(t, repo1)
+	usedBlobs3 := testGetUsedBlobs(t, repo3)
+	rtest.Assert(t, len(usedBlobs1) == len(usedBlobs3),
+		"used blob length must be identical in both repositories, but is not: (normal) %d <=> (batched) %d",
+		len(usedBlobs1), len(usedBlobs3))
+
+	// compare usedBlobs1 <=> usedBlobs3
+	good := true
+	for bh := range usedBlobs1 {
+		if !usedBlobs3.Has(bh) {
+			good = false
+			break
+		}
+	}
+	rtest.Assert(t, good, "all blobs in both repositories should be equal but they are not")
+
+	_, _, countBlobs1 := getCounts(t, repo1)
+	countTreePacks3, countDataPacks3, countBlobs3 := getCounts(t, repo3)
+
+	rtest.Assert(t, countBlobs1 == countBlobs3,
+		"expected 1 blob count in boths repos to be equal, but got %d and %d blobs",
+		countBlobs1, countBlobs3)
+
+	rtest.Assert(t, countTreePacks3 == 1 && countDataPacks3 == 1,
+		"expected 1 data packfile and 1 tree packfile, but got %d trees and %d data packfiles",
+		countTreePacks3, countDataPacks3)
 }
 
 func TestCopyIncremental(t *testing.T) {

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -216,6 +216,14 @@ example from a local to a remote repository, you can use the ``copy`` command:
     snapshot 4e5d5487 of [/home/user/work] at 2020-05-01 22:44:07.012113 +0200 CEST by user@kasimir
     skipping snapshot 4e5d5487, was already copied to snapshot 50eb62b7
 
+In case you want to copy a repository which contains many backups with little changes
+between ``restic backup`` runs, you can use the option ``--batch`` to make full use of
+the ``--pack-size`` option. Newly created packfiles are saved when the ``copy``
+operation for one snapshot finishes. The option ``--batch`` disregards these snapshot boundaries
+and creates optimally filled packfiles. You can always always achieve the same effect
+by running ``restic prune`` after a ``restic copy`` operation, but this involves the extra
+``prune`` step.
+
 The example command copies all snapshots from the source repository
 ``/srv/restic-repo`` to the destination repository ``/srv/restic-repo-copy``.
 Snapshots which have previously been copied between repositories will
@@ -353,7 +361,7 @@ modifying the repository. Instead restic will only print the actions it would
 perform.
 
 .. note:: The ``rewrite`` command verifies that it does not modify snapshots in
-    unexpected ways and fails with an ``cannot encode tree at "[...]" without losing information``
+    unexpected ways and fails with an ``cannot encode tree at "[...]" without loosing information``
     error otherwise. This can occur when rewriting a snapshot created by a newer
     version of restic or some third-party implementation.
 

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -205,21 +205,28 @@ example from a local to a remote repository, you can use the ``copy`` command:
 
 .. code-block:: console
 
-    $ restic -r /srv/restic-repo-copy copy --from-repo /srv/restic-repo
+    $ restic -r /srv/restic-repo-copy copy --from-repo /srv/restic-repo --verbose
     repository d6504c63 opened successfully
     repository 3dd0878c opened successfully
+    [0:00] 100.00%  2 / 2 index files loaded
+    [0:00] 100.00%  7 / 7 index files loaded
 
     snapshot 410b18a2 of [/home/user/work] at 2020-06-09 23:15:57.305305 +0200 CEST by user@kasimir
       copy started, this may take a while...
-    snapshot 7a746a07 saved
+    [0:00] 100.00%  13 / 13 packs copied
 
     snapshot 4e5d5487 of [/home/user/work] at 2020-05-01 22:44:07.012113 +0200 CEST by user@kasimir
     skipping snapshot 4e5d5487, was already copied to snapshot 50eb62b7
 
+    snapshot 7a746a07 saved, copied from source snapshot 410b18a2
+
 The example command copies all snapshots from the source repository
 ``/srv/restic-repo`` to the destination repository ``/srv/restic-repo-copy``.
 Snapshots which have previously been copied between repositories will
-be skipped by later copy runs.
+be skipped by later copy runs. Information about skipped snapshots is only
+printed when ``--verbose`` is passed to the command. For efficiency reasons,
+the snapshots are copied in batches, such that the ``snapshot [...] saved``
+messages can appear some time after the snapshot content was copied.
 
 .. important:: This process will have to both download (read) and upload (write)
     the entire snapshot(s) due to the different encryption keys used in the

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -216,14 +216,6 @@ example from a local to a remote repository, you can use the ``copy`` command:
     snapshot 4e5d5487 of [/home/user/work] at 2020-05-01 22:44:07.012113 +0200 CEST by user@kasimir
     skipping snapshot 4e5d5487, was already copied to snapshot 50eb62b7
 
-In case you want to copy a repository which contains many backups with little changes
-between ``restic backup`` runs, you can use the option ``--batch`` to make full use of
-the ``--pack-size`` option. Newly created packfiles are saved when the ``copy``
-operation for one snapshot finishes. The option ``--batch`` disregards these snapshot boundaries
-and creates optimally filled packfiles. You can always always achieve the same effect
-by running ``restic prune`` after a ``restic copy`` operation, but this involves the extra
-``prune`` step.
-
 The example command copies all snapshots from the source repository
 ``/srv/restic-repo`` to the destination repository ``/srv/restic-repo-copy``.
 Snapshots which have previously been copied between repositories will

--- a/internal/backend/local/local_windows.go
+++ b/internal/backend/local/local_windows.go
@@ -24,7 +24,7 @@ func removeFile(f string) error {
 	// as Windows won't let you delete a read-only file
 	err := os.Chmod(f, 0666)
 	if err != nil && !os.IsPermission(err) {
-		 return errors.WithStack(err)
+		return errors.WithStack(err)
 	}
 
 	return os.Remove(f)

--- a/internal/repository/index/master_index_test.go
+++ b/internal/repository/index/master_index_test.go
@@ -74,9 +74,6 @@ func TestMasterIndex(t *testing.T) {
 	mIdx.Insert(idx2)
 
 	// test idInIdx1
-	found := mIdx.Has(bhInIdx1)
-	rtest.Equals(t, true, found)
-
 	blobs := mIdx.Lookup(bhInIdx1)
 	rtest.Equals(t, []restic.PackedBlob{blob1}, blobs)
 
@@ -85,9 +82,6 @@ func TestMasterIndex(t *testing.T) {
 	rtest.Equals(t, uint(10), size)
 
 	// test idInIdx2
-	found = mIdx.Has(bhInIdx2)
-	rtest.Equals(t, true, found)
-
 	blobs = mIdx.Lookup(bhInIdx2)
 	rtest.Equals(t, []restic.PackedBlob{blob2}, blobs)
 
@@ -96,9 +90,6 @@ func TestMasterIndex(t *testing.T) {
 	rtest.Equals(t, uint(200), size)
 
 	// test idInIdx12
-	found = mIdx.Has(bhInIdx12)
-	rtest.Equals(t, true, found)
-
 	blobs = mIdx.Lookup(bhInIdx12)
 	rtest.Equals(t, 2, len(blobs))
 
@@ -121,8 +112,6 @@ func TestMasterIndex(t *testing.T) {
 	rtest.Equals(t, uint(80), size)
 
 	// test not in index
-	found = mIdx.Has(restic.BlobHandle{ID: restic.NewRandomID(), Type: restic.TreeBlob})
-	rtest.Assert(t, !found, "Expected no blobs when fetching with a random id")
 	blobs = mIdx.Lookup(restic.NewRandomBlobHandle())
 	rtest.Assert(t, blobs == nil, "Expected no blobs when fetching with a random id")
 	_, found = mIdx.LookupSize(restic.NewRandomBlobHandle())
@@ -521,7 +510,7 @@ func TestRewriteOversizedIndex(t *testing.T) {
 
 	// verify that blobs are still in the index
 	for _, blob := range blobs {
-		found := mi2.Has(blob.BlobHandle)
+		_, found := mi2.LookupSize(blob.BlobHandle)
 		rtest.Assert(t, found, "blob %v missing after rewrite", blob.ID)
 	}
 

--- a/internal/repository/prune.go
+++ b/internal/repository/prune.go
@@ -105,7 +105,7 @@ func PlanPrune(ctx context.Context, opts PruneOptions, repo *Repository, getUsed
 	if repo.Config().Version < 2 && opts.RepackUncompressed {
 		return nil, fmt.Errorf("compression requires at least repository format version 2")
 	}
-	if opts.SmallPackBytes > uint64(repo.packSize()) {
+	if opts.SmallPackBytes > uint64(repo.PackSize()) {
 		return nil, fmt.Errorf("repack-smaller-than exceeds repository packsize")
 	}
 
@@ -329,12 +329,12 @@ func decidePackAction(ctx context.Context, opts PruneOptions, repo *Repository, 
 	var repackSmallCandidates []packInfoWithID
 	repoVersion := repo.Config().Version
 	// only repack very small files by default
-	targetPackSize := repo.packSize() / 25
+	targetPackSize := repo.PackSize() / 25
 	if opts.SmallPackBytes > 0 {
 		targetPackSize = uint(opts.SmallPackBytes)
 	} else if opts.RepackSmall {
 		// consider files with at least 80% of the target size as large enough
-		targetPackSize = repo.packSize() / 5 * 4
+		targetPackSize = repo.PackSize() / 5 * 4
 	}
 
 	// loop over all packs and decide what to do

--- a/internal/repository/prune.go
+++ b/internal/repository/prune.go
@@ -563,7 +563,9 @@ func (plan *PrunePlan) Execute(ctx context.Context, printer progress.Printer) er
 	if len(plan.repackPacks) != 0 {
 		printer.P("repacking packs\n")
 		bar := printer.NewCounter("packs repacked")
-		err := Repack(ctx, repo, repo, plan.repackPacks, plan.keepBlobs, bar, printer.P)
+		err := repo.WithBlobUploader(ctx, func(ctx context.Context, uploader restic.BlobSaver) error {
+			return CopyBlobs(ctx, repo, repo, uploader, plan.repackPacks, plan.keepBlobs, bar, printer.P)
+		})
 		if err != nil {
 			return errors.Fatalf("%s", err)
 		}

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -21,17 +21,18 @@ type repackBlobSet interface {
 
 type LogFunc func(msg string, args ...interface{})
 
-// Repack takes a list of packs together with a list of blobs contained in
+// CopyBlobs takes a list of packs together with a list of blobs contained in
 // these packs. Each pack is loaded and the blobs listed in keepBlobs is saved
 // into a new pack. Returned is the list of obsolete packs which can then
 // be removed.
 //
-// The map keepBlobs is modified by Repack, it is used to keep track of which
+// The map keepBlobs is modified by CopyBlobs, it is used to keep track of which
 // blobs have been processed.
-func Repack(
+func CopyBlobs(
 	ctx context.Context,
 	repo restic.Repository,
 	dstRepo restic.Repository,
+	dstUploader restic.BlobSaver,
 	packs restic.IDSet,
 	keepBlobs repackBlobSet,
 	p *progress.Counter,
@@ -49,24 +50,7 @@ func Repack(
 		return errors.New("repack step requires a backend connection limit of at least two")
 	}
 
-	return dstRepo.WithBlobUploader(ctx, func(ctx context.Context, uploader restic.BlobSaver) error {
-		return repack(ctx, repo, dstRepo, uploader, packs, keepBlobs, p, logf)
-	})
-}
-
-// CopyBlobs is a wrapper around repack(). The parameter 'uploader' is passed through
-// from WithBlobUploader() to CopyBlobs() via cmd/restic/cmd_copy.copyTree().
-func CopyBlobs(
-	ctx context.Context,
-	repo restic.Repository,
-	dstRepo restic.Repository,
-	uploader restic.BlobSaver,
-	packs restic.IDSet,
-	keepBlobs repackBlobSet,
-	p *progress.Counter,
-	logf LogFunc,
-) error {
-	return repack(ctx, repo, dstRepo, uploader, packs, keepBlobs, p, logf)
+	return repack(ctx, repo, dstRepo, dstUploader, packs, keepBlobs, p, logf)
 }
 
 func repack(

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -54,6 +54,26 @@ func Repack(
 	})
 }
 
+/* the following code is a terrible hack, but there is currently no other way
+   of calling the functionality in repack() without a lot duplication of code.
+
+   Repack() is still called from `restic prune` via plan.Execute() inside prune.go
+*/
+// CopyBlobs is a wrapper around repack(). The parameter 'uploader' is passed through
+// from WithBlobUploader() to CopyBlobs() via cmd/restic/cmd_copy.copyTree().
+func CopyBlobs(
+	ctx context.Context,
+	repo restic.Repository,
+	dstRepo restic.Repository,
+	uploader restic.BlobSaver,
+	packs restic.IDSet,
+	keepBlobs repackBlobSet,
+	p *progress.Counter,
+	logf LogFunc,
+) error {
+	return repack(ctx, repo, dstRepo, uploader, packs, keepBlobs, p, logf)
+}
+
 func repack(
 	ctx context.Context,
 	repo restic.Repository,

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -54,7 +54,7 @@ func Repack(
 	})
 }
 
-/* the following code is a terrible hack, but there is currently no other way
+/* CopyBlobs: the following code is a terrible hack, but there is currently no other way
    of calling the functionality in repack() without a lot duplication of code.
 
    Repack() is still called from `restic prune` via plan.Execute() inside prune.go

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -54,11 +54,6 @@ func Repack(
 	})
 }
 
-/* CopyBlobs: the following code is a terrible hack, but there is currently no other way
-   of calling the functionality in repack() without a lot duplication of code.
-
-   Repack() is still called from `restic prune` via plan.Execute() inside prune.go
-*/
 // CopyBlobs is a wrapper around repack(). The parameter 'uploader' is passed through
 // from WithBlobUploader() to CopyBlobs() via cmd/restic/cmd_copy.copyTree().
 func CopyBlobs(

--- a/internal/repository/repack_test.go
+++ b/internal/repository/repack_test.go
@@ -150,7 +150,9 @@ func findPacksForBlobs(t *testing.T, repo restic.Repository, blobs restic.BlobSe
 }
 
 func repack(t *testing.T, repo restic.Repository, be backend.Backend, packs restic.IDSet, blobs restic.BlobSet) {
-	rtest.OK(t, repository.Repack(context.TODO(), repo, repo, packs, blobs, nil, nil))
+	rtest.OK(t, repo.WithBlobUploader(context.TODO(), func(ctx context.Context, uploader restic.BlobSaver) error {
+		return repository.CopyBlobs(ctx, repo, repo, uploader, packs, blobs, nil, nil)
+	}))
 
 	for id := range packs {
 		rtest.OK(t, be.Remove(context.TODO(), backend.Handle{Type: restic.PackFile, Name: id.String()}))
@@ -263,7 +265,9 @@ func testRepackCopy(t *testing.T, version uint) {
 	_, keepBlobs := selectBlobs(t, random, repo, 0.2)
 	copyPacks := findPacksForBlobs(t, repo, keepBlobs)
 
-	rtest.OK(t, repository.Repack(context.TODO(), repoWrapped, dstRepoWrapped, copyPacks, keepBlobs, nil, nil))
+	rtest.OK(t, repoWrapped.WithBlobUploader(context.TODO(), func(ctx context.Context, uploader restic.BlobSaver) error {
+		return repository.CopyBlobs(ctx, repoWrapped, dstRepoWrapped, uploader, copyPacks, keepBlobs, nil, nil)
+	}))
 	rebuildAndReloadIndex(t, dstRepo)
 
 	for h := range keepBlobs {
@@ -299,7 +303,9 @@ func testRepackWrongBlob(t *testing.T, version uint) {
 	_, keepBlobs := selectBlobs(t, random, repo, 0)
 	rewritePacks := findPacksForBlobs(t, repo, keepBlobs)
 
-	err := repository.Repack(context.TODO(), repo, repo, rewritePacks, keepBlobs, nil, nil)
+	err := repo.WithBlobUploader(context.TODO(), func(ctx context.Context, uploader restic.BlobSaver) error {
+		return repository.CopyBlobs(ctx, repo, repo, uploader, rewritePacks, keepBlobs, nil, nil)
+	})
 	if err == nil {
 		t.Fatal("expected repack to fail but got no error")
 	}
@@ -346,7 +352,9 @@ func testRepackBlobFallback(t *testing.T, version uint) {
 	}))
 
 	// repack must fallback to valid copy
-	rtest.OK(t, repository.Repack(context.TODO(), repo, repo, rewritePacks, keepBlobs, nil, nil))
+	rtest.OK(t, repo.WithBlobUploader(context.TODO(), func(ctx context.Context, uploader restic.BlobSaver) error {
+		return repository.CopyBlobs(ctx, repo, repo, uploader, rewritePacks, keepBlobs, nil, nil)
+	}))
 
 	keepBlobs = restic.NewBlobSet(restic.BlobHandle{Type: restic.DataBlob, ID: id})
 	packs := findPacksForBlobs(t, repo, keepBlobs)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -154,8 +154,8 @@ func (r *Repository) Config() restic.Config {
 	return r.cfg
 }
 
-// packSize return the target size of a pack file when uploading
-func (r *Repository) packSize() uint {
+// PackSize return the target size of a pack file when uploading
+func (r *Repository) PackSize() uint {
 	return r.opts.PackSize
 }
 
@@ -590,8 +590,8 @@ func (r *Repository) startPackUploader(ctx context.Context, wg *errgroup.Group) 
 	innerWg, ctx := errgroup.WithContext(ctx)
 	r.packerWg = innerWg
 	r.uploader = newPackerUploader(ctx, innerWg, r, r.Connections())
-	r.treePM = newPackerManager(r.key, restic.TreeBlob, r.packSize(), r.packerCount, r.uploader.QueuePacker)
-	r.dataPM = newPackerManager(r.key, restic.DataBlob, r.packSize(), r.packerCount, r.uploader.QueuePacker)
+	r.treePM = newPackerManager(r.key, restic.TreeBlob, r.PackSize(), r.packerCount, r.uploader.QueuePacker)
+	r.dataPM = newPackerManager(r.key, restic.DataBlob, r.PackSize(), r.packerCount, r.uploader.QueuePacker)
 
 	wg.Go(func() error {
 		return innerWg.Wait()

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -640,7 +640,7 @@ func (r *Repository) LookupBlob(tpe restic.BlobType, id restic.ID) []restic.Pack
 	return r.idx.Lookup(restic.BlobHandle{Type: tpe, ID: id})
 }
 
-// LookupBlobSize returns the size of blob id.
+// LookupBlobSize returns the size of blob id. Also returns pending blobs.
 func (r *Repository) LookupBlobSize(tpe restic.BlobType, id restic.ID) (uint, bool) {
 	return r.idx.LookupSize(restic.BlobHandle{Type: tpe, ID: id})
 }
@@ -968,7 +968,7 @@ func (r *Repository) saveBlob(ctx context.Context, t restic.BlobType, buf []byte
 	}
 
 	// first try to add to pending blobs; if not successful, this blob is already known
-	known = !r.idx.AddPending(restic.BlobHandle{ID: newID, Type: t})
+	known = !r.idx.AddPending(restic.BlobHandle{ID: newID, Type: t}, uint(len(buf)))
 
 	// only save when needed or explicitly told
 	if !known || storeDuplicate {

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -18,6 +18,7 @@ type Repository interface {
 	// Connections returns the maximum number of concurrent backend operations
 	Connections() uint
 	Config() Config
+	PackSize() uint
 	Key() *crypto.Key
 
 	LoadIndex(ctx context.Context, p TerminalCounterFactory) error


### PR DESCRIPTION
restic copy now allows to optimize the repository packsize across multiple snapshots when copying from one repository to another repository.

changelog/unreleased/issue-5453:
announce new option `--batch`.

cmd/restic/cmd_check_integration_test.go:
add stream test

cmd/restic/cmd_copy.go:
new functions collectAllSnapshots(), copyTreeBatched()  to perfrom the batch copy.

cmd/restic/cmd_copy_integration_test.go:
a new streaming test

doc/045_working_with_repos.rst:
a short note about option `--batch`

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR modifies the way the ``copy`` operation works. With the ``--batch`` option, one large request list is built and sent to repository.Repack(), instead of one request list per snapshot to be copied. This allows optimizing the repository packsize while copying ``restic backup``with only minor changes between different snapshots. Normally, one new index file is created per snapshots, together with at least two packfiles for each new snapshot. When changes between backups are small, this can result in a lot of smallish packfiles. 

Yes, this can always be fixed by running ``restic prune``, but this is an extra step.  
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
closes #5453
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [X] I have added tests for all code changes.
- [X] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.
