### PR TITLE
Cleanup fatalf usage

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -502,7 +502,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 	if opts.TimeStamp != "" {
 		timeStamp, err = time.ParseInLocation(TimeFormat, opts.TimeStamp, time.Local)
 		if err != nil {
-			return errors.Fatalf("error in time option: %v\n", err)
+			return errors.Fatalf("error in time option: %v", err)
 		}
 	}
 

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -109,7 +109,7 @@ func runCat(ctx context.Context, gopts GlobalOptions, args []string, term ui.Ter
 	case "snapshot":
 		sn, _, err := restic.FindSnapshot(ctx, repo, repo, args[1])
 		if err != nil {
-			return errors.Fatalf("could not find snapshot: %v\n", err)
+			return errors.Fatalf("could not find snapshot: %v", err)
 		}
 
 		buf, err := json.MarshalIndent(sn, "", "  ")
@@ -195,7 +195,7 @@ func runCat(ctx context.Context, gopts GlobalOptions, args []string, term ui.Ter
 	case "tree":
 		sn, subfolder, err := restic.FindSnapshot(ctx, repo, repo, args[1])
 		if err != nil {
-			return errors.Fatalf("could not find snapshot: %v\n", err)
+			return errors.Fatalf("could not find snapshot: %v", err)
 		}
 
 		bar := newIndexTerminalProgress(printer)

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -102,7 +102,7 @@ func runInit(ctx context.Context, opts InitOptions, gopts GlobalOptions, args []
 
 	be, err := create(ctx, gopts.Repo, gopts, gopts.extended, printer)
 	if err != nil {
-		return errors.Fatalf("create repository at %s failed: %v\n", location.StripPassword(gopts.backends, gopts.Repo), err)
+		return errors.Fatalf("create repository at %s failed: %v", location.StripPassword(gopts.backends, gopts.Repo), err)
 	}
 
 	s, err := repository.New(be, repository.Options{
@@ -115,7 +115,7 @@ func runInit(ctx context.Context, opts InitOptions, gopts GlobalOptions, args []
 
 	err = s.Init(ctx, version, gopts.password, chunkerPolynomial)
 	if err != nil {
-		return errors.Fatalf("create key in repository at %s failed: %v\n", location.StripPassword(gopts.backends, gopts.Repo), err)
+		return errors.Fatalf("create key in repository at %s failed: %v", location.StripPassword(gopts.backends, gopts.Repo), err)
 	}
 
 	if !gopts.JSON {

--- a/cmd/restic/cmd_key_add.go
+++ b/cmd/restic/cmd_key_add.go
@@ -79,7 +79,7 @@ func addKey(ctx context.Context, repo *repository.Repository, gopts GlobalOption
 
 	id, err := repository.AddKey(ctx, repo, pw, opts.Username, opts.Hostname, repo.Key())
 	if err != nil {
-		return errors.Fatalf("creating new key failed: %v\n", err)
+		return errors.Fatalf("creating new key failed: %v", err)
 	}
 
 	err = switchToNewKeyAndRemoveIfBroken(ctx, repo, id, pw)

--- a/cmd/restic/cmd_key_passwd.go
+++ b/cmd/restic/cmd_key_passwd.go
@@ -74,7 +74,7 @@ func changePassword(ctx context.Context, repo *repository.Repository, gopts Glob
 
 	id, err := repository.AddKey(ctx, repo, pw, "", "", repo.Key())
 	if err != nil {
-		return errors.Fatalf("creating new key failed: %v\n", err)
+		return errors.Fatalf("creating new key failed: %v", err)
 	}
 	oldID := repo.KeyID()
 

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -251,7 +251,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 	progress.Finish()
 
 	if totalErrors > 0 {
-		return errors.Fatalf("There were %d errors\n", totalErrors)
+		return errors.Fatalf("There were %d errors", totalErrors)
 	}
 
 	if opts.Verify {
@@ -266,7 +266,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 			return err
 		}
 		if totalErrors > 0 {
-			return errors.Fatalf("There were %d errors\n", totalErrors)
+			return errors.Fatalf("There were %d errors", totalErrors)
 		}
 
 		if !gopts.JSON {

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -93,7 +93,7 @@ func (sma snapshotMetadataArgs) convert() (*snapshotMetadata, error) {
 	if sma.Time != "" {
 		t, err := time.ParseInLocation(TimeFormat, sma.Time, time.Local)
 		if err != nil {
-			return nil, errors.Fatalf("error in time option: %v\n", err)
+			return nil, errors.Fatalf("error in time option: %v", err)
 		}
 		timeStamp = &t
 	}

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -171,7 +171,7 @@ func (opts *GlobalOptions) PreRun(needsPassword bool) error {
 	}
 	pwd, err := resolvePassword(opts, "RESTIC_PASSWORD")
 	if err != nil {
-		return errors.Fatal(fmt.Sprintf("Resolving password failed: %v\n", err))
+		return errors.Fatalf("Resolving password failed: %v", err)
 	}
 	opts.password = pwd
 	return nil

--- a/internal/fs/fs_reader_command.go
+++ b/internal/fs/fs_reader_command.go
@@ -87,7 +87,7 @@ func (fp *CommandReader) wait() error {
 	err := fp.cmd.Wait()
 	if err != nil {
 		// Use a fatal error to abort the snapshot.
-		return errors.Fatal(fmt.Errorf("command failed: %w", err).Error())
+		return errors.Fatalf("command failed: %v", err)
 	}
 	return nil
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
I found a few more creative usages of `errors.Fatal`. Clean those up and remove trailing newlines from fatal error messages.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Follow up to https://github.com/restic/restic/pull/5363 .
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
