### PR TITLE
Replace Repository.SetIndex with internal helper

### DIFF
--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -257,10 +257,10 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 	errorsFound := false
 	for _, hint := range hints {
 		switch hint.(type) {
-		case *checker.ErrDuplicatePacks:
+		case *repository.ErrDuplicatePacks:
 			printer.S("%s", hint.Error())
 			summary.HintRepairIndex = true
-		case *checker.ErrMixedPack:
+		case *repository.ErrMixedPack:
 			printer.S("%s", hint.Error())
 			summary.HintPrune = true
 		default:
@@ -295,7 +295,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 	go chkr.Packs(ctx, errChan)
 
 	for err := range errChan {
-		var packErr *checker.PackError
+		var packErr *repository.PackError
 		if errors.As(err, &packErr) {
 			if packErr.Orphaned {
 				orphanedPacks++

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -1421,7 +1421,7 @@ func TestArchiverSnapshot(t *testing.T) {
 			}
 			TestEnsureSnapshot(t, repo, snapshotID, want)
 
-			checker.TestCheckRepo(t, repo, false)
+			checker.TestCheckRepo(t, repo)
 
 			// check that the snapshot contains the targets with absolute paths
 			for i, target := range sn.Paths {
@@ -1641,7 +1641,7 @@ func TestArchiverSnapshotSelect(t *testing.T) {
 			}
 			TestEnsureSnapshot(t, repo, snapshotID, want)
 
-			checker.TestCheckRepo(t, repo, false)
+			checker.TestCheckRepo(t, repo)
 		})
 	}
 }
@@ -1866,7 +1866,7 @@ func TestArchiverParent(t *testing.T) {
 				t.Logf("testfs: %v", testFS)
 			}
 
-			checker.TestCheckRepo(t, repo, false)
+			checker.TestCheckRepo(t, repo)
 		})
 	}
 }
@@ -2021,7 +2021,7 @@ func TestArchiverErrorReporting(t *testing.T) {
 			}
 			TestEnsureSnapshot(t, repo, snapshotID, want)
 
-			checker.TestCheckRepo(t, repo, false)
+			checker.TestCheckRepo(t, repo)
 		})
 	}
 }
