### PR TITLE
Reduce terminal progress fps to 10

### DIFF
--- a/changelog/unreleased/issue-5383
+++ b/changelog/unreleased/issue-5383
@@ -1,0 +1,9 @@
+Enhancement: Reduce progress bar refresh rates to reduce energy usage
+
+Progress bars were updated with 60fps which can cause high CPU or GPU usage
+for some terminal emulators. Reduce it to 10fps to conserve energy.
+In addition, this lower frequency seem to be necessary to allow selecting
+anything in the terminal with certain terminal emulators.
+
+https://github.com/restic/restic/issues/5383
+https://github.com/restic/restic/pull/5551

--- a/internal/ui/progress.go
+++ b/internal/ui/progress.go
@@ -13,7 +13,7 @@ import (
 // or if unset returns an interval for 60fps on interactive terminals and 0 (=disabled)
 // for non-interactive terminals or when run using the --quiet flag
 func CalculateProgressInterval(show bool, json bool, canUpdateStatus bool) time.Duration {
-	interval := time.Second / 60
+	interval := time.Second / 10
 	fps, err := strconv.ParseFloat(os.Getenv("RESTIC_PROGRESS_FPS"), 64)
 	if err == nil && fps > 0 {
 		if fps > 60 {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Progress bars were updated with 60fps which can cause high CPU or GPU usage
for some terminal emulators. Reduce it to 10fps to conserve energy.
In addition, this lower frequency seem to be necessary to allow selecting
anything in the terminal with certain terminal emulators.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Sort of fixes https://github.com/restic/restic/issues/5383
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
