### PR TITLE
termstatus: flush before reading password from terminal

### DIFF
--- a/changelog/unreleased/issue-5477
+++ b/changelog/unreleased/issue-5477
@@ -1,0 +1,7 @@
+Bugfix: Password prompt was sometimes not shown
+
+The password prompt for a repository was sometimes not shown when running
+the `backup -v` command. This has been fixed.
+
+https://github.com/restic/restic/issues/5477
+https://github.com/restic/restic/pull/5554

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -42,8 +42,9 @@ type Terminal struct {
 }
 
 type message struct {
-	line string
-	err  bool
+	line    string
+	err     bool
+	barrier chan struct{}
 }
 
 type status struct {
@@ -79,6 +80,7 @@ func Setup(stdin io.ReadCloser, stdout, stderr io.Writer, quiet bool) (*Terminal
 		if term.outputWriter != nil {
 			_ = term.outputWriter.Close()
 		}
+		term.Flush()
 		// shutdown termstatus
 		cancel()
 		wg.Wait()
@@ -141,6 +143,7 @@ func (t *Terminal) InputRaw() io.ReadCloser {
 
 func (t *Terminal) ReadPassword(ctx context.Context, prompt string) (string, error) {
 	if t.InputIsTerminal() {
+		t.Flush()
 		return terminal.ReadPassword(ctx, int(t.inFd), t.errWriter, prompt)
 	}
 	if t.OutputIsTerminal() {
@@ -210,6 +213,10 @@ func (t *Terminal) run(ctx context.Context) {
 			return
 
 		case msg := <-t.msg:
+			if msg.barrier != nil {
+				msg.barrier <- struct{}{}
+				continue
+			}
 			if terminal.IsProcessBackground(t.fd) {
 				// ignore all messages, do nothing, we are in the background process group
 				continue
@@ -284,6 +291,10 @@ func (t *Terminal) runWithoutStatus(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case msg := <-t.msg:
+			if msg.barrier != nil {
+				msg.barrier <- struct{}{}
+				continue
+			}
 
 			var dst io.Writer
 			if msg.err {
@@ -304,6 +315,20 @@ func (t *Terminal) runWithoutStatus(ctx context.Context) {
 				}
 			}
 		}
+	}
+}
+
+// Flush waits for all pending messages to be printed.
+func (t *Terminal) Flush() {
+	ch := make(chan struct{})
+	defer close(ch)
+	select {
+	case t.msg <- message{barrier: ch}:
+	case <-t.closed:
+	}
+	select {
+	case <-ch:
+	case <-t.closed:
 	}
 }
 

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -180,6 +180,7 @@ func (t *Terminal) OutputWriter() io.Writer {
 // other option. Must not be used in combination with Print, Error, SetStatus
 // or any other method that writes to the terminal.
 func (t *Terminal) OutputRaw() io.Writer {
+	t.Flush()
 	return t.wr
 }
 

--- a/internal/ui/termstatus/status_test.go
+++ b/internal/ui/termstatus/status_test.go
@@ -124,7 +124,8 @@ func TestReadPasswordTerminal(t *testing.T) {
 func TestRawInputOutput(t *testing.T) {
 	input := io.NopCloser(strings.NewReader("password"))
 	var output bytes.Buffer
-	term := New(input, &output, io.Discard, false)
+	term, cancel := Setup(input, &output, io.Discard, false)
+	defer cancel()
 	rtest.Equals(t, input, term.InputRaw())
 	rtest.Equals(t, false, term.InputIsTerminal())
 	rtest.Equals(t, &output, term.OutputRaw())


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Fix the output race condition between printing `open repository` and requesting the password from the user. `termstatus` now flushes the output before showing the password prompt.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/5477
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