@@ -2384,7 +2384,7 @@ func TestMetadataChanged(t *testing.T) {
 	// make sure the content matches
 	TestEnsureFileContent(context.Background(), t, repo, "testfile", node3, files["testfile"].(TestFile))
 
-	checker.TestCheckRepo(t, repo, false)
+	checker.TestCheckRepo(t, repo)
 }
 
 func TestRacyFileTypeSwap(t *testing.T) {

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func prepareTempdirRepoSrc(t testing.TB, src TestDir) (string, restic.Repository) {
+func prepareTempdirRepoSrc(t testing.TB, src TestDir) (string, *repository.Repository) {
 	tempdir := rtest.TempDir(t)
 	repo := repository.TestRepository(t)
 

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -33,10 +33,15 @@ type Checker struct {
 	repo restic.Repository
 }
 
+type checkerRepository interface {
+	restic.Repository
+	Checker() *repository.Checker
+}
+
 // New returns a new checker which runs on repo.
-func New(repo restic.Repository, trackUnused bool) *Checker {
+func New(repo checkerRepository, trackUnused bool) *Checker {
 	c := &Checker{
-		Checker:     repository.NewChecker(repo),
+		Checker:     repo.Checker(),
 		repo:        repo,
 		trackUnused: trackUnused,
 	}

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -1,19 +1,15 @@
 package checker
 
 import (
-	"bufio"
 	"context"
 	"fmt"
 	"runtime"
 	"sync"
 
-	"github.com/klauspost/compress/zstd"
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
-	"github.com/restic/restic/internal/repository/index"
-	"github.com/restic/restic/internal/repository/pack"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui/progress"
 	"golang.org/x/sync/errgroup"
@@ -25,7 +21,7 @@ import (
 // A Checker only tests for internal errors within the data structures of the
 // repository (e.g. missing blobs), and needs a valid Repository to work on.
 type Checker struct {
-	packs    map[restic.ID]int64
+	*repository.Checker
 	blobRefs struct {
 		sync.Mutex
 		M restic.BlobSet
@@ -40,7 +36,7 @@ type Checker struct {
 // New returns a new checker which runs on repo.
 func New(repo restic.Repository, trackUnused bool) *Checker {
 	c := &Checker{
-		packs:       make(map[restic.ID]int64),
+		Checker:     repository.NewChecker(repo),
 		repo:        repo,
 		trackUnused: trackUnused,
 	}
@@ -50,185 +46,10 @@ func New(repo restic.Repository, trackUnused bool) *Checker {
 	return c
 }
 
-// ErrDuplicatePacks is returned when a pack is found in more than one index.
-type ErrDuplicatePacks struct {
-	PackID  restic.ID
-	Indexes restic.IDSet
-}
-
-func (e *ErrDuplicatePacks) Error() string {
-	return fmt.Sprintf("pack %v contained in several indexes: %v", e.PackID, e.Indexes)
-}
-
-// ErrMixedPack is returned when a pack is found that contains both tree and data blobs.
-type ErrMixedPack struct {
-	PackID restic.ID
-}
-
-func (e *ErrMixedPack) Error() string {
-	return fmt.Sprintf("pack %v contains a mix of tree and data blobs", e.PackID.Str())
-}
-
 func (c *Checker) LoadSnapshots(ctx context.Context) error {
 	var err error
 	c.snapshots, err = restic.MemorizeList(ctx, c.repo, restic.SnapshotFile)
 	return err
-}
-
-func computePackTypes(ctx context.Context, idx restic.ListBlobser) (map[restic.ID]restic.BlobType, error) {
-	packs := make(map[restic.ID]restic.BlobType)
-	err := idx.ListBlobs(ctx, func(pb restic.PackedBlob) {
-		tpe, exists := packs[pb.PackID]
-		if exists {
-			if pb.Type != tpe {
-				tpe = restic.InvalidBlob
-			}
-		} else {
-			tpe = pb.Type
-		}
-		packs[pb.PackID] = tpe
-	})
-	return packs, err
-}
-
-// LoadIndex loads all index files.
-func (c *Checker) LoadIndex(ctx context.Context, p restic.TerminalCounterFactory) (hints []error, errs []error) {
-	debug.Log("Start")
-
-	var bar *progress.Counter
-	if p != nil {
-		bar = p.NewCounterTerminalOnly("index files loaded")
-	}
-
-	packToIndex := make(map[restic.ID]restic.IDSet)
-	masterIndex := index.NewMasterIndex()
-	err := masterIndex.Load(ctx, c.repo, bar, func(id restic.ID, idx *index.Index, err error) error {
-		debug.Log("process index %v, err %v", id, err)
-		err = errors.Wrapf(err, "error loading index %v", id)
-
-		if err != nil {
-			errs = append(errs, err)
-			return nil
-		}
-
-		debug.Log("process blobs")
-		cnt := 0
-		err = idx.Each(ctx, func(blob restic.PackedBlob) {
-			cnt++
-
-			if _, ok := packToIndex[blob.PackID]; !ok {
-				packToIndex[blob.PackID] = restic.NewIDSet()
-			}
-			packToIndex[blob.PackID].Insert(id)
-		})
-
-		debug.Log("%d blobs processed", cnt)
-		return err
-	})
-	if err != nil {
-		// failed to load the index
-		return hints, append(errs, err)
-	}
-
-	err = c.repo.SetIndex(masterIndex)
-	if err != nil {
-		debug.Log("SetIndex returned error: %v", err)
-		errs = append(errs, err)
-	}
-
-	// compute pack size using index entries
-	c.packs, err = pack.Size(ctx, c.repo, false)
-	if err != nil {
-		return hints, append(errs, err)
-	}
-	packTypes, err := computePackTypes(ctx, c.repo)
-	if err != nil {
-		return hints, append(errs, err)
-	}
-
-	debug.Log("checking for duplicate packs")
-	for packID := range c.packs {
-		debug.Log("  check pack %v: contained in %d indexes", packID, len(packToIndex[packID]))
-		if len(packToIndex[packID]) > 1 {
-			hints = append(hints, &ErrDuplicatePacks{
-				PackID:  packID,
-				Indexes: packToIndex[packID],
-			})
-		}
-		if packTypes[packID] == restic.InvalidBlob {
-			hints = append(hints, &ErrMixedPack{
-				PackID: packID,
-			})
-		}
-	}
-
-	return hints, errs
-}
-
-// PackError describes an error with a specific pack.
-type PackError struct {
-	ID        restic.ID
-	Orphaned  bool
-	Truncated bool
-	Err       error
-}
-
-func (e *PackError) Error() string {
-	return "pack " + e.ID.String() + ": " + e.Err.Error()
-}
-
-// Packs checks that all packs referenced in the index are still available and
-// there are no packs that aren't in an index. errChan is closed after all
-// packs have been checked.
-func (c *Checker) Packs(ctx context.Context, errChan chan<- error) {
-	defer close(errChan)
-	debug.Log("checking for %d packs", len(c.packs))
-
-	debug.Log("listing repository packs")
-	repoPacks := make(map[restic.ID]int64)
-
-	err := c.repo.List(ctx, restic.PackFile, func(id restic.ID, size int64) error {
-		repoPacks[id] = size
-		return nil
-	})
-
-	if err != nil {
-		errChan <- err
-	}
-
-	for id, size := range c.packs {
-		reposize, ok := repoPacks[id]
-		// remove from repoPacks so we can find orphaned packs
-		delete(repoPacks, id)
-
-		// missing: present in c.packs but not in the repo
-		if !ok {
-			select {
-			case <-ctx.Done():
-				return
-			case errChan <- &PackError{ID: id, Err: errors.New("does not exist")}:
-			}
-			continue
-		}
-
-		// size not matching: present in c.packs and in the repo, but sizes do not match
-		if size != reposize {
-			select {
-			case <-ctx.Done():
-				return
-			case errChan <- &PackError{ID: id, Truncated: true, Err: errors.Errorf("unexpected file size: got %d, expected %d", reposize, size)}:
-			}
-		}
-	}
-
-	// orphaned: present in the repo but not in c.packs
-	for orphanID := range repoPacks {
-		select {
-		case <-ctx.Done():
-			return
-		case errChan <- &PackError{ID: orphanID, Orphaned: true, Err: errors.New("not referenced in any index")}:
-		}
-	}
 }
 
 // Error is an error that occurred while checking a repository.
@@ -432,98 +253,4 @@ func (c *Checker) UnusedBlobs(ctx context.Context) (blobs restic.BlobHandles, er
 	})
 
 	return blobs, err
-}
-
-// CountPacks returns the number of packs in the repository.
-func (c *Checker) CountPacks() uint64 {
-	return uint64(len(c.packs))
-}
-
-// GetPacks returns IDSet of packs in the repository
-func (c *Checker) GetPacks() map[restic.ID]int64 {
-	return c.packs
-}
-
-// ReadData loads all data from the repository and checks the integrity.
-func (c *Checker) ReadData(ctx context.Context, errChan chan<- error) {
-	c.ReadPacks(ctx, c.packs, nil, errChan)
-}
-
-const maxStreamBufferSize = 4 * 1024 * 1024
-
-// ReadPacks loads data from specified packs and checks the integrity.
-func (c *Checker) ReadPacks(ctx context.Context, packs map[restic.ID]int64, p *progress.Counter, errChan chan<- error) {
-	defer close(errChan)
-
-	g, ctx := errgroup.WithContext(ctx)
-	type checkTask struct {
-		id    restic.ID
-		size  int64
-		blobs []restic.Blob
-	}
-	ch := make(chan checkTask)
-
-	// as packs are streamed the concurrency is limited by IO
-	workerCount := int(c.repo.Connections())
-	// run workers
-	for i := 0; i < workerCount; i++ {
-		g.Go(func() error {
-			bufRd := bufio.NewReaderSize(nil, maxStreamBufferSize)
-			dec, err := zstd.NewReader(nil)
-			if err != nil {
-				panic(dec)
-			}
-			defer dec.Close()
-			for {
-				var ps checkTask
-				var ok bool
-
-				select {
-				case <-ctx.Done():
-					return nil
-				case ps, ok = <-ch:
-					if !ok {
-						return nil
-					}
-				}
-
-				err := repository.CheckPack(ctx, c.repo.(*repository.Repository), ps.id, ps.blobs, ps.size, bufRd, dec)
-				p.Add(1)
-				if err == nil {
-					continue
-				}
-
-				select {
-				case <-ctx.Done():
-					return nil
-				case errChan <- err:
-				}
-			}
-		})
-	}
-
-	packSet := restic.NewIDSet()
-	for pack := range packs {
-		packSet.Insert(pack)
-	}
-
-	// push packs to ch
-	for pbs := range c.repo.ListPacksFromIndex(ctx, packSet) {
-		size := packs[pbs.PackID]
-		debug.Log("listed %v", pbs.PackID)
-		select {
-		case ch <- checkTask{id: pbs.PackID, size: size, blobs: pbs.Blobs}:
-		case <-ctx.Done():
-		}
-	}
-	close(ch)
-
-	err := g.Wait()
-	if err != nil {
-		select {
-		case <-ctx.Done():
-			return
-		case errChan <- err:
-		}
-	}
 }

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -435,7 +435,7 @@ func TestCheckerModifiedData(t *testing.T) {
 
 // loadTreesOnceRepository allows each tree to be loaded only once
 type loadTreesOnceRepository struct {
-	restic.Repository
+	*repository.Repository
 	loadedTrees   restic.IDSet
 	mutex         sync.Mutex
 	DuplicateTree bool
@@ -476,7 +476,7 @@ func TestCheckerNoDuplicateTreeDecodes(t *testing.T) {
 
 // delayRepository delays read of a specific handle.
 type delayRepository struct {
-	restic.Repository
+	*repository.Repository
 	DelayTree      restic.ID
 	UnblockChannel chan struct{}
 	Unblocker      sync.Once

--- a/internal/checker/checker_test.go
+++ b/internal/checker/checker_test.go
@@ -67,7 +67,7 @@ func checkData(chkr *checker.Checker) []error {
 
 func assertOnlyMixedPackHints(t *testing.T, hints []error) {
 	for _, err := range hints {
-		if _, ok := err.(*checker.ErrMixedPack); !ok {
+		if _, ok := err.(*repository.ErrMixedPack); !ok {
 			t.Fatalf("expected mixed pack hint, got %v", err)
 		}
 	}
@@ -110,7 +110,7 @@ func TestMissingPack(t *testing.T) {
 	test.Assert(t, len(errs) == 1,
 		"expected exactly one error, got %v", len(errs))
 
-	if err, ok := errs[0].(*checker.PackError); ok {
+	if err, ok := errs[0].(*repository.PackError); ok {
 		test.Equals(t, packID, err.ID)
 	} else {
 		t.Errorf("expected error returned by checker.Packs() to be PackError, got %v", err)
@@ -138,7 +138,7 @@ func TestUnreferencedPack(t *testing.T) {
 	test.Assert(t, len(errs) == 1,
 		"expected exactly one error, got %v", len(errs))
 
-	if err, ok := errs[0].(*checker.PackError); ok {
+	if err, ok := errs[0].(*repository.PackError); ok {
 		test.Equals(t, packID, err.ID.String())
 	} else {
 		t.Errorf("expected error returned by checker.Packs() to be PackError, got %v", err)
@@ -269,7 +269,7 @@ func TestDuplicatePacksInIndex(t *testing.T) {
 
 	found := false
 	for _, hint := range hints {
-		if _, ok := hint.(*checker.ErrDuplicatePacks); ok {
+		if _, ok := hint.(*repository.ErrDuplicatePacks); ok {
 			found = true
 		} else {
 			t.Errorf("got unexpected hint: %v", hint)
@@ -613,7 +613,7 @@ func loadBenchRepository(t *testing.B) (*checker.Checker, restic.Repository, fun
 	}
 
 	for _, err := range hints {
-		if _, ok := err.(*checker.ErrMixedPack); !ok {
+		if _, ok := err.(*repository.ErrMixedPack); !ok {
 			t.Fatalf("expected mixed pack hint, got %v", err)
 		}
 	}

--- a/internal/checker/testing.go
+++ b/internal/checker/testing.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TestCheckRepo runs the checker on repo.
-func TestCheckRepo(t testing.TB, repo restic.Repository, skipStructure bool) {
+func TestCheckRepo(t testing.TB, repo restic.Repository) {
 	chkr := New(repo, true)
 
 	hints, errs := chkr.LoadIndex(context.TODO(), nil)
@@ -33,23 +33,21 @@ func TestCheckRepo(t testing.TB, repo restic.Repository, skipStructure bool) {
 		t.Error(err)
 	}
 
-	if !skipStructure {
-		// structure
-		errChan = make(chan error)
-		go chkr.Structure(context.TODO(), nil, errChan)
+	// structure
+	errChan = make(chan error)
+	go chkr.Structure(context.TODO(), nil, errChan)
 
-		for err := range errChan {
-			t.Error(err)
-		}
+	for err := range errChan {
+		t.Error(err)
+	}
 
-		// unused blobs
-		blobs, err := chkr.UnusedBlobs(context.TODO())
-		if err != nil {
-			t.Error(err)
-		}
-		if len(blobs) > 0 {
-			t.Errorf("unused blobs found: %v", blobs)
-		}
+	// unused blobs
+	blobs, err := chkr.UnusedBlobs(context.TODO())
+	if err != nil {
+		t.Error(err)
+	}
+	if len(blobs) > 0 {
+		t.Errorf("unused blobs found: %v", blobs)
 	}
 
 	// read data

--- a/internal/checker/testing.go
+++ b/internal/checker/testing.go
@@ -3,12 +3,10 @@ package checker
 import (
 	"context"
 	"testing"
-
-	"github.com/restic/restic/internal/restic"
 )
 
 // TestCheckRepo runs the checker on repo.
-func TestCheckRepo(t testing.TB, repo restic.Repository) {
+func TestCheckRepo(t testing.TB, repo checkerRepository) {
 	chkr := New(repo, true)
 
 	hints, errs := chkr.LoadIndex(context.TODO(), nil)

--- a/internal/data/testing_test.go
+++ b/internal/data/testing_test.go
@@ -46,7 +46,7 @@ func TestCreateSnapshot(t *testing.T) {
 		t.Fatalf("snapshot has zero tree ID")
 	}
 
-	checker.TestCheckRepo(t, repo, false)
+	checker.TestCheckRepo(t, repo)
 }
 
 func BenchmarkTestCreateSnapshot(t *testing.B) {

--- a/internal/repository/checker.go
+++ b/internal/repository/checker.go
@@ -51,11 +51,11 @@ func (e *PackError) Error() string {
 // Checker handles index-related operations for repository checking.
 type Checker struct {
 	packs map[restic.ID]int64
-	repo  restic.Repository
+	repo  *Repository
 }
 
 // NewChecker creates a new Checker.
-func NewChecker(repo restic.Repository) *Checker {
+func NewChecker(repo *Repository) *Checker {
 	return &Checker{
 		packs: make(map[restic.ID]int64),
 		repo:  repo,
@@ -256,7 +256,7 @@ func (c *Checker) ReadPacks(ctx context.Context, packs map[restic.ID]int64, p *p
 					}
 				}
 
-				err := CheckPack(ctx, c.repo.(*Repository), ps.id, ps.blobs, ps.size, bufRd, dec)
+				err := CheckPack(ctx, c.repo, ps.id, ps.blobs, ps.size, bufRd, dec)
 				p.Add(1)
 				if err == nil {
 					continue

--- a/internal/repository/checker.go
+++ b/internal/repository/checker.go
@@ -1,0 +1,298 @@
+package repository
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+
+	"github.com/klauspost/compress/zstd"
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/repository/index"
+	"github.com/restic/restic/internal/repository/pack"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/ui/progress"
+	"golang.org/x/sync/errgroup"
+)
+
+const maxStreamBufferSize = 4 * 1024 * 1024
+
+// ErrDuplicatePacks is returned when a pack is found in more than one index.
+type ErrDuplicatePacks struct {
+	PackID  restic.ID
+	Indexes restic.IDSet
+}
+
+func (e *ErrDuplicatePacks) Error() string {
+	return fmt.Sprintf("pack %v contained in several indexes: %v", e.PackID, e.Indexes)
+}
+
+// ErrMixedPack is returned when a pack is found that contains both tree and data blobs.
+type ErrMixedPack struct {
+	PackID restic.ID
+}
+
+func (e *ErrMixedPack) Error() string {
+	return fmt.Sprintf("pack %v contains a mix of tree and data blobs", e.PackID.Str())
+}
+
+// PackError describes an error with a specific pack.
+type PackError struct {
+	ID        restic.ID
+	Orphaned  bool
+	Truncated bool
+	Err       error
+}
+
+func (e *PackError) Error() string {
+	return "pack " + e.ID.String() + ": " + e.Err.Error()
+}
+
+// Checker handles index-related operations for repository checking.
+type Checker struct {
+	packs map[restic.ID]int64
+	repo  restic.Repository
+}
+
+// NewChecker creates a new Checker.
+func NewChecker(repo restic.Repository) *Checker {
+	return &Checker{
+		packs: make(map[restic.ID]int64),
+		repo:  repo,
+	}
+}
+func computePackTypes(ctx context.Context, idx restic.ListBlobser) (map[restic.ID]restic.BlobType, error) {
+	packs := make(map[restic.ID]restic.BlobType)
+	err := idx.ListBlobs(ctx, func(pb restic.PackedBlob) {
+		tpe, exists := packs[pb.PackID]
+		if exists {
+			if pb.Type != tpe {
+				tpe = restic.InvalidBlob
+			}
+		} else {
+			tpe = pb.Type
+		}
+		packs[pb.PackID] = tpe
+	})
+	return packs, err
+}
+
+// LoadIndex loads all index files.
+func (c *Checker) LoadIndex(ctx context.Context, p restic.TerminalCounterFactory) (hints []error, errs []error) {
+	debug.Log("Start")
+
+	var bar *progress.Counter
+	if p != nil {
+		bar = p.NewCounterTerminalOnly("index files loaded")
+	}
+
+	packToIndex := make(map[restic.ID]restic.IDSet)
+	masterIndex := index.NewMasterIndex()
+	err := masterIndex.Load(ctx, c.repo, bar, func(id restic.ID, idx *index.Index, err error) error {
+		debug.Log("process index %v, err %v", id, err)
+		err = errors.Wrapf(err, "error loading index %v", id)
+
+		if err != nil {
+			errs = append(errs, err)
+			return nil
+		}
+
+		debug.Log("process blobs")
+		cnt := 0
+		err = idx.Each(ctx, func(blob restic.PackedBlob) {
+			cnt++
+
+			if _, ok := packToIndex[blob.PackID]; !ok {
+				packToIndex[blob.PackID] = restic.NewIDSet()
+			}
+			packToIndex[blob.PackID].Insert(id)
+		})
+
+		debug.Log("%d blobs processed", cnt)
+		return err
+	})
+	if err != nil {
+		// failed to load the index
+		return hints, append(errs, err)
+	}
+
+	err = c.repo.SetIndex(masterIndex)
+	if err != nil {
+		debug.Log("SetIndex returned error: %v", err)
+		errs = append(errs, err)
+	}
+
+	// compute pack size using index entries
+	c.packs, err = pack.Size(ctx, c.repo, false)
+	if err != nil {
+		return hints, append(errs, err)
+	}
+	packTypes, err := computePackTypes(ctx, c.repo)
+	if err != nil {
+		return hints, append(errs, err)
+	}
+
+	debug.Log("checking for duplicate packs")
+	for packID := range c.packs {
+		debug.Log("  check pack %v: contained in %d indexes", packID, len(packToIndex[packID]))
+		if len(packToIndex[packID]) > 1 {
+			hints = append(hints, &ErrDuplicatePacks{
+				PackID:  packID,
+				Indexes: packToIndex[packID],
+			})
+		}
+		if packTypes[packID] == restic.InvalidBlob {
+			hints = append(hints, &ErrMixedPack{
+				PackID: packID,
+			})
+		}
+	}
+
+	return hints, errs
+}
+
+// Packs checks that all packs referenced in the index are still available and
+// there are no packs that aren't in an index. errChan is closed after all
+// packs have been checked.
+func (c *Checker) Packs(ctx context.Context, errChan chan<- error) {
+	defer close(errChan)
+	debug.Log("checking for %d packs", len(c.packs))
+
+	debug.Log("listing repository packs")
+	repoPacks := make(map[restic.ID]int64)
+
+	err := c.repo.List(ctx, restic.PackFile, func(id restic.ID, size int64) error {
+		repoPacks[id] = size
+		return nil
+	})
+
+	if err != nil {
+		errChan <- err
+	}
+
+	for id, size := range c.packs {
+		reposize, ok := repoPacks[id]
+		// remove from repoPacks so we can find orphaned packs
+		delete(repoPacks, id)
+
+		// missing: present in c.packs but not in the repo
+		if !ok {
+			select {
+			case <-ctx.Done():
+				return
+			case errChan <- &PackError{ID: id, Err: errors.New("does not exist")}:
+			}
+			continue
+		}
+
+		// size not matching: present in c.packs and in the repo, but sizes do not match
+		if size != reposize {
+			select {
+			case <-ctx.Done():
+				return
+			case errChan <- &PackError{ID: id, Truncated: true, Err: errors.Errorf("unexpected file size: got %d, expected %d", reposize, size)}:
+			}
+		}
+	}
+
+	// orphaned: present in the repo but not in c.packs
+	for orphanID := range repoPacks {
+		select {
+		case <-ctx.Done():
+			return
+		case errChan <- &PackError{ID: orphanID, Orphaned: true, Err: errors.New("not referenced in any index")}:
+		}
+	}
+}
+
+// CountPacks returns the number of packs in the repository.
+func (c *Checker) CountPacks() uint64 {
+	return uint64(len(c.packs))
+}
+
+// GetPacks returns IDSet of packs in the repository
+func (c *Checker) GetPacks() map[restic.ID]int64 {
+	return c.packs
+}
+
+// ReadData loads all data from the repository and checks the integrity.
+func (c *Checker) ReadData(ctx context.Context, errChan chan<- error) {
+	c.ReadPacks(ctx, c.packs, nil, errChan)
+}
+
+// ReadPacks loads data from specified packs and checks the integrity.
+func (c *Checker) ReadPacks(ctx context.Context, packs map[restic.ID]int64, p *progress.Counter, errChan chan<- error) {
+	defer close(errChan)
+
+	g, ctx := errgroup.WithContext(ctx)
+	type checkTask struct {
+		id    restic.ID
+		size  int64
+		blobs []restic.Blob
+	}
+	ch := make(chan checkTask)
+
+	// as packs are streamed the concurrency is limited by IO
+	workerCount := int(c.repo.Connections())
+	// run workers
+	for i := 0; i < workerCount; i++ {
+		g.Go(func() error {
+			bufRd := bufio.NewReaderSize(nil, maxStreamBufferSize)
+			dec, err := zstd.NewReader(nil)
+			if err != nil {
+				panic(dec)
+			}
+			defer dec.Close()
+			for {
+				var ps checkTask
+				var ok bool
+
+				select {
+				case <-ctx.Done():
+					return nil
+				case ps, ok = <-ch:
+					if !ok {
+						return nil
+					}
+				}
+
+				err := CheckPack(ctx, c.repo.(*Repository), ps.id, ps.blobs, ps.size, bufRd, dec)
+				p.Add(1)
+				if err == nil {
+					continue
+				}
+
+				select {
+				case <-ctx.Done():
+					return nil
+				case errChan <- err:
+				}
+			}
+		})
+	}
+
+	packSet := restic.NewIDSet()
+	for pack := range packs {
+		packSet.Insert(pack)
+	}
+
+	// push packs to ch
+	for pbs := range c.repo.ListPacksFromIndex(ctx, packSet) {
+		size := packs[pbs.PackID]
+		debug.Log("listed %v", pbs.PackID)
+		select {
+		case ch <- checkTask{id: pbs.PackID, size: size, blobs: pbs.Blobs}:
+		case <-ctx.Done():
+		}
+	}
+	close(ch)
+
+	err := g.Wait()
+	if err != nil {
+		select {
+		case <-ctx.Done():
+			return
+		case errChan <- err:
+		}
+	}
+}

--- a/internal/repository/index/master_index_test.go
+++ b/internal/repository/index/master_index_test.go
@@ -402,7 +402,7 @@ func testIndexSave(t *testing.T, version uint) {
 			}))
 			rtest.Equals(t, 0, len(blobs), "saved index is missing blobs")
 
-			checker.TestCheckRepo(t, repo, false)
+			checker.TestCheckRepo(t, repo)
 		})
 	}
 }
@@ -449,7 +449,7 @@ func testIndexSavePartial(t *testing.T, version uint) {
 	// remove pack files to make check happy
 	rtest.OK(t, restic.ParallelRemove(context.TODO(), unpacked, newPacks, restic.PackFile, nil, nil))
 
-	checker.TestCheckRepo(t, repo, false)
+	checker.TestCheckRepo(t, repo)
 }
 
 func listPacks(t testing.TB, repo restic.Lister) restic.IDSet {

--- a/internal/repository/index/master_index_test.go
+++ b/internal/repository/index/master_index_test.go
@@ -347,7 +347,7 @@ var (
 	depth        = 3
 )
 
-func createFilledRepo(t testing.TB, snapshots int, version uint) (restic.Repository, restic.Unpacked[restic.FileType]) {
+func createFilledRepo(t testing.TB, snapshots int, version uint) (*repository.Repository, restic.Unpacked[restic.FileType]) {
 	repo, unpacked, _ := repository.TestRepositoryWithVersion(t, version)
 
 	for i := 0; i < snapshots; i++ {

--- a/internal/repository/prune_test.go
+++ b/internal/repository/prune_test.go
@@ -8,7 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/restic/restic/internal/checker"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/repository/pack"
 	"github.com/restic/restic/internal/restic"
@@ -49,7 +48,7 @@ func testPrune(t *testing.T, opts repository.PruneOptions, errOnUnused bool) {
 	rtest.OK(t, plan.Execute(context.TODO(), &progress.NoopPrinter{}))
 
 	repo = repository.TestOpenBackend(t, be)
-	checker.TestCheckRepo(t, repo, true)
+	repository.TestCheckRepo(t, repo)
 
 	if errOnUnused {
 		existing := listBlobs(repo)
@@ -181,7 +180,7 @@ func TestPruneSmall(t *testing.T) {
 
 	// repopen repository
 	repo = repository.TestOpenBackend(t, be)
-	checker.TestCheckRepo(t, repo, true)
+	repository.TestCheckRepo(t, repo)
 
 	// load all blobs
 	for blob := range keep {

--- a/internal/repository/repair_index_test.go
+++ b/internal/repository/repair_index_test.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/restic/restic/internal/backend"
-	"github.com/restic/restic/internal/checker"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
@@ -36,7 +35,7 @@ func testRebuildIndex(t *testing.T, readAllPacks bool, damage func(t *testing.T,
 		ReadAllPacks: readAllPacks,
 	}, &progress.NoopPrinter{}))
 
-	checker.TestCheckRepo(t, repo, true)
+	repository.TestCheckRepo(t, repo)
 }
 
 func TestRebuildIndex(t *testing.T) {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -178,6 +178,10 @@ func (r *Repository) SetDryRun() {
 	r.be = dryrun.New(r.be)
 }
 
+func (r *Repository) Checker() *Checker {
+	return NewChecker(r)
+}
+
 // LoadUnpacked loads and decrypts the file with the given type and ID.
 func (r *Repository) LoadUnpacked(ctx context.Context, t restic.FileType, id restic.ID) ([]byte, error) {
 	debug.Log("load %v with id %v", t, id)

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/restic/restic/internal/backend/cache"
 	"github.com/restic/restic/internal/backend/local"
 	"github.com/restic/restic/internal/backend/mem"
-	"github.com/restic/restic/internal/checker"
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository"
@@ -131,7 +130,7 @@ func testSavePackMerging(t *testing.T, targetPercentage int, expectedPacks int) 
 	}))
 	rtest.Equals(t, expectedPacks, packs, "unexpected number of pack files")
 
-	checker.TestCheckRepo(t, repo, true)
+	repository.TestCheckRepo(t, repo)
 }
 
 func BenchmarkSaveAndEncrypt(t *testing.B) {

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -164,7 +164,7 @@ func TestNewLock(_ *testing.T, repo *Repository, exclusive bool) (*restic.Lock, 
 }
 
 // TestCheckRepo runs the checker on repo.
-func TestCheckRepo(t testing.TB, repo restic.Repository) {
+func TestCheckRepo(t testing.TB, repo *Repository) {
 	chkr := NewChecker(repo)
 
 	hints, errs := chkr.LoadIndex(context.TODO(), nil)

--- a/internal/repository/testing.go
+++ b/internal/repository/testing.go
@@ -162,3 +162,33 @@ func TestNewLock(_ *testing.T, repo *Repository, exclusive bool) (*restic.Lock, 
 	// TODO get rid of this test helper
 	return restic.NewLock(context.TODO(), &internalRepository{repo}, exclusive)
 }
+
+// TestCheckRepo runs the checker on repo.
+func TestCheckRepo(t testing.TB, repo restic.Repository) {
+	chkr := NewChecker(repo)
+
+	hints, errs := chkr.LoadIndex(context.TODO(), nil)
+	if len(errs) != 0 {
+		t.Fatalf("errors loading index: %v", errs)
+	}
+
+	if len(hints) != 0 {
+		t.Fatalf("errors loading index: %v", hints)
+	}
+
+	// packs
+	errChan := make(chan error)
+	go chkr.Packs(context.TODO(), errChan)
+
+	for err := range errChan {
+		t.Error(err)
+	}
+
+	// read data
+	errChan = make(chan error)
+	go chkr.ReadData(context.TODO(), errChan)
+
+	for err := range errChan {
+		t.Error(err)
+	}
+}

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -22,7 +22,6 @@ type Repository interface {
 	Key() *crypto.Key
 
 	LoadIndex(ctx context.Context, p TerminalCounterFactory) error
-	SetIndex(mi MasterIndex) error
 
 	LookupBlob(t BlobType, id ID) []PackedBlob
 	LookupBlobSize(t BlobType, id ID) (size uint, exists bool)
@@ -135,17 +134,6 @@ type TerminalCounterFactory interface {
 	// NewCounterTerminalOnly returns a new progress counter that is only shown if stdout points to a
 	// terminal. It is not shown if --quiet or --json is specified.
 	NewCounterTerminalOnly(description string) *progress.Counter
-}
-
-// MasterIndex keeps track of the blobs are stored within files.
-type MasterIndex interface {
-	Has(bh BlobHandle) bool
-	Lookup(bh BlobHandle) []PackedBlob
-
-	// Each runs fn on all blobs known to the index. When the context is cancelled,
-	// the index iteration returns immediately with ctx.Err(). This blocks any modification of the index.
-	Each(ctx context.Context, fn func(PackedBlob)) error
-	ListPacks(ctx context.Context, packs IDSet) <-chan PackBlobs
 }
 
 // Lister allows listing files in a backend.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
`Repository.SetIndex` is only used by the `Checker` code and `RepairIndex`. To allow converting `SetIndex` into a repository internal API, first split the checker into two parts: one that checks packs+index and another that checks the snapshot, tree and blob structure. Then `SetIndex` is replaced by `loadIndexWithCallback` which allows ignoring index load errors and inspecting the loaded indexes.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] ~~I have added tests for all code changes.~~ No new tests. Keeping the tests in the `checker` package, but moving a lot of code to the `repository` package isn't ideal, but I didn't find a good line along which to split the code.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I'm done! This pull request is ready for review.
