### PR TITLE
index: port to  modern Go iterators

### DIFF
--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -73,9 +73,13 @@ func runList(ctx context.Context, gopts global.Options, args []string, term ui.T
 			if err != nil {
 				return err
 			}
-			return idx.Each(ctx, func(blobs restic.PackedBlob) {
+			for blobs := range idx.Values() {
+				if ctx.Err() != nil {
+					return ctx.Err()
+				}
 				printer.S("%v %v", blobs.Type, blobs.ID)
-			})
+			}
+			return nil
 		})
 	default:
 		return errors.Fatal("invalid type")

--- a/internal/repository/checker.go
+++ b/internal/repository/checker.go
@@ -92,17 +92,20 @@ func (c *Checker) LoadIndex(ctx context.Context, p restic.TerminalCounterFactory
 
 		debug.Log("process blobs")
 		cnt := 0
-		err = idx.Each(ctx, func(blob restic.PackedBlob) {
+		for blob := range idx.Values() {
+			if ctx.Err() != nil {
+				return ctx.Err()
+			}
 			cnt++
 
 			if _, ok := packToIndex[blob.PackID]; !ok {
 				packToIndex[blob.PackID] = restic.NewIDSet()
 			}
 			packToIndex[blob.PackID].Insert(id)
-		})
+		}
 
 		debug.Log("%d blobs processed", cnt)
-		return err
+		return nil
 	})
 	if err != nil {
 		// failed to load the index

--- a/internal/repository/index/associated_data.go
+++ b/internal/repository/index/associated_data.go
@@ -1,6 +1,8 @@
 package index
 
 import (
+	"iter"
+	"slices"
 	"sort"
 
 	"github.com/restic/restic/internal/restic"
@@ -108,42 +110,48 @@ func (a *AssociatedSet[T]) Delete(bh restic.BlobHandle) {
 
 func (a *AssociatedSet[T]) Len() int {
 	count := 0
-	a.For(func(_ restic.BlobHandle, _ T) {
+	for range a.All() {
 		count++
-	})
+	}
 	return count
 }
 
-func (a *AssociatedSet[T]) For(cb func(bh restic.BlobHandle, val T)) {
-	for k, v := range a.overflow {
-		cb(k, v)
-	}
-
-	for pb := range a.idx.Values() {
-		if _, ok := a.overflow[pb.BlobHandle]; ok {
-			// already reported via overflow set
-			continue
+func (a *AssociatedSet[T]) All() iter.Seq2[restic.BlobHandle, T] {
+	return func(yield func(restic.BlobHandle, T) bool) {
+		for k, v := range a.overflow {
+			if !yield(k, v) {
+				return
+			}
 		}
 
-		val, known := a.Get(pb.BlobHandle)
-		if known {
-			cb(pb.BlobHandle, val)
+		for pb := range a.idx.Values() {
+			if _, ok := a.overflow[pb.BlobHandle]; ok {
+				// already reported via overflow set
+				continue
+			}
+
+			val, known := a.Get(pb.BlobHandle)
+			if known {
+				if !yield(pb.BlobHandle, val) {
+					return
+				}
+			}
 		}
 	}
 }
 
-// List returns a sorted slice of all BlobHandle in the set.
-func (a *AssociatedSet[T]) List() restic.BlobHandles {
-	list := make(restic.BlobHandles, 0)
-	a.For(func(bh restic.BlobHandle, _ T) {
-		list = append(list, bh)
-	})
-
-	return list
+func (a *AssociatedSet[T]) Keys() iter.Seq[restic.BlobHandle] {
+	return func(yield func(restic.BlobHandle) bool) {
+		for bh := range a.All() {
+			if !yield(bh) {
+				return
+			}
+		}
+	}
 }
 
 func (a *AssociatedSet[T]) String() string {
-	list := a.List()
+	list := restic.BlobHandles(slices.Collect(a.Keys()))
 	sort.Sort(list)
 
 	str := list.String()

--- a/internal/repository/index/associated_data.go
+++ b/internal/repository/index/associated_data.go
@@ -1,7 +1,6 @@
 package index
 
 import (
-	"context"
 	"sort"
 
 	"github.com/restic/restic/internal/restic"
@@ -120,17 +119,17 @@ func (a *AssociatedSet[T]) For(cb func(bh restic.BlobHandle, val T)) {
 		cb(k, v)
 	}
 
-	_ = a.idx.Each(context.Background(), func(pb restic.PackedBlob) {
+	for pb := range a.idx.Values() {
 		if _, ok := a.overflow[pb.BlobHandle]; ok {
 			// already reported via overflow set
-			return
+			continue
 		}
 
 		val, known := a.Get(pb.BlobHandle)
 		if known {
 			cb(pb.BlobHandle, val)
 		}
-	})
+	}
 }
 
 // List returns a sorted slice of all BlobHandle in the set.

--- a/internal/repository/index/associated_data_test.go
+++ b/internal/repository/index/associated_data_test.go
@@ -2,6 +2,7 @@ package index
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/restic/restic/internal/crypto"
@@ -31,6 +32,10 @@ func makeFakePackedBlob() (restic.BlobHandle, restic.PackedBlob) {
 	return bh, blob
 }
 
+func list(bs *AssociatedSet[uint8]) restic.BlobHandles {
+	return restic.BlobHandles(slices.Collect(bs.Keys()))
+}
+
 func TestAssociatedSet(t *testing.T) {
 	bh, blob := makeFakePackedBlob()
 
@@ -40,7 +45,7 @@ func TestAssociatedSet(t *testing.T) {
 
 	bs := NewAssociatedSet[uint8](mi)
 	test.Equals(t, bs.Len(), 0)
-	test.Equals(t, bs.List(), restic.BlobHandles{})
+	test.Equals(t, list(bs), restic.BlobHandles(nil))
 
 	// check non existent
 	test.Equals(t, bs.Has(bh), false)
@@ -51,7 +56,7 @@ func TestAssociatedSet(t *testing.T) {
 	bs.Insert(bh)
 	test.Equals(t, bs.Has(bh), true)
 	test.Equals(t, bs.Len(), 1)
-	test.Equals(t, bs.List(), restic.BlobHandles{bh})
+	test.Equals(t, list(bs), restic.BlobHandles{bh})
 	test.Equals(t, 0, len(bs.overflow))
 
 	// test set
@@ -69,7 +74,7 @@ func TestAssociatedSet(t *testing.T) {
 	bs.Delete(bh)
 	test.Equals(t, bs.Len(), 0)
 	test.Equals(t, bs.Has(bh), false)
-	test.Equals(t, bs.List(), restic.BlobHandles{})
+	test.Equals(t, list(bs), restic.BlobHandles(nil))
 
 	test.Equals(t, "{}", bs.String())
 
@@ -99,7 +104,7 @@ func TestAssociatedSet(t *testing.T) {
 	val, ok = bs.Get(of)
 	test.Equals(t, true, ok)
 	test.Equals(t, uint8(7), val)
-	test.Equals(t, bs.List(), restic.BlobHandles{of, bh})
+	test.Equals(t, list(bs), restic.BlobHandles{of, bh})
 	// update
 	bs.Set(of, 8)
 	val, ok = bs.Get(of)
@@ -110,7 +115,7 @@ func TestAssociatedSet(t *testing.T) {
 	bs.Delete(of)
 	test.Equals(t, bs.Len(), 1)
 	test.Equals(t, bs.Has(of), false)
-	test.Equals(t, bs.List(), restic.BlobHandles{bh})
+	test.Equals(t, list(bs), restic.BlobHandles{bh})
 	test.Equals(t, 0, len(bs.overflow))
 }
 
@@ -138,7 +143,7 @@ func TestAssociatedSetWithExtendedIndex(t *testing.T) {
 	val, ok := bs.Get(of)
 	test.Equals(t, true, ok)
 	test.Equals(t, uint8(5), val)
-	test.Equals(t, bs.List(), restic.BlobHandles{of})
+	test.Equals(t, list(bs), restic.BlobHandles{of})
 	// update
 	bs.Set(of, 8)
 	val, ok = bs.Get(of)
@@ -149,6 +154,6 @@ func TestAssociatedSetWithExtendedIndex(t *testing.T) {
 	bs.Delete(of)
 	test.Equals(t, bs.Len(), 0)
 	test.Equals(t, bs.Has(of), false)
-	test.Equals(t, bs.List(), restic.BlobHandles{})
+	test.Equals(t, list(bs), restic.BlobHandles(nil))
 	test.Equals(t, 0, len(bs.overflow))
 }

--- a/internal/repository/index/index_test.go
+++ b/internal/repository/index/index_test.go
@@ -325,11 +325,11 @@ func TestIndexUnserialize(t *testing.T) {
 }
 
 func listPack(t testing.TB, idx *index.Index, id restic.ID) (pbs []restic.PackedBlob) {
-	rtest.OK(t, idx.Each(context.TODO(), func(pb restic.PackedBlob) {
+	for pb := range idx.Values() {
 		if pb.PackID.Equal(id) {
 			pbs = append(pbs, pb)
 		}
-	}))
+	}
 	return pbs
 }
 

--- a/internal/repository/index/indexmap_test.go
+++ b/internal/repository/index/indexmap_test.go
@@ -36,7 +36,9 @@ func TestIndexMapForeach(t *testing.T) {
 	var m indexMap
 
 	// Don't crash on empty map.
-	m.foreach(func(*indexEntry) bool { return true })
+	for range m.values() {
+		// empty iteration
+	}
 
 	for i := 0; i < N; i++ {
 		var id restic.ID
@@ -45,7 +47,7 @@ func TestIndexMapForeach(t *testing.T) {
 	}
 
 	seen := make(map[int]struct{})
-	m.foreach(func(e *indexEntry) bool {
+	for e := range m.values() {
 		i := int(e.id[0])
 		rtest.Assert(t, i < N, "unknown id %v in indexMap", e.id)
 		rtest.Equals(t, i, e.packIndex)
@@ -54,16 +56,15 @@ func TestIndexMapForeach(t *testing.T) {
 		rtest.Equals(t, i/2, int(e.uncompressedLength))
 
 		seen[i] = struct{}{}
-		return true
-	})
+	}
 
 	rtest.Equals(t, N, len(seen))
 
 	ncalls := 0
-	m.foreach(func(*indexEntry) bool {
+	for range m.values() {
 		ncalls++
-		return false
-	})
+		break
+	}
 	rtest.Equals(t, 1, ncalls)
 }
 
@@ -81,7 +82,9 @@ func TestIndexMapForeachWithID(t *testing.T) {
 
 	// No result (and no crash) for empty map.
 	n := 0
-	m.foreachWithID(id, func(*indexEntry) { n++ })
+	for range m.valuesWithID(id) {
+		n++
+	}
 	rtest.Equals(t, 0, n)
 
 	// Test insertion and retrieval of duplicates.
@@ -97,10 +100,10 @@ func TestIndexMapForeachWithID(t *testing.T) {
 
 	n = 0
 	var packs [ndups]bool
-	m.foreachWithID(id, func(e *indexEntry) {
+	for e := range m.valuesWithID(id) {
 		packs[e.packIndex] = true
 		n++
-	})
+	}
 	rtest.Equals(t, ndups, n)
 
 	for i := range packs {

--- a/internal/repository/index/indexmap_test.go
+++ b/internal/repository/index/indexmap_test.go
@@ -36,6 +36,7 @@ func TestIndexMapForeach(t *testing.T) {
 	var m indexMap
 
 	// Don't crash on empty map.
+	//nolint:revive // ignore empty iteration
 	for range m.values() {
 		// empty iteration
 	}

--- a/internal/repository/index/master_index_test.go
+++ b/internal/repository/index/master_index_test.go
@@ -170,9 +170,9 @@ func TestMasterMergeFinalIndexes(t *testing.T) {
 	rtest.Equals(t, ids, mIdx.IDs())
 
 	blobCount := 0
-	rtest.OK(t, mIdx.Each(context.TODO(), func(pb restic.PackedBlob) {
+	for range mIdx.Values() {
 		blobCount++
-	}))
+	}
 	rtest.Equals(t, 2, blobCount)
 
 	blobs := mIdx.Lookup(bhInIdx1)
@@ -204,9 +204,9 @@ func TestMasterMergeFinalIndexes(t *testing.T) {
 	rtest.Equals(t, []restic.PackedBlob{blob2}, blobs)
 
 	blobCount = 0
-	rtest.OK(t, mIdx.Each(context.TODO(), func(pb restic.PackedBlob) {
+	for range mIdx.Values() {
 		blobCount++
-	}))
+	}
 	rtest.Equals(t, 2, blobCount)
 }
 
@@ -325,9 +325,9 @@ func BenchmarkMasterIndexEach(b *testing.B) {
 
 	for i := 0; i < b.N; i++ {
 		entries := 0
-		rtest.OK(b, mIdx.Each(context.TODO(), func(pb restic.PackedBlob) {
+		for range mIdx.Values() {
 			entries++
-		}))
+		}
 	}
 }
 
@@ -385,21 +385,21 @@ func testIndexSave(t *testing.T, version uint) {
 			idx := index.NewMasterIndex()
 			rtest.OK(t, idx.Load(context.TODO(), repo, nil, nil))
 			blobs := make(map[restic.PackedBlob]struct{})
-			rtest.OK(t, idx.Each(context.TODO(), func(pb restic.PackedBlob) {
+			for pb := range idx.Values() {
 				blobs[pb] = struct{}{}
-			}))
+			}
 
 			rtest.OK(t, test.saver(idx, unpacked))
 			idx = index.NewMasterIndex()
 			rtest.OK(t, idx.Load(context.TODO(), repo, nil, nil))
 
-			rtest.OK(t, idx.Each(context.TODO(), func(pb restic.PackedBlob) {
+			for pb := range idx.Values() {
 				if _, ok := blobs[pb]; ok {
 					delete(blobs, pb)
 				} else {
 					t.Fatalf("unexpected blobs %v", pb)
 				}
-			}))
+			}
 			rtest.Equals(t, 0, len(blobs), "saved index is missing blobs")
 
 			checker.TestCheckRepo(t, repo)
@@ -418,9 +418,9 @@ func testIndexSavePartial(t *testing.T, version uint) {
 	idx := index.NewMasterIndex()
 	rtest.OK(t, idx.Load(context.TODO(), repo, nil, nil))
 	blobs := make(map[restic.PackedBlob]struct{})
-	rtest.OK(t, idx.Each(context.TODO(), func(pb restic.PackedBlob) {
+	for pb := range idx.Values() {
 		blobs[pb] = struct{}{}
-	}))
+	}
 
 	// add+remove new snapshot and track its pack files
 	packsBefore := listPacks(t, repo)
@@ -437,13 +437,13 @@ func testIndexSavePartial(t *testing.T, version uint) {
 	// check blobs
 	idx = index.NewMasterIndex()
 	rtest.OK(t, idx.Load(context.TODO(), repo, nil, nil))
-	rtest.OK(t, idx.Each(context.TODO(), func(pb restic.PackedBlob) {
+	for pb := range idx.Values() {
 		if _, ok := blobs[pb]; ok {
 			delete(blobs, pb)
 		} else {
 			t.Fatalf("unexpected blobs %v", pb)
 		}
-	}))
+	}
 	rtest.Equals(t, 0, len(blobs), "saved index is missing blobs")
 
 	// remove pack files to make check happy

--- a/internal/repository/prune.go
+++ b/internal/repository/prune.go
@@ -176,12 +176,12 @@ func packInfoFromIndex(ctx context.Context, idx restic.ListBlobser, usedBlobs *i
 
 	// Check if all used blobs have been found in index
 	missingBlobs := restic.NewBlobSet()
-	usedBlobs.For(func(bh restic.BlobHandle, count uint8) {
+	for bh, count := range usedBlobs.All() {
 		if count == 0 {
 			// blob does not exist in any pack files
 			missingBlobs.Insert(bh)
 		}
-	})
+	}
 
 	if len(missingBlobs) != 0 {
 		printer.E("%v not found in the index\n\n"+
@@ -311,11 +311,11 @@ func packInfoFromIndex(ctx context.Context, idx restic.ListBlobser, usedBlobs *i
 
 	// Sanity check. If no duplicates exist, all blobs have value 1. After handling
 	// duplicates, this also applies to duplicates.
-	usedBlobs.For(func(_ restic.BlobHandle, count uint8) {
+	for _, count := range usedBlobs.All() {
 		if count != 1 {
 			panic("internal error during blob selection")
 		}
-	})
+	}
 
 	return usedBlobs, indexPack, nil
 }

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -397,13 +397,13 @@ func testRepositoryIncrementalIndex(t *testing.T, version uint) {
 		idx, err := loadIndex(context.TODO(), repo, id)
 		rtest.OK(t, err)
 
-		rtest.OK(t, idx.Each(context.TODO(), func(pb restic.PackedBlob) {
+		for pb := range idx.Values() {
 			if _, ok := packEntries[pb.PackID]; !ok {
 				packEntries[pb.PackID] = make(map[restic.ID]struct{})
 			}
 
 			packEntries[pb.PackID][id] = struct{}{}
-		}))
+		}
 		return nil
 	})
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Convert MasterIndex, Index and AssociatedSet to use modern Go iterators. I've kept the Repository interface unchanged for now. The change was originally intended to allow removing the `packs` argument from `repository.Repack`. However, to not negatively affect `Prune`, this requires more work than I currently want to spend. Thus, this PR only contains the independently useful index refactorings.

Refactoring made using Cursor AI.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
