### PR TITLE
Add configurable HTTP range request size

### DIFF
--- a/internal/repository/repository_internal_test.go
+++ b/internal/repository/repository_internal_test.go
@@ -324,7 +324,7 @@ func testStreamPack(t *testing.T, version uint) {
 
 				loadCalls = 0
 				shortFirstLoad = test.shortFirstLoad
-				err := streamPack(ctx, load, nil, dec, &key, restic.ID{}, test.blobs, handleBlob)
+				err := streamPack(ctx, load, nil, dec, &key, restic.ID{}, test.blobs, handleBlob, 2*DefaultPackSize)
 				if err != nil {
 					t.Fatal(err)
 				}
@@ -387,7 +387,7 @@ func testStreamPack(t *testing.T, version uint) {
 					return err
 				}
 
-				err := streamPack(ctx, load, nil, dec, &key, restic.ID{}, test.blobs, handleBlob)
+				err := streamPack(ctx, load, nil, dec, &key, restic.ID{}, test.blobs, handleBlob, 2*DefaultPackSize)
 				if err == nil {
 					t.Fatalf("wanted error %v, got nil", test.err)
 				}
@@ -563,7 +563,7 @@ func TestStreamPackFallback(t *testing.T) {
 			return err
 		}
 
-		err := streamPack(ctx, loadPack, loadBlob, dec, &key, restic.ID{}, blobs, handleBlob)
+		err := streamPack(ctx, loadPack, loadBlob, dec, &key, restic.ID{}, blobs, handleBlob, 2*DefaultPackSize)
 		rtest.OK(t, err)
 		rtest.Assert(t, blobOK, "blob failed to load")
 	}


### PR DESCRIPTION
# Add configurable HTTP range request size

## Summary

This PR makes the HTTP Range request size configurable to allow users to reduce the number of HTTP requests when using REST and other HTTP-based backends.

Previously, restic used a hardcoded maximum chunk size of 32 MB (2 × DefaultPackSize) when loading blobs from pack files via HTTP Range requests. This meant that any blob retrieval operation would be split into multiple 32 MB range requests. For backends with high per-request overhead (latency, API rate limits, connection costs), this could be inefficient.

This change introduces a new `--http-range-size` flag and `RESTIC_HTTP_RANGE_SIZE` environment variable to configure this limit, allowing users to increase it and reduce the number of HTTP requests at the cost of potentially transferring more unused data.

## Changes

- **`internal/global/global.go`**: Added `HTTPRangeSize` field to `Options` struct with command-line flag and environment variable support
- **`internal/repository/repository.go`**:
  - Added `HTTPRangeSize` field to repository `Options` struct
  - Modified `LoadBlobsFromPack()` to use configurable range size with a default of 32 MB when not specified
  - Updated `streamPack()` function signature to accept `maxChunkSize` as a parameter instead of using a hardcoded constant
- **`internal/repository/repository_internal_test.go`**: Updated all test calls to `streamPack()` to include the default chunk size parameter

## Usage

```bash
# Use 64 MB range requests instead of the default 32 MB
restic --http-range-size 64 restore latest

# Or set via environment variable
export RESTIC_HTTP_RANGE_SIZE=64
restic backup /data
```

## Backward Compatibility

The default behavior (32 MB) is maintained when the option is not specified, ensuring full backward compatibility.

## Testing

- All existing repository tests pass
- Build succeeds without errors
- New flag appears correctly in `--help` output
- Default behavior preserved when flag is not specified