### PR TITLE
ui/backup: Prepend, then sort (micro-optimization)

### DIFF
--- a/internal/ui/backup/text.go
+++ b/internal/ui/backup/text.go
@@ -62,12 +62,12 @@ func (b *TextProgress) Update(total, processed Counter, errors uint, currentFile
 		)
 	}
 
-	lines := make([]string, 0, len(currentFiles)+1)
+	lines := make([]string, 1, len(currentFiles)+1)
+	lines[0] = status
 	for filename := range currentFiles {
 		lines = append(lines, filename)
 	}
-	sort.Strings(lines)
-	lines = append([]string{status}, lines...)
+	sort.Strings(lines[1:])
 
 	b.term.SetStatus(lines)
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Skips an allocation in the backup text ui.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
