### PR TITLE
Avoid panic in duration parsing

### DIFF
--- a/internal/restic/duration.go
+++ b/internal/restic/duration.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"strconv"
 	"strings"
-	"unicode"
 
 	"github.com/restic/restic/internal/errors"
 )
@@ -52,7 +51,7 @@ func nextNumber(input string) (num int, rest string, err error) {
 	}
 
 	for i, s := range input {
-		if !unicode.IsNumber(s) {
+		if s < '0' || s > '9' {
 			rest = input[i:]
 			break
 		}

--- a/internal/restic/duration_test.go
+++ b/internal/restic/duration_test.go
@@ -37,6 +37,9 @@ func TestNextNumber(t *testing.T) {
 		{
 			input: "5d  ", num: 5, rest: "d  ",
 		},
+		{
+			input: "5", num: 5, rest: "",
+		},
 	}
 
 	for _, test := range tests {
@@ -78,6 +81,7 @@ func TestParseDuration(t *testing.T) {
 		{input: "2w", err: true},
 		{input: "1y4m3w1d", err: true},
 		{input: "s", err: true},
+		{input: "\xdf\x80", err: true}, // NKO DIGIT ZERO; we want ASCII digits
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Fixes a panic when internal/restic.ParseDuration is fed non-ASCII digits. Also simplifies the function a bit.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Fixes #5485.

Checklist
---------

- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
