### PR TITLE
Allow for a personal token to be specified for self-updates

### DIFF
--- a/changelog/unreleased/issue-3738
+++ b/changelog/unreleased/issue-3738
@@ -1,0 +1,7 @@
+Enhancement: Allow Github personal access token to be specified for `self-update`
+
+`restic self-update` previously used unauthenticated GitHub API requests when checking for the latest release. This caused users sharing IP addresses to hit the GitHub rate limit, resulting in a 403 Forbidden error and preventing updates.
+Restic now supports authenticated GitHub API requests during `self-update`. Users can set the `$GITHUB_ACCESS_TOKEN` environment variable to use a [personal access token](https://github.com/settings/tokens), avoiding update failures due to rate limiting.
+
+https://github.com/restic/restic/issues/3738
+https://github.com/restic/restic/pull/5568

--- a/changelog/unreleased/issue-3738
+++ b/changelog/unreleased/issue-3738
@@ -1,7 +1,8 @@
 Enhancement: Allow Github personal access token to be specified for `self-update`
 
-`restic self-update` previously used unauthenticated GitHub API requests when checking for the latest release. This caused users sharing IP addresses to hit the GitHub rate limit, resulting in a 403 Forbidden error and preventing updates.
-Restic now supports authenticated GitHub API requests during `self-update`. Users can set the `$GITHUB_ACCESS_TOKEN` environment variable to use a [personal access token](https://github.com/settings/tokens), avoiding update failures due to rate limiting.
+`restic self-update` previously only used unauthenticated GitHub API requests when checking for the latest release. This caused some users sharing IP addresses to hit the GitHub rate limit, resulting in a 403 Forbidden error and preventing updates.
+
+Restic still uses unauthenticated requests by default, but it now optionally supports authenticated GitHub API requests during `self-update`. Users can set the `$GITHUB_ACCESS_TOKEN` environment variable to use a [personal access token](https://github.com/settings/tokens) for this effect, avoiding update failures due to rate limiting.
 
 https://github.com/restic/restic/issues/3738
 https://github.com/restic/restic/pull/5568

--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -25,7 +25,7 @@ you can download and run without having to do additional installation work.
 
 Please see the :ref:`official_binaries` section below for various downloads.
 Official binaries can be updated in place by using the ``restic self-update``
-command.
+command. The environment variable ``$GITHUB_ACCESS_TOKEN`` can be set to use a personal access token when updating.
 
 Alpine Linux
 ============

--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -25,7 +25,12 @@ you can download and run without having to do additional installation work.
 
 Please see the :ref:`official_binaries` section below for various downloads.
 Official binaries can be updated in place by using the ``restic self-update``
-command. The environment variable ``$GITHUB_ACCESS_TOKEN`` can be set to use a personal access token when updating.
+command. 
+
+The environment variable ``$GITHUB_ACCESS_TOKEN`` can be set to use a personal 
+access token when updating. This increases the rate limit through authenticated GitHub API 
+requests, and prevents update failures when many 
+unauthenticated requests have already been made from the same IP.
 
 Alpine Linux
 ============

--- a/internal/selfupdate/github.go
+++ b/internal/selfupdate/github.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"os"
 	"strings"
 	"time"
 
@@ -59,6 +60,11 @@ func GitHubLatestRelease(ctx context.Context, owner, repo string) (Release, erro
 
 	// pin API version 3
 	req.Header.Set("Accept", "application/vnd.github.v3+json")
+
+	// parse personal access token from env, if not exists or empty it will not be added to the request
+	if token := os.Getenv("GITHUB_ACCESS_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {
@@ -118,6 +124,11 @@ func getGithubData(ctx context.Context, url string) ([]byte, error) {
 
 	// request binary data
 	req.Header.Set("Accept", "application/octet-stream")
+
+	// parse personal access token from env, if not exists or empty it will not be added to the request
+	if token := os.Getenv("GITHUB_ACCESS_TOKEN"); token != "" {
+		req.Header.Set("Authorization", "token "+token)
+	}
 
 	res, err := http.DefaultClient.Do(req)
 	if err != nil {

--- a/internal/selfupdate/github_test.go
+++ b/internal/selfupdate/github_test.go
@@ -1,0 +1,37 @@
+package selfupdate
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestNewGitHubRequest(t *testing.T) {
+	ctx := context.Background()
+	url := "https://api.github.com/repos/restic/restic/releases/latest"
+	acceptHeader := "application/vnd.github.v3+json"
+
+	t.Run("With GITHUB_ACCESS_TOKEN", func(t *testing.T) {
+		expectedToken := "testtoken123"
+		t.Setenv("GITHUB_ACCESS_TOKEN", expectedToken)
+
+		req, err := newGitHubRequest(ctx, url, acceptHeader)
+		rtest.OK(t, err)
+
+		rtest.Assert(t, req.Method == http.MethodGet, "expected method %s, got %s", http.MethodGet, req.Method)
+		rtest.Assert(t, req.URL.String() == url, "expected URL %s, got %s", url, req.URL.String())
+		rtest.Assert(t, req.Header.Get("Accept") == acceptHeader, "expected Accept header %s, got %s", acceptHeader, req.Header.Get("Accept"))
+		rtest.Assert(t, req.Header.Get("Authorization") == "token "+expectedToken, "expected Authorization header 'token %s', got %s", expectedToken, req.Header.Get("Authorization"))
+	})
+
+	t.Run("Without GITHUB_ACCESS_TOKEN", func(t *testing.T) {
+		t.Setenv("GITHUB_ACCESS_TOKEN", "")
+
+		req, err := newGitHubRequest(ctx, url, acceptHeader)
+		rtest.OK(t, err)
+
+		rtest.Assert(t, req.Header.Get("Authorization") == "", "expected no Authorization header, got %s", req.Header.Get("Authorization"))
+	})
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->
This change will allow for setting the $GITHUB_ACCESS_TOKEN environment variable with a Github personal access token, allowing e.g. for higher rate limits

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
Closes #3738

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
