### PR TITLE
s3: drop manual credentials loading from environment

### DIFF
--- a/internal/backend/s3/config.go
+++ b/internal/backend/s3/config.go
@@ -17,8 +17,6 @@ import (
 type Config struct {
 	Endpoint     string
 	UseHTTP      bool
-	KeyID        string
-	Secret       options.SecretString
 	Bucket       string
 	Prefix       string
 	Layout       string `option:"layout" help:"use this backend layout (default: auto-detect) (deprecated)"`
@@ -35,6 +33,10 @@ type Config struct {
 	BucketLookup        string `option:"bucket-lookup" help:"bucket lookup style: 'auto', 'dns', or 'path'"`
 	ListObjectsV1       bool   `option:"list-objects-v1" help:"use deprecated V1 api for ListObjects calls"`
 	UnsafeAnonymousAuth bool   `option:"unsafe-anonymous-auth" help:"use anonymous authentication"`
+
+	// For testing only
+	KeyID  string
+	Secret options.SecretString
 }
 
 // NewConfig returns a new Config with the default values filled in.
@@ -109,12 +111,6 @@ var _ backend.ApplyEnvironmenter = &Config{}
 
 // ApplyEnvironment saves values from the environment to the config.
 func (cfg *Config) ApplyEnvironment(prefix string) {
-	if cfg.KeyID == "" {
-		cfg.KeyID = os.Getenv(prefix + "AWS_ACCESS_KEY_ID")
-	}
-	if cfg.Secret.String() == "" {
-		cfg.Secret = options.NewSecretString(os.Getenv(prefix + "AWS_SECRET_ACCESS_KEY"))
-	}
 	if cfg.Region == "" {
 		cfg.Region = os.Getenv(prefix + "AWS_DEFAULT_REGION")
 	}

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -57,12 +57,6 @@ func open(cfg Config, rt http.RoundTripper) (*Backend, error) {
 		return nil, fmt.Errorf("feature flag `s3-restore` is required to use `-o s3.enable-restore=true`")
 	}
 
-	if cfg.KeyID == "" && cfg.Secret.String() != "" {
-		return nil, errors.Fatalf("unable to open S3 backend: Key ID ($AWS_ACCESS_KEY_ID) is empty")
-	} else if cfg.KeyID != "" && cfg.Secret.String() == "" {
-		return nil, errors.Fatalf("unable to open S3 backend: Secret ($AWS_SECRET_ACCESS_KEY) is empty")
-	}
-
 	if cfg.MaxRetries > 0 {
 		minio.MaxRetry = int(cfg.MaxRetries)
 	}
@@ -112,7 +106,7 @@ func getCredentials(cfg Config, tr http.RoundTripper) (*credentials.Credentials,
 	}
 
 	// Chains all credential types, in the following order:
-	// 	- Static credentials provided by user
+	// 	- Static credentials (test only)
 	//	- AWS env vars (i.e. AWS_ACCESS_KEY_ID)
 	//  - Minio env vars (i.e. MINIO_ACCESS_KEY)
 	//  - AWS creds file (i.e. AWS_SHARED_CREDENTIALS_FILE or ~/.aws/credentials)
@@ -121,13 +115,13 @@ func getCredentials(cfg Config, tr http.RoundTripper) (*credentials.Credentials,
 	//    call to a pre-defined endpoint, only valid inside
 	//    configured ec2 instances)
 	creds := credentials.NewChainCredentials([]credentials.Provider{
-		&credentials.EnvAWS{},
-		&credentials.Static{
+		&credentials.Static{ // test only
 			Value: credentials.Value{
 				AccessKeyID:     cfg.KeyID,
 				SecretAccessKey: cfg.Secret.Unwrap(),
 			},
 		},
+		&credentials.EnvAWS{},
 		&credentials.EnvMinio{},
 		&credentials.FileAWSCredentials{},
 		&credentials.FileMinioClient{},
@@ -141,6 +135,14 @@ func getCredentials(cfg Config, tr http.RoundTripper) (*credentials.Credentials,
 	}
 
 	if c.SignerType == credentials.SignatureAnonymous {
+		keyID := os.Getenv("AWS_ACCESS_KEY_ID")
+		secret := os.Getenv("AWS_SECRET_ACCESS_KEY")
+		if keyID == "" && secret != "" {
+			return nil, errors.Fatalf("no credentials found. $AWS_SECRET_ACCESS_KEY is set but $AWS_ACCESS_KEY_ID is empty")
+		} else if keyID != "" && secret == "" {
+			return nil, errors.Fatalf("no credentials found. $AWS_ACCESS_KEY_ID is set but $AWS_SECRET_ACCESS_KEY is empty")
+		}
+
 		// Fail if no credentials were found to prevent repeated attempts to (unsuccessfully) retrieve new credentials.
 		// The first attempt still has to timeout which slows down restic usage considerably. Thus, migrate towards forcing
 		// users to explicitly decide between authenticated and anonymous access.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

credentials.EnvAWS offers a superset of the manually implemented credentials loading. Rework the error message that is shown if no credentials were found but either access or secret key are set.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
See https://github.com/restic/restic/issues/5521#issuecomment-3330206199
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I'm done! This pull request is ready for review.
