### PR TITLE
repository: fix LookupBlobSize to also return pending blobs

### DIFF
--- a/internal/repository/index/master_index_test.go
+++ b/internal/repository/index/master_index_test.go
@@ -118,6 +118,85 @@ func TestMasterIndex(t *testing.T) {
 	rtest.Assert(t, !found, "Expected no blobs when fetching with a random id")
 }
 
+func TestMasterIndexAddPending(t *testing.T) {
+	mIdx := index.NewMasterIndex()
+
+	// Test AddPending: successfully add a new blob
+	bhPending := restic.NewRandomBlobHandle()
+	added := mIdx.AddPending(bhPending, 100)
+	rtest.Equals(t, true, added)
+
+	// Test AddPending: try to add the same blob again (should return false)
+	added = mIdx.AddPending(bhPending, 200)
+	rtest.Equals(t, false, added)
+
+	// Test AddPending: try to add a blob that's already in an index (should return false)
+	bhInIndex := restic.NewRandomBlobHandle()
+	idx := index.NewIndex()
+	idx.StorePack(restic.NewRandomID(), []restic.Blob{{
+		BlobHandle:         bhInIndex,
+		Length:             uint(crypto.CiphertextLength(50)),
+		Offset:             0,
+		UncompressedLength: 50,
+	}})
+	mIdx.Insert(idx)
+
+	added = mIdx.AddPending(bhInIndex, 100)
+	rtest.Equals(t, false, added)
+
+	// Test LookupSize: returns pending blob size when blob is pending
+	size, found := mIdx.LookupSize(bhPending)
+	rtest.Equals(t, true, found)
+	rtest.Equals(t, uint(100), size)
+}
+
+// noopSaver is a no-op implementation of SaverUnpacked for testing.
+type noopSaver struct{}
+
+func (n *noopSaver) Connections() uint {
+	return 2
+}
+
+func (n *noopSaver) SaveUnpacked(_ context.Context, _ restic.FileType, buf []byte) (restic.ID, error) {
+	return restic.Hash(buf), nil
+}
+
+func TestMasterIndexStorePackRemovesPending(t *testing.T) {
+	mIdx := index.NewMasterIndex()
+
+	// Add a blob as pending
+	bhPending := restic.NewRandomBlobHandle()
+	added := mIdx.AddPending(bhPending, 75)
+	rtest.Equals(t, true, added)
+
+	// Store the blob in a pack
+	packID := restic.NewRandomID()
+	blob := restic.Blob{
+		BlobHandle:         bhPending,
+		Length:             uint(crypto.CiphertextLength(75)),
+		Offset:             0,
+		UncompressedLength: 75,
+	}
+	saver := &noopSaver{}
+	err := mIdx.StorePack(context.Background(), packID, []restic.Blob{blob}, saver)
+	rtest.OK(t, err)
+
+	// Verify it is still found
+	size, found := mIdx.LookupSize(bhPending)
+	rtest.Equals(t, true, found)
+	rtest.Equals(t, uint(75), size)
+
+	// Verify the blob can be found via Lookup from the index
+	blobs := mIdx.Lookup(bhPending)
+	rtest.Assert(t, len(blobs) > 0, "blob should be found in index after StorePack")
+	rtest.Equals(t, packID, blobs[0].PackID)
+	rtest.Equals(t, bhPending, blobs[0].BlobHandle)
+
+	// Test that adding the same blob as pending again fails (it's now in index)
+	added = mIdx.AddPending(bhPending, 100)
+	rtest.Equals(t, false, added)
+}
+
 func TestMasterMergeFinalIndexes(t *testing.T) {
 	bhInIdx1 := restic.NewRandomBlobHandle()
 	bhInIdx2 := restic.NewRandomBlobHandle()

--- a/internal/repository/index/master_index_test.go
+++ b/internal/repository/index/master_index_test.go
@@ -74,9 +74,6 @@ func TestMasterIndex(t *testing.T) {
 	mIdx.Insert(idx2)
 
 	// test idInIdx1
-	found := mIdx.Has(bhInIdx1)
-	rtest.Equals(t, true, found)
-
 	blobs := mIdx.Lookup(bhInIdx1)
 	rtest.Equals(t, []restic.PackedBlob{blob1}, blobs)
 
@@ -85,9 +82,6 @@ func TestMasterIndex(t *testing.T) {
 	rtest.Equals(t, uint(10), size)
 
 	// test idInIdx2
-	found = mIdx.Has(bhInIdx2)
-	rtest.Equals(t, true, found)
-
 	blobs = mIdx.Lookup(bhInIdx2)
 	rtest.Equals(t, []restic.PackedBlob{blob2}, blobs)
 
@@ -96,9 +90,6 @@ func TestMasterIndex(t *testing.T) {
 	rtest.Equals(t, uint(200), size)
 
 	// test idInIdx12
-	found = mIdx.Has(bhInIdx12)
-	rtest.Equals(t, true, found)
-
 	blobs = mIdx.Lookup(bhInIdx12)
 	rtest.Equals(t, 2, len(blobs))
 
@@ -121,8 +112,6 @@ func TestMasterIndex(t *testing.T) {
 	rtest.Equals(t, uint(80), size)
 
 	// test not in index
-	found = mIdx.Has(restic.BlobHandle{ID: restic.NewRandomID(), Type: restic.TreeBlob})
-	rtest.Assert(t, !found, "Expected no blobs when fetching with a random id")
 	blobs = mIdx.Lookup(restic.NewRandomBlobHandle())
 	rtest.Assert(t, blobs == nil, "Expected no blobs when fetching with a random id")
 	_, found = mIdx.LookupSize(restic.NewRandomBlobHandle())
@@ -521,7 +510,7 @@ func TestRewriteOversizedIndex(t *testing.T) {
 
 	// verify that blobs are still in the index
 	for _, blob := range blobs {
-		found := mi2.Has(blob.BlobHandle)
+		_, found := mi2.LookupSize(blob.BlobHandle)
 		rtest.Assert(t, found, "blob %v missing after rewrite", blob.ID)
 	}
 

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -640,7 +640,7 @@ func (r *Repository) LookupBlob(tpe restic.BlobType, id restic.ID) []restic.Pack
 	return r.idx.Lookup(restic.BlobHandle{Type: tpe, ID: id})
 }
 
-// LookupBlobSize returns the size of blob id.
+// LookupBlobSize returns the size of blob id. Also returns pending blobs.
 func (r *Repository) LookupBlobSize(tpe restic.BlobType, id restic.ID) (uint, bool) {
 	return r.idx.LookupSize(restic.BlobHandle{Type: tpe, ID: id})
 }
@@ -968,7 +968,7 @@ func (r *Repository) saveBlob(ctx context.Context, t restic.BlobType, buf []byte
 	}
 
 	// first try to add to pending blobs; if not successful, this blob is already known
-	known = !r.idx.AddPending(restic.BlobHandle{ID: newID, Type: t})
+	known = !r.idx.AddPending(restic.BlobHandle{ID: newID, Type: t}, uint(len(buf)))
 
 	// only save when needed or explicitly told
 	if !known || storeDuplicate {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Extracted from https://github.com/restic/restic/pull/5472 as this is relevant independent of that PR. This change isn't really user visible. At the moment this could only result in a few warnings less from the `backup`  command when it reuploads missing blobs. All other places that write to a repository don't rely on knowing about pending blobs so far.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Extracted from #5472
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I'm done! This pull request is ready for review.
