### PR TITLE
backend/local: fix "operation not supported" when unlocking

### DIFF
--- a/changelog/unreleased/issue-5595
+++ b/changelog/unreleased/issue-5595
@@ -1,0 +1,8 @@
+Bugfix: Fix "chmod not supported" errors when unlocking
+
+Restic 0.18.0 introduced a bug that caused "chmod xxx: operation not supported"
+errors to appear when unlocking with a stale lock, on a local file repository
+that did not support chmod (like CIFS or WebDAV mounted via FUSE). Restic now
+just doesn't bother calling chmod in that case on Unix, as it is unnecessary.
+
+https://github.com/restic/restic/issues/5595

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -255,13 +255,7 @@ func (b *Local) Stat(_ context.Context, h backend.Handle) (backend.FileInfo, err
 func (b *Local) Remove(_ context.Context, h backend.Handle) error {
 	fn := b.Filename(h)
 
-	// reset read-only flag
-	err := os.Chmod(fn, 0666)
-	if err != nil && !os.IsPermission(err) {
-		return errors.WithStack(err)
-	}
-
-	return os.Remove(fn)
+	return removeFile(fn)
 }
 
 // List runs fn for each file in the backend which has the type t. When an

--- a/internal/backend/local/local_unix.go
+++ b/internal/backend/local/local_unix.go
@@ -52,3 +52,7 @@ func setFileReadonly(f string, mode os.FileMode) error {
 
 	return err
 }
+
+func removeFile(f string) error {
+	return os.Remove(f)
+}

--- a/internal/backend/local/local_windows.go
+++ b/internal/backend/local/local_windows.go
@@ -2,6 +2,8 @@ package local
 
 import (
 	"os"
+
+	"github.com/restic/restic/internal/errors"
 )
 
 // Can't explicitly flush directory changes on Windows.
@@ -15,4 +17,15 @@ func isMacENOTTY(_ error) bool { return false }
 // and this isn't common practice on this platform.
 func setFileReadonly(_ string, _ os.FileMode) error {
 	return nil
+}
+
+func removeFile(f string) error {
+	// Reset read-only flag,
+	// as Windows won't let you delete a read-only file
+	err := os.Chmod(f, 0666)
+	if err != nil && !os.IsPermission(err) {
+		 return errors.WithStack(err)
+	}
+
+	return os.Remove(f)
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
If the repo is on a mounted folder that doesn't support chmod (like SMB), it was causing an "operation not supported" error when trying to chmod 666 a file before deleting it.

But it isn't generally needed before deleting a file (the folder permissions matter there, not the file permissions). So, just drop it.

This code path I'm deleting was introduced [ten years ago](https://github.com/restic/restic/commit/264472219804ac7c62ab1f90d3cf4a156b89495b) without comment. Is there a platform that Restic supports that *does* care about the file permissions before deleting? If so, I can fix this another way - by ignoring ErrUnsupported for Unix (like the [other recent fix](https://github.com/restic/restic/pull/5345/commits/a8535aba58c3fe5056d35e5fd14d0400e757ca38) I made did)

The only remaining `chmod` call I can see that might be a problem is in ResetPermissions in file.go (which could call the file_xxx.go's `chmod` abstraction, but I think there we actually do want to raise an issue if we can't correctly reset permissions - it's only used when there's an access denied error already. So the fact that chmod is unsupported is relevant when explicitly trying to reset permissions.)

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #5595

Checklist
---------
- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
