### PR TITLE
ui: collect Quote and Truncate helpers

### DIFF
--- a/internal/ui/backup/text.go
+++ b/internal/ui/backup/text.go
@@ -8,7 +8,6 @@ import (
 	"github.com/restic/restic/internal/archiver"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
-	"github.com/restic/restic/internal/ui/termstatus"
 )
 
 // TextProgress reports progress for the `backup` command.
@@ -90,7 +89,7 @@ func (b *TextProgress) Error(_ string, err error) error {
 // CompleteItem is the status callback function for the archiver when a
 // file/dir has been saved successfully.
 func (b *TextProgress) CompleteItem(messageType, item string, s archiver.ItemStats, d time.Duration) {
-	item = termstatus.Quote(item)
+	item = ui.Quote(item)
 
 	switch messageType {
 	case "dir new":

--- a/internal/ui/format_test.go
+++ b/internal/ui/format_test.go
@@ -1,9 +1,10 @@
 package ui
 
 import (
+	"strconv"
 	"testing"
 
-	"github.com/restic/restic/internal/test"
+	rtest "github.com/restic/restic/internal/test"
 )
 
 func TestFormatBytes(t *testing.T) {
@@ -61,8 +62,8 @@ func TestParseBytes(t *testing.T) {
 		{"9223372036854775807", 1<<63 - 1},
 	} {
 		actual, err := ParseBytes(tt.in)
-		test.OK(t, err)
-		test.Equals(t, tt.expected, actual)
+		rtest.OK(t, err)
+		rtest.Equals(t, tt.expected, actual)
 	}
 }
 
@@ -81,11 +82,11 @@ func TestParseBytesInvalid(t *testing.T) {
 		if err == nil {
 			t.Errorf("wanted error for invalid value %q, got nil", s)
 		}
-		test.Equals(t, int64(0), v)
+		rtest.Equals(t, int64(0), v)
 	}
 }
 
-func TestTerminalDisplayWidth(t *testing.T) {
+func TestDisplayWidth(t *testing.T) {
 	for _, c := range []struct {
 		input string
 		want  int
@@ -96,9 +97,94 @@ func TestTerminalDisplayWidth(t *testing.T) {
 		{"a’b", 3},
 		{"aあb", 4},
 	} {
-		if got := TerminalDisplayWidth(c.input); got != c.want {
+		if got := DisplayWidth(c.input); got != c.want {
 			t.Errorf("wrong display width for '%s', want %d, got %d", c.input, c.want, got)
 		}
 	}
 
+}
+
+func TestQuote(t *testing.T) {
+	for _, c := range []struct {
+		in        string
+		needQuote bool
+	}{
+		{"foo.bar/baz", false},
+		{"föó_bàŕ-bãẑ", false},
+		{" foo ", false},
+		{"foo bar", false},
+		{"foo\nbar", true},
+		{"foo\rbar", true},
+		{"foo\abar", true},
+		{"\xff", true},
+		{`c:\foo\bar`, false},
+		// Issue #2260: terminal control characters.
+		{"\x1bm_red_is_beautiful", true},
+	} {
+		if c.needQuote {
+			rtest.Equals(t, strconv.Quote(c.in), Quote(c.in))
+		} else {
+			rtest.Equals(t, c.in, Quote(c.in))
+		}
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	var tests = []struct {
+		input  string
+		width  int
+		output string
+	}{
+		{"", 80, ""},
+		{"", 0, ""},
+		{"", -1, ""},
+		{"foo", 80, "foo"},
+		{"foo", 4, "foo"},
+		{"foo", 3, "foo"},
+		{"foo", 2, "fo"},
+		{"foo", 1, "f"},
+		{"foo", 0, ""},
+		{"foo", -1, ""},
+		{"Löwen", 4, "Löwe"},
+		{"あああああ/data", 7, "あああ"},
+		{"あああああ/data", 10, "あああああ"},
+		{"あああああ/data", 11, "あああああ/"},
+	}
+
+	for _, test := range tests {
+		t.Run("", func(t *testing.T) {
+			out := Truncate(test.input, test.width)
+			if out != test.output {
+				t.Fatalf("wrong output for input %v, width %d: want %q, got %q",
+					test.input, test.width, test.output, out)
+			}
+		})
+	}
+}
+
+func benchmarkTruncate(b *testing.B, s string, w int) {
+	for i := 0; i < b.N; i++ {
+		Truncate(s, w)
+	}
+}
+
+func BenchmarkTruncateASCII(b *testing.B) {
+	s := "This is an ASCII-only status message...\r\n"
+	benchmarkTruncate(b, s, len(s)-1)
+}
+
+func BenchmarkTruncateUnicode(b *testing.B) {
+	s := "Hello World or Καλημέρα κόσμε or こんにちは 世界"
+	w := 0
+	for i := 0; i < len(s); {
+		w++
+		wide, utfsize := wideRune(s[i:])
+		if wide {
+			w++
+		}
+		i += int(utfsize)
+	}
+	b.ResetTimer()
+
+	benchmarkTruncate(b, s, w-1)
 }

--- a/internal/ui/table/table.go
+++ b/internal/ui/table/table.go
@@ -90,7 +90,7 @@ func printLine(w io.Writer, print func(io.Writer, string) error, sep string, dat
 			}
 
 			// apply padding
-			pad := widths[fieldNum] - ui.TerminalDisplayWidth(v)
+			pad := widths[fieldNum] - ui.DisplayWidth(v)
 			if pad > 0 {
 				v += strings.Repeat(" ", pad)
 			}
@@ -140,7 +140,7 @@ func (t *Table) Write(w io.Writer) error {
 	columnWidths := make([]int, columns)
 	for i, desc := range t.columns {
 		for _, line := range strings.Split(desc, "\n") {
-			width := ui.TerminalDisplayWidth(line)
+			width := ui.DisplayWidth(line)
 			if columnWidths[i] < width {
 				columnWidths[i] = width
 			}
@@ -149,7 +149,7 @@ func (t *Table) Write(w io.Writer) error {
 	for _, line := range lines {
 		for i, content := range line {
 			for _, l := range strings.Split(content, "\n") {
-				width := ui.TerminalDisplayWidth(l)
+				width := ui.DisplayWidth(l)
 				if columnWidths[i] < width {
 					columnWidths[i] = width
 				}
@@ -162,7 +162,7 @@ func (t *Table) Write(w io.Writer) error {
 	for _, width := range columnWidths {
 		totalWidth += width
 	}
-	totalWidth += (columns - 1) * ui.TerminalDisplayWidth(t.CellSeparator)
+	totalWidth += (columns - 1) * ui.DisplayWidth(t.CellSeparator)
 
 	// write header
 	if len(t.columns) > 0 {

--- a/internal/ui/termstatus/status_test.go
+++ b/internal/ui/termstatus/status_test.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"strconv"
 	"testing"
 
 	"github.com/restic/restic/internal/terminal"
@@ -56,91 +55,6 @@ func TestSetStatus(t *testing.T) {
 
 	<-term.closed
 	rtest.Equals(t, exp, buf.String())
-}
-
-func TestQuote(t *testing.T) {
-	for _, c := range []struct {
-		in        string
-		needQuote bool
-	}{
-		{"foo.bar/baz", false},
-		{"föó_bàŕ-bãẑ", false},
-		{" foo ", false},
-		{"foo bar", false},
-		{"foo\nbar", true},
-		{"foo\rbar", true},
-		{"foo\abar", true},
-		{"\xff", true},
-		{`c:\foo\bar`, false},
-		// Issue #2260: terminal control characters.
-		{"\x1bm_red_is_beautiful", true},
-	} {
-		if c.needQuote {
-			rtest.Equals(t, strconv.Quote(c.in), Quote(c.in))
-		} else {
-			rtest.Equals(t, c.in, Quote(c.in))
-		}
-	}
-}
-
-func TestTruncate(t *testing.T) {
-	var tests = []struct {
-		input  string
-		width  int
-		output string
-	}{
-		{"", 80, ""},
-		{"", 0, ""},
-		{"", -1, ""},
-		{"foo", 80, "foo"},
-		{"foo", 4, "foo"},
-		{"foo", 3, "foo"},
-		{"foo", 2, "fo"},
-		{"foo", 1, "f"},
-		{"foo", 0, ""},
-		{"foo", -1, ""},
-		{"Löwen", 4, "Löwe"},
-		{"あああああ/data", 7, "あああ"},
-		{"あああああ/data", 10, "あああああ"},
-		{"あああああ/data", 11, "あああああ/"},
-	}
-
-	for _, test := range tests {
-		t.Run("", func(t *testing.T) {
-			out := Truncate(test.input, test.width)
-			if out != test.output {
-				t.Fatalf("wrong output for input %v, width %d: want %q, got %q",
-					test.input, test.width, test.output, out)
-			}
-		})
-	}
-}
-
-func benchmarkTruncate(b *testing.B, s string, w int) {
-	for i := 0; i < b.N; i++ {
-		Truncate(s, w)
-	}
-}
-
-func BenchmarkTruncateASCII(b *testing.B) {
-	s := "This is an ASCII-only status message...\r\n"
-	benchmarkTruncate(b, s, len(s)-1)
-}
-
-func BenchmarkTruncateUnicode(b *testing.B) {
-	s := "Hello World or Καλημέρα κόσμε or こんにちは 世界"
-	w := 0
-	for i := 0; i < len(s); {
-		w++
-		wide, utfsize := wideRune(s[i:])
-		if wide {
-			w++
-		}
-		i += int(utfsize)
-	}
-	b.ResetTimer()
-
-	benchmarkTruncate(b, s, w-1)
 }
 
 func TestSanitizeLines(t *testing.T) {


### PR DESCRIPTION
Collect ui formatting helpers in the ui package

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Minor refactoring. It makes little sense to have functionality like termstatus.Truncate but also ui.DisplayWidth in different packages. Thus, collect them all in one place.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
