### PR TITLE
docs: sync compatibility section with website

### DIFF
--- a/doc/090_participating.rst
+++ b/doc/090_participating.rst
@@ -130,14 +130,17 @@ Backward compatibility for backups is important so that our users are
 always able to restore saved data. Therefore restic follows `Semantic
 Versioning <https://semver.org>`__ to clearly define which versions are
 compatible. The repository and data structures contained therein are
-considered the "Public API" in the sense of Semantic Versioning. This
-goes for all released versions of restic, this may not be the case for
-the master branch.
+considered the "Public API" in the sense of Semantic Versioning.
 
-We guarantee backward compatibility of all repositories within one major
-version; as long as we do not increment the major version, data can be
-read and restored. We strive to be fully backward compatible to all
-prior versions.
+Once version 1.0.0 is released, we guarantee backward compatibility of
+all repositories within one major version; as long as we do not
+increment the major version, data can be read and restored. We strive
+to be fully backward compatible to all prior versions.
+
+During initial development (versions prior to 1.0.0), maintainers and
+developers will do their utmost to keep backwards compatibility and
+stability, although there might be breaking changes without increasing
+the major version.
 
 **********************
 Building documentation


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Sync the text of the compatibility section in the sphinx docs with that on the website. This is no change in policy, just a more precise description of the status quo.

There are no plans for major deprecations in the repository format so far, although further minor deprecations (like the S3 legacy layout or the very old index format) may happen if necessary.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/5445
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- ~~[ ] I have added tests for all code changes.~~
- [x] I have added documentation for relevant changes (in the manual).
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I'm done! This pull request is ready for review.
