### PR TITLE
azure: use PutBlob API for uploads instead of PutBlock API + PutBlock List API

### DIFF
--- a/changelog/unreleased/issue-5531
+++ b/changelog/unreleased/issue-5531
@@ -1,0 +1,15 @@
+Enhancement: Reduce Azure storage costs by optimizing upload method
+
+Restic previously used Azure's PutBlock and PutBlockList APIs for all file
+uploads, which resulted in two transactions per file and doubled the storage
+operation costs. For backups with many pack files, this could lead to
+significant Azure storage transaction fees.
+
+Restic now uses the more efficient PutBlob API for files up to 256 MiB,
+requiring only a single transaction per file. This reduces Azure storage
+operation costs by approximately 50% for typical backup workloads. Files
+larger than 256 MiB continue to use the block-based upload method as required
+by Azure's API limits.
+
+https://github.com/restic/restic/issues/5531
+https://github.com/restic/restic/pull/5544

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -42,7 +42,7 @@ type Backend struct {
 }
 
 const singleUploadMaxSize = 256 * 1024 * 1024
-const singleBlockMaxSize = 32 * 1024 * 1024
+const singleBlockMaxSize = 100 * 1024 * 1024
 const defaultListMaxItems = 5000
 
 // make sure that *Backend implements backend.Backend

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -41,8 +41,8 @@ type Backend struct {
 	accessTier blob.AccessTier
 }
 
-const singleBlobMaxSize = 5000 * 1024 * 1024  // 5000 MiB - max size for Put Blob API in service version 2019-12-12+
-const singleBlockMaxSize = 2000 * 1024 * 1024 // 2000 MiB - max size for a stage block API since on 32-bit systems, the max size for an int is 2047 MiB
+const singleUploadMaxSize = 256 * 1024 * 1024
+const singleBlockMaxSize = 32 * 1024 * 1024
 const defaultListMaxItems = 5000
 
 // make sure that *Backend implements backend.Backend
@@ -261,7 +261,7 @@ func (be *Backend) Save(ctx context.Context, h backend.Handle, rd backend.Rewind
 
 	// If the file size is less than or equal to the max size for a single blob, use the single blob upload
 	// otherwise, use the block-based upload
-	if fileSize <= singleBlobMaxSize {
+	if fileSize <= singleUploadMaxSize {
 		err = be.saveSingleBlob(ctx, objName, rd, accessTier)
 	} else {
 		err = be.saveLarge(ctx, objName, rd, accessTier)

--- a/internal/backend/azure/azure.go
+++ b/internal/backend/azure/azure.go
@@ -42,7 +42,7 @@ type Backend struct {
 }
 
 const singleBlobMaxSize = 5000 * 1024 * 1024  // 5000 MiB - max size for Put Blob API in service version 2019-12-12+
-const singleBlockMaxSize = 4000 * 1024 * 1024 // 4000 MiB - max size for StageBlock API in service version 2019-12-12+
+const singleBlockMaxSize = 2000 * 1024 * 1024 // 2000 MiB - max size for a stage block API since on 32-bit systems, the max size for an int is 2047 MiB
 const defaultListMaxItems = 5000
 
 // make sure that *Backend implements backend.Backend

--- a/internal/backend/azure/config.go
+++ b/internal/backend/azure/config.go
@@ -22,16 +22,14 @@ type Config struct {
 	Container          string
 	Prefix             string
 
-	Connections  uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
-	AccessTier   string `option:"access-tier" help:"set the access tier for the blob storage (default: inferred from the storage account defaults)"`
-	UploadMethod string `option:"upload-method" help:"blob upload method: 'auto' (single blob for <=5000 MiB), 'single' (always single blob), or 'blocks' (legacy block-based) (default: auto)"`
+	Connections uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	AccessTier  string `option:"access-tier" help:"set the access tier for the blob storage (default: inferred from the storage account defaults)"`
 }
 
 // NewConfig returns a new Config with the default values filled in.
 func NewConfig() Config {
 	return Config{
-		Connections:  5,
-		UploadMethod: "auto",
+		Connections: 5,
 	}
 }
 
@@ -86,17 +84,4 @@ func (cfg *Config) ApplyEnvironment(prefix string) {
 	if cfg.EndpointSuffix == "" {
 		cfg.EndpointSuffix = os.Getenv(prefix + "AZURE_ENDPOINT_SUFFIX")
 	}
-}
-
-// Validate checks the configuration for errors.
-func (cfg *Config) Validate() error {
-	// Normalize upload method to lowercase
-	uploadMethod := strings.ToLower(cfg.UploadMethod)
-	if uploadMethod != "auto" && uploadMethod != "single" && uploadMethod != "blocks" && uploadMethod != "" {
-		return errors.Errorf("invalid upload method %q, must be 'auto', 'single', or 'blocks'", cfg.UploadMethod)
-	}
-	if uploadMethod != "" {
-		cfg.UploadMethod = uploadMethod
-	}
-	return nil
 }

--- a/internal/backend/azure/config.go
+++ b/internal/backend/azure/config.go
@@ -22,14 +22,16 @@ type Config struct {
 	Container          string
 	Prefix             string
 
-	Connections uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
-	AccessTier  string `option:"access-tier" help:"set the access tier for the blob storage (default: inferred from the storage account defaults)"`
+	Connections  uint   `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	AccessTier   string `option:"access-tier" help:"set the access tier for the blob storage (default: inferred from the storage account defaults)"`
+	UploadMethod string `option:"upload-method" help:"blob upload method: 'auto' (single blob for <=5000 MiB), 'single' (always single blob), or 'blocks' (legacy block-based) (default: auto)"`
 }
 
 // NewConfig returns a new Config with the default values filled in.
 func NewConfig() Config {
 	return Config{
-		Connections: 5,
+		Connections:  5,
+		UploadMethod: "auto",
 	}
 }
 
@@ -84,4 +86,17 @@ func (cfg *Config) ApplyEnvironment(prefix string) {
 	if cfg.EndpointSuffix == "" {
 		cfg.EndpointSuffix = os.Getenv(prefix + "AZURE_ENDPOINT_SUFFIX")
 	}
+}
+
+// Validate checks the configuration for errors.
+func (cfg *Config) Validate() error {
+	// Normalize upload method to lowercase
+	uploadMethod := strings.ToLower(cfg.UploadMethod)
+	if uploadMethod != "auto" && uploadMethod != "single" && uploadMethod != "blocks" && uploadMethod != "" {
+		return errors.Errorf("invalid upload method %q, must be 'auto', 'single', or 'blocks'", cfg.UploadMethod)
+	}
+	if uploadMethod != "" {
+		cfg.UploadMethod = uploadMethod
+	}
+	return nil
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The Azure Storage backend will now support uploading pack files in a single API call using the `PutBlob` API. This will reduce the cost implications of the current approach by 50% where a combination of `PutBlock` and `Put Block List` API is used. (Azure charges per operation)

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #5531 

Checklist
---------
- ~[ ] I have added tests for all code changes.~ Existing test cases cover the changes.
- ~[ ] I have added documentation for relevant changes (in the manual).~ The changes are not user facing. It's an internal optimization.
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
