### PR TITLE
Add OpenContainers labels to Dockerfile.release

### DIFF
--- a/changelog/unreleased/pull-5523
+++ b/changelog/unreleased/pull-5523
@@ -1,0 +1,6 @@
+Enhancement: Add OpenContainers labels to Dockerfile.release
+
+The restic Docker image now includes labels from the OpenContainers Annotations Spec.
+This information can be used by third party services.
+
+https://github.com/restic/restic/pull/5523

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -12,6 +12,12 @@ RUN mv /output/restic_${TARGETOS}_${TARGETARCH} /output/restic
 
 FROM alpine:latest
 
+LABEL org.opencontainers.image.title="restic"
+LABEL org.opencontainers.image.description="Fast, secure, efficient backup program"
+LABEL org.opencontainers.image.url="https://restic.net"
+LABEL org.opencontainers.image.documentation="https://restic.readthedocs.io"
+LABEL org.opencontainers.image.source="https://github.com/restic/restic"
+
 COPY --from=helper /output/restic /usr/bin
 RUN apk add --no-cache ca-certificates fuse openssh-client tzdata jq
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds some labels from the [OpenContainers Annotations Spec](https://specs.opencontainers.org/image-spec/annotations/) to the Dockerfile.release file.

My main motivation for this change is the `org.opencontainers.image.source` label which allows Renovate to show the restic changelog and link to the restic repository when creating a PR: https://docs.renovatebot.com/key-concepts/changelogs/#how-renovate-detects-changelogs https://docs.renovatebot.com/modules/datasource/docker/ (see "Source URL support")

However, the metadata can of course also be useful for other services.

Tested with:
- `podman build -t test -f docker/Dockerfile.release --platform linux/amd64 .`
- `podman image inspect --format='{{json .Config.Labels}}' test`

Output: 
```
{"io.buildah.version":"1.41.4","org.opencontainers.image.description":"Fast, secure, efficient backup program","org.opencontainers.image.documentation":"https://restic.readthedocs.io","org.opencontainers.image.source":"https://github.com/restic/restic","org.opencontainers.image.title":"restic","org.opencontainers.image.url":"https://restic.net"}
```

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No

Checklist
---------

- [x] I have added tests for all code changes. -> no code changes
- [x] I have added documentation for relevant changes (in the manual). -> no documentation necessary
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
