### PR TITLE
check: fix error reporting on download retry

### DIFF
--- a/changelog/unreleased/issue-5467
+++ b/changelog/unreleased/issue-5467
@@ -1,0 +1,11 @@
+Bugfix: Improve handling of download retries in `check` command
+
+In very rare cases, the `check` command could unnecessarily report a
+repository damage if the backend returns incomplete, corrupted data on
+the first download try which is resolved by a download retry.
+
+Now, only the check result of the last download attempt is reported as
+intended.
+
+https://github.com/restic/restic/issues/5467
+https://github.com/restic/restic/pull/5495

--- a/changelog/unreleased/issue-5467
+++ b/changelog/unreleased/issue-5467
@@ -4,7 +4,23 @@ In very rare cases, the `check` command could unnecessarily report a
 repository damage if the backend returns incomplete, corrupted data on
 the first download try which is resolved by a download retry.
 
-Now, only the check result of the last download attempt is reported as
+This could result in an error output like the following:
+```
+Load(<data/34567890ab>, 33918928, 0) returned error, retrying after 871.35598ms: readFull: unexpected EOF
+Load(<data/34567890ab>, 33918928, 0) operation successful after 1 retries
+check successful on second attempt, original error pack 34567890ab[...] contains 6 errors: [blob 12345678[...]: decrypting blob <data/12345678> from 34567890 failed: ciphertext verification failed ...]
+[...]
+Fatal: repository contains errors
+```
+
+This fix only applies to a very specific case. The required condition is
+a `operation successful after 1 retries` error in the log, later followed by
+a `check successful on second attempt, original error` error that only reports
+`ciphertext verification failed` errors in the pack file. If any other errors
+are reported in the pack file, then the repository still has to be considered
+as damaged.
+
+Now, only the check result of the last download retry is reported as
 intended.
 
 https://github.com/restic/restic/issues/5467


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Reset all blob decoding errors in a pack file when retrying the download. We're only interested in the result for the last attempt as otherwise the overall pack file hash check and the blob errors are inconsistent with each other.

For a perfect backend, this shouldn't make any difference as the backend would only ever return incomplete data but never garbage data. Hence the checks inside the `Load(...)` call wouldn't report errors. But if the first incomplete attempt returned garbage data but the second attempt was successful, then `check` would report an error for individual blobs, but not the overall pack file. This is highly confusing.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Partially addresses https://github.com/restic/restic/issues/5467
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
