### PR TITLE
add example for "Pulling a Backup with HTTP over a ssh tunnel"

### DIFF
--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -354,55 +354,50 @@ system.
    root@a3e580b6369d:/# sudo -u restic /home/restic/bin/restic --exclude={/dev,/media,/mnt,/proc,/run,/sys,/tmp,/var/tmp} -r /tmp backup /
 
 *****************************************************
-Pulling a Backup with HTTP over a ssh tunnel 
+Backup to an internal host over a reverse ssh tunnel
 *****************************************************
 
-This example will show you how to pull a backup from a remote machine via http over a ssh tunnel. 
-
-Motivation
+Idea
 ==========
 
-If you do a backup like this, you do not need a publicly exposed server where the backup can be stored (like a sftp server).
+The idea is to run a rest server locally and forwarding it via a http over ssh tunnel to the remote server. 
+Then running restic on the remote machine to the forwarded restic server.  
+
+By backing up like this, you do not need a publicly exposed server where the backup can be stored (like a sftp server).
 
 A specific use case for this could be a backup of a cloud server (e.g. VPS) to your local PC.
 
-Running a local restic rest server
+Running a local rest server
 ==================================
 
 Install the container image for the `rest server <https://github.com/restic/rest-server>`__:
 
 .. hint:: you can use podman or docker, both should work
 
-.. code-block:: console
-
-   docker pull restic/rest-server:latest
-
-Run container / rest server:
+Run rest server and make it accessible at port 2555:
 
 .. code-block:: console
 
-   docker run --rm -e DISABLE_AUTHENTICATION=0 -p 2555:8000 -v /path/to/local/repo:/data --name restic_rest_server restic/rest-server
-
-.. note:: ``-p 2555:8000`` maps the ports from the docker container to the host (``host_port:container_port``)
+   docker run --rm -p 127.0.0.1:2555:8000 -v ./test:/data --name restic_rest_server restic/rest-server:latest rest-server --path /data --append-only --no-auth
 
 Create a SSH tunnel to the remote machine
 ===========================================
 
-SSH into the Server with http tunneling:
+SSH into the server and forward rest-server:
 
 .. code-block:: console
 
-   ssh -R 2555:localhost:2555 user@server_ip
+   ssh -R 2555:127.0.0.1:2555 user@server_ip
 
 
-.. note:: ``-R 2555:localhost:2555`` (``local_port:localhost:remote_port``) specifies remote port forwarding → forwarding connections from the remote machine to the local machine
+.. note:: ``-R 2555:127.0.0.1:2555`` (``local_port:127.0.0.1:remote_port``) specifies remote port forwarding → forwarding connections from the remote machine to the local machine
 
 
 Run restic on the remote machine
 ================================
 
-Then you can use restic through the ssh connection like this
+Then you can run restic through the ssh connection like this
 
 .. code-block:: console
 
-   restic -r rest:http://localhost:2555/ init
+   restic -r rest:http://127.0.0.1:2555/ init

--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -353,3 +353,56 @@ system.
 
    root@a3e580b6369d:/# sudo -u restic /home/restic/bin/restic --exclude={/dev,/media,/mnt,/proc,/run,/sys,/tmp,/var/tmp} -r /tmp backup /
 
+*****************************************************
+Pulling a Backup with HTTP over a ssh tunnel 
+*****************************************************
+
+This example will show you how to pull a backup from a remote machine via http over a ssh tunnel. 
+
+Motivation
+==========
+
+If you do a backup like this, you do not need a publicly exposed server where the backup can be stored (like a sftp server).
+
+A specific use case for this could be a backup of a cloud server (e.g. VPS) to your local PC.
+
+Running a local restic rest server
+==================================
+
+Install the container image for the `rest server <https://github.com/restic/rest-server>`__:
+
+.. hint:: you can use podman or docker, both should work
+
+.. code-block:: console
+
+   docker pull restic/rest-server:latest
+
+Run container / rest server:
+
+.. code-block:: console
+
+   docker run --rm -e DISABLE_AUTHENTICATION=0 -p 2555:8000 -v /path/to/local/repo:/data --name restic_rest_server restic/rest-server
+
+.. note:: ``-p 2555:8000`` maps the ports from the docker container to the host (``host_port:container_port``)
+
+Create a SSH tunnel to the remote machine
+===========================================
+
+SSH into the Server with http tunneling:
+
+.. code-block:: console
+
+   ssh -R 2555:localhost:2555 user@server_ip
+
+
+.. note:: ``-R 2555:localhost:2555`` (``local_port:localhost:remote_port``) specifies remote port forwarding → forwarding connections from the remote machine to the local machine
+
+
+Run restic on the remote machine
+================================
+
+Then you can use restic through the ssh connection like this
+
+.. code-block:: console
+
+   restic -r rest:http://localhost:2555/ init

