### PR TITLE
snapshots: Show timezone in non-compact output

### DIFF
--- a/changelog/unreleased/pull-5588
+++ b/changelog/unreleased/pull-5588
@@ -1,0 +1,10 @@
+Enhancement: Display timezone information in snapshots output
+
+The `snapshots` command now displays which timezone is being used to show
+timestamps. Since snapshots can be created in different timezones but are
+always displayed in the local timezone, a footer line is now shown indicating
+the timezone used for display (e.g., "Timestamps shown in CET timezone").
+This helps prevent confusion when comparing snapshots in a multi-user
+environment.
+
+https://github.com/restic/restic/pull/5588

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/global"
@@ -265,7 +266,15 @@ func PrintSnapshots(stdout io.Writer, list data.Snapshots, reasons []data.KeepRe
 		tab.AddRow(data)
 	}
 
-	tab.AddFooter(fmt.Sprintf("%d snapshots", len(list)))
+	// Add timezone information to prevent confusion:
+	// Each snapshot can be registered in different timezones,
+	// but we display them all in local timezone on this output.
+	footer := fmt.Sprintf("%d snapshots", len(list))
+	zoneName, _ := time.Now().Local().Zone()
+	if zoneName != "" {
+		footer = fmt.Sprintf("Timestamps shown in %s timezone\n%s", zoneName, footer)
+	}
+	tab.AddFooter(footer)
 
 	if multiline {
 		// print an additional blank line between snapshots


### PR DESCRIPTION

What does this PR change? What problem does it solve?
-----------------------------------------------------

Restic lists snapshots in user's current timezone. It's very convenient but might be confusing in case of multiple users accessing the same repository without realizing they're on different timezones.

This change is an attempt to solve it by showing one-line information to the bottom of the snapshot list (plus, it is a best effort trying to get the timezone info, since I am not sure how reliable would this method be on non-Linux operating systems).

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

https://forum.restic.net/t/timezone-question/10228

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
