### PR TITLE
internal/archiver: fixed BackupEnd when SkipIfUnchanged is true

### DIFF
--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -927,6 +927,7 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 	if opts.ParentSnapshot != nil && opts.SkipIfUnchanged {
 		ps := opts.ParentSnapshot
 		if ps.Tree != nil && rootTreeID.Equal(*ps.Tree) {
+			arch.summary.BackupEnd = time.Now()
 			return nil, restic.ID{}, arch.summary, nil
 		}
 	}


### PR DESCRIPTION
Hi! First of all, **thank you** so much for this amazing project 🙂 I use Restic for some of my backups and I think it's great! Extremely useful to me.

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR is a very simple bugfix.

Basically I noticed that, in case I run `restic backup -v --skip-if-unchanged myfiles` with **no changes** since the latest snapshot, I got the following output:

```
open repository
using parent snapshot 0989166b
load index files
start scan on [myfiles]
start backup on [myfiles]
scan finished in 0.006s: 2 files, 60 B

Files:           0 new,     0 changed,     2 unmodified
Dirs:            0 new,     0 changed,     6 unmodified
Data Blobs:      0 new
Tree Blobs:      0 new
Added to the repository: 0 B   (0 B   stored)

processed 2 files, 60 B in 5124095573468383:13:00
skipped creating snapshot
```

I noticed the time was `5124095573468383:13:00`, so I decided to investigate, and I found that `arch.summary.BackupEnd` was not set in case `opts.SkipIfUnchanged` is `true`, because the function returned early in such case:

https://github.com/restic/restic/blob/93d1e3b2110c3e1b108e103d977445d31498224d/internal/archiver/archiver.go#L927-L932

Setting the right value before returning fixed the problem:

https://github.com/restic/restic/blob/9017fefdddba050ee99a4bbae06267687558cd58/internal/archiver/archiver.go#L930

I also extended the tests and added a test case to `internal/archiver/archiver_test.go` to test such scenario.

I hope this is useful :) let me know what you think. Thanks in advance!

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

I don't think so. I tried to search but couldn't find anything related :)

Checklist
---------

- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
