### PR TITLE
docs: add info about ssd wear in backend connections

### DIFF
--- a/changelog/unreleased/pull-5496
+++ b/changelog/unreleased/pull-5496
@@ -1,0 +1,9 @@
+Enhancement: Docs about backend connections indicate potentiel effect on ssd wear
+
+In the docs, in chapter `Tuning Backup Parameters`, `backend connections` potential effect 
+for increased upload time (per single pack), when using more connections, is now pointed out.
+And also the effect for potential SSD wear, because the temporary pack files might stay 
+longer in TMP while uploading.
+
+
+https://github.com/restic/restic/pull/5496

--- a/changelog/unreleased/pull-5496
+++ b/changelog/unreleased/pull-5496
@@ -1,9 +1,0 @@
-Enhancement: Docs about backend connections indicate potentiel effect on ssd wear
-
-In the docs, in chapter `Tuning Backup Parameters`, `backend connections` potential effect 
-for increased upload time (per single pack), when using more connections, is now pointed out.
-And also the effect for potential SSD wear, because the temporary pack files might stay 
-longer in TMP while uploading.
-
-
-https://github.com/restic/restic/pull/5496

--- a/doc/047_tuning_backup_parameters.rst
+++ b/doc/047_tuning_backup_parameters.rst
@@ -39,7 +39,9 @@ the REST backend the parameter would be ``-o rest.connections=5`` or for the loc
 except for the local backend which uses a limit of ``2``. The defaults should work well in
 most cases. For high-latency backends it can be beneficial to increase the number of 
 connections. Please be aware that this increases the resource consumption of restic and 
-that a too high connection count *will degrade performance*.
+that a too high connection count *will degrade performance* and can also result in longer 
+upload times for single temporary packs. The latter can lead to more disk wear on SSDs (see
+:ref:`Pack Size`).
 
 
 CPU Usage
@@ -84,6 +86,8 @@ by reading more files in parallel. You can specify the concurrency of file reads
 ``RESTIC_READ_CONCURRENCY`` environment variable or the ``--read-concurrency`` option of
 the ``backup`` command.
 
+
+.. Pack Size:
 
 Pack Size
 =========

--- a/doc/047_tuning_backup_parameters.rst
+++ b/doc/047_tuning_backup_parameters.rst
@@ -34,13 +34,13 @@ Backend Connections
 
 Restic uses a global limit for the number of concurrent connections to a backend.
 This limit can be configured using ``-o <backend-name>.connections=5``, for example for
-the REST backend the parameter would be ``-o rest.connections=5`` or for the local backend 
-``-o local.connections=2``. By default restic uses ``5`` connections for each backend, 
+the REST backend the parameter would be ``-o rest.connections=5`` or for the local backend
+``-o local.connections=2``. By default restic uses ``5`` connections for each backend,
 except for the local backend which uses a limit of ``2``. The defaults should work well in
-most cases. For high-latency backends it can be beneficial to increase the number of 
-connections. Please be aware that this increases the resource consumption of restic and 
-that a too high connection count *will degrade performance* and can also result in longer 
-upload times for single temporary packs. The latter can lead to more disk wear on SSDs (see
+most cases. For high-latency backends it can be beneficial to increase the number of
+connections. Please be aware that this increases the resource consumption of restic and
+that a too high connection count *will degrade performance*. This can also result in longer
+upload times for single temporary packs, which can lead to more disk wear on SSDs (see
 :ref:`Pack Size`).
 
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
It occured to me while reading the docs, that more concurrent requests lead potentially to more ssd wear (and not only pack size). I wanted this information to be added to the docs for others to see. (My OS e.g. writes to SSD after ~30/35 sec and longer uploading times increase the potential for that - and not only pack size - if i understand correctly, do I ***?***).

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
I did a quick search and didn't see anything relevant.

Checklist
---------

This is a *very* simple pull request. I'm here just a restic end user. So please bear with me.

- [x] I have added tests for all code changes.: *I added no program logic.*
- [x] I have added documentation for relevant changes (in the manual).:  *Not for relevant changes in the code*
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).: *I think i need a pull request number before i can add the Changelog entry. So i can only do that, after making this request?*
- [x] I'm done! This pull request is ready for review.
