### PR TITLE
Fail fast for invalid RESTIC_PACK_SIZE env values

### DIFF
--- a/changelog/unreleased/pull-5592
+++ b/changelog/unreleased/pull-5592
@@ -1,0 +1,7 @@
+Bugfix: Return error if `RESTIC_PACK_SIZE` contains invalid value
+
+If the environment variable `RESTIC_PACK_SIZE` could not be parsed, then
+restic ignored its value. Now, the restic commands fail with an error, unless
+the command-line option `--pack-size` was specified.
+
+https://github.com/restic/restic/pull/5592

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -49,6 +49,10 @@ The full documentation can be found at https://restic.readthedocs.io/ .
 		DisableAutoGenTag: true,
 
 		PersistentPreRunE: func(c *cobra.Command, _ []string) error {
+			switch c.Name() {
+			case "__complete", "__completeNoDesc":
+				return nil
+			}
 			return globalOptions.PreRun(needsPassword(c.Name()))
 		},
 	}
@@ -114,7 +118,7 @@ The full documentation can be found at https://restic.readthedocs.io/ .
 // user for authentication).
 func needsPassword(cmd string) bool {
 	switch cmd {
-	case "cache", "generate", "help", "options", "self-update", "version", "__complete":
+	case "cache", "generate", "help", "options", "self-update", "version", "__complete", "__completeNoDesc":
 		return false
 	default:
 		return true

--- a/internal/global/global_test.go
+++ b/internal/global/global_test.go
@@ -75,3 +75,18 @@ func TestPackSizeEnvApplied(t *testing.T) {
 	rtest.OK(t, err)
 	rtest.Equals(t, uint(64), gopts.PackSize)
 }
+
+func TestPackSizeEnvIgnoredWhenFlagSet(t *testing.T) {
+	t.Setenv("RESTIC_PACK_SIZE", "64MiB")
+
+	var gopts Options
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	gopts.AddFlags(fs)
+
+	err := fs.Set("pack-size", "64")
+	rtest.OK(t, err)
+
+	err = gopts.PreRun(false)
+	rtest.OK(t, err)
+	rtest.Equals(t, uint(64), gopts.PackSize)
+}

--- a/internal/global/global_test.go
+++ b/internal/global/global_test.go
@@ -7,6 +7,9 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/spf13/pflag"
+
+	"github.com/restic/restic/internal/errors"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -48,4 +51,27 @@ func TestReadEmptyPassword(t *testing.T) {
 	opts.Password = "invalid"
 	_, err = readPassword(context.TODO(), opts, "test")
 	rtest.Assert(t, strings.Contains(err.Error(), "must not be specified together with providing a password via a cli option or environment variable"), "unexpected error message, got %v", err)
+}
+
+func TestPackSizeEnvParseError(t *testing.T) {
+	t.Setenv("RESTIC_PACK_SIZE", "64MiB")
+
+	var gopts Options
+	gopts.AddFlags(pflag.NewFlagSet("test", pflag.ContinueOnError))
+
+	err := gopts.PreRun(false)
+	rtest.Assert(t, err != nil, "expected error for invalid pack size env")
+	rtest.Assert(t, errors.IsFatal(err), "expected fatal error for invalid pack size env, got %T", err)
+	rtest.Assert(t, strings.Contains(err.Error(), "RESTIC_PACK_SIZE"), "error should mention RESTIC_PACK_SIZE, got %v", err)
+}
+
+func TestPackSizeEnvApplied(t *testing.T) {
+	t.Setenv("RESTIC_PACK_SIZE", "64")
+
+	var gopts Options
+	gopts.AddFlags(pflag.NewFlagSet("test", pflag.ContinueOnError))
+
+	err := gopts.PreRun(false)
+	rtest.OK(t, err)
+	rtest.Equals(t, uint(64), gopts.PackSize)
 }


### PR DESCRIPTION
## What does this PR change? What problem does it solve?

- previously a typo like RESTIC_PACK_SIZE=64MiB let a backup run to completion while silently falling back to the default pack size, so you only learn much later that the wrong pack size was used; now we return a fatal error as soon as the env var can’t be parsed, matching the CLI flag’s validation
- document the rationale inline so future readers know why we guard the env path
- add tests that cover both the failure case (64MiB) and a valid numeric env value

## Was the change previously discussed in an issue or on the forum?

- small bugfix, no prior discussion

## Checklist

- [x] I have added tests for all code changes
- [x] I have added documentation for relevant changes (not needed)
- [x] There's a new file in changelog/unreleased/ (not needed for this small bugfix)
- [x] I'm done! This pull request is ready for review

## Tests

- GOCACHE=$(pwd)/.gocache go test ./internal/global