### PR TITLE
backends: configurable maxElapsedTime for retry operations

### DIFF
--- a/changelog/unreleased/issue-5571
+++ b/changelog/unreleased/issue-5571
@@ -1,0 +1,9 @@
+Enhancement: Configurable retry timeout
+
+Restic's retry operations used a hardcoded timeout of 15 minutes,
+forcing users to wait the full duration when backends were down or misconfigured.
+
+Restic now allows setting the retry timeout via the --retry-max-elapsed-time flag.
+This permits commands like `restic cat config` to fail quickly when backends are unreachable.
+
+https://github.com/restic/restic/issues/5571

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -44,23 +44,24 @@ type BackendWrapper func(r backend.Backend) (backend.Backend, error)
 
 // Options hold all global options for restic.
 type Options struct {
-	Repo               string
-	RepositoryFile     string
-	PasswordFile       string
-	PasswordCommand    string
-	KeyHint            string
-	Quiet              bool
-	Verbose            int
-	NoLock             bool
-	RetryLock          time.Duration
-	JSON               bool
-	CacheDir           string
-	NoCache            bool
-	CleanupCache       bool
-	Compression        repository.CompressionMode
-	PackSize           uint
-	NoExtraVerify      bool
-	InsecureNoPassword bool
+	Repo                string
+	RepositoryFile      string
+	PasswordFile        string
+	PasswordCommand     string
+	KeyHint             string
+	Quiet               bool
+	Verbose             int
+	NoLock              bool
+	RetryLock           time.Duration
+	JSON                bool
+	CacheDir            string
+	NoCache             bool
+	CleanupCache        bool
+	Compression         repository.CompressionMode
+	PackSize            uint
+	NoExtraVerify       bool
+	InsecureNoPassword  bool
+	RetryMaxElapsedTime time.Duration
 
 	backend.TransportOptions
 	limiter.Limits
@@ -110,6 +111,7 @@ func (opts *Options) AddFlags(f *pflag.FlagSet) {
 	f.StringSliceVarP(&opts.Options, "option", "o", []string{}, "set extended option (`key=value`, can be specified multiple times)")
 	f.StringVar(&opts.HTTPUserAgent, "http-user-agent", "", "set a http user agent for outgoing http requests")
 	f.DurationVar(&opts.StuckRequestTimeout, "stuck-request-timeout", 5*time.Minute, "`duration` after which to retry stuck requests")
+	f.DurationVar(&opts.RetryMaxElapsedTime, "retry-max-elapsed-time", 15*time.Minute, "max elapsed time for retry operations")
 
 	opts.Repo = os.Getenv("RESTIC_REPOSITORY")
 	opts.RepositoryFile = os.Getenv("RESTIC_REPOSITORY_FILE")
@@ -597,7 +599,8 @@ func wrapBackend(be backend.Backend, gopts Options, printer progress.Printer) (b
 	success := func(msg string, retries int) {
 		printer.E("%v operation successful after %d retries", msg, retries)
 	}
-	be = retry.New(be, 15*time.Minute, report, success)
+
+	be = retry.New(be, gopts.RetryMaxElapsedTime, report, success)
 
 	// wrap backend if a test specified a hook
 	if gopts.BackendTestHook != nil {


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

Add --retry-max-elapsed-time flag to configure the maximum elapsed time for retry operations. The default remains 15 minutes.

Previously, the timeout was hardcoded at 15 minutes, forcing users to wait the full duration when backends were down or misconfigured.

Many of us automate our backups using scripts or other tools. A common operation is to check if a repo is initialized
before performing backups. This is usually done with `restic cat config`. However, if the backend is down or misconfigured, it's ideal for the operation to fail fast and return an error. Unfortunately, the retry mechanism is hardcoded to run for 15mins.
 

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

use "Closes #5571 "

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
