### PR TITLE
Adjust s3 credential init order

### DIFF
--- a/changelog/unreleased/issue-5521
+++ b/changelog/unreleased/issue-5521
@@ -1,0 +1,6 @@
+Bugfix: Adjust s3 credential init order
+
+Prior to this change, the initialization order of S3 credentials in restic placed AWS env vars before static credentials provided by user, which was contrary to the sequence documented in the comments. 
+The modification now guarantees that static credentials provided by user take highest priority.
+
+https://github.com/restic/restic/issues/5521

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -121,13 +121,13 @@ func getCredentials(cfg Config, tr http.RoundTripper) (*credentials.Credentials,
 	//    call to a pre-defined endpoint, only valid inside
 	//    configured ec2 instances)
 	creds := credentials.NewChainCredentials([]credentials.Provider{
-		&credentials.EnvAWS{},
 		&credentials.Static{
 			Value: credentials.Value{
 				AccessKeyID:     cfg.KeyID,
 				SecretAccessKey: cfg.Secret.Unwrap(),
 			},
 		},
+		&credentials.EnvAWS{},
 		&credentials.EnvMinio{},
 		&credentials.FileAWSCredentials{},
 		&credentials.FileMinioClient{},


### PR DESCRIPTION
Adjust the credential order when init a s3 backend to ensure the static credentials provided by user take the top highest priority.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
It change the file internal/backend/s3/s3.go

This resolves the current unreasonable issue where   AWS env vars take precedence over static credentials provided by user during restic's initialization of the S3 backend.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #5521 

Checklist
---------

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.