### PR TITLE
check/copy/diff/stats: reduce memory usage

### DIFF
--- a/changelog/unreleased/pull-5610
+++ b/changelog/unreleased/pull-5610
@@ -1,0 +1,7 @@
+Enhancement: reduce memory usage of check/copy/diff/stats commands
+
+We have optimized the memory usage of the `check`, `copy`, `diff` and
+`stats` commands. These now require less memory when processing large
+snapshots.
+
+https://github.com/restic/restic/pull/5610

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -252,7 +252,7 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 		return visited
 	}, nil)
 
-	copyBlobs := restic.NewBlobSet()
+	copyBlobs := srcRepo.NewAssociatedBlobSet()
 	packList := restic.NewIDSet()
 
 	enqueue := func(h restic.BlobHandle) {
@@ -299,11 +299,11 @@ func copyTree(ctx context.Context, srcRepo restic.Repository, dstRepo restic.Rep
 }
 
 // copyStats: print statistics for the blobs to be copied
-func copyStats(srcRepo restic.Repository, copyBlobs restic.BlobSet, packList restic.IDSet, printer progress.Printer) uint64 {
+func copyStats(srcRepo restic.Repository, copyBlobs restic.AssociatedBlobSet, packList restic.IDSet, printer progress.Printer) uint64 {
 	// count and size
 	countBlobs := 0
 	sizeBlobs := uint64(0)
-	for blob := range copyBlobs {
+	for blob := range copyBlobs.Keys() {
 		for _, blob := range srcRepo.LookupBlob(blob.Type, blob.ID) {
 			countBlobs++
 			sizeBlobs += uint64(blob.Length)

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -130,7 +130,7 @@ func runStats(ctx context.Context, opts StatsOptions, gopts global.Options, args
 	stats := &statsContainer{
 		uniqueFiles:    make(map[fileID]struct{}),
 		fileBlobs:      make(map[string]restic.IDSet),
-		blobs:          restic.NewBlobSet(),
+		blobs:          repo.NewAssociatedBlobSet(),
 		SnapshotsCount: 0,
 	}
 
@@ -146,7 +146,7 @@ func runStats(ctx context.Context, opts StatsOptions, gopts global.Options, args
 
 	if opts.countMode == countModeRawData {
 		// the blob handles have been collected, but not yet counted
-		for blobHandle := range stats.blobs {
+		for blobHandle := range stats.blobs.Keys() {
 			pbs := repo.LookupBlob(blobHandle.Type, blobHandle.ID)
 			if len(pbs) == 0 {
 				return fmt.Errorf("blob %v not found", blobHandle)
@@ -350,7 +350,7 @@ type statsContainer struct {
 
 	// blobs is used to count individual unique blobs,
 	// independent of references to files
-	blobs restic.BlobSet
+	blobs restic.AssociatedBlobSet
 }
 
 // fileID is a 256-bit hash that distinguishes unique files.

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -24,7 +24,7 @@ type Checker struct {
 	*repository.Checker
 	blobRefs struct {
 		sync.Mutex
-		M restic.BlobSet
+		M restic.AssociatedBlobSet
 	}
 	trackUnused bool
 
@@ -46,7 +46,7 @@ func New(repo checkerRepository, trackUnused bool) *Checker {
 		trackUnused: trackUnused,
 	}
 
-	c.blobRefs.M = restic.NewBlobSet()
+	c.blobRefs.M = c.repo.NewAssociatedBlobSet()
 
 	return c
 }
@@ -245,7 +245,7 @@ func (c *Checker) UnusedBlobs(ctx context.Context) (blobs restic.BlobHandles, er
 	c.blobRefs.Lock()
 	defer c.blobRefs.Unlock()
 
-	debug.Log("checking %d blobs", len(c.blobRefs.M))
+	debug.Log("checking %d blobs", c.blobRefs.M.Len())
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -787,6 +787,22 @@ func (r *Repository) createIndexFromPacks(ctx context.Context, packsize map[rest
 	return invalid, nil
 }
 
+func (r *Repository) NewAssociatedBlobSet() restic.AssociatedBlobSet {
+	return &associatedBlobSet{*index.NewAssociatedSet[struct{}](r.idx)}
+}
+
+// associatedBlobSet is a wrapper around index.AssociatedSet to implement the restic.AssociatedBlobSet interface.
+type associatedBlobSet struct {
+	index.AssociatedSet[struct{}]
+}
+
+func (s *associatedBlobSet) Intersect(other restic.AssociatedBlobSet) restic.AssociatedBlobSet {
+	return &associatedBlobSet{*s.AssociatedSet.Intersect(other)}
+}
+func (s *associatedBlobSet) Sub(other restic.AssociatedBlobSet) restic.AssociatedBlobSet {
+	return &associatedBlobSet{*s.AssociatedSet.Sub(other)}
+}
+
 // prepareCache initializes the local cache. indexIDs is the list of IDs of
 // index files still present in the repo.
 func (r *Repository) prepareCache() error {

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -2,6 +2,7 @@ package restic
 
 import (
 	"context"
+	"iter"
 
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/crypto"
@@ -26,6 +27,7 @@ type Repository interface {
 	LookupBlob(t BlobType, id ID) []PackedBlob
 	LookupBlobSize(t BlobType, id ID) (size uint, exists bool)
 
+	NewAssociatedBlobSet() AssociatedBlobSet
 	// ListBlobs runs fn on all blobs known to the index. When the context is cancelled,
 	// the index iteration returns immediately with ctx.Err(). This blocks any modification of the index.
 	ListBlobs(ctx context.Context, fn func(PackedBlob)) error
@@ -185,4 +187,14 @@ type WarmupJob interface {
 type FindBlobSet interface {
 	Has(bh BlobHandle) bool
 	Insert(bh BlobHandle)
+}
+
+type AssociatedBlobSet interface {
+	Has(bh BlobHandle) bool
+	Insert(bh BlobHandle)
+	Delete(bh BlobHandle)
+	Len() int
+	Keys() iter.Seq[BlobHandle]
+	Intersect(other AssociatedBlobSet) AssociatedBlobSet
+	Sub(other AssociatedBlobSet) AssociatedBlobSet
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The `index.AssociatedSet` is a very memory efficient way to track BlobHandles. Up to now its usage was limited to the `prune` command. However, after https://github.com/restic/restic/pull/5560 it's now easily possible to use it in place of a `restic.BlobSet`. Replace all BlobSet usages where it is expected that a large number of BlobHandles are stored there.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Test generation was AI assisted.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No. I had the idea while reviewing https://github.com/restic/restic/pull/5469 .
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
