### PR TITLE
Work around broken Readdirnames

### DIFF
--- a/changelog/unreleased/pull-5607
+++ b/changelog/unreleased/pull-5607
@@ -1,0 +1,7 @@
+Bugfix: Work around FUSE readdir bug on Linux
+
+Restic used to use the Go standard library Readdirnames() function, which ignored files with a zero inode. With certain versions of FUSE, this caused `restic check` to fail on some FUSE filesystems, being unable to find some pack files. This applied particularly to usage of Restic by Deja Dup.
+
+Now, we use our own readdirnames() implementation that doesn't ignore any files, and `restic check` should succeed even with buggy versions of FUSE.
+
+https://github.com/restic/restic/pull/5607

--- a/internal/backend/local/local.go
+++ b/internal/backend/local/local.go
@@ -286,7 +286,7 @@ func visitDirs(ctx context.Context, dir string, fn func(backend.FileInfo) error)
 		return err
 	}
 
-	sub, err := d.Readdirnames(-1)
+	sub, err := readdirnames(d)
 	if err != nil {
 		// ignore subsequent errors
 		_ = d.Close()

--- a/internal/backend/local/local_linux.go
+++ b/internal/backend/local/local_linux.go
@@ -1,0 +1,47 @@
+package local
+
+import (
+	"os"
+	"syscall"
+	"unsafe"
+)
+
+// Read all dir entries, including even entries with st_ino == 0
+// Works around bugs in FUSE's synthetic inode number generation.
+
+func parseDirent(buf []byte) (consumed int, name string, err error) {
+	dirent := (*syscall.Dirent)(unsafe.Pointer(&buf[0]))
+	nameBytes := (*[256]byte)(unsafe.Pointer(&dirent.Name[0]))
+	for i := 0; i < 256; i++ {
+		if nameBytes[i] == 0 {
+			name = string(nameBytes[:i])
+			break
+		}
+	}
+	return int(dirent.Reclen), name, nil
+}
+
+func readdirnames(f *os.File) ([]string, error) {
+	buf := make([]byte, 8192)
+	names := []string{}
+	for {
+		bytes, err := syscall.Getdents(int(f.Fd()), buf)
+		if err != nil {
+			return nil, err
+		}
+		if bytes == 0 {
+			break
+		}
+		for n := 0; n < bytes; {
+			consumed, name, err := parseDirent(buf[n:])
+			if err != nil {
+				return nil, err
+			}
+			if name != ".." && name != "." {
+				names = append(names, name)
+			}
+			n += consumed
+		}
+	}
+	return names, nil
+}

--- a/internal/backend/local/local_nonlinux.go
+++ b/internal/backend/local/local_nonlinux.go
@@ -1,0 +1,10 @@
+//go:build !linux
+// +build !linux
+
+package local
+
+import "os"
+
+func readdirnames(f *os.File) ([]string, error) {
+	return f.Readdirnames(-1)
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

FUSE on Linux sometimes returns dir-entries with st_ino == 0, which causes Readdirnames() to filter those items out. This break `restic check` on those filesystems. Instead, use our own `readdirnames()` that includes those items.

This affects potentially all uses of Restic in Deja Dup, see this ticket: https://gitlab.gnome.org/World/deja-dup/-/issues/623#note_2606051

This is probably a bug in FUSE, see ticket: https://github.com/libfuse/libfuse/issues/1338 . But there's no fix yet, and versions with the bug have been released into the wild, so we should workaround it when possible.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Discussed in the Deja Dup issue tracker: https://gitlab.gnome.org/World/deja-dup/-/issues/623#note_2606051

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
     - It's not clear that there's a good way to test this, it relies on the version of libfuse installed
- [x] I have added documentation for relevant changes (in the manual).
    - Should not be user-visible
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
