### PR TITLE
Split globalOptions into separate package

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -24,6 +24,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/filter"
 	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/textfile"
@@ -31,7 +32,7 @@ import (
 	"github.com/restic/restic/internal/ui/backup"
 )
 
-func newBackupCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newBackupCommand(globalOptions *global.Options) *cobra.Command {
 	var opts BackupOptions
 
 	cmd := &cobra.Command{
@@ -274,7 +275,7 @@ func readFilenamesRaw(r io.Reader) (names []string, err error) {
 }
 
 // Check returns an error when an invalid combination of options was set.
-func (opts BackupOptions) Check(gopts GlobalOptions, args []string) error {
+func (opts BackupOptions) Check(gopts global.Options, args []string) error {
 	if gopts.Password == "" && !gopts.InsecureNoPassword {
 		if opts.Stdin {
 			return errors.Fatal("cannot read both password and data from stdin")
@@ -475,7 +476,7 @@ func findParentSnapshot(ctx context.Context, repo restic.ListerLoaderUnpacked, o
 	return sn, err
 }
 
-func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, term ui.Terminal, args []string) error {
+func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, term ui.Terminal, args []string) error {
 	var vsscfg fs.VSSConfig
 	var err error
 
@@ -509,7 +510,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 	timeStamp := time.Now()
 	backupStart := timeStamp
 	if opts.TimeStamp != "" {
-		timeStamp, err = time.ParseInLocation(TimeFormat, opts.TimeStamp, time.Local)
+		timeStamp, err = time.ParseInLocation(global.TimeFormat, opts.TimeStamp, time.Local)
 		if err != nil {
 			return errors.Fatalf("error in time option: %v", err)
 		}
@@ -668,7 +669,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 		Time:            timeStamp,
 		Hostname:        opts.Host,
 		ParentSnapshot:  parentSnapshot,
-		ProgramVersion:  "restic " + version,
+		ProgramVersion:  "restic " + global.Version,
 		SkipIfUnchanged: opts.SkipIfUnchanged,
 	}
 

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -64,7 +64,7 @@ Exit status is 12 if the password is incorrect.
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runBackup(cmd.Context(), opts, *globalOptions, globalOptions.term, args)
+			return runBackup(cmd.Context(), opts, *globalOptions, globalOptions.Term, args)
 		},
 	}
 
@@ -275,7 +275,7 @@ func readFilenamesRaw(r io.Reader) (names []string, err error) {
 
 // Check returns an error when an invalid combination of options was set.
 func (opts BackupOptions) Check(gopts GlobalOptions, args []string) error {
-	if gopts.password == "" && !gopts.InsecureNoPassword {
+	if gopts.Password == "" && !gopts.InsecureNoPassword {
 		if opts.Stdin {
 			return errors.Fatal("cannot read both password and data from stdin")
 		}
@@ -481,12 +481,12 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 
 	var printer backup.ProgressPrinter
 	if gopts.JSON {
-		printer = backup.NewJSONProgress(term, gopts.verbosity)
+		printer = backup.NewJSONProgress(term, gopts.Verbosity)
 	} else {
-		printer = backup.NewTextProgress(term, gopts.verbosity)
+		printer = backup.NewTextProgress(term, gopts.Verbosity)
 	}
 	if runtime.GOOS == "windows" {
-		if vsscfg, err = fs.ParseVSSConfig(gopts.extended); err != nil {
+		if vsscfg, err = fs.ParseVSSConfig(gopts.Extended); err != nil {
 			return err
 		}
 	}
@@ -515,7 +515,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts GlobalOptions, ter
 		}
 	}
 
-	if gopts.verbosity >= 2 && !gopts.JSON {
+	if gopts.Verbosity >= 2 && !gopts.JSON {
 		printer.P("open repository")
 	}
 

--- a/cmd/restic/cmd_backup_integration_test.go
+++ b/cmd/restic/cmd_backup_integration_test.go
@@ -12,12 +12,13 @@ import (
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunBackupAssumeFailure(t testing.TB, dir string, target []string, opts BackupOptions, gopts GlobalOptions) error {
-	return withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunBackupAssumeFailure(t testing.TB, dir string, target []string, opts BackupOptions, gopts global.Options) error {
+	return withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		t.Logf("backing up %v in %v", target, dir)
 		if dir != "" {
 			cleanup := rtest.Chdir(t, dir)
@@ -29,7 +30,7 @@ func testRunBackupAssumeFailure(t testing.TB, dir string, target []string, opts 
 	})
 }
 
-func testRunBackup(t testing.TB, dir string, target []string, opts BackupOptions, gopts GlobalOptions) {
+func testRunBackup(t testing.TB, dir string, target []string, opts BackupOptions, gopts global.Options) {
 	err := testRunBackupAssumeFailure(t, dir, target, opts, gopts)
 	rtest.Assert(t, err == nil, "Error while backing up: %v", err)
 }
@@ -512,7 +513,7 @@ func TestBackupProgramVersion(t *testing.T) {
 	if newest == nil {
 		t.Fatal("expected a backup, got nil")
 	}
-	resticVersion := "restic " + version
+	resticVersion := "restic " + global.Version
 	rtest.Assert(t, newest.ProgramVersion == resticVersion,
 		"expected %v, got %v", resticVersion, newest.ProgramVersion)
 }

--- a/cmd/restic/cmd_backup_integration_test.go
+++ b/cmd/restic/cmd_backup_integration_test.go
@@ -25,7 +25,7 @@ func testRunBackupAssumeFailure(t testing.TB, dir string, target []string, opts 
 		}
 
 		opts.GroupBy = data.SnapshotGroupByOptions{Host: true, Path: true}
-		return runBackup(ctx, opts, gopts, gopts.term, target)
+		return runBackup(ctx, opts, gopts, gopts.Term, target)
 	})
 }
 
@@ -706,7 +706,7 @@ func TestBackupEmptyPassword(t *testing.T) {
 	env, cleanup := withTestEnvironment(t)
 	defer cleanup()
 
-	env.gopts.password = ""
+	env.gopts.Password = ""
 	env.gopts.InsecureNoPassword = true
 
 	testSetupBackupData(t, env)

--- a/cmd/restic/cmd_cache.go
+++ b/cmd/restic/cmd_cache.go
@@ -34,7 +34,7 @@ Exit status is 1 if there was any error.
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runCache(opts, *globalOptions, args, globalOptions.term)
+			return runCache(opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -56,7 +56,7 @@ func (opts *CacheOptions) AddFlags(f *pflag.FlagSet) {
 }
 
 func runCache(opts CacheOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	if len(args) > 0 {
 		return errors.Fatal("the cache command expects no arguments, only options - please see `restic help cache` for usage and flags")
@@ -161,7 +161,7 @@ func runCache(opts CacheOptions, gopts GlobalOptions, args []string, term ui.Ter
 		})
 	}
 
-	_ = tab.Write(gopts.term.OutputWriter())
+	_ = tab.Write(gopts.Term.OutputWriter())
 	printer.S("%d cache dirs in %s", len(dirs), cachedir)
 
 	return nil

--- a/cmd/restic/cmd_cache.go
+++ b/cmd/restic/cmd_cache.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/restic/restic/internal/backend/cache"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/table"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-func newCacheCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newCacheCommand(globalOptions *global.Options) *cobra.Command {
 	var opts CacheOptions
 
 	cmd := &cobra.Command{
@@ -55,7 +56,7 @@ func (opts *CacheOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.NoSize, "no-size", false, "do not output the size of the cache directories")
 }
 
-func runCache(opts CacheOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runCache(opts CacheOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	if len(args) > 0 {

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
@@ -16,7 +17,7 @@ import (
 
 var catAllowedCmds = []string{"config", "index", "snapshot", "key", "masterkey", "lock", "pack", "blob", "tree"}
 
-func newCatCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newCatCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "cat [flags] [masterkey|config|pack ID|blob ID|snapshot ID|index ID|key ID|lock ID|tree snapshot:subfolder]",
 		Short: "Print internal objects to stdout",
@@ -65,7 +66,7 @@ func validateCatArgs(args []string) error {
 	return nil
 }
 
-func runCat(ctx context.Context, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runCat(ctx context.Context, gopts global.Options, args []string, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	if err := validateCatArgs(args); err != nil {

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -35,7 +35,7 @@ Exit status is 12 if the password is incorrect.
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runCat(cmd.Context(), *globalOptions, args, globalOptions.term)
+			return runCat(cmd.Context(), *globalOptions, args, globalOptions.Term)
 		},
 		ValidArgs: catAllowedCmds,
 	}
@@ -66,7 +66,7 @@ func validateCatArgs(args []string) error {
 }
 
 func runCat(ctx context.Context, gopts GlobalOptions, args []string, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	if err := validateCatArgs(args); err != nil {
 		return err

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -46,12 +46,12 @@ Exit status is 12 if the password is incorrect.
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			summary, err := runCheck(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			summary, err := runCheck(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 			if globalOptions.JSON {
 				if err != nil && summary.NumErrors == 0 {
 					summary.NumErrors = 1
 				}
-				globalOptions.term.Print(ui.ToJSONString(summary))
+				globalOptions.Term.Print(ui.ToJSONString(summary))
 			}
 			return err
 		},
@@ -225,7 +225,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args 
 
 	var printer progress.Printer
 	if !gopts.JSON {
-		printer = ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+		printer = ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 	} else {
 		printer = newJSONErrorPrinter(term)
 	}

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -16,13 +16,14 @@ import (
 	"github.com/restic/restic/internal/backend/cache"
 	"github.com/restic/restic/internal/checker"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 )
 
-func newCheckCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newCheckCommand(globalOptions *global.Options) *cobra.Command {
 	var opts CheckOptions
 	cmd := &cobra.Command{
 		Use:   "check [flags]",
@@ -170,7 +171,7 @@ func parsePercentage(s string) (float64, error) {
 //   - if the user explicitly requested --no-cache, we don't use any cache
 //   - if the user provides --cache-dir, we use a cache in a temporary sub-directory of the specified directory and the sub-directory is deleted after the check
 //   - by default, we use a cache in a temporary directory that is deleted after the check
-func prepareCheckCache(opts CheckOptions, gopts *GlobalOptions, printer progress.Printer) (cleanup func()) {
+func prepareCheckCache(opts CheckOptions, gopts *global.Options, printer progress.Printer) (cleanup func()) {
 	cleanup = func() {}
 	if opts.WithCache {
 		// use the default cache, no setup needed
@@ -217,7 +218,7 @@ func prepareCheckCache(opts CheckOptions, gopts *GlobalOptions, printer progress
 	return cleanup
 }
 
-func runCheck(ctx context.Context, opts CheckOptions, gopts GlobalOptions, args []string, term ui.Terminal) (checkSummary, error) {
+func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args []string, term ui.Terminal) (checkSummary, error) {
 	summary := checkSummary{MessageType: "summary"}
 	if len(args) != 0 {
 		return summary, errors.Fatal("the check command expects no arguments, only options - please see `restic help check` for usage and flags")

--- a/cmd/restic/cmd_check_integration_test.go
+++ b/cmd/restic/cmd_check_integration_test.go
@@ -4,10 +4,11 @@ import (
 	"context"
 	"testing"
 
+	"github.com/restic/restic/internal/global"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunCheck(t testing.TB, gopts GlobalOptions) {
+func testRunCheck(t testing.TB, gopts global.Options) {
 	t.Helper()
 	output, err := testRunCheckOutput(t, gopts, true)
 	if err != nil {
@@ -16,14 +17,14 @@ func testRunCheck(t testing.TB, gopts GlobalOptions) {
 	}
 }
 
-func testRunCheckMustFail(t testing.TB, gopts GlobalOptions) {
+func testRunCheckMustFail(t testing.TB, gopts global.Options) {
 	t.Helper()
 	_, err := testRunCheckOutput(t, gopts, false)
 	rtest.Assert(t, err != nil, "expected non nil error after check of damaged repository")
 }
 
-func testRunCheckOutput(t testing.TB, gopts GlobalOptions, checkUnused bool) (string, error) {
-	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunCheckOutput(t testing.TB, gopts global.Options, checkUnused bool) (string, error) {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		opts := CheckOptions{
 			ReadData:    true,
 			CheckUnused: checkUnused,

--- a/cmd/restic/cmd_check_integration_test.go
+++ b/cmd/restic/cmd_check_integration_test.go
@@ -28,7 +28,7 @@ func testRunCheckOutput(t testing.TB, gopts GlobalOptions, checkUnused bool) (st
 			ReadData:    true,
 			CheckUnused: checkUnused,
 		}
-		_, err := runCheck(context.TODO(), opts, gopts, nil, gopts.term)
+		_, err := runCheck(context.TODO(), opts, gopts, nil, gopts.Term)
 		return err
 	})
 	return buf.String(), err

--- a/cmd/restic/cmd_check_test.go
+++ b/cmd/restic/cmd_check_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 	"github.com/restic/restic/internal/ui/progress"
@@ -202,7 +203,7 @@ func TestPrepareCheckCache(t *testing.T) {
 				err := os.Remove(tmpDirBase)
 				rtest.OK(t, err)
 			}
-			gopts := GlobalOptions{CacheDir: tmpDirBase}
+			gopts := global.Options{CacheDir: tmpDirBase}
 			cleanup := prepareCheckCache(testCase.opts, &gopts, &progress.NoopPrinter{})
 			files, err := os.ReadDir(tmpDirBase)
 			rtest.OK(t, err)
@@ -232,7 +233,7 @@ func TestPrepareCheckCache(t *testing.T) {
 }
 
 func TestPrepareDefaultCheckCache(t *testing.T) {
-	gopts := GlobalOptions{CacheDir: ""}
+	gopts := global.Options{CacheDir: ""}
 	cleanup := prepareCheckCache(CheckOptions{}, &gopts, &progress.NoopPrinter{})
 	_, err := os.ReadDir(gopts.CacheDir)
 	rtest.OK(t, err)

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -50,7 +50,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runCopy(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runCopy(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -70,7 +70,7 @@ func (opts *CopyOptions) AddFlags(f *pflag.FlagSet) {
 }
 
 func runCopy(ctx context.Context, opts CopyOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 	secondaryGopts, isFromRepo, err := fillSecondaryGlobalOpts(ctx, opts.secondaryRepoOptions, gopts, "destination")
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -7,6 +7,7 @@ import (
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
@@ -17,7 +18,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newCopyCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newCopyCommand(globalOptions *global.Options) *cobra.Command {
 	var opts CopyOptions
 	cmd := &cobra.Command{
 		Use:   "copy [flags] [snapshotID ...]",
@@ -60,18 +61,18 @@ Exit status is 12 if the password is incorrect.
 
 // CopyOptions bundles all options for the copy command.
 type CopyOptions struct {
-	secondaryRepoOptions
+	global.SecondaryRepoOptions
 	data.SnapshotFilter
 }
 
 func (opts *CopyOptions) AddFlags(f *pflag.FlagSet) {
-	opts.secondaryRepoOptions.AddFlags(f, "destination", "to copy snapshots from")
+	opts.SecondaryRepoOptions.AddFlags(f, "destination", "to copy snapshots from")
 	initMultiSnapshotFilter(f, &opts.SnapshotFilter, true)
 }
 
-func runCopy(ctx context.Context, opts CopyOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
-	secondaryGopts, isFromRepo, err := fillSecondaryGlobalOpts(ctx, opts.secondaryRepoOptions, gopts, "destination")
+	secondaryGopts, isFromRepo, err := opts.SecondaryRepoOptions.FillGlobalOpts(ctx, gopts, "destination")
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_copy_integration_test.go
+++ b/cmd/restic/cmd_copy_integration_test.go
@@ -12,18 +12,18 @@ import (
 func testRunCopy(t testing.TB, srcGopts GlobalOptions, dstGopts GlobalOptions) {
 	gopts := srcGopts
 	gopts.Repo = dstGopts.Repo
-	gopts.password = dstGopts.password
+	gopts.Password = dstGopts.Password
 	gopts.InsecureNoPassword = dstGopts.InsecureNoPassword
 	copyOpts := CopyOptions{
 		secondaryRepoOptions: secondaryRepoOptions{
 			Repo:               srcGopts.Repo,
-			password:           srcGopts.password,
+			password:           srcGopts.Password,
 			InsecureNoPassword: srcGopts.InsecureNoPassword,
 		},
 	}
 
 	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runCopy(context.TODO(), copyOpts, gopts, nil, gopts.term)
+		return runCopy(context.TODO(), copyOpts, gopts, nil, gopts.Term)
 	}))
 }
 
@@ -144,7 +144,7 @@ func TestCopyToEmptyPassword(t *testing.T) {
 	defer cleanup()
 	env2, cleanup2 := withTestEnvironment(t)
 	defer cleanup2()
-	env2.gopts.password = ""
+	env2.gopts.Password = ""
 	env2.gopts.InsecureNoPassword = true
 
 	testSetupBackupData(t, env)

--- a/cmd/restic/cmd_copy_integration_test.go
+++ b/cmd/restic/cmd_copy_integration_test.go
@@ -6,23 +6,24 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/restic/restic/internal/global"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunCopy(t testing.TB, srcGopts GlobalOptions, dstGopts GlobalOptions) {
+func testRunCopy(t testing.TB, srcGopts global.Options, dstGopts global.Options) {
 	gopts := srcGopts
 	gopts.Repo = dstGopts.Repo
 	gopts.Password = dstGopts.Password
 	gopts.InsecureNoPassword = dstGopts.InsecureNoPassword
 	copyOpts := CopyOptions{
-		secondaryRepoOptions: secondaryRepoOptions{
+		SecondaryRepoOptions: global.SecondaryRepoOptions{
 			Repo:               srcGopts.Repo,
-			password:           srcGopts.Password,
+			Password:           srcGopts.Password,
 			InsecureNoPassword: srcGopts.InsecureNoPassword,
 		},
 	}
 
-	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runCopy(context.TODO(), copyOpts, gopts, nil, gopts.Term)
 	}))
 }

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -69,7 +69,7 @@ Exit status is 12 if the password is incorrect.
 `,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDebugDump(cmd.Context(), *globalOptions, args, globalOptions.term)
+			return runDebugDump(cmd.Context(), *globalOptions, args, globalOptions.Term)
 		},
 	}
 	return cmd
@@ -83,7 +83,7 @@ func newDebugExamineCommand(globalOptions *GlobalOptions) *cobra.Command {
 		Short:             "Examine a pack file",
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDebugExamine(cmd.Context(), *globalOptions, opts, args, globalOptions.term)
+			return runDebugExamine(cmd.Context(), *globalOptions, opts, args, globalOptions.Term)
 		},
 	}
 
@@ -185,7 +185,7 @@ func dumpIndexes(ctx context.Context, repo restic.ListerLoaderUnpacked, wr io.Wr
 }
 
 func runDebugDump(ctx context.Context, gopts GlobalOptions, args []string, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	if len(args) != 1 {
 		return errors.Fatal("type not specified")
@@ -201,20 +201,20 @@ func runDebugDump(ctx context.Context, gopts GlobalOptions, args []string, term 
 
 	switch tpe {
 	case "indexes":
-		return dumpIndexes(ctx, repo, gopts.term.OutputWriter(), printer)
+		return dumpIndexes(ctx, repo, gopts.Term.OutputWriter(), printer)
 	case "snapshots":
-		return debugPrintSnapshots(ctx, repo, gopts.term.OutputWriter())
+		return debugPrintSnapshots(ctx, repo, gopts.Term.OutputWriter())
 	case "packs":
-		return printPacks(ctx, repo, gopts.term.OutputWriter(), printer)
+		return printPacks(ctx, repo, gopts.Term.OutputWriter(), printer)
 	case "all":
 		printer.S("snapshots:")
-		err := debugPrintSnapshots(ctx, repo, gopts.term.OutputWriter())
+		err := debugPrintSnapshots(ctx, repo, gopts.Term.OutputWriter())
 		if err != nil {
 			return err
 		}
 
 		printer.S("indexes:")
-		err = dumpIndexes(ctx, repo, gopts.term.OutputWriter(), printer)
+		err = dumpIndexes(ctx, repo, gopts.Term.OutputWriter(), printer)
 		if err != nil {
 			return err
 		}
@@ -456,7 +456,7 @@ func storePlainBlob(id restic.ID, prefix string, plain []byte, printer progress.
 }
 
 func runDebugExamine(ctx context.Context, gopts GlobalOptions, opts DebugExamineOptions, args []string, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	if opts.ExtractPack && gopts.NoLock {
 		return fmt.Errorf("--extract-pack and --no-lock are mutually exclusive")

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -24,6 +24,7 @@ import (
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/repository/index"
 	"github.com/restic/restic/internal/repository/pack"
@@ -32,13 +33,13 @@ import (
 	"github.com/restic/restic/internal/ui/progress"
 )
 
-func registerDebugCommand(cmd *cobra.Command, globalOptions *GlobalOptions) {
+func registerDebugCommand(cmd *cobra.Command, globalOptions *global.Options) {
 	cmd.AddCommand(
 		newDebugCommand(globalOptions),
 	)
 }
 
-func newDebugCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newDebugCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "debug",
 		Short:             "Debug commands",
@@ -50,7 +51,7 @@ func newDebugCommand(globalOptions *GlobalOptions) *cobra.Command {
 	return cmd
 }
 
-func newDebugDumpCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newDebugDumpCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "dump [indexes|snapshots|all|packs]",
 		Short: "Dump data structures",
@@ -75,7 +76,7 @@ Exit status is 12 if the password is incorrect.
 	return cmd
 }
 
-func newDebugExamineCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newDebugExamineCommand(globalOptions *global.Options) *cobra.Command {
 	var opts DebugExamineOptions
 
 	cmd := &cobra.Command{
@@ -184,7 +185,7 @@ func dumpIndexes(ctx context.Context, repo restic.ListerLoaderUnpacked, wr io.Wr
 	})
 }
 
-func runDebugDump(ctx context.Context, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runDebugDump(ctx context.Context, gopts global.Options, args []string, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	if len(args) != 1 {
@@ -455,7 +456,7 @@ func storePlainBlob(id restic.ID, prefix string, plain []byte, printer progress.
 	return nil
 }
 
-func runDebugExamine(ctx context.Context, gopts GlobalOptions, opts DebugExamineOptions, args []string, term ui.Terminal) error {
+func runDebugExamine(ctx context.Context, gopts global.Options, opts DebugExamineOptions, args []string, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	if opts.ExtractPack && gopts.NoLock {

--- a/cmd/restic/cmd_debug_disabled.go
+++ b/cmd/restic/cmd_debug_disabled.go
@@ -2,8 +2,11 @@
 
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/restic/restic/internal/global"
+	"github.com/spf13/cobra"
+)
 
-func registerDebugCommand(_ *cobra.Command, _ *GlobalOptions) {
+func registerDebugCommand(_ *cobra.Command, _ *global.Options) {
 	// No commands to register in non-debug mode
 }

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -53,7 +53,7 @@ Exit status is 12 if the password is incorrect.
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runDiff(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runDiff(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -366,7 +366,7 @@ func runDiff(ctx context.Context, opts DiffOptions, gopts GlobalOptions, args []
 		return errors.Fatalf("specify two snapshot IDs")
 	}
 
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	ctx, repo, unlock, err := openWithReadLock(ctx, gopts, gopts.NoLock, printer)
 	if err != nil {
@@ -424,7 +424,7 @@ func runDiff(ctx context.Context, opts DiffOptions, gopts GlobalOptions, args []
 	}
 
 	if gopts.JSON {
-		enc := json.NewEncoder(gopts.term.OutputWriter())
+		enc := json.NewEncoder(gopts.Term.OutputWriter())
 		c.printChange = func(change *Change) {
 			err := enc.Encode(change)
 			if err != nil {
@@ -458,7 +458,7 @@ func runDiff(ctx context.Context, opts DiffOptions, gopts GlobalOptions, args []
 	updateBlobs(repo, stats.BlobsAfter.Sub(both).Sub(stats.BlobsCommon), &stats.Added, printer.E)
 
 	if gopts.JSON {
-		err := json.NewEncoder(gopts.term.OutputWriter()).Encode(stats)
+		err := json.NewEncoder(gopts.Term.OutputWriter()).Encode(stats)
 		if err != nil {
 			printer.E("JSON encode failed: %v", err)
 		}

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -10,13 +10,14 @@ import (
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-func newDiffCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newDiffCommand(globalOptions *global.Options) *cobra.Command {
 	var opts DiffOptions
 
 	cmd := &cobra.Command{
@@ -361,7 +362,7 @@ func (c *Comparer) diffTree(ctx context.Context, stats *DiffStatsContainer, pref
 	return ctx.Err()
 }
 
-func runDiff(ctx context.Context, opts DiffOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runDiff(ctx context.Context, opts DiffOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	if len(args) != 2 {
 		return errors.Fatalf("specify two snapshot IDs")
 	}

--- a/cmd/restic/cmd_diff_integration_test.go
+++ b/cmd/restic/cmd_diff_integration_test.go
@@ -11,11 +11,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/restic/restic/internal/global"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunDiffOutput(t testing.TB, gopts GlobalOptions, firstSnapshotID string, secondSnapshotID string) (string, error) {
-	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunDiffOutput(t testing.TB, gopts global.Options, firstSnapshotID string, secondSnapshotID string) (string, error) {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		opts := DiffOptions{
 			ShowMetadata: false,
 		}

--- a/cmd/restic/cmd_diff_integration_test.go
+++ b/cmd/restic/cmd_diff_integration_test.go
@@ -19,7 +19,7 @@ func testRunDiffOutput(t testing.TB, gopts GlobalOptions, firstSnapshotID string
 		opts := DiffOptions{
 			ShowMetadata: false,
 		}
-		return runDiff(ctx, opts, gopts, []string{firstSnapshotID, secondSnapshotID}, gopts.term)
+		return runDiff(ctx, opts, gopts, []string{firstSnapshotID, secondSnapshotID}, gopts.Term)
 	})
 	return buf.String(), err
 }

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -11,6 +11,7 @@ import (
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/dump"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
 
@@ -18,7 +19,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newDumpCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newDumpCommand(globalOptions *global.Options) *cobra.Command {
 	var opts DumpOptions
 	cmd := &cobra.Command{
 		Use:   "dump [flags] snapshotID file",
@@ -127,7 +128,7 @@ func printFromTree(ctx context.Context, tree *data.Tree, repo restic.BlobLoader,
 	return fmt.Errorf("path %q not found in snapshot", item)
 }
 
-func runDump(ctx context.Context, opts DumpOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runDump(ctx context.Context, opts DumpOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	if len(args) != 2 {
 		return errors.Fatal("no file and no snapshot ID specified")
 	}

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -49,7 +49,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runDump(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runDump(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -132,7 +132,7 @@ func runDump(ctx context.Context, opts DumpOptions, gopts GlobalOptions, args []
 		return errors.Fatal("no file and no snapshot ID specified")
 	}
 
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	switch opts.Archive {
 	case "tar", "zip":

--- a/cmd/restic/cmd_features.go
+++ b/cmd/restic/cmd_features.go
@@ -3,12 +3,13 @@ package main
 import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/feature"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/ui/table"
 
 	"github.com/spf13/cobra"
 )
 
-func newFeaturesCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newFeaturesCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "features",
 		Short: "Print list of feature flags",

--- a/cmd/restic/cmd_features.go
+++ b/cmd/restic/cmd_features.go
@@ -37,7 +37,7 @@ Exit status is 1 if there was any error.
 				return errors.Fatal("the feature command expects no arguments")
 			}
 
-			globalOptions.term.Print("All Feature Flags:\n")
+			globalOptions.Term.Print("All Feature Flags:\n")
 			flags := feature.Flag.List()
 
 			tab := table.New()
@@ -49,7 +49,7 @@ Exit status is 1 if there was any error.
 			for _, flag := range flags {
 				tab.AddRow(flag)
 			}
-			return tab.Write(globalOptions.term.OutputWriter())
+			return tab.Write(globalOptions.Term.OutputWriter())
 		},
 	}
 

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -53,7 +53,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runFind(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runFind(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -584,7 +584,7 @@ func runFind(ctx context.Context, opts FindOptions, gopts GlobalOptions, args []
 		return errors.Fatal("wrong number of arguments")
 	}
 
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	var err error
 	pat := findPattern{pattern: args}

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -16,12 +16,13 @@ import (
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/filter"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/walker"
 )
 
-func newFindCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newFindCommand(globalOptions *global.Options) *cobra.Command {
 	var opts FindOptions
 
 	cmd := &cobra.Command{
@@ -187,7 +188,7 @@ func (s *statefulOutput) PrintPatternNormal(path string, node *data.Node) {
 			s.printer.P("")
 		}
 		s.oldsn = s.newsn
-		s.printer.P("Found matching entries in snapshot %s from %s", s.oldsn.ID().Str(), s.oldsn.Time.Local().Format(TimeFormat))
+		s.printer.P("Found matching entries in snapshot %s from %s", s.oldsn.ID().Str(), s.oldsn.Time.Local().Format(global.TimeFormat))
 	}
 	s.printer.S(formatNode(path, node, s.ListLong, s.HumanReadable))
 }
@@ -240,7 +241,7 @@ func (s *statefulOutput) PrintObjectNormal(kind, id, nodepath, treeID string, sn
 	} else {
 		s.printer.S(" ... path %s", nodepath)
 	}
-	s.printer.S(" ... in snapshot %s (%s)", sn.ID().Str(), sn.Time.Local().Format(TimeFormat))
+	s.printer.S(" ... in snapshot %s (%s)", sn.ID().Str(), sn.Time.Local().Format(global.TimeFormat))
 }
 
 func (s *statefulOutput) PrintObject(kind, id, nodepath, treeID string, sn *data.Snapshot) {
@@ -579,7 +580,7 @@ func (f *Finder) findObjectsPacks() {
 	}
 }
 
-func runFind(ctx context.Context, opts FindOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runFind(ctx context.Context, opts FindOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	if len(args) == 0 {
 		return errors.Fatal("wrong number of arguments")
 	}

--- a/cmd/restic/cmd_find_integration_test.go
+++ b/cmd/restic/cmd_find_integration_test.go
@@ -14,7 +14,7 @@ func testRunFind(t testing.TB, wantJSON bool, opts FindOptions, gopts GlobalOpti
 	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
 		gopts.JSON = wantJSON
 
-		return runFind(ctx, opts, gopts, []string{pattern}, gopts.term)
+		return runFind(ctx, opts, gopts, []string{pattern}, gopts.Term)
 	})
 	rtest.OK(t, err)
 	return buf.Bytes()

--- a/cmd/restic/cmd_find_integration_test.go
+++ b/cmd/restic/cmd_find_integration_test.go
@@ -7,11 +7,12 @@ import (
 	"testing"
 	"time"
 
+	"github.com/restic/restic/internal/global"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunFind(t testing.TB, wantJSON bool, opts FindOptions, gopts GlobalOptions, pattern string) []byte {
-	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunFind(t testing.TB, wantJSON bool, opts FindOptions, gopts global.Options, pattern string) []byte {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		gopts.JSON = wantJSON
 
 		return runFind(ctx, opts, gopts, []string{pattern}, gopts.Term)

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -9,13 +9,14 @@ import (
 
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-func newForgetCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newForgetCommand(globalOptions *global.Options) *cobra.Command {
 	var opts ForgetOptions
 	var pruneOpts PruneOptions
 
@@ -173,7 +174,7 @@ func verifyForgetOptions(opts *ForgetOptions) error {
 	return nil
 }
 
-func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOptions, gopts GlobalOptions, term ui.Terminal, args []string) error {
+func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOptions, gopts global.Options, term ui.Terminal, args []string) error {
 	err := verifyForgetOptions(&opts)
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -51,7 +51,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runForget(cmd.Context(), opts, pruneOpts, *globalOptions, globalOptions.term, args)
+			return runForget(cmd.Context(), opts, pruneOpts, *globalOptions, globalOptions.Term, args)
 		},
 	}
 
@@ -188,7 +188,7 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 		return errors.Fatal("--no-lock is only applicable in combination with --dry-run for forget command")
 	}
 
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, opts.DryRun && gopts.NoLock, printer)
 	if err != nil {
 		return err
@@ -253,7 +253,7 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 			}
 
 			if gopts.Verbose >= 1 && !gopts.JSON {
-				err = PrintSnapshotGroupHeader(gopts.term.OutputWriter(), k)
+				err = PrintSnapshotGroupHeader(gopts.Term.OutputWriter(), k)
 				if err != nil {
 					return err
 				}
@@ -276,7 +276,7 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 			}
 			if len(keep) != 0 && !gopts.Quiet && !gopts.JSON {
 				printer.P("keep %d snapshots:\n", len(keep))
-				if err := PrintSnapshots(gopts.term.OutputWriter(), keep, reasons, opts.Compact); err != nil {
+				if err := PrintSnapshots(gopts.Term.OutputWriter(), keep, reasons, opts.Compact); err != nil {
 					return err
 				}
 				printer.P("\n")
@@ -285,7 +285,7 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 
 			if len(remove) != 0 && !gopts.Quiet && !gopts.JSON {
 				printer.P("remove %d snapshots:\n", len(remove))
-				if err := PrintSnapshots(gopts.term.OutputWriter(), remove, nil, opts.Compact); err != nil {
+				if err := PrintSnapshots(gopts.Term.OutputWriter(), remove, nil, opts.Compact); err != nil {
 					return err
 				}
 				printer.P("\n")
@@ -330,7 +330,7 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 	}
 
 	if gopts.JSON && len(jsonGroups) > 0 {
-		err = printJSONForget(gopts.term.OutputWriter(), jsonGroups)
+		err = printJSONForget(gopts.Term.OutputWriter(), jsonGroups)
 		if err != nil {
 			return err
 		}

--- a/cmd/restic/cmd_forget_integration_test.go
+++ b/cmd/restic/cmd_forget_integration_test.go
@@ -15,7 +15,7 @@ func testRunForgetMayFail(t testing.TB, gopts GlobalOptions, opts ForgetOptions,
 		MaxUnused: "5%",
 	}
 	return withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runForget(context.TODO(), opts, pruneOpts, gopts, gopts.term, args)
+		return runForget(context.TODO(), opts, pruneOpts, gopts, gopts.Term, args)
 	})
 }
 

--- a/cmd/restic/cmd_forget_integration_test.go
+++ b/cmd/restic/cmd_forget_integration_test.go
@@ -7,19 +7,20 @@ import (
 	"testing"
 
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/global"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunForgetMayFail(t testing.TB, gopts GlobalOptions, opts ForgetOptions, args ...string) error {
+func testRunForgetMayFail(t testing.TB, gopts global.Options, opts ForgetOptions, args ...string) error {
 	pruneOpts := PruneOptions{
 		MaxUnused: "5%",
 	}
-	return withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	return withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runForget(context.TODO(), opts, pruneOpts, gopts, gopts.Term, args)
 	})
 }
 
-func testRunForget(t testing.TB, gopts GlobalOptions, opts ForgetOptions, args ...string) {
+func testRunForget(t testing.TB, gopts global.Options, opts ForgetOptions, args ...string) {
 	rtest.OK(t, testRunForgetMayFail(t, gopts, opts, args...))
 }
 

--- a/cmd/restic/cmd_generate.go
+++ b/cmd/restic/cmd_generate.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 	"github.com/spf13/cobra"
@@ -13,7 +14,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newGenerateCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newGenerateCommand(globalOptions *global.Options) *cobra.Command {
 	var opts generateOptions
 
 	cmd := &cobra.Command{
@@ -72,7 +73,7 @@ func writeManpages(root *cobra.Command, dir string, printer progress.Printer) er
 	return doc.GenManTree(root, header, dir)
 }
 
-func writeCompletion(filename string, shell string, generate func(w io.Writer) error, printer progress.Printer, gopts GlobalOptions) (err error) {
+func writeCompletion(filename string, shell string, generate func(w io.Writer) error, printer progress.Printer, gopts global.Options) (err error) {
 	printer.PT("writing %s completion file to %v", shell, filename)
 	var outWriter io.Writer
 	if filename != "-" {
@@ -110,13 +111,13 @@ func checkStdoutForSingleShell(opts generateOptions) error {
 	return nil
 }
 
-func runGenerate(opts generateOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runGenerate(opts generateOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	if len(args) > 0 {
 		return errors.Fatal("the generate command expects no arguments, only options - please see `restic help generate` for usage and flags")
 	}
 
 	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
-	cmdRoot := newRootCommand(&GlobalOptions{})
+	cmdRoot := newRootCommand(&global.Options{})
 
 	if opts.ManDir != "" {
 		err := writeManpages(cmdRoot, opts.ManDir, printer)

--- a/cmd/restic/cmd_generate.go
+++ b/cmd/restic/cmd_generate.go
@@ -31,7 +31,7 @@ Exit status is 1 if there was any error.
 `,
 		DisableAutoGenTag: true,
 		RunE: func(_ *cobra.Command, args []string) error {
-			return runGenerate(opts, *globalOptions, args, globalOptions.term)
+			return runGenerate(opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 	opts.AddFlags(cmd.Flags())
@@ -84,7 +84,7 @@ func writeCompletion(filename string, shell string, generate func(w io.Writer) e
 		defer func() { err = outFile.Close() }()
 		outWriter = outFile
 	} else {
-		outWriter = gopts.term.OutputWriter()
+		outWriter = gopts.Term.OutputWriter()
 	}
 
 	err = generate(outWriter)
@@ -115,7 +115,7 @@ func runGenerate(opts generateOptions, gopts GlobalOptions, args []string, term 
 		return errors.Fatal("the generate command expects no arguments, only options - please see `restic help generate` for usage and flags")
 	}
 
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 	cmdRoot := newRootCommand(&GlobalOptions{})
 
 	if opts.ManDir != "" {

--- a/cmd/restic/cmd_generate_integration_test.go
+++ b/cmd/restic/cmd_generate_integration_test.go
@@ -10,7 +10,7 @@ import (
 
 func testRunGenerate(t testing.TB, gopts GlobalOptions, opts generateOptions) ([]byte, error) {
 	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runGenerate(opts, gopts, []string{}, gopts.term)
+		return runGenerate(opts, gopts, []string{}, gopts.Term)
 	})
 	return buf.Bytes(), err
 }

--- a/cmd/restic/cmd_generate_integration_test.go
+++ b/cmd/restic/cmd_generate_integration_test.go
@@ -5,11 +5,12 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/restic/restic/internal/global"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunGenerate(t testing.TB, gopts GlobalOptions, opts generateOptions) ([]byte, error) {
-	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunGenerate(t testing.TB, gopts global.Options, opts generateOptions) ([]byte, error) {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runGenerate(opts, gopts, []string{}, gopts.Term)
 	})
 	return buf.Bytes(), err
@@ -28,14 +29,14 @@ func TestGenerateStdout(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			output, err := testRunGenerate(t, GlobalOptions{}, tc.opts)
+			output, err := testRunGenerate(t, global.Options{}, tc.opts)
 			rtest.OK(t, err)
 			rtest.Assert(t, strings.Contains(string(output), "# "+tc.name+" completion for restic"), "has no expected completion header")
 		})
 	}
 
 	t.Run("Generate shell completions to stdout for two shells", func(t *testing.T) {
-		_, err := testRunGenerate(t, GlobalOptions{}, generateOptions{BashCompletionFile: "-", FishCompletionFile: "-"})
+		_, err := testRunGenerate(t, global.Options{}, generateOptions{BashCompletionFile: "-", FishCompletionFile: "-"})
 		rtest.Assert(t, err != nil, "generate shell completions to stdout for two shells fails")
 	})
 }

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -35,7 +35,7 @@ Exit status is 1 if there was any error.
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runInit(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runInit(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 	opts.AddFlags(cmd.Flags())
@@ -60,7 +60,7 @@ func runInit(ctx context.Context, opts InitOptions, gopts GlobalOptions, args []
 		return errors.Fatal("the init command expects no arguments, only options - please see `restic help init` for usage and flags")
 	}
 
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	var version uint
 	switch opts.RepositoryVersion {
@@ -90,16 +90,16 @@ func runInit(ctx context.Context, opts InitOptions, gopts GlobalOptions, args []
 		return err
 	}
 
-	gopts.password, err = ReadPasswordTwice(ctx, gopts,
+	gopts.Password, err = ReadPasswordTwice(ctx, gopts,
 		"enter password for new repository: ",
 		"enter password again: ")
 	if err != nil {
 		return err
 	}
 
-	be, err := create(ctx, gopts.Repo, gopts, gopts.extended, printer)
+	be, err := create(ctx, gopts.Repo, gopts, gopts.Extended, printer)
 	if err != nil {
-		return errors.Fatalf("create repository at %s failed: %v", location.StripPassword(gopts.backends, gopts.Repo), err)
+		return errors.Fatalf("create repository at %s failed: %v", location.StripPassword(gopts.Backends, gopts.Repo), err)
 	}
 
 	s, err := repository.New(be, repository.Options{
@@ -110,13 +110,13 @@ func runInit(ctx context.Context, opts InitOptions, gopts GlobalOptions, args []
 		return errors.Fatalf("%s", err)
 	}
 
-	err = s.Init(ctx, version, gopts.password, chunkerPolynomial)
+	err = s.Init(ctx, version, gopts.Password, chunkerPolynomial)
 	if err != nil {
-		return errors.Fatalf("create key in repository at %s failed: %v", location.StripPassword(gopts.backends, gopts.Repo), err)
+		return errors.Fatalf("create key in repository at %s failed: %v", location.StripPassword(gopts.Backends, gopts.Repo), err)
 	}
 
 	if !gopts.JSON {
-		printer.P("created restic repository %v at %s", s.Config().ID[:10], location.StripPassword(gopts.backends, gopts.Repo))
+		printer.P("created restic repository %v at %s", s.Config().ID[:10], location.StripPassword(gopts.Backends, gopts.Repo))
 		if opts.CopyChunkerParameters && chunkerPolynomial != nil {
 			printer.P(" with chunker parameters copied from secondary repository")
 		}
@@ -129,9 +129,9 @@ func runInit(ctx context.Context, opts InitOptions, gopts GlobalOptions, args []
 		status := initSuccess{
 			MessageType: "initialized",
 			ID:          s.Config().ID,
-			Repository:  location.StripPassword(gopts.backends, gopts.Repo),
+			Repository:  location.StripPassword(gopts.Backends, gopts.Repo),
 		}
-		return json.NewEncoder(gopts.term.OutputWriter()).Encode(status)
+		return json.NewEncoder(gopts.Term.OutputWriter()).Encode(status)
 	}
 
 	return nil

--- a/cmd/restic/cmd_init_integration_test.go
+++ b/cmd/restic/cmd_init_integration_test.go
@@ -6,18 +6,19 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 	"github.com/restic/restic/internal/ui/progress"
 )
 
-func testRunInit(t testing.TB, gopts GlobalOptions) {
+func testRunInit(t testing.TB, gopts global.Options) {
 	repository.TestUseLowSecurityKDFParameters(t)
 	restic.TestDisableCheckPolynomial(t)
 	restic.TestSetLockTimeout(t, 0)
 
-	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runInit(ctx, InitOptions{}, gopts, nil, gopts.Term)
 	})
 	rtest.OK(t, err)
@@ -38,32 +39,32 @@ func TestInitCopyChunkerParams(t *testing.T) {
 	testRunInit(t, env2.gopts)
 
 	initOpts := InitOptions{
-		secondaryRepoOptions: secondaryRepoOptions{
+		SecondaryRepoOptions: global.SecondaryRepoOptions{
 			Repo:     env2.gopts.Repo,
-			password: env2.gopts.Password,
+			Password: env2.gopts.Password,
 		},
 	}
-	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runInit(ctx, initOpts, gopts, nil, gopts.Term)
 	})
 	rtest.Assert(t, err != nil, "expected invalid init options to fail")
 
 	initOpts.CopyChunkerParameters = true
-	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runInit(ctx, initOpts, gopts, nil, gopts.Term)
 	})
 	rtest.OK(t, err)
 
 	var repo *repository.Repository
-	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		repo, err = OpenRepository(ctx, gopts, &progress.NoopPrinter{})
+	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
+		repo, err = global.OpenRepository(ctx, gopts, &progress.NoopPrinter{})
 		return err
 	})
 	rtest.OK(t, err)
 
 	var otherRepo *repository.Repository
-	err = withTermStatus(t, env2.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		otherRepo, err = OpenRepository(ctx, gopts, &progress.NoopPrinter{})
+	err = withTermStatus(t, env2.gopts, func(ctx context.Context, gopts global.Options) error {
+		otherRepo, err = global.OpenRepository(ctx, gopts, &progress.NoopPrinter{})
 		return err
 	})
 	rtest.OK(t, err)

--- a/cmd/restic/cmd_init_integration_test.go
+++ b/cmd/restic/cmd_init_integration_test.go
@@ -18,7 +18,7 @@ func testRunInit(t testing.TB, gopts GlobalOptions) {
 	restic.TestSetLockTimeout(t, 0)
 
 	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runInit(ctx, InitOptions{}, gopts, nil, gopts.term)
+		return runInit(ctx, InitOptions{}, gopts, nil, gopts.Term)
 	})
 	rtest.OK(t, err)
 	t.Logf("repository initialized at %v", gopts.Repo)
@@ -40,17 +40,17 @@ func TestInitCopyChunkerParams(t *testing.T) {
 	initOpts := InitOptions{
 		secondaryRepoOptions: secondaryRepoOptions{
 			Repo:     env2.gopts.Repo,
-			password: env2.gopts.password,
+			password: env2.gopts.Password,
 		},
 	}
 	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runInit(ctx, initOpts, gopts, nil, gopts.term)
+		return runInit(ctx, initOpts, gopts, nil, gopts.Term)
 	})
 	rtest.Assert(t, err != nil, "expected invalid init options to fail")
 
 	initOpts.CopyChunkerParameters = true
 	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runInit(ctx, initOpts, gopts, nil, gopts.term)
+		return runInit(ctx, initOpts, gopts, nil, gopts.Term)
 	})
 	rtest.OK(t, err)
 

--- a/cmd/restic/cmd_key.go
+++ b/cmd/restic/cmd_key.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"github.com/restic/restic/internal/global"
 	"github.com/spf13/cobra"
 )
 
-func newKeyCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newKeyCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "key",
 		Short: "Manage keys (passwords)",

--- a/cmd/restic/cmd_key_add.go
+++ b/cmd/restic/cmd_key_add.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
@@ -12,7 +13,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newKeyAddCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newKeyAddCommand(globalOptions *global.Options) *cobra.Command {
 	var opts KeyAddOptions
 
 	cmd := &cobra.Command{
@@ -54,7 +55,7 @@ func (opts *KeyAddOptions) Add(flags *pflag.FlagSet) {
 	flags.StringVarP(&opts.Hostname, "host", "", "", "the hostname for new key")
 }
 
-func runKeyAdd(ctx context.Context, gopts GlobalOptions, opts KeyAddOptions, args []string, term ui.Terminal) error {
+func runKeyAdd(ctx context.Context, gopts global.Options, opts KeyAddOptions, args []string, term ui.Terminal) error {
 	if len(args) > 0 {
 		return fmt.Errorf("the key add command expects no arguments, only options - please see `restic help key add` for usage and flags")
 	}
@@ -69,7 +70,7 @@ func runKeyAdd(ctx context.Context, gopts GlobalOptions, opts KeyAddOptions, arg
 	return addKey(ctx, repo, gopts, opts, printer)
 }
 
-func addKey(ctx context.Context, repo *repository.Repository, gopts GlobalOptions, opts KeyAddOptions, printer progress.Printer) error {
+func addKey(ctx context.Context, repo *repository.Repository, gopts global.Options, opts KeyAddOptions, printer progress.Printer) error {
 	pw, err := getNewPassword(ctx, gopts, opts.NewPasswordFile, opts.InsecureNoPassword)
 	if err != nil {
 		return err
@@ -93,7 +94,7 @@ func addKey(ctx context.Context, repo *repository.Repository, gopts GlobalOption
 // testKeyNewPassword is used to set a new password during integration testing.
 var testKeyNewPassword string
 
-func getNewPassword(ctx context.Context, gopts GlobalOptions, newPasswordFile string, insecureNoPassword bool) (string, error) {
+func getNewPassword(ctx context.Context, gopts global.Options, newPasswordFile string, insecureNoPassword bool) (string, error) {
 	if testKeyNewPassword != "" {
 		return testKeyNewPassword, nil
 	}
@@ -106,7 +107,7 @@ func getNewPassword(ctx context.Context, gopts GlobalOptions, newPasswordFile st
 	}
 
 	if newPasswordFile != "" {
-		password, err := loadPasswordFromFile(newPasswordFile)
+		password, err := global.LoadPasswordFromFile(newPasswordFile)
 		if err != nil {
 			return "", err
 		}
@@ -123,7 +124,7 @@ func getNewPassword(ctx context.Context, gopts GlobalOptions, newPasswordFile st
 	// empty passwords are already handled above
 	newopts.InsecureNoPassword = false
 
-	return ReadPasswordTwice(ctx, newopts,
+	return global.ReadPasswordTwice(ctx, newopts,
 		"enter new password: ",
 		"enter password again: ")
 }

--- a/cmd/restic/cmd_key_add.go
+++ b/cmd/restic/cmd_key_add.go
@@ -32,7 +32,7 @@ Exit status is 12 if the password is incorrect.
 	`,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runKeyAdd(cmd.Context(), *globalOptions, opts, args, globalOptions.term)
+			return runKeyAdd(cmd.Context(), *globalOptions, opts, args, globalOptions.Term)
 		},
 	}
 
@@ -59,7 +59,7 @@ func runKeyAdd(ctx context.Context, gopts GlobalOptions, opts KeyAddOptions, arg
 		return fmt.Errorf("the key add command expects no arguments, only options - please see `restic help key add` for usage and flags")
 	}
 
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 	ctx, repo, unlock, err := openWithAppendLock(ctx, gopts, false, printer)
 	if err != nil {
 		return err
@@ -119,7 +119,7 @@ func getNewPassword(ctx context.Context, gopts GlobalOptions, newPasswordFile st
 	// Since we already have an open repository, temporary remove the password
 	// to prompt the user for the passwd.
 	newopts := gopts
-	newopts.password = ""
+	newopts.Password = ""
 	// empty passwords are already handled above
 	newopts.InsecureNoPassword = false
 

--- a/cmd/restic/cmd_key_integration_test.go
+++ b/cmd/restic/cmd_key_integration_test.go
@@ -17,7 +17,7 @@ import (
 
 func testRunKeyListOtherIDs(t testing.TB, gopts GlobalOptions) []string {
 	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyList(ctx, gopts, []string{}, gopts.term)
+		return runKeyList(ctx, gopts, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
 
@@ -41,7 +41,7 @@ func testRunKeyAddNewKey(t testing.TB, newPassword string, gopts GlobalOptions) 
 	}()
 
 	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyAdd(ctx, gopts, KeyAddOptions{}, []string{}, gopts.term)
+		return runKeyAdd(ctx, gopts, KeyAddOptions{}, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
 }
@@ -57,7 +57,7 @@ func testRunKeyAddNewKeyUserHost(t testing.TB, gopts GlobalOptions) {
 		return runKeyAdd(ctx, gopts, KeyAddOptions{
 			Username: "john",
 			Hostname: "example.com",
-		}, []string{}, gopts.term)
+		}, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
 
@@ -80,7 +80,7 @@ func testRunKeyPasswd(t testing.TB, newPassword string, gopts GlobalOptions) {
 	}()
 
 	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyPasswd(ctx, gopts, KeyPasswdOptions{}, []string{}, gopts.term)
+		return runKeyPasswd(ctx, gopts, KeyPasswdOptions{}, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
 }
@@ -89,7 +89,7 @@ func testRunKeyRemove(t testing.TB, gopts GlobalOptions, IDs []string) {
 	t.Logf("remove %d keys: %q\n", len(IDs), IDs)
 	for _, id := range IDs {
 		err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-			return runKeyRemove(ctx, gopts, []string{id}, gopts.term)
+			return runKeyRemove(ctx, gopts, []string{id}, gopts.Term)
 		})
 		rtest.OK(t, err)
 	}
@@ -103,26 +103,26 @@ func TestKeyAddRemove(t *testing.T) {
 
 	env, cleanup := withTestEnvironment(t)
 	// must list keys more than once
-	env.gopts.backendTestHook = nil
+	env.gopts.BackendTestHook = nil
 	defer cleanup()
 
 	testRunInit(t, env.gopts)
 
 	testRunKeyPasswd(t, "geheim2", env.gopts)
-	env.gopts.password = "geheim2"
-	t.Logf("changed password to %q", env.gopts.password)
+	env.gopts.Password = "geheim2"
+	t.Logf("changed password to %q", env.gopts.Password)
 
 	for _, newPassword := range passwordList {
 		testRunKeyAddNewKey(t, newPassword, env.gopts)
 		t.Logf("added new password %q", newPassword)
-		env.gopts.password = newPassword
+		env.gopts.Password = newPassword
 		testRunKeyRemove(t, env.gopts, testRunKeyListOtherIDs(t, env.gopts))
 	}
 
-	env.gopts.password = passwordList[len(passwordList)-1]
-	t.Logf("testing access with last password %q\n", env.gopts.password)
+	env.gopts.Password = passwordList[len(passwordList)-1]
+	t.Logf("testing access with last password %q\n", env.gopts.Password)
 	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyList(ctx, gopts, []string{}, gopts.term)
+		return runKeyList(ctx, gopts, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
 	testRunCheck(t, env.gopts)
@@ -139,7 +139,7 @@ func TestKeyAddInvalid(t *testing.T) {
 		return runKeyAdd(ctx, gopts, KeyAddOptions{
 			NewPasswordFile:    "some-file",
 			InsecureNoPassword: true,
-		}, []string{}, gopts.term)
+		}, []string{}, gopts.Term)
 	})
 	rtest.Assert(t, strings.Contains(err.Error(), "only either"), "unexpected error message, got %q", err)
 
@@ -149,7 +149,7 @@ func TestKeyAddInvalid(t *testing.T) {
 	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
 		return runKeyAdd(ctx, gopts, KeyAddOptions{
 			NewPasswordFile: pwfile,
-		}, []string{}, gopts.term)
+		}, []string{}, gopts.Term)
 	})
 	rtest.Assert(t, strings.Contains(err.Error(), "an empty password is not allowed by default"), "unexpected error message, got %q", err)
 }
@@ -157,18 +157,18 @@ func TestKeyAddInvalid(t *testing.T) {
 func TestKeyAddEmpty(t *testing.T) {
 	env, cleanup := withTestEnvironment(t)
 	// must list keys more than once
-	env.gopts.backendTestHook = nil
+	env.gopts.BackendTestHook = nil
 	defer cleanup()
 	testRunInit(t, env.gopts)
 
 	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
 		return runKeyAdd(ctx, gopts, KeyAddOptions{
 			InsecureNoPassword: true,
-		}, []string{}, gopts.term)
+		}, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
 
-	env.gopts.password = ""
+	env.gopts.Password = ""
 	env.gopts.InsecureNoPassword = true
 
 	testRunCheck(t, env.gopts)
@@ -187,7 +187,7 @@ func TestKeyProblems(t *testing.T) {
 	defer cleanup()
 
 	testRunInit(t, env.gopts)
-	env.gopts.backendTestHook = func(r backend.Backend) (backend.Backend, error) {
+	env.gopts.BackendTestHook = func(r backend.Backend) (backend.Backend, error) {
 		return &emptySaveBackend{r}, nil
 	}
 
@@ -197,20 +197,20 @@ func TestKeyProblems(t *testing.T) {
 	}()
 
 	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyPasswd(ctx, gopts, KeyPasswdOptions{}, []string{}, gopts.term)
+		return runKeyPasswd(ctx, gopts, KeyPasswdOptions{}, []string{}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil, "expected passwd change to fail")
 
 	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyAdd(ctx, gopts, KeyAddOptions{}, []string{}, gopts.term)
+		return runKeyAdd(ctx, gopts, KeyAddOptions{}, []string{}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil, "expected key adding to fail")
 
-	t.Logf("testing access with initial password %q\n", env.gopts.password)
+	t.Logf("testing access with initial password %q\n", env.gopts.Password)
 	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyList(ctx, gopts, []string{}, gopts.term)
+		return runKeyList(ctx, gopts, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
 	testRunCheck(t, env.gopts)
@@ -221,36 +221,36 @@ func TestKeyCommandInvalidArguments(t *testing.T) {
 	defer cleanup()
 
 	testRunInit(t, env.gopts)
-	env.gopts.backendTestHook = func(r backend.Backend) (backend.Backend, error) {
+	env.gopts.BackendTestHook = func(r backend.Backend) (backend.Backend, error) {
 		return &emptySaveBackend{r}, nil
 	}
 
 	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyAdd(ctx, gopts, KeyAddOptions{}, []string{"johndoe"}, gopts.term)
+		return runKeyAdd(ctx, gopts, KeyAddOptions{}, []string{"johndoe"}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil && strings.Contains(err.Error(), "no arguments"), "unexpected error for key add: %v", err)
 
 	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyPasswd(ctx, gopts, KeyPasswdOptions{}, []string{"johndoe"}, gopts.term)
+		return runKeyPasswd(ctx, gopts, KeyPasswdOptions{}, []string{"johndoe"}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil && strings.Contains(err.Error(), "no arguments"), "unexpected error for key passwd: %v", err)
 
 	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyList(ctx, gopts, []string{"johndoe"}, gopts.term)
+		return runKeyList(ctx, gopts, []string{"johndoe"}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil && strings.Contains(err.Error(), "no arguments"), "unexpected error for key list: %v", err)
 
 	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyRemove(ctx, gopts, []string{}, gopts.term)
+		return runKeyRemove(ctx, gopts, []string{}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil && strings.Contains(err.Error(), "one argument"), "unexpected error for key remove: %v", err)
 
 	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runKeyRemove(ctx, gopts, []string{"john", "doe"}, gopts.term)
+		return runKeyRemove(ctx, gopts, []string{"john", "doe"}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil && strings.Contains(err.Error(), "one argument"), "unexpected error for key remove: %v", err)

--- a/cmd/restic/cmd_key_integration_test.go
+++ b/cmd/restic/cmd_key_integration_test.go
@@ -10,13 +10,14 @@ import (
 	"testing"
 
 	"github.com/restic/restic/internal/backend"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	rtest "github.com/restic/restic/internal/test"
 	"github.com/restic/restic/internal/ui/progress"
 )
 
-func testRunKeyListOtherIDs(t testing.TB, gopts GlobalOptions) []string {
-	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunKeyListOtherIDs(t testing.TB, gopts global.Options) []string {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyList(ctx, gopts, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
@@ -34,26 +35,26 @@ func testRunKeyListOtherIDs(t testing.TB, gopts GlobalOptions) []string {
 	return IDs
 }
 
-func testRunKeyAddNewKey(t testing.TB, newPassword string, gopts GlobalOptions) {
+func testRunKeyAddNewKey(t testing.TB, newPassword string, gopts global.Options) {
 	testKeyNewPassword = newPassword
 	defer func() {
 		testKeyNewPassword = ""
 	}()
 
-	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyAdd(ctx, gopts, KeyAddOptions{}, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
 }
 
-func testRunKeyAddNewKeyUserHost(t testing.TB, gopts GlobalOptions) {
+func testRunKeyAddNewKeyUserHost(t testing.TB, gopts global.Options) {
 	testKeyNewPassword = "john's geheimnis"
 	defer func() {
 		testKeyNewPassword = ""
 	}()
 
 	t.Log("adding key for john@example.com")
-	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyAdd(ctx, gopts, KeyAddOptions{
 			Username: "john",
 			Hostname: "example.com",
@@ -61,8 +62,8 @@ func testRunKeyAddNewKeyUserHost(t testing.TB, gopts GlobalOptions) {
 	})
 	rtest.OK(t, err)
 
-	_ = withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		repo, err := OpenRepository(ctx, gopts, &progress.NoopPrinter{})
+	_ = withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		repo, err := global.OpenRepository(ctx, gopts, &progress.NoopPrinter{})
 		rtest.OK(t, err)
 		key, err := repository.SearchKey(ctx, repo, testKeyNewPassword, 2, "")
 		rtest.OK(t, err)
@@ -73,22 +74,22 @@ func testRunKeyAddNewKeyUserHost(t testing.TB, gopts GlobalOptions) {
 	})
 }
 
-func testRunKeyPasswd(t testing.TB, newPassword string, gopts GlobalOptions) {
+func testRunKeyPasswd(t testing.TB, newPassword string, gopts global.Options) {
 	testKeyNewPassword = newPassword
 	defer func() {
 		testKeyNewPassword = ""
 	}()
 
-	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyPasswd(ctx, gopts, KeyPasswdOptions{}, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
 }
 
-func testRunKeyRemove(t testing.TB, gopts GlobalOptions, IDs []string) {
+func testRunKeyRemove(t testing.TB, gopts global.Options, IDs []string) {
 	t.Logf("remove %d keys: %q\n", len(IDs), IDs)
 	for _, id := range IDs {
-		err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+		err := withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 			return runKeyRemove(ctx, gopts, []string{id}, gopts.Term)
 		})
 		rtest.OK(t, err)
@@ -121,7 +122,7 @@ func TestKeyAddRemove(t *testing.T) {
 
 	env.gopts.Password = passwordList[len(passwordList)-1]
 	t.Logf("testing access with last password %q\n", env.gopts.Password)
-	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyList(ctx, gopts, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
@@ -135,7 +136,7 @@ func TestKeyAddInvalid(t *testing.T) {
 	defer cleanup()
 	testRunInit(t, env.gopts)
 
-	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyAdd(ctx, gopts, KeyAddOptions{
 			NewPasswordFile:    "some-file",
 			InsecureNoPassword: true,
@@ -146,7 +147,7 @@ func TestKeyAddInvalid(t *testing.T) {
 	pwfile := filepath.Join(t.TempDir(), "pwfile")
 	rtest.OK(t, os.WriteFile(pwfile, []byte{}, 0o666))
 
-	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyAdd(ctx, gopts, KeyAddOptions{
 			NewPasswordFile: pwfile,
 		}, []string{}, gopts.Term)
@@ -161,7 +162,7 @@ func TestKeyAddEmpty(t *testing.T) {
 	defer cleanup()
 	testRunInit(t, env.gopts)
 
-	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyAdd(ctx, gopts, KeyAddOptions{
 			InsecureNoPassword: true,
 		}, []string{}, gopts.Term)
@@ -196,20 +197,20 @@ func TestKeyProblems(t *testing.T) {
 		testKeyNewPassword = ""
 	}()
 
-	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyPasswd(ctx, gopts, KeyPasswdOptions{}, []string{}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil, "expected passwd change to fail")
 
-	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyAdd(ctx, gopts, KeyAddOptions{}, []string{}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil, "expected key adding to fail")
 
 	t.Logf("testing access with initial password %q\n", env.gopts.Password)
-	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyList(ctx, gopts, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
@@ -225,31 +226,31 @@ func TestKeyCommandInvalidArguments(t *testing.T) {
 		return &emptySaveBackend{r}, nil
 	}
 
-	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyAdd(ctx, gopts, KeyAddOptions{}, []string{"johndoe"}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil && strings.Contains(err.Error(), "no arguments"), "unexpected error for key add: %v", err)
 
-	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyPasswd(ctx, gopts, KeyPasswdOptions{}, []string{"johndoe"}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil && strings.Contains(err.Error(), "no arguments"), "unexpected error for key passwd: %v", err)
 
-	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyList(ctx, gopts, []string{"johndoe"}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil && strings.Contains(err.Error(), "no arguments"), "unexpected error for key list: %v", err)
 
-	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyRemove(ctx, gopts, []string{}, gopts.Term)
 	})
 	t.Log(err)
 	rtest.Assert(t, err != nil && strings.Contains(err.Error(), "one argument"), "unexpected error for key remove: %v", err)
 
-	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err = withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runKeyRemove(ctx, gopts, []string{"john", "doe"}, gopts.Term)
 	})
 	t.Log(err)

--- a/cmd/restic/cmd_key_list.go
+++ b/cmd/restic/cmd_key_list.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
@@ -14,7 +15,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newKeyListCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newKeyListCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "list",
 		Short: "List keys (passwords)",
@@ -40,7 +41,7 @@ Exit status is 12 if the password is incorrect.
 	return cmd
 }
 
-func runKeyList(ctx context.Context, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runKeyList(ctx context.Context, gopts global.Options, args []string, term ui.Terminal) error {
 	if len(args) > 0 {
 		return fmt.Errorf("the key list command expects no arguments, only options - please see `restic help key list` for usage and flags")
 	}
@@ -55,7 +56,7 @@ func runKeyList(ctx context.Context, gopts GlobalOptions, args []string, term ui
 	return listKeys(ctx, repo, gopts, printer)
 }
 
-func listKeys(ctx context.Context, s *repository.Repository, gopts GlobalOptions, printer progress.Printer) error {
+func listKeys(ctx context.Context, s *repository.Repository, gopts global.Options, printer progress.Printer) error {
 	type keyInfo struct {
 		Current  bool   `json:"current"`
 		ID       string `json:"id"`
@@ -81,7 +82,7 @@ func listKeys(ctx context.Context, s *repository.Repository, gopts GlobalOptions
 			ShortID:  id.Str(),
 			UserName: k.Username,
 			HostName: k.Hostname,
-			Created:  k.Created.Local().Format(TimeFormat),
+			Created:  k.Created.Local().Format(global.TimeFormat),
 		}
 
 		m.Lock()

--- a/cmd/restic/cmd_key_list.go
+++ b/cmd/restic/cmd_key_list.go
@@ -34,7 +34,7 @@ Exit status is 12 if the password is incorrect.
 	`,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runKeyList(cmd.Context(), *globalOptions, args, globalOptions.term)
+			return runKeyList(cmd.Context(), *globalOptions, args, globalOptions.Term)
 		},
 	}
 	return cmd
@@ -45,7 +45,7 @@ func runKeyList(ctx context.Context, gopts GlobalOptions, args []string, term ui
 		return fmt.Errorf("the key list command expects no arguments, only options - please see `restic help key list` for usage and flags")
 	}
 
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 	ctx, repo, unlock, err := openWithReadLock(ctx, gopts, gopts.NoLock, printer)
 	if err != nil {
 		return err
@@ -95,7 +95,7 @@ func listKeys(ctx context.Context, s *repository.Repository, gopts GlobalOptions
 	}
 
 	if gopts.JSON {
-		return json.NewEncoder(gopts.term.OutputWriter()).Encode(keys)
+		return json.NewEncoder(gopts.Term.OutputWriter()).Encode(keys)
 	}
 
 	tab := table.New()
@@ -108,5 +108,5 @@ func listKeys(ctx context.Context, s *repository.Repository, gopts GlobalOptions
 		tab.AddRow(key)
 	}
 
-	return tab.Write(gopts.term.OutputWriter())
+	return tab.Write(gopts.Term.OutputWriter())
 }

--- a/cmd/restic/cmd_key_passwd.go
+++ b/cmd/restic/cmd_key_passwd.go
@@ -33,7 +33,7 @@ Exit status is 12 if the password is incorrect.
 	`,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runKeyPasswd(cmd.Context(), *globalOptions, opts, args, globalOptions.term)
+			return runKeyPasswd(cmd.Context(), *globalOptions, opts, args, globalOptions.Term)
 		},
 	}
 
@@ -54,7 +54,7 @@ func runKeyPasswd(ctx context.Context, gopts GlobalOptions, opts KeyPasswdOption
 		return fmt.Errorf("the key passwd command expects no arguments, only options - please see `restic help key passwd` for usage and flags")
 	}
 
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_key_passwd.go
+++ b/cmd/restic/cmd_key_passwd.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
@@ -12,7 +13,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newKeyPasswdCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newKeyPasswdCommand(globalOptions *global.Options) *cobra.Command {
 	var opts KeyPasswdOptions
 
 	cmd := &cobra.Command{
@@ -49,7 +50,7 @@ func (opts *KeyPasswdOptions) AddFlags(flags *pflag.FlagSet) {
 	opts.KeyAddOptions.Add(flags)
 }
 
-func runKeyPasswd(ctx context.Context, gopts GlobalOptions, opts KeyPasswdOptions, args []string, term ui.Terminal) error {
+func runKeyPasswd(ctx context.Context, gopts global.Options, opts KeyPasswdOptions, args []string, term ui.Terminal) error {
 	if len(args) > 0 {
 		return fmt.Errorf("the key passwd command expects no arguments, only options - please see `restic help key passwd` for usage and flags")
 	}
@@ -64,7 +65,7 @@ func runKeyPasswd(ctx context.Context, gopts GlobalOptions, opts KeyPasswdOption
 	return changePassword(ctx, repo, gopts, opts, printer)
 }
 
-func changePassword(ctx context.Context, repo *repository.Repository, gopts GlobalOptions, opts KeyPasswdOptions, printer progress.Printer) error {
+func changePassword(ctx context.Context, repo *repository.Repository, gopts global.Options, opts KeyPasswdOptions, printer progress.Printer) error {
 	pw, err := getNewPassword(ctx, gopts, opts.NewPasswordFile, opts.InsecureNoPassword)
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_key_remove.go
+++ b/cmd/restic/cmd_key_remove.go
@@ -31,7 +31,7 @@ Exit status is 12 if the password is incorrect.
 	`,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runKeyRemove(cmd.Context(), *globalOptions, args, globalOptions.term)
+			return runKeyRemove(cmd.Context(), *globalOptions, args, globalOptions.Term)
 		},
 	}
 	return cmd
@@ -42,7 +42,7 @@ func runKeyRemove(ctx context.Context, gopts GlobalOptions, args []string, term 
 		return fmt.Errorf("key remove expects one argument as the key id")
 	}
 
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_key_remove.go
+++ b/cmd/restic/cmd_key_remove.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
@@ -12,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newKeyRemoveCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newKeyRemoveCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "remove [ID]",
 		Short: "Remove key ID (password) from the repository.",
@@ -37,7 +38,7 @@ Exit status is 12 if the password is incorrect.
 	return cmd
 }
 
-func runKeyRemove(ctx context.Context, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runKeyRemove(ctx context.Context, gopts global.Options, args []string, term ui.Terminal) error {
 	if len(args) != 1 {
 		return fmt.Errorf("key remove expects one argument as the key id")
 	}

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository/index"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
@@ -12,7 +13,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func newListCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newListCommand(globalOptions *global.Options) *cobra.Command {
 	var listAllowedArgs = []string{"blobs", "packs", "index", "snapshots", "keys", "locks"}
 	var listAllowedArgsUseString = strings.Join(listAllowedArgs, "|")
 
@@ -42,7 +43,7 @@ Exit status is 12 if the password is incorrect.
 	return cmd
 }
 
-func runList(ctx context.Context, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runList(ctx context.Context, gopts global.Options, args []string, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	if len(args) != 1 {

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -34,7 +34,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		GroupID:           cmdGroupDefault,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runList(cmd.Context(), *globalOptions, args, globalOptions.term)
+			return runList(cmd.Context(), *globalOptions, args, globalOptions.Term)
 		},
 		ValidArgs: listAllowedArgs,
 		Args:      cobra.MatchAll(cobra.ExactArgs(1), cobra.OnlyValidArgs),
@@ -43,7 +43,7 @@ Exit status is 12 if the password is incorrect.
 }
 
 func runList(ctx context.Context, gopts GlobalOptions, args []string, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	if len(args) != 1 {
 		return errors.Fatal("type not specified")

--- a/cmd/restic/cmd_list_integration_test.go
+++ b/cmd/restic/cmd_list_integration_test.go
@@ -15,7 +15,7 @@ import (
 
 func testRunList(t testing.TB, gopts GlobalOptions, tpe string) restic.IDs {
 	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runList(ctx, gopts, []string{tpe}, gopts.term)
+		return runList(ctx, gopts, []string{tpe}, gopts.Term)
 	})
 	rtest.OK(t, err)
 	return parseIDsFromReader(t, buf)
@@ -60,7 +60,7 @@ func testListSnapshots(t testing.TB, gopts GlobalOptions, expected int) restic.I
 // extract blob set from repository index
 func testListBlobs(t testing.TB, gopts GlobalOptions) (blobSetFromIndex restic.IDSet) {
 	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		_, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
 		defer unlock()

--- a/cmd/restic/cmd_list_integration_test.go
+++ b/cmd/restic/cmd_list_integration_test.go
@@ -8,13 +8,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 	"github.com/restic/restic/internal/ui"
 )
 
-func testRunList(t testing.TB, gopts GlobalOptions, tpe string) restic.IDs {
-	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunList(t testing.TB, gopts global.Options, tpe string) restic.IDs {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runList(ctx, gopts, []string{tpe}, gopts.Term)
 	})
 	rtest.OK(t, err)
@@ -50,7 +51,7 @@ func parseIDsFromReader(t testing.TB, rd io.Reader) restic.IDs {
 	return IDs
 }
 
-func testListSnapshots(t testing.TB, gopts GlobalOptions, expected int) restic.IDs {
+func testListSnapshots(t testing.TB, gopts global.Options, expected int) restic.IDs {
 	t.Helper()
 	snapshotIDs := testRunList(t, gopts, "snapshots")
 	rtest.Assert(t, len(snapshotIDs) == expected, "expected %v snapshot, got %v", expected, snapshotIDs)
@@ -58,8 +59,8 @@ func testListSnapshots(t testing.TB, gopts GlobalOptions, expected int) restic.I
 }
 
 // extract blob set from repository index
-func testListBlobs(t testing.TB, gopts GlobalOptions) (blobSetFromIndex restic.IDSet) {
-	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testListBlobs(t testing.TB, gopts global.Options) (blobSetFromIndex restic.IDSet) {
+	err := withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		_, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -62,7 +62,7 @@ Exit status is 12 if the password is incorrect.
 		GroupID:           cmdGroupDefault,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runLs(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runLs(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 	opts.AddFlags(cmd.Flags())
@@ -304,7 +304,7 @@ type toSortOutput struct {
 }
 
 func runLs(ctx context.Context, opts LsOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
-	termPrinter := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	termPrinter := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	if len(args) == 0 {
 		return errors.Fatal("no snapshot ID specified, specify snapshot ID or use special ID 'latest'")
@@ -383,11 +383,11 @@ func runLs(ctx context.Context, opts LsOptions, gopts GlobalOptions, args []stri
 
 	if gopts.JSON {
 		printer = &jsonLsPrinter{
-			enc: json.NewEncoder(gopts.term.OutputWriter()),
+			enc: json.NewEncoder(gopts.Term.OutputWriter()),
 		}
 	} else if opts.Ncdu {
 		printer = &ncduLsPrinter{
-			out: gopts.term.OutputWriter(),
+			out: gopts.Term.OutputWriter(),
 		}
 	} else {
 		printer = &textLsPrinter{

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -18,12 +18,13 @@ import (
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/walker"
 )
 
-func newLsCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newLsCommand(globalOptions *global.Options) *cobra.Command {
 	var opts LsOptions
 
 	cmd := &cobra.Command{
@@ -303,7 +304,7 @@ type toSortOutput struct {
 	node     *data.Node
 }
 
-func runLs(ctx context.Context, opts LsOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runLs(ctx context.Context, opts LsOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	termPrinter := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	if len(args) == 0 {

--- a/cmd/restic/cmd_ls_integration_test.go
+++ b/cmd/restic/cmd_ls_integration_test.go
@@ -16,7 +16,7 @@ import (
 func testRunLsWithOpts(t testing.TB, gopts GlobalOptions, opts LsOptions, args []string) []byte {
 	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
 		gopts.Quiet = true
-		return runLs(context.TODO(), opts, gopts, args, gopts.term)
+		return runLs(context.TODO(), opts, gopts, args, gopts.Term)
 	})
 	rtest.OK(t, err)
 	return buf.Bytes()

--- a/cmd/restic/cmd_ls_integration_test.go
+++ b/cmd/restic/cmd_ls_integration_test.go
@@ -9,12 +9,13 @@ import (
 	"testing"
 
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunLsWithOpts(t testing.TB, gopts GlobalOptions, opts LsOptions, args []string) []byte {
-	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunLsWithOpts(t testing.TB, gopts global.Options, opts LsOptions, args []string) []byte {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		gopts.Quiet = true
 		return runLs(context.TODO(), opts, gopts, args, gopts.Term)
 	})
@@ -22,7 +23,7 @@ func testRunLsWithOpts(t testing.TB, gopts GlobalOptions, opts LsOptions, args [
 	return buf.Bytes()
 }
 
-func testRunLs(t testing.TB, gopts GlobalOptions, snapshotID string) []string {
+func testRunLs(t testing.TB, gopts global.Options, snapshotID string) []string {
 	out := testRunLsWithOpts(t, gopts, LsOptions{}, []string{snapshotID})
 	return strings.Split(string(out), "\n")
 }

--- a/cmd/restic/cmd_migrate.go
+++ b/cmd/restic/cmd_migrate.go
@@ -35,7 +35,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		GroupID:           cmdGroupDefault,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runMigrate(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runMigrate(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -134,7 +134,7 @@ func applyMigrations(ctx context.Context, opts MigrateOptions, gopts GlobalOptio
 }
 
 func runMigrate(ctx context.Context, opts MigrateOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
 	if err != nil {

--- a/cmd/restic/cmd_migrate.go
+++ b/cmd/restic/cmd_migrate.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/migrations"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
@@ -12,7 +13,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newMigrateCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newMigrateCommand(globalOptions *global.Options) *cobra.Command {
 	var opts MigrateOptions
 
 	cmd := &cobra.Command{
@@ -75,7 +76,7 @@ func checkMigrations(ctx context.Context, repo restic.Repository, printer progre
 	return nil
 }
 
-func applyMigrations(ctx context.Context, opts MigrateOptions, gopts GlobalOptions, repo restic.Repository, args []string, term ui.Terminal, printer progress.Printer) error {
+func applyMigrations(ctx context.Context, opts MigrateOptions, gopts global.Options, repo restic.Repository, args []string, term ui.Terminal, printer progress.Printer) error {
 	var firsterr error
 	for _, name := range args {
 		found := false
@@ -133,7 +134,7 @@ func applyMigrations(ctx context.Context, opts MigrateOptions, gopts GlobalOptio
 	return firsterr
 }
 
-func runMigrate(ctx context.Context, opts MigrateOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runMigrate(ctx context.Context, opts MigrateOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -83,7 +83,7 @@ Exit status is 12 if the password is incorrect.
 		GroupID:           cmdGroupDefault,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runMount(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runMount(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -115,7 +115,7 @@ func (opts *MountOptions) AddFlags(f *pflag.FlagSet) {
 }
 
 func runMount(ctx context.Context, opts MountOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	if opts.TimeTemplate == "" {
 		return errors.Fatal("time template string cannot be empty")

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -16,6 +16,7 @@ import (
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/ui"
 
 	"github.com/restic/restic/internal/fuse"
@@ -24,11 +25,11 @@ import (
 	"github.com/anacrolix/fuse/fs"
 )
 
-func registerMountCommand(cmdRoot *cobra.Command, globalOptions *GlobalOptions) {
+func registerMountCommand(cmdRoot *cobra.Command, globalOptions *global.Options) {
 	cmdRoot.AddCommand(newMountCommand(globalOptions))
 }
 
-func newMountCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newMountCommand(globalOptions *global.Options) *cobra.Command {
 	var opts MountOptions
 
 	cmd := &cobra.Command{
@@ -114,7 +115,7 @@ func (opts *MountOptions) AddFlags(f *pflag.FlagSet) {
 	_ = f.MarkDeprecated("snapshot-template", "use --time-template")
 }
 
-func runMount(ctx context.Context, opts MountOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	if opts.TimeTemplate == "" {

--- a/cmd/restic/cmd_mount_disabled.go
+++ b/cmd/restic/cmd_mount_disabled.go
@@ -3,8 +3,11 @@
 
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/restic/restic/internal/global"
+	"github.com/spf13/cobra"
+)
 
-func registerMountCommand(_ *cobra.Command, _ *GlobalOptions) {
+func registerMountCommand(_ *cobra.Command, _ *global.Options) {
 	// Mount command not supported on these platforms
 }

--- a/cmd/restic/cmd_mount_integration_test.go
+++ b/cmd/restic/cmd_mount_integration_test.go
@@ -64,7 +64,7 @@ func testRunMount(t testing.TB, gopts GlobalOptions, dir string, wg *sync.WaitGr
 		TimeTemplate: time.RFC3339,
 	}
 	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runMount(context.TODO(), opts, gopts, []string{dir}, gopts.term)
+		return runMount(context.TODO(), opts, gopts, []string{dir}, gopts.Term)
 	}))
 }
 
@@ -130,7 +130,7 @@ func checkSnapshots(t testing.TB, gopts GlobalOptions, mountpoint string, snapsh
 	}
 
 	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		_, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		if err != nil {
 			return err
@@ -177,7 +177,7 @@ func TestMount(t *testing.T) {
 
 	env, cleanup := withTestEnvironment(t)
 	// must list snapshots more than once
-	env.gopts.backendTestHook = nil
+	env.gopts.BackendTestHook = nil
 	defer cleanup()
 
 	testRunInit(t, env.gopts)
@@ -224,7 +224,7 @@ func TestMountSameTimestamps(t *testing.T) {
 
 	env, cleanup := withTestEnvironment(t)
 	// must list snapshots more than once
-	env.gopts.backendTestHook = nil
+	env.gopts.BackendTestHook = nil
 	defer cleanup()
 
 	rtest.SetupTarTestFixture(t, env.base, filepath.Join("testdata", "repo-same-timestamps.tar.gz"))

--- a/cmd/restic/cmd_mount_integration_test.go
+++ b/cmd/restic/cmd_mount_integration_test.go
@@ -15,6 +15,7 @@ import (
 	systemFuse "github.com/anacrolix/fuse"
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 	"github.com/restic/restic/internal/ui"
@@ -58,12 +59,12 @@ func waitForMount(t testing.TB, dir string) {
 	t.Errorf("subdir %q of dir %s never appeared", mountTestSubdir, dir)
 }
 
-func testRunMount(t testing.TB, gopts GlobalOptions, dir string, wg *sync.WaitGroup) {
+func testRunMount(t testing.TB, gopts global.Options, dir string, wg *sync.WaitGroup) {
 	defer wg.Done()
 	opts := MountOptions{
 		TimeTemplate: time.RFC3339,
 	}
-	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runMount(context.TODO(), opts, gopts, []string{dir}, gopts.Term)
 	}))
 }
@@ -91,7 +92,7 @@ func listSnapshots(t testing.TB, dir string) []string {
 	return names
 }
 
-func checkSnapshots(t testing.TB, gopts GlobalOptions, mountpoint string, snapshotIDs restic.IDs, expectedSnapshotsInFuseDir int) {
+func checkSnapshots(t testing.TB, gopts global.Options, mountpoint string, snapshotIDs restic.IDs, expectedSnapshotsInFuseDir int) {
 	t.Logf("checking for %d snapshots: %v", len(snapshotIDs), snapshotIDs)
 
 	var wg sync.WaitGroup
@@ -129,7 +130,7 @@ func checkSnapshots(t testing.TB, gopts GlobalOptions, mountpoint string, snapsh
 		}
 	}
 
-	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		_, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		if err != nil {

--- a/cmd/restic/cmd_options.go
+++ b/cmd/restic/cmd_options.go
@@ -24,7 +24,7 @@ Exit status is 1 if there was any error.
 		GroupID:           cmdGroupAdvanced,
 		DisableAutoGenTag: true,
 		Run: func(_ *cobra.Command, _ []string) {
-			globalOptions.term.Print("All Extended Options:")
+			globalOptions.Term.Print("All Extended Options:")
 			var maxLen int
 			for _, opt := range options.List() {
 				if l := len(opt.Namespace + "." + opt.Name); l > maxLen {
@@ -32,7 +32,7 @@ Exit status is 1 if there was any error.
 				}
 			}
 			for _, opt := range options.List() {
-				globalOptions.term.Print(fmt.Sprintf("  %*s  %s", -maxLen, opt.Namespace+"."+opt.Name, opt.Text))
+				globalOptions.Term.Print(fmt.Sprintf("  %*s  %s", -maxLen, opt.Namespace+"."+opt.Name, opt.Text))
 			}
 		},
 	}

--- a/cmd/restic/cmd_options.go
+++ b/cmd/restic/cmd_options.go
@@ -3,12 +3,13 @@ package main
 import (
 	"fmt"
 
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/options"
 
 	"github.com/spf13/cobra"
 )
 
-func newOptionsCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newOptionsCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "options",
 		Short: "Print list of extended options",

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -10,6 +10,7 @@ import (
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
@@ -19,7 +20,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newPruneCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newPruneCommand(globalOptions *global.Options) *cobra.Command {
 	var opts PruneOptions
 
 	cmd := &cobra.Command{
@@ -153,7 +154,7 @@ func verifyPruneOptions(opts *PruneOptions) error {
 	return nil
 }
 
-func runPrune(ctx context.Context, opts PruneOptions, gopts GlobalOptions, term ui.Terminal) error {
+func runPrune(ctx context.Context, opts PruneOptions, gopts global.Options, term ui.Terminal) error {
 	err := verifyPruneOptions(&opts)
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -41,7 +41,7 @@ Exit status is 12 if the password is incorrect.
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runPrune(cmd.Context(), opts, *globalOptions, globalOptions.term)
+			return runPrune(cmd.Context(), opts, *globalOptions, globalOptions.Term)
 		},
 	}
 
@@ -167,7 +167,7 @@ func runPrune(ctx context.Context, opts PruneOptions, gopts GlobalOptions, term 
 		return errors.Fatal("--no-lock is only applicable in combination with --dry-run for prune command")
 	}
 
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, opts.DryRun && gopts.NoLock, printer)
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_prune_integration_test.go
+++ b/cmd/restic/cmd_prune_integration_test.go
@@ -23,13 +23,13 @@ func testRunPruneMustFail(t testing.TB, gopts GlobalOptions, opts PruneOptions) 
 }
 
 func testRunPruneOutput(t testing.TB, gopts GlobalOptions, opts PruneOptions) error {
-	oldHook := gopts.backendTestHook
-	gopts.backendTestHook = func(r backend.Backend) (backend.Backend, error) { return newListOnceBackend(r), nil }
+	oldHook := gopts.BackendTestHook
+	gopts.BackendTestHook = func(r backend.Backend) (backend.Backend, error) { return newListOnceBackend(r), nil }
 	defer func() {
-		gopts.backendTestHook = oldHook
+		gopts.BackendTestHook = oldHook
 	}()
 	return withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runPrune(context.TODO(), opts, gopts, gopts.term)
+		return runPrune(context.TODO(), opts, gopts, gopts.Term)
 	})
 }
 
@@ -98,7 +98,7 @@ func testRunForgetJSON(t testing.TB, gopts GlobalOptions, args ...string) {
 		pruneOpts := PruneOptions{
 			MaxUnused: "5%",
 		}
-		return runForget(context.TODO(), opts, pruneOpts, gopts, gopts.term, args)
+		return runForget(context.TODO(), opts, pruneOpts, gopts, gopts.Term, args)
 	})
 	rtest.OK(t, err)
 
@@ -120,7 +120,7 @@ func testPrune(t *testing.T, pruneOpts PruneOptions, checkOpts CheckOptions) {
 	createPrunableRepo(t, env)
 	testRunPrune(t, env.gopts, pruneOpts)
 	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		_, err := runCheck(context.TODO(), checkOpts, gopts, nil, gopts.term)
+		_, err := runCheck(context.TODO(), checkOpts, gopts, nil, gopts.Term)
 		return err
 	}))
 }
@@ -149,14 +149,14 @@ func TestPruneWithDamagedRepository(t *testing.T) {
 	testListSnapshots(t, env.gopts, 1)
 	removePacksExcept(env.gopts, t, oldPacks, false)
 
-	oldHook := env.gopts.backendTestHook
-	env.gopts.backendTestHook = func(r backend.Backend) (backend.Backend, error) { return newListOnceBackend(r), nil }
+	oldHook := env.gopts.BackendTestHook
+	env.gopts.BackendTestHook = func(r backend.Backend) (backend.Backend, error) { return newListOnceBackend(r), nil }
 	defer func() {
-		env.gopts.backendTestHook = oldHook
+		env.gopts.BackendTestHook = oldHook
 	}()
 	// prune should fail
 	rtest.Equals(t, repository.ErrPacksMissing, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runPrune(context.TODO(), pruneDefaultOptions, gopts, gopts.term)
+		return runPrune(context.TODO(), pruneDefaultOptions, gopts, gopts.Term)
 	}), "prune should have reported index not complete error")
 }
 
@@ -229,7 +229,7 @@ func testEdgeCaseRepo(t *testing.T, tarfile string, optionsCheck CheckOptions, o
 		testRunCheck(t, env.gopts)
 	} else {
 		rtest.Assert(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-			_, err := runCheck(context.TODO(), optionsCheck, gopts, nil, gopts.term)
+			_, err := runCheck(context.TODO(), optionsCheck, gopts, nil, gopts.Term)
 			return err
 		}) != nil,
 			"check should have reported an error")
@@ -240,7 +240,7 @@ func testEdgeCaseRepo(t *testing.T, tarfile string, optionsCheck CheckOptions, o
 		testRunCheck(t, env.gopts)
 	} else {
 		rtest.Assert(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-			return runPrune(context.TODO(), optionsPrune, gopts, gopts.term)
+			return runPrune(context.TODO(), optionsPrune, gopts, gopts.Term)
 		}) != nil,
 			"prune should have reported an error")
 	}

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -36,7 +36,7 @@ Exit status is 12 if the password is incorrect.
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runRecover(cmd.Context(), *globalOptions, globalOptions.term)
+			return runRecover(cmd.Context(), *globalOptions, globalOptions.Term)
 		},
 	}
 	return cmd
@@ -48,7 +48,7 @@ func runRecover(ctx context.Context, gopts GlobalOptions, term ui.Terminal) erro
 		return err
 	}
 
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
@@ -15,7 +16,7 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-func newRecoverCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newRecoverCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "recover [flags]",
 		Short: "Recover data from the repository not referenced by snapshots",
@@ -42,7 +43,7 @@ Exit status is 12 if the password is incorrect.
 	return cmd
 }
 
-func runRecover(ctx context.Context, gopts GlobalOptions, term ui.Terminal) error {
+func runRecover(ctx context.Context, gopts global.Options, term ui.Terminal) error {
 	hostname, err := os.Hostname()
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_recover_integration_test.go
+++ b/cmd/restic/cmd_recover_integration_test.go
@@ -9,14 +9,14 @@ import (
 
 func testRunRecover(t testing.TB, gopts GlobalOptions) {
 	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runRecover(context.TODO(), gopts, gopts.term)
+		return runRecover(context.TODO(), gopts, gopts.Term)
 	}))
 }
 
 func TestRecover(t *testing.T) {
 	env, cleanup := withTestEnvironment(t)
 	// must list index more than once
-	env.gopts.backendTestHook = nil
+	env.gopts.BackendTestHook = nil
 	defer cleanup()
 
 	testSetupBackupData(t, env)
@@ -33,6 +33,6 @@ func TestRecover(t *testing.T) {
 	testRunCheck(t, env.gopts)
 	// check that the root tree is included in the snapshot
 	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runCat(context.TODO(), gopts, []string{"tree", ids[0].String() + ":" + sn.Tree.Str()}, gopts.term)
+		return runCat(context.TODO(), gopts, []string{"tree", ids[0].String() + ":" + sn.Tree.Str()}, gopts.Term)
 	}))
 }

--- a/cmd/restic/cmd_recover_integration_test.go
+++ b/cmd/restic/cmd_recover_integration_test.go
@@ -4,11 +4,12 @@ import (
 	"context"
 	"testing"
 
+	"github.com/restic/restic/internal/global"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunRecover(t testing.TB, gopts GlobalOptions) {
-	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunRecover(t testing.TB, gopts global.Options) {
+	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runRecover(context.TODO(), gopts, gopts.Term)
 	}))
 }
@@ -32,7 +33,7 @@ func TestRecover(t *testing.T) {
 	ids = testListSnapshots(t, env.gopts, 1)
 	testRunCheck(t, env.gopts)
 	// check that the root tree is included in the snapshot
-	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runCat(context.TODO(), gopts, []string{"tree", ids[0].String() + ":" + sn.Tree.Str()}, gopts.Term)
 	}))
 }

--- a/cmd/restic/cmd_repair.go
+++ b/cmd/restic/cmd_repair.go
@@ -1,10 +1,11 @@
 package main
 
 import (
+	"github.com/restic/restic/internal/global"
 	"github.com/spf13/cobra"
 )
 
-func newRepairCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newRepairCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "repair",
 		Short:             "Repair the repository",

--- a/cmd/restic/cmd_repair_index.go
+++ b/cmd/restic/cmd_repair_index.go
@@ -30,7 +30,7 @@ Exit status is 12 if the password is incorrect.
 `,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runRebuildIndex(cmd.Context(), opts, *globalOptions, globalOptions.term)
+			return runRebuildIndex(cmd.Context(), opts, *globalOptions, globalOptions.Term)
 		},
 	}
 
@@ -60,7 +60,7 @@ func newRebuildIndexCommand(globalOptions *GlobalOptions) *cobra.Command {
 		// must create a new instance of the run function as it captures opts
 		// by reference
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runRebuildIndex(cmd.Context(), opts, *globalOptions, globalOptions.term)
+			return runRebuildIndex(cmd.Context(), opts, *globalOptions, globalOptions.Term)
 		},
 	}
 
@@ -69,7 +69,7 @@ func newRebuildIndexCommand(globalOptions *GlobalOptions) *cobra.Command {
 }
 
 func runRebuildIndex(ctx context.Context, opts RepairIndexOptions, gopts GlobalOptions, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
 	if err != nil {

--- a/cmd/restic/cmd_repair_index.go
+++ b/cmd/restic/cmd_repair_index.go
@@ -3,13 +3,14 @@ package main
 import (
 	"context"
 
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-func newRepairIndexCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newRepairIndexCommand(globalOptions *global.Options) *cobra.Command {
 	var opts RepairIndexOptions
 
 	cmd := &cobra.Command{
@@ -47,7 +48,7 @@ func (opts *RepairIndexOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.ReadAllPacks, "read-all-packs", false, "read all pack files to generate new index from scratch")
 }
 
-func newRebuildIndexCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newRebuildIndexCommand(globalOptions *global.Options) *cobra.Command {
 	var opts RepairIndexOptions
 
 	replacement := newRepairIndexCommand(globalOptions)
@@ -68,7 +69,7 @@ func newRebuildIndexCommand(globalOptions *GlobalOptions) *cobra.Command {
 	return cmd
 }
 
-func runRebuildIndex(ctx context.Context, opts RepairIndexOptions, gopts GlobalOptions, term ui.Terminal) error {
+func runRebuildIndex(ctx context.Context, opts RepairIndexOptions, gopts global.Options, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)

--- a/cmd/restic/cmd_repair_index_integration_test.go
+++ b/cmd/restic/cmd_repair_index_integration_test.go
@@ -18,11 +18,11 @@ import (
 func testRunRebuildIndex(t testing.TB, gopts GlobalOptions) {
 	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
 		gopts.Quiet = true
-		return runRebuildIndex(context.TODO(), RepairIndexOptions{}, gopts, gopts.term)
+		return runRebuildIndex(context.TODO(), RepairIndexOptions{}, gopts, gopts.Term)
 	}))
 }
 
-func testRebuildIndex(t *testing.T, backendTestHook backendWrapper) {
+func testRebuildIndex(t *testing.T, backendTestHook BackendWrapper) {
 	env, cleanup := withTestEnvironment(t)
 	defer cleanup()
 
@@ -42,10 +42,10 @@ func testRebuildIndex(t *testing.T, backendTestHook backendWrapper) {
 		t.Fatalf("did not find hint for repair index command")
 	}
 
-	env.gopts.backendTestHook = backendTestHook
+	env.gopts.BackendTestHook = backendTestHook
 	testRunRebuildIndex(t, env.gopts)
 
-	env.gopts.backendTestHook = nil
+	env.gopts.BackendTestHook = nil
 	out, err = testRunCheckOutput(t, env.gopts, false)
 	if len(out) != 0 {
 		t.Fatalf("expected no output from the checker, got: %v", out)
@@ -125,12 +125,12 @@ func TestRebuildIndexFailsOnAppendOnly(t *testing.T) {
 	datafile := filepath.Join("..", "..", "internal", "checker", "testdata", "duplicate-packs-in-index-test-repo.tar.gz")
 	rtest.SetupTarTestFixture(t, env.base, datafile)
 
-	env.gopts.backendTestHook = func(r backend.Backend) (backend.Backend, error) {
+	env.gopts.BackendTestHook = func(r backend.Backend) (backend.Backend, error) {
 		return &appendOnlyBackend{r}, nil
 	}
 	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
 		gopts.Quiet = true
-		return runRebuildIndex(context.TODO(), RepairIndexOptions{}, gopts, gopts.term)
+		return runRebuildIndex(context.TODO(), RepairIndexOptions{}, gopts, gopts.Term)
 	})
 
 	if err == nil {

--- a/cmd/restic/cmd_repair_index_integration_test.go
+++ b/cmd/restic/cmd_repair_index_integration_test.go
@@ -10,19 +10,20 @@ import (
 
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository/index"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunRebuildIndex(t testing.TB, gopts GlobalOptions) {
-	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunRebuildIndex(t testing.TB, gopts global.Options) {
+	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		gopts.Quiet = true
 		return runRebuildIndex(context.TODO(), RepairIndexOptions{}, gopts, gopts.Term)
 	}))
 }
 
-func testRebuildIndex(t *testing.T, backendTestHook BackendWrapper) {
+func testRebuildIndex(t *testing.T, backendTestHook global.BackendWrapper) {
 	env, cleanup := withTestEnvironment(t)
 	defer cleanup()
 
@@ -128,7 +129,7 @@ func TestRebuildIndexFailsOnAppendOnly(t *testing.T) {
 	env.gopts.BackendTestHook = func(r backend.Backend) (backend.Backend, error) {
 		return &appendOnlyBackend{r}, nil
 	}
-	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		gopts.Quiet = true
 		return runRebuildIndex(context.TODO(), RepairIndexOptions{}, gopts, gopts.Term)
 	})

--- a/cmd/restic/cmd_repair_packs.go
+++ b/cmd/restic/cmd_repair_packs.go
@@ -32,7 +32,7 @@ Exit status is 12 if the password is incorrect.
 `,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runRepairPacks(cmd.Context(), *globalOptions, globalOptions.term, args)
+			return runRepairPacks(cmd.Context(), *globalOptions, globalOptions.Term, args)
 		},
 	}
 	return cmd
@@ -51,7 +51,7 @@ func runRepairPacks(ctx context.Context, gopts GlobalOptions, term ui.Terminal, 
 		return errors.Fatal("no ids specified")
 	}
 
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
 	if err != nil {

--- a/cmd/restic/cmd_repair_packs.go
+++ b/cmd/restic/cmd_repair_packs.go
@@ -7,13 +7,14 @@ import (
 	"os"
 
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 )
 
-func newRepairPacksCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newRepairPacksCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "packs [packIDs...]",
 		Short: "Salvage damaged pack files",
@@ -38,7 +39,7 @@ Exit status is 12 if the password is incorrect.
 	return cmd
 }
 
-func runRepairPacks(ctx context.Context, gopts GlobalOptions, term ui.Terminal, args []string) error {
+func runRepairPacks(ctx context.Context, gopts global.Options, term ui.Terminal, args []string) error {
 	ids := restic.NewIDSet()
 	for _, arg := range args {
 		id, err := restic.ParseID(arg)

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -52,7 +52,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runRepairSnapshots(cmd.Context(), *globalOptions, opts, args, globalOptions.term)
+			return runRepairSnapshots(cmd.Context(), *globalOptions, opts, args, globalOptions.Term)
 		},
 	}
 
@@ -76,7 +76,7 @@ func (opts *RepairOptions) AddFlags(f *pflag.FlagSet) {
 }
 
 func runRepairSnapshots(ctx context.Context, gopts GlobalOptions, opts RepairOptions, args []string, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, opts.DryRun, printer)
 	if err != nil {

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/walker"
@@ -13,7 +14,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newRepairSnapshotsCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newRepairSnapshotsCommand(globalOptions *global.Options) *cobra.Command {
 	var opts RepairOptions
 
 	cmd := &cobra.Command{
@@ -75,7 +76,7 @@ func (opts *RepairOptions) AddFlags(f *pflag.FlagSet) {
 	initMultiSnapshotFilter(f, &opts.SnapshotFilter, true)
 }
 
-func runRepairSnapshots(ctx context.Context, gopts GlobalOptions, opts RepairOptions, args []string, term ui.Terminal) error {
+func runRepairSnapshots(ctx context.Context, gopts global.Options, opts RepairOptions, args []string, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	ctx, repo, unlock, err := openWithExclusiveLock(ctx, gopts, opts.DryRun, printer)

--- a/cmd/restic/cmd_repair_snapshots_integration_test.go
+++ b/cmd/restic/cmd_repair_snapshots_integration_test.go
@@ -10,16 +10,17 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunRepairSnapshot(t testing.TB, gopts GlobalOptions, forget bool) {
+func testRunRepairSnapshot(t testing.TB, gopts global.Options, forget bool) {
 	opts := RepairOptions{
 		Forget: forget,
 	}
 
-	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runRepairSnapshots(context.TODO(), gopts, opts, nil, gopts.Term)
 	}))
 }

--- a/cmd/restic/cmd_repair_snapshots_integration_test.go
+++ b/cmd/restic/cmd_repair_snapshots_integration_test.go
@@ -20,7 +20,7 @@ func testRunRepairSnapshot(t testing.TB, gopts GlobalOptions, forget bool) {
 	}
 
 	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runRepairSnapshots(context.TODO(), gopts, opts, nil, gopts.term)
+		return runRepairSnapshots(context.TODO(), gopts, opts, nil, gopts.Term)
 	}))
 }
 

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -47,7 +47,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runRestore(cmd.Context(), opts, *globalOptions, globalOptions.term, args)
+			return runRestore(cmd.Context(), opts, *globalOptions, globalOptions.Term, args)
 		},
 	}
 
@@ -92,9 +92,9 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
 
 	var printer restoreui.ProgressPrinter
 	if gopts.JSON {
-		printer = restoreui.NewJSONProgress(term, gopts.verbosity)
+		printer = restoreui.NewJSONProgress(term, gopts.Verbosity)
 	} else {
-		printer = restoreui.NewTextProgress(term, gopts.verbosity)
+		printer = restoreui.NewTextProgress(term, gopts.Verbosity)
 	}
 
 	excludePatternFns, err := opts.ExcludePatternOptions.CollectPatterns(printer.E)

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -9,6 +9,7 @@ import (
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/filter"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restorer"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
@@ -18,7 +19,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newRestoreCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newRestoreCommand(globalOptions *global.Options) *cobra.Command {
 	var opts RestoreOptions
 
 	cmd := &cobra.Command{
@@ -87,7 +88,7 @@ func (opts *RestoreOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.Delete, "delete", false, "delete files from target directory if they do not exist in snapshot. Use '--dry-run -vv' to check what would be deleted")
 }
 
-func runRestore(ctx context.Context, opts RestoreOptions, gopts GlobalOptions,
+func runRestore(ctx context.Context, opts RestoreOptions, gopts global.Options,
 	term ui.Terminal, args []string) error {
 
 	var printer restoreui.ProgressPrinter

--- a/cmd/restic/cmd_restore_integration_test.go
+++ b/cmd/restic/cmd_restore_integration_test.go
@@ -12,15 +12,16 @@ import (
 	"time"
 
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunRestore(t testing.TB, gopts GlobalOptions, dir string, snapshotID string) {
+func testRunRestore(t testing.TB, gopts global.Options, dir string, snapshotID string) {
 	testRunRestoreExcludes(t, gopts, dir, snapshotID, nil)
 }
 
-func testRunRestoreExcludes(t testing.TB, gopts GlobalOptions, dir string, snapshotID string, excludes []string) {
+func testRunRestoreExcludes(t testing.TB, gopts global.Options, dir string, snapshotID string, excludes []string) {
 	opts := RestoreOptions{
 		Target: dir,
 	}
@@ -29,13 +30,13 @@ func testRunRestoreExcludes(t testing.TB, gopts GlobalOptions, dir string, snaps
 	rtest.OK(t, testRunRestoreAssumeFailure(t, snapshotID, opts, gopts))
 }
 
-func testRunRestoreAssumeFailure(t testing.TB, snapshotID string, opts RestoreOptions, gopts GlobalOptions) error {
-	return withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunRestoreAssumeFailure(t testing.TB, snapshotID string, opts RestoreOptions, gopts global.Options) error {
+	return withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runRestore(ctx, opts, gopts, gopts.Term, []string{snapshotID})
 	})
 }
 
-func testRunRestoreLatest(t testing.TB, gopts GlobalOptions, dir string, paths []string, hosts []string) {
+func testRunRestoreLatest(t testing.TB, gopts global.Options, dir string, paths []string, hosts []string) {
 	opts := RestoreOptions{
 		Target: dir,
 		SnapshotFilter: data.SnapshotFilter{
@@ -47,7 +48,7 @@ func testRunRestoreLatest(t testing.TB, gopts GlobalOptions, dir string, paths [
 	rtest.OK(t, testRunRestoreAssumeFailure(t, "latest", opts, gopts))
 }
 
-func testRunRestoreIncludes(t testing.TB, gopts GlobalOptions, dir string, snapshotID restic.ID, includes []string) {
+func testRunRestoreIncludes(t testing.TB, gopts global.Options, dir string, snapshotID restic.ID, includes []string) {
 	opts := RestoreOptions{
 		Target: dir,
 	}
@@ -56,7 +57,7 @@ func testRunRestoreIncludes(t testing.TB, gopts GlobalOptions, dir string, snaps
 	rtest.OK(t, testRunRestoreAssumeFailure(t, snapshotID.String(), opts, gopts))
 }
 
-func testRunRestoreIncludesFromFile(t testing.TB, gopts GlobalOptions, dir string, snapshotID restic.ID, includesFile string) {
+func testRunRestoreIncludesFromFile(t testing.TB, gopts global.Options, dir string, snapshotID restic.ID, includesFile string) {
 	opts := RestoreOptions{
 		Target: dir,
 	}
@@ -65,7 +66,7 @@ func testRunRestoreIncludesFromFile(t testing.TB, gopts GlobalOptions, dir strin
 	rtest.OK(t, testRunRestoreAssumeFailure(t, snapshotID.String(), opts, gopts))
 }
 
-func testRunRestoreExcludesFromFile(t testing.TB, gopts GlobalOptions, dir string, snapshotID restic.ID, excludesFile string) {
+func testRunRestoreExcludesFromFile(t testing.TB, gopts global.Options, dir string, snapshotID restic.ID, excludesFile string) {
 	opts := RestoreOptions{
 		Target: dir,
 	}

--- a/cmd/restic/cmd_restore_integration_test.go
+++ b/cmd/restic/cmd_restore_integration_test.go
@@ -31,7 +31,7 @@ func testRunRestoreExcludes(t testing.TB, gopts GlobalOptions, dir string, snaps
 
 func testRunRestoreAssumeFailure(t testing.TB, snapshotID string, opts RestoreOptions, gopts GlobalOptions) error {
 	return withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runRestore(ctx, opts, gopts, gopts.term, []string{snapshotID})
+		return runRestore(ctx, opts, gopts, gopts.Term, []string{snapshotID})
 	})
 }
 

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -12,6 +12,7 @@ import (
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/filter"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
@@ -19,7 +20,7 @@ import (
 	"github.com/restic/restic/internal/walker"
 )
 
-func newRewriteCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newRewriteCommand(globalOptions *global.Options) *cobra.Command {
 	var opts RewriteOptions
 
 	cmd := &cobra.Command{
@@ -91,7 +92,7 @@ func (sma snapshotMetadataArgs) convert() (*snapshotMetadata, error) {
 
 	var timeStamp *time.Time
 	if sma.Time != "" {
-		t, err := time.ParseInLocation(TimeFormat, sma.Time, time.Local)
+		t, err := time.ParseInLocation(global.TimeFormat, sma.Time, time.Local)
 		if err != nil {
 			return nil, errors.Fatalf("error in time option: %v", err)
 		}
@@ -291,7 +292,7 @@ func filterAndReplaceSnapshot(ctx context.Context, repo restic.Repository, sn *d
 	return true, nil
 }
 
-func runRewrite(ctx context.Context, opts RewriteOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	if !opts.SnapshotSummary && opts.ExcludePatternOptions.Empty() && opts.Metadata.empty() {
 		return errors.Fatal("Nothing to do: no excludes provided and no new metadata provided")
 	}

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -62,7 +62,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runRewrite(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runRewrite(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -296,7 +296,7 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts GlobalOptions, a
 		return errors.Fatal("Nothing to do: no excludes provided and no new metadata provided")
 	}
 
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	var (
 		repo   *repository.Repository

--- a/cmd/restic/cmd_rewrite_integration_test.go
+++ b/cmd/restic/cmd_rewrite_integration_test.go
@@ -22,7 +22,7 @@ func testRunRewriteExclude(t testing.TB, gopts GlobalOptions, excludes []string,
 	}
 
 	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runRewrite(context.TODO(), opts, gopts, nil, gopts.term)
+		return runRewrite(context.TODO(), opts, gopts, nil, gopts.Term)
 	}))
 }
 
@@ -43,7 +43,7 @@ func getSnapshot(t testing.TB, snapshotID restic.ID, env *testEnvironment) *data
 
 	var snapshots []*data.Snapshot
 	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		ctx, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
 		defer unlock()
@@ -119,7 +119,7 @@ func testRewriteMetadata(t *testing.T, metadata snapshotMetadataArgs) {
 
 	var snapshots []*data.Snapshot
 	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		ctx, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
 		defer unlock()
@@ -159,7 +159,7 @@ func TestRewriteSnaphotSummary(t *testing.T) {
 	createBasicRewriteRepo(t, env)
 
 	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runRewrite(context.TODO(), RewriteOptions{SnapshotSummary: true}, gopts, []string{}, gopts.term)
+		return runRewrite(context.TODO(), RewriteOptions{SnapshotSummary: true}, gopts, []string{}, gopts.Term)
 	}))
 	// no new snapshot should be created as the snapshot already has a summary
 	snapshots := testListSnapshots(t, env.gopts, 1)
@@ -167,7 +167,7 @@ func TestRewriteSnaphotSummary(t *testing.T) {
 	// replace snapshot by one without a summary
 	var oldSummary *data.SnapshotSummary
 	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		_, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
 		defer unlock()
@@ -184,7 +184,7 @@ func TestRewriteSnaphotSummary(t *testing.T) {
 
 	// rewrite snapshot and lookup ID of new snapshot
 	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runRewrite(context.TODO(), RewriteOptions{SnapshotSummary: true}, gopts, []string{}, gopts.term)
+		return runRewrite(context.TODO(), RewriteOptions{SnapshotSummary: true}, gopts, []string{}, gopts.Term)
 	}))
 	newSnapshots := testListSnapshots(t, env.gopts, 2)
 	newSnapshot := restic.NewIDSet(newSnapshots...).Sub(restic.NewIDSet(snapshots...)).List()[0]

--- a/cmd/restic/cmd_rewrite_integration_test.go
+++ b/cmd/restic/cmd_rewrite_integration_test.go
@@ -7,12 +7,13 @@ import (
 
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/filter"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 	"github.com/restic/restic/internal/ui"
 )
 
-func testRunRewriteExclude(t testing.TB, gopts GlobalOptions, excludes []string, forget bool, metadata snapshotMetadataArgs) {
+func testRunRewriteExclude(t testing.TB, gopts global.Options, excludes []string, forget bool, metadata snapshotMetadataArgs) {
 	opts := RewriteOptions{
 		ExcludePatternOptions: filter.ExcludePatternOptions{
 			Excludes: excludes,
@@ -21,7 +22,7 @@ func testRunRewriteExclude(t testing.TB, gopts GlobalOptions, excludes []string,
 		Metadata: metadata,
 	}
 
-	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runRewrite(context.TODO(), opts, gopts, nil, gopts.Term)
 	}))
 }
@@ -42,7 +43,7 @@ func getSnapshot(t testing.TB, snapshotID restic.ID, env *testEnvironment) *data
 	t.Helper()
 
 	var snapshots []*data.Snapshot
-	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		ctx, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
@@ -118,7 +119,7 @@ func testRewriteMetadata(t *testing.T, metadata snapshotMetadataArgs) {
 	testRunRewriteExclude(t, env.gopts, []string{}, true, metadata)
 
 	var snapshots []*data.Snapshot
-	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		ctx, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
@@ -132,7 +133,7 @@ func testRewriteMetadata(t *testing.T, metadata snapshotMetadataArgs) {
 	newSnapshot := snapshots[0]
 
 	if metadata.Time != "" {
-		rtest.Assert(t, newSnapshot.Time.Format(TimeFormat) == metadata.Time, "New snapshot should have time %s", metadata.Time)
+		rtest.Assert(t, newSnapshot.Time.Format(global.TimeFormat) == metadata.Time, "New snapshot should have time %s", metadata.Time)
 	}
 
 	if metadata.Hostname != "" {
@@ -158,7 +159,7 @@ func TestRewriteSnaphotSummary(t *testing.T) {
 	defer cleanup()
 	createBasicRewriteRepo(t, env)
 
-	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runRewrite(context.TODO(), RewriteOptions{SnapshotSummary: true}, gopts, []string{}, gopts.Term)
 	}))
 	// no new snapshot should be created as the snapshot already has a summary
@@ -166,7 +167,7 @@ func TestRewriteSnaphotSummary(t *testing.T) {
 
 	// replace snapshot by one without a summary
 	var oldSummary *data.SnapshotSummary
-	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		_, repo, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
@@ -183,7 +184,7 @@ func TestRewriteSnaphotSummary(t *testing.T) {
 	rtest.OK(t, err)
 
 	// rewrite snapshot and lookup ID of new snapshot
-	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runRewrite(context.TODO(), RewriteOptions{SnapshotSummary: true}, gopts, []string{}, gopts.Term)
 	}))
 	newSnapshots := testListSnapshots(t, env.gopts, 2)

--- a/cmd/restic/cmd_self_update.go
+++ b/cmd/restic/cmd_self_update.go
@@ -8,19 +8,20 @@ import (
 	"path/filepath"
 
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/selfupdate"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-func registerSelfUpdateCommand(cmd *cobra.Command, globalOptions *GlobalOptions) {
+func registerSelfUpdateCommand(cmd *cobra.Command, globalOptions *global.Options) {
 	cmd.AddCommand(
 		newSelfUpdateCommand(globalOptions),
 	)
 }
 
-func newSelfUpdateCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newSelfUpdateCommand(globalOptions *global.Options) *cobra.Command {
 	var opts SelfUpdateOptions
 
 	cmd := &cobra.Command{
@@ -60,7 +61,7 @@ func (opts *SelfUpdateOptions) AddFlags(f *pflag.FlagSet) {
 	f.StringVar(&opts.Output, "output", "", "Save the downloaded file as `filename` (default: running binary itself)")
 }
 
-func runSelfUpdate(ctx context.Context, opts SelfUpdateOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runSelfUpdate(ctx context.Context, opts SelfUpdateOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	if opts.Output == "" {
 		file, err := os.Executable()
 		if err != nil {
@@ -89,12 +90,12 @@ func runSelfUpdate(ctx context.Context, opts SelfUpdateOptions, gopts GlobalOpti
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 	printer.P("writing restic to %v", opts.Output)
 
-	v, err := selfupdate.DownloadLatestStableRelease(ctx, opts.Output, version, printer.P)
+	v, err := selfupdate.DownloadLatestStableRelease(ctx, opts.Output, global.Version, printer.P)
 	if err != nil {
 		return errors.Fatalf("unable to update restic: %v", err)
 	}
 
-	if v != version {
+	if v != global.Version {
 		printer.S("successfully updated restic to version %v", v)
 	}
 

--- a/cmd/restic/cmd_self_update.go
+++ b/cmd/restic/cmd_self_update.go
@@ -43,7 +43,7 @@ Exit status is 12 if the password is incorrect.
 `,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runSelfUpdate(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runSelfUpdate(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -86,7 +86,7 @@ func runSelfUpdate(ctx context.Context, opts SelfUpdateOptions, gopts GlobalOpti
 		}
 	}
 
-	printer := ui.NewProgressPrinter(false, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 	printer.P("writing restic to %v", opts.Output)
 
 	v, err := selfupdate.DownloadLatestStableRelease(ctx, opts.Output, version, printer.P)

--- a/cmd/restic/cmd_self_update_disabled.go
+++ b/cmd/restic/cmd_self_update_disabled.go
@@ -2,8 +2,11 @@
 
 package main
 
-import "github.com/spf13/cobra"
+import (
+	"github.com/restic/restic/internal/global"
+	"github.com/spf13/cobra"
+)
 
-func registerSelfUpdateCommand(_ *cobra.Command, _ *GlobalOptions) {
+func registerSelfUpdateCommand(_ *cobra.Command, _ *global.Options) {
 	// No commands to register in non-selfupdate mode
 }

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/table"
@@ -16,7 +17,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newSnapshotsCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newSnapshotsCommand(globalOptions *global.Options) *cobra.Command {
 	var opts SnapshotOptions
 
 	cmd := &cobra.Command{
@@ -68,7 +69,7 @@ func (opts *SnapshotOptions) AddFlags(f *pflag.FlagSet) {
 	f.VarP(&opts.GroupBy, "group-by", "g", "`group` snapshots by host, paths and/or tags, separated by comma")
 }
 
-func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 	ctx, repo, unlock, err := openWithReadLock(ctx, gopts, gopts.NoLock, printer)
 	if err != nil {
@@ -242,7 +243,7 @@ func PrintSnapshots(stdout io.Writer, list data.Snapshots, reasons []data.KeepRe
 	for _, sn := range list {
 		data := snapshot{
 			ID:        sn.ID().Str(),
-			Timestamp: sn.Time.Local().Format(TimeFormat),
+			Timestamp: sn.Time.Local().Format(global.TimeFormat),
 			Hostname:  sn.Hostname,
 			Tags:      sn.Tags,
 			Paths:     sn.Paths,

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -38,7 +38,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runSnapshots(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runSnapshots(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -69,7 +69,7 @@ func (opts *SnapshotOptions) AddFlags(f *pflag.FlagSet) {
 }
 
 func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 	ctx, repo, unlock, err := openWithReadLock(ctx, gopts, gopts.NoLock, printer)
 	if err != nil {
 		return err
@@ -105,7 +105,7 @@ func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts GlobalOptions
 	}
 
 	if gopts.JSON {
-		err := printSnapshotGroupJSON(gopts.term.OutputWriter(), snapshotGroups, grouped)
+		err := printSnapshotGroupJSON(gopts.Term.OutputWriter(), snapshotGroups, grouped)
 		if err != nil {
 			printer.E("error printing snapshots: %v", err)
 		}
@@ -118,12 +118,12 @@ func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts GlobalOptions
 		}
 
 		if grouped {
-			err := PrintSnapshotGroupHeader(gopts.term.OutputWriter(), k)
+			err := PrintSnapshotGroupHeader(gopts.Term.OutputWriter(), k)
 			if err != nil {
 				return err
 			}
 		}
-		err := PrintSnapshots(gopts.term.OutputWriter(), list, nil, opts.Compact)
+		err := PrintSnapshots(gopts.Term.OutputWriter(), list, nil, opts.Compact)
 		if err != nil {
 			return err
 		}

--- a/cmd/restic/cmd_snapshots_integration_test.go
+++ b/cmd/restic/cmd_snapshots_integration_test.go
@@ -5,12 +5,13 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunSnapshots(t testing.TB, gopts GlobalOptions) (newest *Snapshot, snapmap map[restic.ID]Snapshot) {
-	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunSnapshots(t testing.TB, gopts global.Options) (newest *Snapshot, snapmap map[restic.ID]Snapshot) {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		gopts.JSON = true
 
 		opts := SnapshotOptions{}

--- a/cmd/restic/cmd_snapshots_integration_test.go
+++ b/cmd/restic/cmd_snapshots_integration_test.go
@@ -14,7 +14,7 @@ func testRunSnapshots(t testing.TB, gopts GlobalOptions) (newest *Snapshot, snap
 		gopts.JSON = true
 
 		opts := SnapshotOptions{}
-		return runSnapshots(ctx, opts, gopts, []string{}, gopts.term)
+		return runSnapshots(ctx, opts, gopts, []string{}, gopts.Term)
 	})
 	rtest.OK(t, err)
 

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -65,7 +65,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runStats(cmd.Context(), opts, *globalOptions, args, globalOptions.term)
+			return runStats(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -101,7 +101,7 @@ func runStats(ctx context.Context, opts StatsOptions, gopts GlobalOptions, args 
 		return err
 	}
 
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	ctx, repo, unlock, err := openWithReadLock(ctx, gopts, gopts.NoLock, printer)
 	if err != nil {
@@ -170,7 +170,7 @@ func runStats(ctx context.Context, opts StatsOptions, gopts GlobalOptions, args 
 	}
 
 	if gopts.JSON {
-		err = json.NewEncoder(gopts.term.OutputWriter()).Encode(stats)
+		err = json.NewEncoder(gopts.Term.OutputWriter()).Encode(stats)
 		if err != nil {
 			return fmt.Errorf("encoding output: %v", err)
 		}

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -11,6 +11,7 @@ import (
 	"github.com/restic/chunker"
 	"github.com/restic/restic/internal/crypto"
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/restorer"
@@ -23,7 +24,7 @@ import (
 	"github.com/spf13/pflag"
 )
 
-func newStatsCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newStatsCommand(globalOptions *global.Options) *cobra.Command {
 	var opts StatsOptions
 
 	cmd := &cobra.Command{
@@ -95,7 +96,7 @@ func must(err error) {
 	}
 }
 
-func runStats(ctx context.Context, opts StatsOptions, gopts GlobalOptions, args []string, term ui.Terminal) error {
+func runStats(ctx context.Context, opts StatsOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	err := verifyStatsInput(opts)
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -41,8 +41,7 @@ Exit status is 12 if the password is incorrect.
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			finalizeSnapshotFilter(&opts.SnapshotFilter)
-			return runTag(cmd.Context(), opts, *globalOptions, globalOptions.term, args)
+			return runTag(cmd.Context(), opts, *globalOptions, globalOptions.Term, args)
 		},
 	}
 
@@ -120,7 +119,7 @@ func changeTags(ctx context.Context, repo *repository.Repository, sn *data.Snaps
 }
 
 func runTag(ctx context.Context, opts TagOptions, gopts GlobalOptions, term ui.Terminal, args []string) error {
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	if len(opts.SetTags) == 0 && len(opts.AddTags) == 0 && len(opts.RemoveTags) == 0 {
 		return errors.Fatal("nothing to do!")

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -9,12 +9,13 @@ import (
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
 )
 
-func newTagCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newTagCommand(globalOptions *global.Options) *cobra.Command {
 	var opts TagOptions
 
 	cmd := &cobra.Command{
@@ -118,7 +119,7 @@ func changeTags(ctx context.Context, repo *repository.Repository, sn *data.Snaps
 	return changed, nil
 }
 
-func runTag(ctx context.Context, opts TagOptions, gopts GlobalOptions, term ui.Terminal, args []string) error {
+func runTag(ctx context.Context, opts TagOptions, gopts global.Options, term ui.Terminal, args []string) error {
 	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	if len(opts.SetTags) == 0 && len(opts.AddTags) == 0 && len(opts.RemoveTags) == 0 {

--- a/cmd/restic/cmd_tag_integration_test.go
+++ b/cmd/restic/cmd_tag_integration_test.go
@@ -10,7 +10,7 @@ import (
 
 func testRunTag(t testing.TB, opts TagOptions, gopts GlobalOptions) {
 	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runTag(context.TODO(), opts, gopts, gopts.term, []string{})
+		return runTag(context.TODO(), opts, gopts, gopts.Term, []string{})
 	}))
 }
 

--- a/cmd/restic/cmd_tag_integration_test.go
+++ b/cmd/restic/cmd_tag_integration_test.go
@@ -5,11 +5,12 @@ import (
 	"testing"
 
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/global"
 	rtest "github.com/restic/restic/internal/test"
 )
 
-func testRunTag(t testing.TB, opts TagOptions, gopts GlobalOptions) {
-	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
+func testRunTag(t testing.TB, opts TagOptions, gopts global.Options) {
+	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runTag(context.TODO(), opts, gopts, gopts.Term, []string{})
 	}))
 }

--- a/cmd/restic/cmd_unlock.go
+++ b/cmd/restic/cmd_unlock.go
@@ -27,7 +27,7 @@ Exit status is 1 if there was any error.
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return runUnlock(cmd.Context(), opts, *globalOptions, globalOptions.term)
+			return runUnlock(cmd.Context(), opts, *globalOptions, globalOptions.Term)
 		},
 	}
 	opts.AddFlags(cmd.Flags())
@@ -44,7 +44,7 @@ func (opts *UnlockOptions) AddFlags(f *pflag.FlagSet) {
 }
 
 func runUnlock(ctx context.Context, opts UnlockOptions, gopts GlobalOptions, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, term)
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 	repo, err := OpenRepository(ctx, gopts, printer)
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_unlock.go
+++ b/cmd/restic/cmd_unlock.go
@@ -3,13 +3,14 @@ package main
 import (
 	"context"
 
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 )
 
-func newUnlockCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newUnlockCommand(globalOptions *global.Options) *cobra.Command {
 	var opts UnlockOptions
 
 	cmd := &cobra.Command{
@@ -43,9 +44,9 @@ func (opts *UnlockOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.RemoveAll, "remove-all", false, "remove all locks, even non-stale ones")
 }
 
-func runUnlock(ctx context.Context, opts UnlockOptions, gopts GlobalOptions, term ui.Terminal) error {
+func runUnlock(ctx context.Context, opts UnlockOptions, gopts global.Options, term ui.Terminal) error {
 	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
-	repo, err := OpenRepository(ctx, gopts, printer)
+	repo, err := global.OpenRepository(ctx, gopts, printer)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_version.go
+++ b/cmd/restic/cmd_version.go
@@ -24,7 +24,7 @@ Exit status is 1 if there was any error.
 `,
 		DisableAutoGenTag: true,
 		Run: func(_ *cobra.Command, _ []string) {
-			printer := ui.NewProgressPrinter(globalOptions.JSON, globalOptions.verbosity, globalOptions.term)
+			printer := ui.NewProgressPrinter(globalOptions.JSON, globalOptions.Verbosity, globalOptions.Term)
 
 			if globalOptions.JSON {
 				type jsonVersion struct {
@@ -43,7 +43,7 @@ Exit status is 1 if there was any error.
 					GoArch:      runtime.GOARCH,
 				}
 
-				err := json.NewEncoder(globalOptions.term.OutputWriter()).Encode(jsonS)
+				err := json.NewEncoder(globalOptions.Term.OutputWriter()).Encode(jsonS)
 				if err != nil {
 					printer.E("JSON encode failed: %v\n", err)
 					return

--- a/cmd/restic/cmd_version.go
+++ b/cmd/restic/cmd_version.go
@@ -4,11 +4,12 @@ import (
 	"encoding/json"
 	"runtime"
 
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 )
 
-func newVersionCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newVersionCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "version",
 		Short: "Print version information",
@@ -37,7 +38,7 @@ Exit status is 1 if there was any error.
 
 				jsonS := jsonVersion{
 					MessageType: "version",
-					Version:     version,
+					Version:     global.Version,
 					GoVersion:   runtime.Version(),
 					GoOS:        runtime.GOOS,
 					GoArch:      runtime.GOARCH,
@@ -50,7 +51,7 @@ Exit status is 1 if there was any error.
 				}
 			} else {
 				printer.S("restic %s compiled with %v on %v/%v\n",
-					version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+					global.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 			}
 		},
 	}

--- a/cmd/restic/flags_test.go
+++ b/cmd/restic/flags_test.go
@@ -3,12 +3,14 @@ package main
 import (
 	"io"
 	"testing"
+
+	"github.com/restic/restic/internal/global"
 )
 
 // TestFlags checks for double defined flags, the commands will panic on
 // ParseFlags() when a shorthand flag is defined twice.
 func TestFlags(t *testing.T) {
-	for _, cmd := range newRootCommand(&GlobalOptions{}).Commands() {
+	for _, cmd := range newRootCommand(&global.Options{}).Commands() {
 		t.Run(cmd.Name(), func(t *testing.T) {
 			cmd.Flags().SetOutput(io.Discard)
 			err := cmd.ParseFlags([]string{"--help"})

--- a/cmd/restic/format.go
+++ b/cmd/restic/format.go
@@ -5,6 +5,7 @@ import (
 	"os"
 
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/ui"
 )
 
@@ -43,6 +44,6 @@ func formatNode(path string, n *data.Node, long bool, human bool) string {
 
 	return fmt.Sprintf("%s %5d %5d %s %s %s%s",
 		mode|n.Mode, n.UID, n.GID, size,
-		n.ModTime.Local().Format(TimeFormat), path,
+		n.ModTime.Local().Format(global.TimeFormat), path,
 		target)
 }

--- a/cmd/restic/global.go
+++ b/cmd/restic/global.go
@@ -11,21 +11,12 @@ import (
 	"time"
 
 	"github.com/restic/restic/internal/backend"
-	"github.com/restic/restic/internal/backend/azure"
-	"github.com/restic/restic/internal/backend/b2"
 	"github.com/restic/restic/internal/backend/cache"
-	"github.com/restic/restic/internal/backend/gs"
 	"github.com/restic/restic/internal/backend/limiter"
-	"github.com/restic/restic/internal/backend/local"
 	"github.com/restic/restic/internal/backend/location"
 	"github.com/restic/restic/internal/backend/logger"
-	"github.com/restic/restic/internal/backend/rclone"
-	"github.com/restic/restic/internal/backend/rest"
 	"github.com/restic/restic/internal/backend/retry"
-	"github.com/restic/restic/internal/backend/s3"
 	"github.com/restic/restic/internal/backend/sema"
-	"github.com/restic/restic/internal/backend/sftp"
-	"github.com/restic/restic/internal/backend/swift"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/options"
 	"github.com/restic/restic/internal/repository"
@@ -172,20 +163,6 @@ func (opts *GlobalOptions) PreRun(needsPassword bool) error {
 	}
 	opts.password = pwd
 	return nil
-}
-
-func collectBackends() *location.Registry {
-	backends := location.NewRegistry()
-	backends.Register(azure.NewFactory())
-	backends.Register(b2.NewFactory())
-	backends.Register(gs.NewFactory())
-	backends.Register(local.NewFactory())
-	backends.Register(rclone.NewFactory())
-	backends.Register(rest.NewFactory())
-	backends.Register(s3.NewFactory())
-	backends.Register(sftp.NewFactory())
-	backends.Register(swift.NewFactory())
-	return backends
 }
 
 // resolvePassword determines the password to be used for opening the repository.

--- a/cmd/restic/global_test.go
+++ b/cmd/restic/global_test.go
@@ -45,7 +45,7 @@ func TestReadEmptyPassword(t *testing.T) {
 	rtest.OK(t, err)
 	rtest.Equals(t, "", password, "got unexpected password")
 
-	opts.password = "invalid"
+	opts.Password = "invalid"
 	_, err = ReadPassword(context.TODO(), opts, "test")
 	rtest.Assert(t, strings.Contains(err.Error(), "must not be specified together with providing a password via a cli option or environment variable"), "unexpected error message, got %v", err)
 }

--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/restic/restic/internal/backend"
+	"github.com/restic/restic/internal/backend/all"
 	"github.com/restic/restic/internal/backend/retry"
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/errors"
@@ -218,7 +219,7 @@ func withTestEnvironment(t testing.TB) (env *testEnvironment, cleanup func()) {
 		// replace this hook with "nil" if listing a filetype more than once is necessary
 		backendTestHook: func(r backend.Backend) (backend.Backend, error) { return newOrderedListOnceBackend(r), nil },
 		// start with default set of backends
-		backends: collectBackends(),
+		backends: all.Backends(),
 	}
 
 	cleanup = func() {

--- a/cmd/restic/integration_helpers_test.go
+++ b/cmd/restic/integration_helpers_test.go
@@ -213,13 +213,13 @@ func withTestEnvironment(t testing.TB) (env *testEnvironment, cleanup func()) {
 		Repo:     env.repo,
 		Quiet:    true,
 		CacheDir: env.cache,
-		password: rtest.TestPassword,
-		extended: make(options.Options),
+		Password: rtest.TestPassword,
+		Extended: make(options.Options),
 
 		// replace this hook with "nil" if listing a filetype more than once is necessary
-		backendTestHook: func(r backend.Backend) (backend.Backend, error) { return newOrderedListOnceBackend(r), nil },
+		BackendTestHook: func(r backend.Backend) (backend.Backend, error) { return newOrderedListOnceBackend(r), nil },
 		// start with default set of backends
-		backends: all.Backends(),
+		Backends: all.Backends(),
 	}
 
 	cleanup = func() {
@@ -243,7 +243,7 @@ func testSetupBackupData(t testing.TB, env *testEnvironment) string {
 func listPacks(gopts GlobalOptions, t *testing.T) restic.IDSet {
 	var packs restic.IDSet
 	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		ctx, r, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
 		defer unlock()
@@ -262,7 +262,7 @@ func listPacks(gopts GlobalOptions, t *testing.T) restic.IDSet {
 func listTreePacks(gopts GlobalOptions, t *testing.T) restic.IDSet {
 	var treePacks restic.IDSet
 	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		ctx, r, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
 		defer unlock()
@@ -281,7 +281,7 @@ func listTreePacks(gopts GlobalOptions, t *testing.T) restic.IDSet {
 
 func captureBackend(gopts *GlobalOptions) func() backend.Backend {
 	var be backend.Backend
-	gopts.backendTestHook = func(r backend.Backend) (backend.Backend, error) {
+	gopts.BackendTestHook = func(r backend.Backend) (backend.Backend, error) {
 		be = r
 		return r, nil
 	}
@@ -293,7 +293,7 @@ func captureBackend(gopts *GlobalOptions) func() backend.Backend {
 func removePacks(gopts GlobalOptions, t testing.TB, remove restic.IDSet) {
 	be := captureBackend(&gopts)
 	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		ctx, _, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
 		defer unlock()
@@ -309,7 +309,7 @@ func removePacks(gopts GlobalOptions, t testing.TB, remove restic.IDSet) {
 func removePacksExcept(gopts GlobalOptions, t testing.TB, keep restic.IDSet, removeTreePacks bool) {
 	be := captureBackend(&gopts)
 	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		ctx, r, unlock, err := openWithExclusiveLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
 		defer unlock()
@@ -370,7 +370,7 @@ func lastSnapshot(old, new map[string]struct{}) (map[string]struct{}, string) {
 func testLoadSnapshot(t testing.TB, gopts GlobalOptions, id restic.ID) *data.Snapshot {
 	var snapshot *data.Snapshot
 	err := withTermStatus(t, gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		_, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
 		defer unlock()
@@ -432,7 +432,7 @@ func withTermStatusRaw(stdin io.ReadCloser, stdout, stderr io.Writer, gopts Glob
 	var wg sync.WaitGroup
 
 	term := termstatus.New(stdin, stdout, stderr, gopts.Quiet)
-	gopts.term = term
+	gopts.Term = term
 	wg.Add(1)
 	go func() {
 		defer wg.Done()

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -80,7 +80,7 @@ func TestListOnce(t *testing.T) {
 	env, cleanup := withTestEnvironment(t)
 	defer cleanup()
 
-	env.gopts.backendTestHook = func(r backend.Backend) (backend.Backend, error) {
+	env.gopts.BackendTestHook = func(r backend.Backend) (backend.Backend, error) {
 		return newOrderedListOnceBackend(r), nil
 	}
 	pruneOpts := PruneOptions{MaxUnused: "0"}
@@ -89,14 +89,14 @@ func TestListOnce(t *testing.T) {
 	createPrunableRepo(t, env)
 	testRunPrune(t, env.gopts, pruneOpts)
 	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		_, err := runCheck(context.TODO(), checkOpts, gopts, nil, gopts.term)
+		_, err := runCheck(context.TODO(), checkOpts, gopts, nil, gopts.Term)
 		return err
 	}))
 	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runRebuildIndex(context.TODO(), RepairIndexOptions{}, gopts, gopts.term)
+		return runRebuildIndex(context.TODO(), RepairIndexOptions{}, gopts, gopts.Term)
 	}))
 	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		return runRebuildIndex(context.TODO(), RepairIndexOptions{ReadAllPacks: true}, gopts, gopts.term)
+		return runRebuildIndex(context.TODO(), RepairIndexOptions{ReadAllPacks: true}, gopts, gopts.Term)
 	}))
 }
 
@@ -129,7 +129,7 @@ func TestBackendLoadWriteTo(t *testing.T) {
 	defer cleanup()
 
 	// setup backend which only works if it's WriteTo method is correctly propagated upwards
-	env.gopts.backendInnerTestHook = func(r backend.Backend) (backend.Backend, error) {
+	env.gopts.BackendInnerTestHook = func(r backend.Backend) (backend.Backend, error) {
 		return &onlyLoadWithWriteToBackend{Backend: r}, nil
 	}
 
@@ -149,7 +149,7 @@ func TestFindListOnce(t *testing.T) {
 	env, cleanup := withTestEnvironment(t)
 	defer cleanup()
 
-	env.gopts.backendTestHook = func(r backend.Backend) (backend.Backend, error) {
+	env.gopts.BackendTestHook = func(r backend.Backend) (backend.Backend, error) {
 		return newOrderedListOnceBackend(r), nil
 	}
 
@@ -164,7 +164,7 @@ func TestFindListOnce(t *testing.T) {
 
 	var snapshotIDs restic.IDSet
 	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
-		printer := ui.NewProgressPrinter(gopts.JSON, gopts.verbosity, gopts.term)
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		ctx, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)
 		defer unlock()
@@ -214,7 +214,7 @@ func TestBackendRetryConfig(t *testing.T) {
 
 	var wrappedBackend *failConfigOnceBackend
 	// cause config loading to fail once
-	env.gopts.backendInnerTestHook = func(r backend.Backend) (backend.Backend, error) {
+	env.gopts.BackendInnerTestHook = func(r backend.Backend) (backend.Backend, error) {
 		wrappedBackend = &failConfigOnceBackend{Backend: r}
 		return wrappedBackend, nil
 	}

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 	"github.com/restic/restic/internal/ui"
@@ -88,14 +89,14 @@ func TestListOnce(t *testing.T) {
 
 	createPrunableRepo(t, env)
 	testRunPrune(t, env.gopts, pruneOpts)
-	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		_, err := runCheck(context.TODO(), checkOpts, gopts, nil, gopts.Term)
 		return err
 	}))
-	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runRebuildIndex(context.TODO(), RepairIndexOptions{}, gopts, gopts.Term)
 	}))
-	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runRebuildIndex(context.TODO(), RepairIndexOptions{ReadAllPacks: true}, gopts, gopts.Term)
 	}))
 }
@@ -163,7 +164,7 @@ func TestFindListOnce(t *testing.T) {
 	thirdSnapshot := restic.NewIDSet(testListSnapshots(t, env.gopts, 3)...)
 
 	var snapshotIDs restic.IDSet
-	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts GlobalOptions) error {
+	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
 		ctx, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
 		rtest.OK(t, err)

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -3,12 +3,13 @@ package main
 import (
 	"context"
 
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/ui/progress"
 )
 
-func internalOpenWithLocked(ctx context.Context, gopts GlobalOptions, dryRun bool, exclusive bool, printer progress.Printer) (context.Context, *repository.Repository, func(), error) {
-	repo, err := OpenRepository(ctx, gopts, printer)
+func internalOpenWithLocked(ctx context.Context, gopts global.Options, dryRun bool, exclusive bool, printer progress.Printer) (context.Context, *repository.Repository, func(), error) {
+	repo, err := global.OpenRepository(ctx, gopts, printer)
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -34,16 +35,16 @@ func internalOpenWithLocked(ctx context.Context, gopts GlobalOptions, dryRun boo
 	return ctx, repo, unlock, nil
 }
 
-func openWithReadLock(ctx context.Context, gopts GlobalOptions, noLock bool, printer progress.Printer) (context.Context, *repository.Repository, func(), error) {
+func openWithReadLock(ctx context.Context, gopts global.Options, noLock bool, printer progress.Printer) (context.Context, *repository.Repository, func(), error) {
 	// TODO enforce read-only operations once the locking code has moved to the repository
 	return internalOpenWithLocked(ctx, gopts, noLock, false, printer)
 }
 
-func openWithAppendLock(ctx context.Context, gopts GlobalOptions, dryRun bool, printer progress.Printer) (context.Context, *repository.Repository, func(), error) {
+func openWithAppendLock(ctx context.Context, gopts global.Options, dryRun bool, printer progress.Printer) (context.Context, *repository.Repository, func(), error) {
 	// TODO enforce non-exclusive operations once the locking code has moved to the repository
 	return internalOpenWithLocked(ctx, gopts, dryRun, false, printer)
 }
 
-func openWithExclusiveLock(ctx context.Context, gopts GlobalOptions, dryRun bool, printer progress.Printer) (context.Context, *repository.Repository, func(), error) {
+func openWithExclusiveLock(ctx context.Context, gopts global.Options, dryRun bool, printer progress.Printer) (context.Context, *repository.Repository, func(), error) {
 	return internalOpenWithLocked(ctx, gopts, dryRun, true, printer)
 }

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -18,6 +18,7 @@ import (
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/feature"
+	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui/termstatus"
@@ -33,7 +34,7 @@ var ErrOK = errors.New("ok")
 var cmdGroupDefault = "default"
 var cmdGroupAdvanced = "advanced"
 
-func newRootCommand(globalOptions *GlobalOptions) *cobra.Command {
+func newRootCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "restic",
 		Short: "Backup and restore files",
@@ -103,7 +104,7 @@ The full documentation can be found at https://restic.readthedocs.io/ .
 	registerDebugCommand(cmd, globalOptions)
 	registerMountCommand(cmd, globalOptions)
 	registerSelfUpdateCommand(cmd, globalOptions)
-	registerProfiling(cmd, os.Stderr)
+	global.RegisterProfiling(cmd, os.Stderr)
 
 	return cmd
 }
@@ -128,7 +129,7 @@ func tweakGoGC() {
 	}
 }
 
-func printExitError(globalOptions GlobalOptions, code int, message string) {
+func printExitError(globalOptions global.Options, code int, message string) {
 	if globalOptions.JSON {
 		type jsonExitError struct {
 			MessageType string `json:"message_type"` // exit_error
@@ -171,9 +172,9 @@ func main() {
 
 	debug.Log("main %#v", os.Args)
 	debug.Log("restic %s compiled with %v on %v/%v",
-		version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		global.Version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 
-	globalOptions := GlobalOptions{
+	globalOptions := global.Options{
 		Backends: all.Backends(),
 	}
 	func() {
@@ -221,7 +222,7 @@ func main() {
 		exitCode = 3
 	case errors.Is(err, ErrFailedToRemoveOneOrMoreSnapshots):
 		exitCode = 3
-	case errors.Is(err, ErrNoRepository):
+	case errors.Is(err, global.ErrNoRepository):
 		exitCode = 10
 	case restic.IsAlreadyLocked(err):
 		exitCode = 11

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 	"go.uber.org/automaxprocs/maxprocs"
 
+	"github.com/restic/restic/internal/backend/all"
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/feature"
@@ -173,7 +174,7 @@ func main() {
 		version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 
 	globalOptions := GlobalOptions{
-		backends: collectBackends(),
+		backends: all.Backends(),
 	}
 	func() {
 		term, cancel := termstatus.Setup(os.Stdin, os.Stdout, os.Stderr, globalOptions.Quiet)

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -174,12 +174,12 @@ func main() {
 		version, runtime.Version(), runtime.GOOS, runtime.GOARCH)
 
 	globalOptions := GlobalOptions{
-		backends: all.Backends(),
+		Backends: all.Backends(),
 	}
 	func() {
 		term, cancel := termstatus.Setup(os.Stdin, os.Stdout, os.Stderr, globalOptions.Quiet)
 		defer cancel()
-		globalOptions.term = term
+		globalOptions.Term = term
 		ctx := createGlobalContext(os.Stderr)
 		err = newRootCommand(&globalOptions).ExecuteContext(ctx)
 		switch err {

--- a/cmd/restic/secondary_repo.go
+++ b/cmd/restic/secondary_repo.go
@@ -108,14 +108,14 @@ func fillSecondaryGlobalOpts(ctx context.Context, opts secondaryRepoOptions, gop
 	}
 
 	if opts.password != "" {
-		dstGopts.password = opts.password
+		dstGopts.Password = opts.password
 	} else {
-		dstGopts.password, err = resolvePassword(&dstGopts, pwdEnv)
+		dstGopts.Password, err = resolvePassword(&dstGopts, pwdEnv)
 		if err != nil {
 			return GlobalOptions{}, false, err
 		}
 	}
-	dstGopts.password, err = ReadPassword(ctx, dstGopts, "enter password for "+repoPrefix+" repository: ")
+	dstGopts.Password, err = ReadPassword(ctx, dstGopts, "enter password for "+repoPrefix+" repository: ")
 	if err != nil {
 		return GlobalOptions{}, false, err
 	}

--- a/cmd/restic/secondary_repo_test.go
+++ b/cmd/restic/secondary_repo_test.go
@@ -28,7 +28,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 			},
 			DstGOpts: GlobalOptions{
 				Repo:     "backupDst",
-				password: "secretDst",
+				Password: "secretDst",
 			},
 			FromRepo: true,
 		},
@@ -40,7 +40,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 			},
 			DstGOpts: GlobalOptions{
 				RepositoryFile: "backupDst",
-				password:       "secretDst",
+				Password:       "secretDst",
 				PasswordFile:   "passwordFileDst",
 			},
 			FromRepo: true,
@@ -53,7 +53,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 			},
 			DstGOpts: GlobalOptions{
 				RepositoryFile:  "backupDst",
-				password:        "secretDst",
+				Password:        "secretDst",
 				PasswordCommand: "echo secretDst",
 			},
 			FromRepo: true,
@@ -66,7 +66,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 			},
 			DstGOpts: GlobalOptions{
 				Repo:     "backupDst",
-				password: "secretDst",
+				Password: "secretDst",
 			},
 		},
 		{
@@ -77,7 +77,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 			},
 			DstGOpts: GlobalOptions{
 				RepositoryFile: "backupDst",
-				password:       "secretDst",
+				Password:       "secretDst",
 				PasswordFile:   "passwordFileDst",
 			},
 		},
@@ -89,7 +89,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 			},
 			DstGOpts: GlobalOptions{
 				RepositoryFile:  "backupDst",
-				password:        "secretDst",
+				Password:        "secretDst",
 				PasswordCommand: "echo secretDst",
 			},
 		},
@@ -150,7 +150,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 	var gOpts = GlobalOptions{
 		Repo:           "backupSrc",
 		RepositoryFile: "backupSrc",
-		password:       "secretSrc",
+		Password:       "secretSrc",
 		PasswordFile:   "passwordFileSrc",
 	}
 

--- a/helpers/prepare-release/main.go
+++ b/helpers/prepare-release/main.go
@@ -308,9 +308,9 @@ func generateFiles() {
 	}
 }
 
-var versionPattern = `var version = ".*"`
+var versionPattern = `const Version = ".*"`
 
-const versionCodeFile = "cmd/restic/global.go"
+const versionCodeFile = "internal/global/global.go"
 
 func updateVersion() {
 	err := os.WriteFile("VERSION", []byte(opts.Version+"\n"), 0644)
@@ -318,7 +318,7 @@ func updateVersion() {
 		die("unable to write version to file: %v", err)
 	}
 
-	newVersion := fmt.Sprintf("var version = %q", opts.Version)
+	newVersion := fmt.Sprintf("const Version = %q", opts.Version)
 	replace(versionCodeFile, versionPattern, newVersion)
 
 	if len(uncommittedChanges("VERSION")) > 0 || len(uncommittedChanges(versionCodeFile)) > 0 {

--- a/internal/backend/all/all.go
+++ b/internal/backend/all/all.go
@@ -1,0 +1,28 @@
+package all
+
+import (
+	"github.com/restic/restic/internal/backend/azure"
+	"github.com/restic/restic/internal/backend/b2"
+	"github.com/restic/restic/internal/backend/gs"
+	"github.com/restic/restic/internal/backend/local"
+	"github.com/restic/restic/internal/backend/location"
+	"github.com/restic/restic/internal/backend/rclone"
+	"github.com/restic/restic/internal/backend/rest"
+	"github.com/restic/restic/internal/backend/s3"
+	"github.com/restic/restic/internal/backend/sftp"
+	"github.com/restic/restic/internal/backend/swift"
+)
+
+func Backends() *location.Registry {
+	backends := location.NewRegistry()
+	backends.Register(azure.NewFactory())
+	backends.Register(b2.NewFactory())
+	backends.Register(gs.NewFactory())
+	backends.Register(local.NewFactory())
+	backends.Register(rclone.NewFactory())
+	backends.Register(rest.NewFactory())
+	backends.Register(s3.NewFactory())
+	backends.Register(sftp.NewFactory())
+	backends.Register(swift.NewFactory())
+	return backends
+}

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -205,10 +205,10 @@ func LoadPasswordFromFile(pwdFile string) (string, error) {
 	return strings.TrimSpace(string(s)), errors.Wrap(err, "Readfile")
 }
 
-// ReadPassword reads the password from a password file, the environment
+// readPassword reads the password from a password file, the environment
 // variable RESTIC_PASSWORD or prompts the user. If the context is canceled,
 // the function leaks the password reading goroutine.
-func ReadPassword(ctx context.Context, gopts Options, prompt string) (string, error) {
+func readPassword(ctx context.Context, gopts Options, prompt string) (string, error) {
 	if gopts.InsecureNoPassword {
 		if gopts.Password != "" {
 			return "", errors.Fatal("--insecure-no-password must not be specified together with providing a password via a cli option or environment variable")
@@ -236,12 +236,12 @@ func ReadPassword(ctx context.Context, gopts Options, prompt string) (string, er
 // passwords don't match. If the context is canceled, the function leaks the
 // password reading goroutine.
 func ReadPasswordTwice(ctx context.Context, gopts Options, prompt1, prompt2 string) (string, error) {
-	pw1, err := ReadPassword(ctx, gopts, prompt1)
+	pw1, err := readPassword(ctx, gopts, prompt1)
 	if err != nil {
 		return "", err
 	}
 	if gopts.Term.InputIsTerminal() {
-		pw2, err := ReadPassword(ctx, gopts, prompt2)
+		pw2, err := readPassword(ctx, gopts, prompt2)
 		if err != nil {
 			return "", err
 		}
@@ -322,7 +322,7 @@ func OpenRepository(ctx context.Context, gopts Options, printer progress.Printer
 	}
 
 	for ; passwordTriesLeft > 0; passwordTriesLeft-- {
-		gopts.Password, err = ReadPassword(ctx, gopts, "enter password for repository: ")
+		gopts.Password, err = readPassword(ctx, gopts, "enter password for repository: ")
 		if ctx.Err() != nil {
 			return nil, ctx.Err()
 		}

--- a/internal/global/global_debug.go
+++ b/internal/global/global_debug.go
@@ -1,7 +1,7 @@
 //go:build debug || profile
 // +build debug profile
 
-package main
+package global
 
 import (
 	"fmt"
@@ -17,8 +17,8 @@ import (
 	"github.com/pkg/profile"
 )
 
-func registerProfiling(cmd *cobra.Command, stderr io.Writer) {
-	var profiler profiler
+func RegisterProfiling(cmd *cobra.Command, stderr io.Writer) {
+	var profiler Profiler
 
 	origPreRun := cmd.PersistentPreRunE
 	cmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
@@ -40,7 +40,7 @@ func registerProfiling(cmd *cobra.Command, stderr io.Writer) {
 	profiler.opts.AddFlags(cmd.PersistentFlags())
 }
 
-type profiler struct {
+type Profiler struct {
 	opts ProfileOptions
 	stop interface {
 		Stop()
@@ -73,7 +73,7 @@ func (t fakeTestingTB) Logf(msg string, args ...interface{}) {
 	fmt.Fprintf(t.stderr, msg, args...)
 }
 
-func (p *profiler) Start(profileOpts ProfileOptions, stderr io.Writer) error {
+func (p *Profiler) Start(profileOpts ProfileOptions, stderr io.Writer) error {
 	if profileOpts.listen != "" {
 		fmt.Fprintf(stderr, "running profile HTTP server on %v\n", profileOpts.listen)
 		go func() {
@@ -119,7 +119,7 @@ func (p *profiler) Start(profileOpts ProfileOptions, stderr io.Writer) error {
 	return nil
 }
 
-func (p *profiler) Stop() {
+func (p *Profiler) Stop() {
 	if p.stop != nil {
 		p.stop.Stop()
 	}

--- a/internal/global/global_release.go
+++ b/internal/global/global_release.go
@@ -1,7 +1,7 @@
 //go:build !debug && !profile
 // +build !debug,!profile
 
-package main
+package global
 
 import (
 	"io"
@@ -9,6 +9,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func registerProfiling(_ *cobra.Command, _ io.Writer) {
+func RegisterProfiling(_ *cobra.Command, _ io.Writer) {
 	// No profiling in release mode
 }

--- a/internal/global/global_test.go
+++ b/internal/global/global_test.go
@@ -16,7 +16,7 @@ func TestReadRepo(t *testing.T) {
 	// test --repo option
 	var gopts Options
 	gopts.Repo = tempDir
-	repo, err := ReadRepo(gopts)
+	repo, err := readRepo(gopts)
 	rtest.OK(t, err)
 	rtest.Equals(t, tempDir, repo)
 
@@ -27,13 +27,13 @@ func TestReadRepo(t *testing.T) {
 
 	var gopts2 Options
 	gopts2.RepositoryFile = foo
-	repo, err = ReadRepo(gopts2)
+	repo, err = readRepo(gopts2)
 	rtest.OK(t, err)
 	rtest.Equals(t, tempDir, repo)
 
 	var gopts3 Options
 	gopts3.RepositoryFile = foo + "-invalid"
-	_, err = ReadRepo(gopts3)
+	_, err = readRepo(gopts3)
 	if err == nil {
 		t.Fatal("must not read repository path from invalid file path")
 	}

--- a/internal/global/global_test.go
+++ b/internal/global/global_test.go
@@ -1,4 +1,4 @@
-package main
+package global
 
 import (
 	"context"
@@ -14,7 +14,7 @@ func TestReadRepo(t *testing.T) {
 	tempDir := rtest.TempDir(t)
 
 	// test --repo option
-	var gopts GlobalOptions
+	var gopts Options
 	gopts.Repo = tempDir
 	repo, err := ReadRepo(gopts)
 	rtest.OK(t, err)
@@ -25,13 +25,13 @@ func TestReadRepo(t *testing.T) {
 	err = os.WriteFile(foo, []byte(tempDir+"\n"), 0666)
 	rtest.OK(t, err)
 
-	var gopts2 GlobalOptions
+	var gopts2 Options
 	gopts2.RepositoryFile = foo
 	repo, err = ReadRepo(gopts2)
 	rtest.OK(t, err)
 	rtest.Equals(t, tempDir, repo)
 
-	var gopts3 GlobalOptions
+	var gopts3 Options
 	gopts3.RepositoryFile = foo + "-invalid"
 	_, err = ReadRepo(gopts3)
 	if err == nil {
@@ -40,7 +40,7 @@ func TestReadRepo(t *testing.T) {
 }
 
 func TestReadEmptyPassword(t *testing.T) {
-	opts := GlobalOptions{InsecureNoPassword: true}
+	opts := Options{InsecureNoPassword: true}
 	password, err := ReadPassword(context.TODO(), opts, "test")
 	rtest.OK(t, err)
 	rtest.Equals(t, "", password, "got unexpected password")

--- a/internal/global/global_test.go
+++ b/internal/global/global_test.go
@@ -41,11 +41,11 @@ func TestReadRepo(t *testing.T) {
 
 func TestReadEmptyPassword(t *testing.T) {
 	opts := Options{InsecureNoPassword: true}
-	password, err := ReadPassword(context.TODO(), opts, "test")
+	password, err := readPassword(context.TODO(), opts, "test")
 	rtest.OK(t, err)
 	rtest.Equals(t, "", password, "got unexpected password")
 
 	opts.Password = "invalid"
-	_, err = ReadPassword(context.TODO(), opts, "test")
+	_, err = readPassword(context.TODO(), opts, "test")
 	rtest.Assert(t, strings.Contains(err.Error(), "must not be specified together with providing a password via a cli option or environment variable"), "unexpected error message, got %v", err)
 }

--- a/internal/global/secondary_repo.go
+++ b/internal/global/secondary_repo.go
@@ -115,7 +115,7 @@ func (opts *SecondaryRepoOptions) FillGlobalOpts(ctx context.Context, gopts Opti
 			return Options{}, false, err
 		}
 	}
-	dstGopts.Password, err = ReadPassword(ctx, dstGopts, "enter password for "+repoPrefix+" repository: ")
+	dstGopts.Password, err = readPassword(ctx, dstGopts, "enter password for "+repoPrefix+" repository: ")
 	if err != nil {
 		return Options{}, false, err
 	}

--- a/internal/global/secondary_repo.go
+++ b/internal/global/secondary_repo.go
@@ -1,4 +1,4 @@
-package main
+package global
 
 import (
 	"context"
@@ -8,8 +8,8 @@ import (
 	"github.com/spf13/pflag"
 )
 
-type secondaryRepoOptions struct {
-	password string
+type SecondaryRepoOptions struct {
+	Password string
 	// from-repo options
 	Repo               string
 	RepositoryFile     string
@@ -25,7 +25,7 @@ type secondaryRepoOptions struct {
 	LegacyKeyHint         string
 }
 
-func (opts *secondaryRepoOptions) AddFlags(f *pflag.FlagSet, repoPrefix string, repoUsage string) {
+func (opts *SecondaryRepoOptions) AddFlags(f *pflag.FlagSet, repoPrefix string, repoUsage string) {
 	f.StringVarP(&opts.LegacyRepo, "repo2", "", "", repoPrefix+" `repository` "+repoUsage+" (default: $RESTIC_REPOSITORY2)")
 	f.StringVarP(&opts.LegacyRepositoryFile, "repository-file2", "", "", "`file` from which to read the "+repoPrefix+" repository location "+repoUsage+" (default: $RESTIC_REPOSITORY_FILE2)")
 	f.StringVarP(&opts.LegacyPasswordFile, "password-file2", "", "", "`file` to read the "+repoPrefix+" repository password from (default: $RESTIC_PASSWORD_FILE2)")
@@ -59,9 +59,9 @@ func (opts *secondaryRepoOptions) AddFlags(f *pflag.FlagSet, repoPrefix string, 
 	opts.PasswordCommand = os.Getenv("RESTIC_FROM_PASSWORD_COMMAND")
 }
 
-func fillSecondaryGlobalOpts(ctx context.Context, opts secondaryRepoOptions, gopts GlobalOptions, repoPrefix string) (GlobalOptions, bool, error) {
+func (opts *SecondaryRepoOptions) FillGlobalOpts(ctx context.Context, gopts Options, repoPrefix string) (Options, bool, error) {
 	if opts.Repo == "" && opts.RepositoryFile == "" && opts.LegacyRepo == "" && opts.LegacyRepositoryFile == "" {
-		return GlobalOptions{}, false, errors.Fatal("Please specify a source repository location (--from-repo or --from-repository-file)")
+		return Options{}, false, errors.Fatal("Please specify a source repository location (--from-repo or --from-repository-file)")
 	}
 
 	hasFromRepo := opts.Repo != "" || opts.RepositoryFile != "" || opts.PasswordFile != "" ||
@@ -70,7 +70,7 @@ func fillSecondaryGlobalOpts(ctx context.Context, opts secondaryRepoOptions, gop
 		opts.LegacyKeyHint != "" || opts.LegacyPasswordCommand != ""
 
 	if hasFromRepo && hasRepo2 {
-		return GlobalOptions{}, false, errors.Fatal("Option groups repo2 and from-repo are mutually exclusive, please specify only one")
+		return Options{}, false, errors.Fatal("Option groups repo2 and from-repo are mutually exclusive, please specify only one")
 	}
 
 	var err error
@@ -79,7 +79,7 @@ func fillSecondaryGlobalOpts(ctx context.Context, opts secondaryRepoOptions, gop
 
 	if hasFromRepo {
 		if opts.Repo != "" && opts.RepositoryFile != "" {
-			return GlobalOptions{}, false, errors.Fatal("Options --from-repo and --from-repository-file are mutually exclusive, please specify only one")
+			return Options{}, false, errors.Fatal("Options --from-repo and --from-repository-file are mutually exclusive, please specify only one")
 		}
 
 		dstGopts.Repo = opts.Repo
@@ -93,7 +93,7 @@ func fillSecondaryGlobalOpts(ctx context.Context, opts secondaryRepoOptions, gop
 		repoPrefix = "source"
 	} else {
 		if opts.LegacyRepo != "" && opts.LegacyRepositoryFile != "" {
-			return GlobalOptions{}, false, errors.Fatal("Options --repo2 and --repository-file2 are mutually exclusive, please specify only one")
+			return Options{}, false, errors.Fatal("Options --repo2 and --repository-file2 are mutually exclusive, please specify only one")
 		}
 
 		dstGopts.Repo = opts.LegacyRepo
@@ -107,17 +107,17 @@ func fillSecondaryGlobalOpts(ctx context.Context, opts secondaryRepoOptions, gop
 		pwdEnv = "RESTIC_PASSWORD2"
 	}
 
-	if opts.password != "" {
-		dstGopts.Password = opts.password
+	if opts.Password != "" {
+		dstGopts.Password = opts.Password
 	} else {
 		dstGopts.Password, err = resolvePassword(&dstGopts, pwdEnv)
 		if err != nil {
-			return GlobalOptions{}, false, err
+			return Options{}, false, err
 		}
 	}
 	dstGopts.Password, err = ReadPassword(ctx, dstGopts, "enter password for "+repoPrefix+" repository: ")
 	if err != nil {
-		return GlobalOptions{}, false, err
+		return Options{}, false, err
 	}
 	return dstGopts, hasFromRepo, nil
 }

--- a/internal/global/secondary_repo_test.go
+++ b/internal/global/secondary_repo_test.go
@@ -1,4 +1,4 @@
-package main
+package global
 
 import (
 	"context"
@@ -13,8 +13,8 @@ import (
 func TestFillSecondaryGlobalOpts(t *testing.T) {
 	//secondaryRepoTestCase defines a struct for test cases
 	type secondaryRepoTestCase struct {
-		Opts     secondaryRepoOptions
-		DstGOpts GlobalOptions
+		Opts     SecondaryRepoOptions
+		DstGOpts Options
 		FromRepo bool
 	}
 
@@ -22,11 +22,11 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 	var validSecondaryRepoTestCases = []secondaryRepoTestCase{
 		{
 			// Test if Repo and Password are parsed correctly.
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				Repo:     "backupDst",
-				password: "secretDst",
+				Password: "secretDst",
 			},
-			DstGOpts: GlobalOptions{
+			DstGOpts: Options{
 				Repo:     "backupDst",
 				Password: "secretDst",
 			},
@@ -34,11 +34,11 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 		},
 		{
 			// Test if RepositoryFile and PasswordFile are parsed correctly.
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				RepositoryFile: "backupDst",
 				PasswordFile:   "passwordFileDst",
 			},
-			DstGOpts: GlobalOptions{
+			DstGOpts: Options{
 				RepositoryFile: "backupDst",
 				Password:       "secretDst",
 				PasswordFile:   "passwordFileDst",
@@ -47,11 +47,11 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 		},
 		{
 			// Test if RepositoryFile and PasswordCommand are parsed correctly.
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				RepositoryFile:  "backupDst",
 				PasswordCommand: "echo secretDst",
 			},
-			DstGOpts: GlobalOptions{
+			DstGOpts: Options{
 				RepositoryFile:  "backupDst",
 				Password:        "secretDst",
 				PasswordCommand: "echo secretDst",
@@ -60,22 +60,22 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 		},
 		{
 			// Test if LegacyRepo and Password are parsed correctly.
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				LegacyRepo: "backupDst",
-				password:   "secretDst",
+				Password:   "secretDst",
 			},
-			DstGOpts: GlobalOptions{
+			DstGOpts: Options{
 				Repo:     "backupDst",
 				Password: "secretDst",
 			},
 		},
 		{
 			// Test if LegacyRepositoryFile and LegacyPasswordFile are parsed correctly.
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				LegacyRepositoryFile: "backupDst",
 				LegacyPasswordFile:   "passwordFileDst",
 			},
-			DstGOpts: GlobalOptions{
+			DstGOpts: Options{
 				RepositoryFile: "backupDst",
 				Password:       "secretDst",
 				PasswordFile:   "passwordFileDst",
@@ -83,11 +83,11 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 		},
 		{
 			// Test if LegacyRepositoryFile and LegacyPasswordCommand are parsed correctly.
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				LegacyRepositoryFile:  "backupDst",
 				LegacyPasswordCommand: "echo secretDst",
 			},
-			DstGOpts: GlobalOptions{
+			DstGOpts: Options{
 				RepositoryFile:  "backupDst",
 				Password:        "secretDst",
 				PasswordCommand: "echo secretDst",
@@ -99,18 +99,18 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 	var invalidSecondaryRepoTestCases = []secondaryRepoTestCase{
 		{
 			// Test must fail on no repo given.
-			Opts: secondaryRepoOptions{},
+			Opts: SecondaryRepoOptions{},
 		},
 		{
 			// Test must fail as Repo and RepositoryFile are both given
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				Repo:           "backupDst",
 				RepositoryFile: "backupDst",
 			},
 		},
 		{
 			// Test must fail as PasswordFile and PasswordCommand are both given
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				Repo:            "backupDst",
 				PasswordFile:    "passwordFileDst",
 				PasswordCommand: "notEmpty",
@@ -118,28 +118,28 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 		},
 		{
 			// Test must fail as PasswordFile does not exist
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				Repo:         "backupDst",
 				PasswordFile: "NonExistingFile",
 			},
 		},
 		{
 			// Test must fail as PasswordCommand does not exist
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				Repo:            "backupDst",
 				PasswordCommand: "notEmpty",
 			},
 		},
 		{
 			// Test must fail as current and legacy options are mixed
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				Repo:       "backupDst",
 				LegacyRepo: "backupDst",
 			},
 		},
 		{
 			// Test must fail as current and legacy options are mixed
-			Opts: secondaryRepoOptions{
+			Opts: SecondaryRepoOptions{
 				Repo:                  "backupDst",
 				LegacyPasswordCommand: "notEmpty",
 			},
@@ -147,7 +147,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 	}
 
 	//gOpts defines the Global options used in the secondary repository tests
-	var gOpts = GlobalOptions{
+	var gOpts = Options{
 		Repo:           "backupSrc",
 		RepositoryFile: "backupSrc",
 		Password:       "secretSrc",
@@ -165,7 +165,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 
 	// Test all valid cases
 	for _, testCase := range validSecondaryRepoTestCases {
-		DstGOpts, isFromRepo, err := fillSecondaryGlobalOpts(context.TODO(), testCase.Opts, gOpts, "destination")
+		DstGOpts, isFromRepo, err := testCase.Opts.FillGlobalOpts(context.TODO(), gOpts, "destination")
 		rtest.OK(t, err)
 		rtest.Equals(t, DstGOpts, testCase.DstGOpts)
 		rtest.Equals(t, isFromRepo, testCase.FromRepo)
@@ -173,7 +173,7 @@ func TestFillSecondaryGlobalOpts(t *testing.T) {
 
 	// Test all invalid cases
 	for _, testCase := range invalidSecondaryRepoTestCases {
-		_, _, err := fillSecondaryGlobalOpts(context.TODO(), testCase.Opts, gOpts, "destination")
+		_, _, err := testCase.Opts.FillGlobalOpts(context.TODO(), gOpts, "destination")
 		rtest.Assert(t, err != nil, "Expected error, but function did not return an error")
 	}
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Split the globalOptions struct out of `cmd/restic` into `internal/global`. I'd like to slowly extract all reusable code parts from `cmd/restic`. While it might make sense to eventually split the GlobalOptions into smaller parts (e.g. backend and other options), I've chosen the easy way for now and just moved most of the code without significant changes. The code is in a dedicated package as opposed to `internal/repository` as it handles too many backend-related steps to fit into the `repository` package.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