--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -370,15 +370,13 @@ A specific use case for this could be a backup of a cloud server (e.g. VPS) to y
 Running a local rest server
 ==================================
 
-Install the container image for the `rest server <https://github.com/restic/rest-server>`__:
-
-.. hint:: you can use podman or docker, both should work
-
-Run rest server and make it accessible at port 2555:
+Run the local rest server:
 
 .. code-block:: console
 
-   docker run --rm -p 127.0.0.1:2555:8000 -v ./test:/data --name restic_rest_server restic/rest-server:latest rest-server --path /data --append-only --no-auth
+   rclone serve restic /path/to/repo
+
+.. note:: this will start a local restic rest server to the local repo (or any other rclone filesystem) and host it on ``127.0.0.1:8080``
 
 Create a SSH tunnel to the remote machine
 ===========================================
@@ -387,10 +385,9 @@ SSH into the server and forward rest-server:
 
 .. code-block:: console
 
-   ssh -R 2555:127.0.0.1:2555 user@server_ip
+   ssh -R 8080:127.0.0.1:8080 user@server_ip
 
-
-.. note:: ``-R 2555:127.0.0.1:2555`` (``local_port:127.0.0.1:remote_port``) specifies remote port forwarding → forwarding connections from the remote machine to the local machine
+.. note:: ``-R 8080:127.0.0.1:8080`` (``local_port:127.0.0.1:remote_port``) remote port forwarding → forwarding connections from the remote machine to the local machine
 
 
 Run restic on the remote machine
@@ -400,4 +397,4 @@ Then you can run restic through the ssh connection like this
 
 .. code-block:: console
 
-   restic -r rest:http://127.0.0.1:2555/ init
+   restic -r rest:http://127.0.0.1:8080/ init

--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -381,16 +381,16 @@ the ``--no-auth`` option to not require authentication when connecting to it:
 
 .. code-block:: console
 
-   rest-server --path /path/to/repo --no-auth
+   rest-server --listen localhost:8000 --path /path/to/repo --no-auth
 
-.. note:: REST-server by default listens on all network interfaces and port
-          ``8000``.
+.. note:: The ``--listen localhost:8000`` option ensures that REST-server is only
+   accessible from the internal host.
 
 Creating a reverse SSH tunnel
 =============================
 
-On the repository server (the internal host), use ``ssh -R`` to create what's
-called a "reverse" SSH tunnel that listens for connections on the *remote* side
+On the repository server (the internal host), use ``ssh -R`` to create a
+"reverse" SSH tunnel that listens for connections on the *remote* side
 and forwards these back through the tunnel to the *local* side:
 
 .. code-block:: console
@@ -422,3 +422,13 @@ You can then use standard restic commands such as ``backup``, ``snapshots`` and
 ``restore`` with the same repository URL and other options as usual.
 
 .. tip:: The tunnel will be active for the duration of the SSH session.
+
+Alternative: Running a local repository server using rclone
+===========================================================
+
+The program `rclone <https://rclone.org/>`__ can alternatively be used to run a local repository server
+instead of using REST-server.
+
+.. code-block:: console
+
+   rclone serve restic --addr localhost:8000 /path/to/repo


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

It adds a example in the docs for pulling a backup over a ssh tunnel as described [here](https://github.com/restic/restic/issues/299#issuecomment-3263824871).

Checklist
---------

- [X] I have added tests for all code changes.
- [X] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.
