### PR TITLE
Termstatus

### DIFF
--- a/internal/terminal/terminal_posix.go
+++ b/internal/terminal/terminal_posix.go
@@ -1,9 +1,8 @@
 package terminal
 
 import (
-	"bytes"
+	"bufio"
 	"fmt"
-	"io"
 	"os"
 )
 
@@ -18,9 +17,8 @@ const (
 
 // PosixClearCurrentLine removes all characters from the current line and resets the
 // cursor position to the first column.
-func PosixClearCurrentLine(wr io.Writer, _ uintptr) {
-	// clear current line
-	_, err := wr.Write([]byte(PosixControlMoveCursorHome + PosixControlClearLine))
+func PosixClearCurrentLine(w *bufio.Writer, _ uintptr) {
+	_, err := w.WriteString(PosixControlMoveCursorHome + PosixControlClearLine)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "write failed: %v\n", err)
 		return
@@ -28,10 +26,11 @@ func PosixClearCurrentLine(wr io.Writer, _ uintptr) {
 }
 
 // PosixMoveCursorUp moves the cursor to the line n lines above the current one.
-func PosixMoveCursorUp(wr io.Writer, _ uintptr, n int) {
-	data := []byte(PosixControlMoveCursorHome)
-	data = append(data, bytes.Repeat([]byte(PosixControlMoveCursorUp), n)...)
-	_, err := wr.Write(data)
+func PosixMoveCursorUp(w *bufio.Writer, _ uintptr, n int) {
+	_, err := w.WriteString(PosixControlMoveCursorHome)
+	for i := 0; i < n && err == nil; i++ {
+		_, err = w.WriteString(PosixControlMoveCursorUp)
+	}
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "write failed: %v\n", err)
 		return

--- a/internal/terminal/terminal_unix.go
+++ b/internal/terminal/terminal_unix.go
@@ -4,7 +4,7 @@
 package terminal
 
 import (
-	"io"
+	"bufio"
 	"os"
 
 	"golang.org/x/term"
@@ -12,12 +12,12 @@ import (
 
 // ClearCurrentLine removes all characters from the current line and resets the
 // cursor position to the first column.
-func ClearCurrentLine(_ uintptr) func(io.Writer, uintptr) {
+func ClearCurrentLine(_ uintptr) func(*bufio.Writer, uintptr) {
 	return PosixClearCurrentLine
 }
 
 // MoveCursorUp moves the cursor to the line n lines above the current one.
-func MoveCursorUp(_ uintptr) func(io.Writer, uintptr, int) {
+func MoveCursorUp(_ uintptr) func(*bufio.Writer, uintptr, int) {
 	return PosixMoveCursorUp
 }
 

--- a/internal/terminal/terminal_windows.go
+++ b/internal/terminal/terminal_windows.go
@@ -4,7 +4,7 @@
 package terminal
 
 import (
-	"io"
+	"bufio"
 	"strings"
 	"syscall"
 	"unsafe"
@@ -15,7 +15,7 @@ import (
 
 // clearCurrentLine removes all characters from the current line and resets the
 // cursor position to the first column.
-func ClearCurrentLine(fd uintptr) func(io.Writer, uintptr) {
+func ClearCurrentLine(fd uintptr) func(*bufio.Writer, uintptr) {
 	// easy case, the terminal is cmd or psh, without redirection
 	if isWindowsTerminal(fd) {
 		return windowsClearCurrentLine
@@ -26,7 +26,7 @@ func ClearCurrentLine(fd uintptr) func(io.Writer, uintptr) {
 }
 
 // moveCursorUp moves the cursor to the line n lines above the current one.
-func MoveCursorUp(fd uintptr) func(io.Writer, uintptr, int) {
+func MoveCursorUp(fd uintptr) func(*bufio.Writer, uintptr, int) {
 	// easy case, the terminal is cmd or psh, without redirection
 	if isWindowsTerminal(fd) {
 		return windowsMoveCursorUp
@@ -45,7 +45,7 @@ var (
 
 // windowsClearCurrentLine removes all characters from the current line and
 // resets the cursor position to the first column.
-func windowsClearCurrentLine(_ io.Writer, fd uintptr) {
+func windowsClearCurrentLine(_ *bufio.Writer, fd uintptr) {
 	var info windows.ConsoleScreenBufferInfo
 	windows.GetConsoleScreenBufferInfo(windows.Handle(fd), &info)
 
@@ -61,7 +61,7 @@ func windowsClearCurrentLine(_ io.Writer, fd uintptr) {
 }
 
 // windowsMoveCursorUp moves the cursor to the line n lines above the current one.
-func windowsMoveCursorUp(_ io.Writer, fd uintptr, n int) {
+func windowsMoveCursorUp(_ *bufio.Writer, fd uintptr, n int) {
 	var info windows.ConsoleScreenBufferInfo
 	windows.GetConsoleScreenBufferInfo(windows.Handle(fd), &info)
 

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -136,10 +136,6 @@ func (t *Terminal) run(ctx context.Context) {
 
 			t.writeStatus(status)
 
-			if err := t.wr.Flush(); err != nil {
-				fmt.Fprintf(os.Stderr, "flush failed: %v\n", err)
-			}
-
 		case stat := <-t.status:
 			status = append(status[:0], stat.lines...)
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Some small changes to internal/terminal and internal/ui/termstatus. I've been trying to refactor the two packages to clean up the terminal control functions ClearCurrentLine and MoveCursorUp, but I'm not there yet. These are preliminary changes.

It may seem an implementation detail that termstatus.Terminal uses a bufio.Writer, but I think it's actually useful to move some of the flushing logic into internal/terminal. Windows terminals need flushing of data, while POSIX terminals don't, and I'm trying to encapsulate that difference into the terminal package.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
