### PR TITLE
add a dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,11 @@
+# Actual layer caching is impossible due to .git, but
+# that must be included for provenance reasons.  These ignores
+# are strictly for hygenic build.
+*
+!/*.go
+!/go.*
+!/cmd/*
+!/internal/*
+!/helpers/*
+!/VERSION
+!/.git/


### PR DESCRIPTION
This change adds ignore patterns for docker, limiting what it transfers into the build context.  This is strictly to make the resultant container more hygenic in regards to what the build process can truly rely on.  Due to `.git` having to be transferred in, layer caching is impossible even if the VCS changes between the last image and current are just non code changes.

What does this PR change? What problem does it solve?
-----------------------------------------------------

Originally this was intended to make rebuilds of the docker image faster, but due to `.git` being included, this is now just for a more hygenic docker build.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Big ole nope on that one.  This is a QoL offshoot of #5448  .

Checklist
---------

The checklist for docs and tests is fully not applicable for this change.  This is a release process visible change, only.
- [X] not applicable: I have added tests for all code changes.
- [X] not applicable: I have added documentation for relevant changes (in the manual).
- [X] not applicable: There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.
