### PR TITLE
Backup from s3

### DIFF
--- a/changelog/unreleased/pull-5616
+++ b/changelog/unreleased/pull-5616
@@ -1,0 +1,15 @@
+Enhancement: Back up files directly from an S3 source
+
+Restic could only back up files from the local filesystem, or data piped in via
+`--stdin` / `--stdin-from-command`. Backing up the contents of an S3 bucket
+required mounting it first, for example with rclone or s3fs.
+
+Restic can now read backup sources directly from an S3-compatible object store.
+Pass one or more `s3://bucketname/prefix` targets to the `backup` command.
+The endpoint and credentials are read from the
+`AWS_ENDPOINT_URL`, `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment
+variables. S3 sources cannot be combined with local paths in the same command.
+
+https://github.com/restic/restic/pull/5616
+https://forum.restic.net/t/creating-a-restic-backup-of-a-s3-bucket/10335
+https://forum.restic.net/t/backup-of-an-s3-bucket/4852

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -443,13 +443,13 @@ func collectTargets(opts BackupOptions, args []string, warnf func(msg string, ar
 	}
 
 	// example "s3://bucketname/maybe-folder"
-	if strings.HasPrefix(targets[0], fs.S3_PREFIX) {
+	if strings.HasPrefix(targets[0], fs.S3Prefix) {
 		for _, target := range targets {
-			if !strings.HasPrefix(target, fs.S3_PREFIX) {
-				return nil, errors.Fatalf("target=%s has not prefix s3:/", target)
+			if !strings.HasPrefix(target, fs.S3Prefix) {
+				return nil, errors.Fatalf("target=%s has not prefix %s", target, fs.S3Prefix)
 
 			}
-			paths := strings.Split(strings.Replace(target, fs.S3_PREFIX, "", 1), "/")
+			paths := strings.Split(strings.TrimPrefix(target, fs.S3Prefix), "/")
 			if len(paths) < 2 || paths[1] == "" {
 				return nil, errors.Fatalf("target=%s has not bucketName", target)
 			}
@@ -513,21 +513,22 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 
 	success := true
 	targets, err := collectTargets(opts, args, printer.E, term.InputRaw())
-	isS3Source := false
-	if len(targets) > 0 {
-		isS3Source = strings.HasPrefix(targets[0], fs.S3_PREFIX)
-	}
-	if isS3Source {
-		for i, target := range targets {
-			targets[i] = strings.Replace(target, fs.S3_PREFIX, "", 1)
-		}
-	}
 
 	if err != nil {
 		if errors.Is(err, ErrInvalidSourceData) {
 			success = false
 		} else {
 			return err
+		}
+	}
+
+	isS3Source := false
+	if len(targets) > 0 {
+		isS3Source = strings.HasPrefix(targets[0], fs.S3Prefix)
+		if isS3Source {
+			for i, target := range targets {
+				targets[i] = strings.TrimPrefix(target, fs.S3Prefix)
+			}
 		}
 	}
 

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -383,8 +383,6 @@ func collectRejectFuncs(opts BackupOptions, targets []string, fs fs.FS, warnf fu
 	return funcs, nil
 }
 
-const S3_PREFIX = "s3:/"
-
 // collectTargets returns a list of target files/dirs from several sources.
 func collectTargets(opts BackupOptions, args []string, warnf func(msg string, args ...interface{}), stdin io.ReadCloser) (targets []string, err error) {
 	if opts.Stdin || opts.StdinCommand {
@@ -445,9 +443,9 @@ func collectTargets(opts BackupOptions, args []string, warnf func(msg string, ar
 	}
 
 	// example "s3://bucketname/maybe-folder"
-	if strings.HasPrefix(targets[0], S3_PREFIX) {
+	if strings.HasPrefix(targets[0], fs.S3_PREFIX) {
 		for _, target := range targets {
-			if !strings.HasPrefix(target, S3_PREFIX) {
+			if !strings.HasPrefix(target, fs.S3_PREFIX) {
 				return nil, errors.Fatalf("target=%s has not prefix s3:/", target)
 			}
 		}
@@ -510,10 +508,10 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 
 	success := true
 	targets, err := collectTargets(opts, args, printer.E, term.InputRaw())
-	isS3Source := strings.HasPrefix(targets[0], S3_PREFIX)
+	isS3Source := strings.HasPrefix(targets[0], fs.S3_PREFIX)
 	if isS3Source {
 		for i, target := range targets {
-			targets[i] = strings.Replace(target, S3_PREFIX, "", 1)
+			targets[i] = strings.Replace(target, fs.S3_PREFIX, "", 1)
 		}
 	}
 

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -450,7 +450,6 @@ func collectTargets(opts BackupOptions, args []string, warnf func(msg string, ar
 
 			}
 			paths := strings.Split(strings.Replace(target, fs.S3_PREFIX, "", 1), "/")
-			fmt.Println(strings.Replace(target, fs.S3_PREFIX, "", 1), paths, len(paths))
 			if len(paths) < 2 || paths[1] == "" {
 				return nil, errors.Fatalf("target=%s has not bucketName", target)
 			}

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -447,6 +447,12 @@ func collectTargets(opts BackupOptions, args []string, warnf func(msg string, ar
 		for _, target := range targets {
 			if !strings.HasPrefix(target, fs.S3_PREFIX) {
 				return nil, errors.Fatalf("target=%s has not prefix s3:/", target)
+
+			}
+			paths := strings.Split(strings.Replace(target, fs.S3_PREFIX, "", 1), "/")
+			fmt.Println(strings.Replace(target, fs.S3_PREFIX, "", 1), paths, len(paths))
+			if len(paths) < 2 || paths[1] == "" {
+				return nil, errors.Fatalf("target=%s has not bucketName", target)
 			}
 		}
 		return targets, nil
@@ -508,7 +514,10 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 
 	success := true
 	targets, err := collectTargets(opts, args, printer.E, term.InputRaw())
-	isS3Source := strings.HasPrefix(targets[0], fs.S3_PREFIX)
+	isS3Source := false
+	if len(targets) > 0 {
+		isS3Source = strings.HasPrefix(targets[0], fs.S3_PREFIX)
+	}
 	if isS3Source {
 		for i, target := range targets {
 			targets[i] = strings.Replace(target, fs.S3_PREFIX, "", 1)

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -449,9 +449,13 @@ func collectTargets(opts BackupOptions, args []string, warnf func(msg string, ar
 				return nil, errors.Fatalf("target=%s has not prefix %s", target, fs.S3Prefix)
 
 			}
+			pathWithoutPrefix := strings.TrimPrefix(target, fs.S3Prefix)
+			if len(pathWithoutPrefix) < 1 || pathWithoutPrefix[0] != '/' {
+				return nil, errors.Fatalf("target=%s has not slash in root path. Example s3://bucketname/maybe-folder", target)
+			}
 			paths := strings.Split(strings.TrimPrefix(target, fs.S3Prefix), "/")
 			if len(paths) < 2 || paths[1] == "" {
-				return nil, errors.Fatalf("target=%s has not bucketName", target)
+				return nil, errors.Fatalf("target=%s has not bucketName. Example s3://bucketname/maybe-folder", target)
 			}
 		}
 		return targets, nil

--- a/cmd/restic/cmd_backup_s3_integration_test.go
+++ b/cmd/restic/cmd_backup_s3_integration_test.go
@@ -1,0 +1,122 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"maps"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/restic/restic/internal/global"
+	rtest "github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/test/s3testutil"
+)
+
+// TestS3BackupIntegration starts a local minio server, seeds it with objects,
+// and runs a set of end-to-end backup tests that use S3 as the source and a
+// local directory as the repository.
+func TestS3BackupIntegration(t *testing.T) {
+	if _, err := exec.LookPath("minio"); err != nil {
+		t.Skip(err)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	addr := s3testutil.FreeAddr(t)
+	key, secret := s3testutil.NewCredentials(t)
+	cleanup := s3testutil.RunMinio(ctx, t, rtest.TempDir(t), key, secret, addr)
+	defer cleanup()
+
+	bucketName := fmt.Sprintf("backup-test-%d", time.Now().UnixNano())
+	client := s3testutil.NewClient(t, addr, key, secret)
+	rtest.OK(t, client.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{}))
+
+	testObjects := map[string][]byte{
+		"file1.txt":           []byte("hello world"),
+		"dir1/file2.txt":      []byte("content of file2"),
+		"dir1/file3.txt":      []byte("content of file3"),
+		"dir1/sub/file4.txt":  []byte("content of file4"),
+		"dir2/sub2/file5.txt": []byte("content of file5"),
+	}
+	s3testutil.UploadObjects(t, ctx, client, bucketName, testObjects)
+
+	t.Setenv("AWS_ENDPOINT_URL", "http://"+addr)
+	t.Setenv("AWS_ACCESS_KEY_ID", key)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", secret)
+
+	s3Target := "s3://" + bucketName
+
+	// newRepo returns gopts for a fresh local repository. It disables the
+	// list-once backend hook because several tests list a filetype more than once.
+	newRepo := func(t *testing.T) global.Options {
+		env, cleanup := withTestEnvironment(t)
+		t.Cleanup(cleanup)
+		env.gopts.BackendTestHook = nil
+		testRunInit(t, env.gopts)
+		return env.gopts
+	}
+
+	t.Run("RestoreBackup", func(t *testing.T) {
+		gopts := newRepo(t)
+		testRunBackup(t, "", []string{s3Target}, BackupOptions{}, gopts)
+
+		restoreDir := filepath.Join(rtest.TempDir(t), "restore")
+		testRunRestore(t, gopts, restoreDir, "latest")
+
+		for key, want := range testObjects {
+			got, err := os.ReadFile(filepath.Join(restoreDir, bucketName, filepath.FromSlash(key)))
+			rtest.OK(t, err)
+			rtest.Equals(t, want, got, fmt.Sprintf("content mismatch for %s", key))
+		}
+	})
+
+	t.Run("AddNewObject", func(t *testing.T) {
+		gopts := newRepo(t)
+		testRunBackup(t, "", []string{s3Target}, BackupOptions{}, gopts)
+		packs1 := listPacks(gopts, t)
+
+		testRunBackup(t, "", []string{s3Target}, BackupOptions{}, gopts)
+		testListSnapshots(t, gopts, 2)
+		testRunCheck(t, gopts)
+
+		// Data packs must not grow: identical content should be fully deduplicated.
+		packs2 := listPacks(gopts, t)
+		rtest.Assert(t, len(packs2) == len(packs1),
+			"expected same number of packs after second identical backup, got %d (was %d)", len(packs2), len(packs1))
+
+		// Adding a new object with fresh content must produce more packs.
+		newKey := "dir1/file5.txt"
+		newContent := []byte("brand new content that has never been backed up before")
+		s3testutil.UploadObjects(t, ctx, client, bucketName, map[string][]byte{newKey: newContent})
+		// Remove the extra object again so the shared bucket is left untouched.
+		defer func() {
+			rtest.OK(t, client.RemoveObject(ctx, bucketName, newKey, minio.RemoveObjectOptions{}))
+		}()
+
+		testRunBackup(t, "", []string{s3Target}, BackupOptions{}, gopts)
+		testListSnapshots(t, gopts, 3)
+		testRunCheck(t, gopts)
+
+		packs3 := listPacks(gopts, t)
+		rtest.Assert(t, len(packs3) > len(packs2),
+			"expected more packs after backing up a new object, got %d (was %d)", len(packs3), len(packs2))
+
+		//check all file
+		restoreDir := filepath.Join(rtest.TempDir(t), "restore")
+		testRunRestore(t, gopts, restoreDir, "latest")
+
+		localTestObjects := maps.Clone(testObjects)
+		localTestObjects[newKey] = newContent
+		for key, want := range localTestObjects {
+			got, err := os.ReadFile(filepath.Join(restoreDir, bucketName, filepath.FromSlash(key)))
+			rtest.OK(t, err)
+			rtest.Equals(t, want, got, fmt.Sprintf("content mismatch for %s", key))
+		}
+	})
+}

--- a/cmd/restic/cmd_backup_s3_integration_test.go
+++ b/cmd/restic/cmd_backup_s3_integration_test.go
@@ -7,7 +7,6 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/restic/restic/internal/global"
@@ -26,15 +25,6 @@ func TestS3BackupIntegration(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	addr := s3testutil.FreeAddr(t)
-	key, secret := s3testutil.NewCredentials(t)
-	cleanup := s3testutil.RunMinio(ctx, t, rtest.TempDir(t), key, secret, addr)
-	defer cleanup()
-
-	bucketName := fmt.Sprintf("backup-test-%d", time.Now().UnixNano())
-	client := s3testutil.NewClient(t, addr, key, secret)
-	rtest.OK(t, client.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{}))
-
 	testObjects := map[string][]byte{
 		"file1.txt":           []byte("hello world"),
 		"dir1/file2.txt":      []byte("content of file2"),
@@ -43,11 +33,11 @@ func TestS3BackupIntegration(t *testing.T) {
 		"dir2/sub2/file5.txt": []byte("content of file5"),
 		"dir2/file6.txt":      []byte("content of file6"),
 	}
-	s3testutil.UploadObjects(t, ctx, client, bucketName, testObjects)
 
-	t.Setenv("AWS_ENDPOINT_URL", "http://"+addr)
-	t.Setenv("AWS_ACCESS_KEY_ID", key)
-	t.Setenv("AWS_SECRET_ACCESS_KEY", secret)
+	srv := s3testutil.StartMinio(ctx, t, "backup-test", testObjects)
+	srv.SetAWSEnv(t)
+	client := srv.Client
+	bucketName := srv.Bucket
 
 	s3Target := "s3://" + bucketName
 

--- a/cmd/restic/cmd_backup_s3_integration_test.go
+++ b/cmd/restic/cmd_backup_s3_integration_test.go
@@ -43,6 +43,7 @@ func TestS3BackupIntegration(t *testing.T) {
 		"dir1/file3.txt":      []byte("content of file3"),
 		"dir1/sub/file4.txt":  []byte("content of file4"),
 		"dir2/sub2/file5.txt": []byte("content of file5"),
+		"dir2/file6.txt":      []byte("content of file6"),
 	}
 	s3testutil.UploadObjects(t, ctx, client, bucketName, testObjects)
 
@@ -117,6 +118,42 @@ func TestS3BackupIntegration(t *testing.T) {
 			got, err := os.ReadFile(filepath.Join(restoreDir, bucketName, filepath.FromSlash(key)))
 			rtest.OK(t, err)
 			rtest.Equals(t, want, got, fmt.Sprintf("content mismatch for %s", key))
+		}
+	})
+
+	t.Run("MultipleSources", func(t *testing.T) {
+		gopts := newRepo(t)
+
+		// Back up two distinct subtrees of the bucket in a single snapshot.
+		targets := []string{
+			s3Target + "/dir1",
+			s3Target + "/dir2/sub2",
+		}
+		testRunBackup(t, "", targets, BackupOptions{}, gopts)
+		testListSnapshots(t, gopts, 1)
+		testRunCheck(t, gopts)
+
+		restoreDir := filepath.Join(rtest.TempDir(t), "restore")
+		testRunRestore(t, gopts, restoreDir, "latest")
+
+		// Only objects below the two selected sources must be present.
+		wantObjects := map[string][]byte{
+			"dir1/file2.txt":      testObjects["dir1/file2.txt"],
+			"dir1/file3.txt":      testObjects["dir1/file3.txt"],
+			"dir1/sub/file4.txt":  testObjects["dir1/sub/file4.txt"],
+			"dir2/sub2/file5.txt": testObjects["dir2/sub2/file5.txt"],
+		}
+		for key, want := range wantObjects {
+			got, err := os.ReadFile(filepath.Join(restoreDir, bucketName, filepath.FromSlash(key)))
+			rtest.OK(t, err)
+			rtest.Equals(t, want, got, fmt.Sprintf("content mismatch for %s", key))
+		}
+
+		// Objects outside the selected sources must not be restored.
+		for _, key := range []string{"file1.txt", "dir2/file6.txt"} {
+			_, err := os.Stat(filepath.Join(restoreDir, bucketName, filepath.FromSlash(key)))
+			rtest.Assert(t, os.IsNotExist(err),
+				"unexpected object %q restored from outside the selected sources, err: %v", key, err)
 		}
 	})
 }

--- a/cmd/restic/cmd_backup_s3_integration_test.go
+++ b/cmd/restic/cmd_backup_s3_integration_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"maps"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"testing"
 	"time"
@@ -20,8 +19,7 @@ import (
 // and runs a set of end-to-end backup tests that use S3 as the source and a
 // local directory as the repository.
 func TestS3BackupIntegration(t *testing.T) {
-	if _, err := exec.LookPath("minio"); err != nil {
-		t.Skip(err)
+	if s3testutil.SkipIfNotFoundMinio(t) {
 		return
 	}
 

--- a/cmd/restic/cmd_backup_test.go
+++ b/cmd/restic/cmd_backup_test.go
@@ -76,6 +76,59 @@ func TestCollectTargets(t *testing.T) {
 	rtest.Assert(t, err == ErrInvalidSourceData, "expected error when not all targets exist")
 }
 
+func TestCollectTargetsS3(t *testing.T) {
+	noWarn := func(string, ...interface{}) {}
+
+	tests := []struct {
+		name    string
+		targets []string
+		wantErr bool
+	}{
+		{
+			name:    "single valid s3 target",
+			targets: []string{"s3://mybucket/prefix"},
+			wantErr: false,
+		},
+		{
+			name:    "multiple valid s3 targets",
+			targets: []string{"s3://bucket1/a", "s3://bucket2/b"},
+			wantErr: false,
+		},
+		{
+			name:    "deep valid s3 targets",
+			targets: []string{"s3://bucket1/a/c/d"},
+			wantErr: false,
+		},
+		{
+			name:    "missing bucket name",
+			targets: []string{"s3:/"},
+			wantErr: true,
+		},
+		{
+			name:    "empty bucket after prefix",
+			targets: []string{"s3://"},
+			wantErr: true,
+		},
+		{
+			name:    "mix of s3 and local paths",
+			targets: []string{"s3://bucket/prefix", "/local/path"},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			targets, err := collectTargets(BackupOptions{}, tc.targets, noWarn, nil)
+			if tc.wantErr {
+				rtest.Assert(t, err != nil, "expected error for targets %v, but got nil", tc.targets)
+			} else {
+				rtest.Equals(t, targets, tc.targets)
+				rtest.OK(t, err)
+			}
+		})
+	}
+}
+
 func TestReadFilenamesRaw(t *testing.T) {
 	// These should all be returned exactly as-is.
 	expected := []string{

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -646,6 +646,41 @@ the pipe and act accordingly (e.g., remove the last backup). Refer to the
 `Use the Unofficial Bash Strict Mode <http://redsymbol.net/articles/unofficial-bash-strict-mode/>`__
 for more details on this.
 
+Backing up from an S3 source
+****************************
+
+Besides the local filesystem, restic can read its backup source directly from an
+S3-compatible object store (AWS S3, MinIO, etc.). Pass one or more targets using
+the ``s3://bucketname/prefix`` syntax to the ``backup`` command. The endpoint and
+credentials are taken from the environment:
+
+.. code-block:: console
+
+    $ export AWS_ENDPOINT_URL=https://s3.example.com
+    $ export AWS_ACCESS_KEY_ID=<access-key>
+    $ export AWS_SECRET_ACCESS_KEY=<secret-key>
+    $ restic -r /srv/restic-repo backup s3://mybucket/some/prefix
+
+You can back up a whole bucket (``s3://mybucket``) or only objects under a given
+prefix (``s3://mybucket/some/prefix``), and you can list several S3 targets in a
+single command to combine them in one snapshot:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo backup s3://bucket-one/data s3://bucket-two/logs
+
+The objects are stored in the snapshot below a directory named after the bucket,
+so ``s3://mybucket/some/prefix/file.txt`` is saved as
+``mybucket/some/prefix/file.txt``. Deduplication and repeated (incremental)
+backups work as usual.
+
+.. note::
+
+    S3 sources cannot be mixed with local paths in the same ``backup`` command,
+    and ``AWS_ENDPOINT_URL`` must be set. Object storage does not provide POSIX
+    ownership or permissions, so files are stored with synthetic modes and
+    without user/group ownership.
+
 Tags for backup
 ***************
 

--- a/internal/backend/s3/s3_test.go
+++ b/internal/backend/s3/s3_test.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"testing"
 	"time"
 
@@ -64,9 +63,7 @@ func TestBackendMinio(t *testing.T) {
 		}
 	}()
 
-	_, err := exec.LookPath("minio")
-	if err != nil {
-		t.Skip(err)
+	if s3testutil.SkipIfNotFoundMinio(t) {
 		return
 	}
 
@@ -77,9 +74,7 @@ func TestBackendMinio(t *testing.T) {
 }
 
 func BenchmarkBackendMinio(t *testing.B) {
-	_, err := exec.LookPath("minio")
-	if err != nil {
-		t.Skip(err)
+	if s3testutil.SkipIfNotFoundMinio(t) {
 		return
 	}
 

--- a/internal/backend/s3/s3_test.go
+++ b/internal/backend/s3/s3_test.go
@@ -2,15 +2,10 @@ package s3_test
 
 import (
 	"context"
-	"crypto/rand"
-	"encoding/hex"
 	"fmt"
-	"io"
-	"net"
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"testing"
 	"time"
 
@@ -20,95 +15,22 @@ import (
 	"github.com/restic/restic/internal/backend/test"
 	"github.com/restic/restic/internal/options"
 	rtest "github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/test/s3testutil"
 )
-
-func mkdir(t testing.TB, dir string) {
-	err := os.MkdirAll(dir, 0700)
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func runMinio(ctx context.Context, t testing.TB, dir, key, secret string) func() {
-	mkdir(t, filepath.Join(dir, "config"))
-	mkdir(t, filepath.Join(dir, "root"))
-
-	cmd := exec.CommandContext(ctx, "minio",
-		"server",
-		"--address", "127.0.0.1:9000",
-		"--config-dir", filepath.Join(dir, "config"),
-		filepath.Join(dir, "root"))
-	cmd.Env = append(os.Environ(),
-		"MINIO_ACCESS_KEY="+key,
-		"MINIO_SECRET_KEY="+secret,
-	)
-	cmd.Stderr = os.Stderr
-
-	err := cmd.Start()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// wait until the TCP port is reachable
-	var success bool
-	for i := 0; i < 100; i++ {
-		time.Sleep(200 * time.Millisecond)
-
-		c, err := net.Dial("tcp", "localhost:9000")
-		if err == nil {
-			success = true
-			if err := c.Close(); err != nil {
-				t.Fatal(err)
-			}
-			break
-		}
-	}
-
-	if !success {
-		t.Fatal("unable to connect to minio server")
-		return nil
-	}
-
-	return func() {
-		err = cmd.Process.Kill()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		// ignore errors, we've killed the process
-		_ = cmd.Wait()
-	}
-}
-
-func newRandomCredentials(t testing.TB) (key, secret string) {
-	buf := make([]byte, 10)
-	_, err := io.ReadFull(rand.Reader, buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	key = hex.EncodeToString(buf)
-
-	_, err = io.ReadFull(rand.Reader, buf)
-	if err != nil {
-		t.Fatal(err)
-	}
-	secret = hex.EncodeToString(buf)
-
-	return key, secret
-}
 
 func newMinioTestSuite(t testing.TB) (*test.Suite[s3.Config], func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 
+	addr := s3testutil.FreeAddr(t)
 	tempdir := rtest.TempDir(t)
-	key, secret := newRandomCredentials(t)
-	cleanup := runMinio(ctx, t, tempdir, key, secret)
+	key, secret := s3testutil.NewCredentials(t)
+	cleanup := s3testutil.RunMinio(ctx, t, tempdir, key, secret, addr)
 
 	return &test.Suite[s3.Config]{
 			// NewConfig returns a config for a new temporary backend that will be used in tests.
 			NewConfig: func() (*s3.Config, error) {
 				cfg := s3.NewConfig()
-				cfg.Endpoint = "localhost:9000"
+				cfg.Endpoint = addr
 				cfg.Bucket = "restictestbucket"
 				cfg.Prefix = fmt.Sprintf("test-%d", time.Now().UnixNano())
 				cfg.UseHTTP = true
@@ -142,7 +64,6 @@ func TestBackendMinio(t *testing.T) {
 		}
 	}()
 
-	// try to find a minio binary
 	_, err := exec.LookPath("minio")
 	if err != nil {
 		t.Skip(err)
@@ -156,7 +77,6 @@ func TestBackendMinio(t *testing.T) {
 }
 
 func BenchmarkBackendMinio(t *testing.B) {
-	// try to find a minio binary
 	_, err := exec.LookPath("minio")
 	if err != nil {
 		t.Skip(err)

--- a/internal/backend/s3/s3_test.go
+++ b/internal/backend/s3/s3_test.go
@@ -20,40 +20,34 @@ import (
 func newMinioTestSuite(t testing.TB) (*test.Suite[s3.Config], func()) {
 	ctx, cancel := context.WithCancel(context.Background())
 
-	addr := s3testutil.FreeAddr(t)
-	tempdir := rtest.TempDir(t)
-	key, secret := s3testutil.NewCredentials(t)
-	cleanup := s3testutil.RunMinio(ctx, t, tempdir, key, secret, addr)
+	minioConfig := s3testutil.StartMinio(ctx, t, "", nil)
 
 	return &test.Suite[s3.Config]{
-			// NewConfig returns a config for a new temporary backend that will be used in tests.
-			NewConfig: func() (*s3.Config, error) {
-				cfg := s3.NewConfig()
-				cfg.Endpoint = addr
-				cfg.Bucket = "restictestbucket"
-				cfg.Prefix = fmt.Sprintf("test-%d", time.Now().UnixNano())
-				cfg.UseHTTP = true
-				cfg.KeyID = key
-				cfg.Secret = options.NewSecretString(secret)
-				return &cfg, nil
-			},
+		// NewConfig returns a config for a new temporary backend that will be used in tests.
+		NewConfig: func() (*s3.Config, error) {
+			cfg := s3.NewConfig()
+			cfg.Endpoint = minioConfig.Addr
+			cfg.Bucket = "restictestbucket"
+			cfg.Prefix = fmt.Sprintf("test-%d", time.Now().UnixNano())
+			cfg.UseHTTP = true
+			cfg.KeyID = minioConfig.Key
+			cfg.Secret = options.NewSecretString(minioConfig.Secret)
+			return &cfg, nil
+		},
 
-			Factory: location.NewHTTPBackendFactory("s3", s3.ParseConfig, location.NoPassword, func(ctx context.Context, cfg s3.Config, rt http.RoundTripper, errorLog func(string, ...interface{})) (be backend.Backend, err error) {
-				for i := 0; i < 50; i++ {
-					be, err = s3.Create(ctx, cfg, rt, errorLog)
-					if err != nil {
-						t.Logf("s3 open: try %d: error %v", i, err)
-						time.Sleep(500 * time.Millisecond)
-						continue
-					}
-					break
+		Factory: location.NewHTTPBackendFactory("s3", s3.ParseConfig, location.NoPassword, func(ctx context.Context, cfg s3.Config, rt http.RoundTripper, errorLog func(string, ...interface{})) (be backend.Backend, err error) {
+			for i := 0; i < 50; i++ {
+				be, err = s3.Create(ctx, cfg, rt, errorLog)
+				if err != nil {
+					t.Logf("s3 open: try %d: error %v", i, err)
+					time.Sleep(500 * time.Millisecond)
+					continue
 				}
-				return be, err
-			}, s3.Open),
-		}, func() {
-			defer cancel()
-			defer cleanup()
-		}
+				break
+			}
+			return be, err
+		}, s3.Open),
+	}, cancel
 }
 
 func TestBackendMinio(t *testing.T) {

--- a/internal/fs/fs_s3.go
+++ b/internal/fs/fs_s3.go
@@ -18,6 +18,8 @@ import (
 	"time"
 )
 
+const S3_PREFIX = "s3:/"
+
 type S3Source struct {
 	s3Client      *minio.Client
 	files         map[string]*ExtendedFileInfo

--- a/internal/fs/fs_s3.go
+++ b/internal/fs/fs_s3.go
@@ -9,6 +9,7 @@ import (
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"io"
+	"net/url"
 	"os"
 	"path"
 	"path/filepath"
@@ -60,8 +61,14 @@ func (fs *S3Source) factoryS3Client() (*minio.Client, error) {
 	} else if endpoint == "" {
 		return nil, errors.Fatalf("no credentials found. $AWS_ENDPOINT_URL is empty")
 	}
-	s3Client, err := minio.New(endpoint, &minio.Options{
-		Creds: credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
+
+	urlEndpoint, err := url.Parse(endpoint)
+	if err != nil {
+		return nil, err
+	}
+	s3Client, err := minio.New(urlEndpoint.Host, &minio.Options{
+		Creds:  credentials.NewStaticV4(accessKeyID, secretAccessKey, ""),
+		Secure: urlEndpoint.Scheme == "https",
 	})
 	if err != nil {
 		return nil, err

--- a/internal/fs/fs_s3.go
+++ b/internal/fs/fs_s3.go
@@ -132,10 +132,11 @@ func (fs *S3Source) WarmingUp(targets []string) error {
 
 					if _, ok := files[objPath]; !ok {
 						fi := &ExtendedFileInfo{
-							Name:    path.Base(objPath),
-							Mode:    os.ModeDir | 0755,
-							ModTime: time.Unix(0, 0),
-							Size:    0,
+							Name:       path.Base(objPath),
+							Mode:       os.ModeDir | 0755,
+							ModTime:    time.Unix(0, 0),
+							ChangeTime: time.Unix(0, 0),
+							Size:       0,
 						}
 						muFiles.Lock()
 						files[objPath] = fi
@@ -155,10 +156,11 @@ func (fs *S3Source) WarmingUp(targets []string) error {
 
 				muFiles.Lock()
 				files[absPath] = &ExtendedFileInfo{
-					Name:    path.Base(absPath),
-					Mode:    0644,
-					ModTime: obj.LastModified,
-					Size:    obj.Size,
+					Name:       path.Base(absPath),
+					Mode:       0644,
+					ModTime:    obj.LastModified,
+					ChangeTime: obj.LastModified,
+					Size:       obj.Size,
 				}
 				muFiles.Unlock()
 			}

--- a/internal/fs/fs_s3.go
+++ b/internal/fs/fs_s3.go
@@ -3,11 +3,6 @@ package fs
 import (
 	"context"
 	"fmt"
-	"github.com/minio/minio-go/v7"
-	"github.com/minio/minio-go/v7/pkg/credentials"
-	"github.com/restic/restic/internal/data"
-	"github.com/restic/restic/internal/debug"
-	"github.com/restic/restic/internal/errors"
 	"io"
 	"io/fs"
 	"net/url"
@@ -16,6 +11,12 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
 )
 
 const S3Prefix = "s3:/"
@@ -124,7 +125,24 @@ func (fs *S3Source) WarmingUp(targets []string) error {
 				}
 
 				absPath := path.Join(root, obj.Key)
+
+				muFiles.Lock()
+				files[absPath] = &ExtendedFileInfo{
+					Name:       path.Base(absPath),
+					Mode:       basePermissionFile,
+					ModTime:    obj.LastModified,
+					ChangeTime: obj.LastModified,
+					Size:       obj.Size,
+				}
+				muFiles.Unlock()
+
 				for currPath := absPath; ; {
+					if parentDir := path.Dir(currPath); parentDir != "/" {
+						muFilesByFolder.Lock()
+						filesByFolder[parentDir] = append(filesByFolder[parentDir], path.Base(currPath))
+						muFilesByFolder.Unlock()
+					}
+
 					currPath = path.Clean(path.Dir(currPath))
 					if currPath == "/" {
 						break
@@ -133,7 +151,6 @@ func (fs *S3Source) WarmingUp(targets []string) error {
 					muFiles.Lock()
 					if _, exists := files[currPath]; exists {
 						muFiles.Unlock()
-						// this tree already added
 						break
 					}
 					files[currPath] = &ExtendedFileInfo{
@@ -145,23 +162,6 @@ func (fs *S3Source) WarmingUp(targets []string) error {
 					}
 					muFiles.Unlock()
 				}
-				{
-					dir, file := path.Split(absPath)
-					dir = path.Clean(dir)
-					muFilesByFolder.Lock()
-					filesByFolder[dir] = append(filesByFolder[dir], file)
-					muFilesByFolder.Unlock()
-				}
-
-				muFiles.Lock()
-				files[absPath] = &ExtendedFileInfo{
-					Name:       path.Base(absPath),
-					Mode:       basePermissionFile,
-					ModTime:    obj.LastModified,
-					ChangeTime: obj.LastModified,
-					Size:       obj.Size,
-				}
-				muFiles.Unlock()
 			}
 		}()
 	}

--- a/internal/fs/fs_s3_test.go
+++ b/internal/fs/fs_s3_test.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
 	"sort"
 	"testing"
 	"time"
@@ -25,9 +24,7 @@ func TestS3SourceWithMinio(t *testing.T) {
 		}
 	}()
 
-	_, err := exec.LookPath("minio")
-	if err != nil {
-		t.Skip(err)
+	if s3testutil.SkipIfNotFoundMinio(t) {
 		return
 	}
 

--- a/internal/fs/fs_s3_test.go
+++ b/internal/fs/fs_s3_test.go
@@ -1,0 +1,216 @@
+package fs_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/fs"
+	rtest "github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/test/s3testutil"
+)
+
+func TestS3SourceWithMinio(t *testing.T) {
+	defer func() {
+		if t.Skipped() {
+			rtest.SkipDisallowed(t, "restic/fs.TestS3SourceWithMinio")
+		}
+	}()
+
+	_, err := exec.LookPath("minio")
+	if err != nil {
+		t.Skip(err)
+		return
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	addr := s3testutil.FreeAddr(t)
+	key, secret := s3testutil.NewCredentials(t)
+	cleanup := s3testutil.RunMinio(ctx, t, rtest.TempDir(t), key, secret, addr)
+	defer cleanup()
+
+	bucketName := fmt.Sprintf("test-fs-s3-%d", time.Now().UnixNano())
+	client := s3testutil.NewClient(t, addr, key, secret)
+	rtest.OK(t, client.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{}))
+
+	testObjects := map[string][]byte{
+		"file1.txt":           []byte("hello world"),
+		"dir1/file2.txt":      []byte("content of file2"),
+		"dir1/file3.txt":      []byte("content of file3"),
+		"dir1/sub/file4.txt":  []byte("content of file4"),
+		"dir2/sub2/file5.txt": []byte("content of file4"),
+	}
+	s3testutil.UploadObjects(t, ctx, client, bucketName, testObjects)
+
+	t.Setenv("AWS_ENDPOINT_URL", "http://"+addr)
+	t.Setenv("AWS_ACCESS_KEY_ID", key)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", secret)
+
+	src := &fs.S3Source{}
+	rtest.OK(t, src.WarmingUp([]string{"/" + bucketName}))
+
+	t.Run("Lstat/file", func(t *testing.T) {
+		fi, err := src.Lstat("/" + bucketName + "/file1.txt")
+		rtest.OK(t, err)
+		rtest.Assert(t, !fi.Mode.IsDir(), "expected file, got dir")
+		rtest.Assert(t, fi.Size == int64(len(testObjects["file1.txt"])), "wrong size: got %d, want %d", fi.Size, len(testObjects["file1.txt"]))
+		rtest.Assert(t, fi.Name == "file1.txt", "wrong name: got %q, want %q", fi.Name, "file1.txt")
+	})
+
+	t.Run("Lstat/dir", func(t *testing.T) {
+		fi, err := src.Lstat("/" + bucketName + "/dir1")
+		rtest.OK(t, err)
+		rtest.Assert(t, fi.Mode.IsDir(), "expected dir, got file")
+		rtest.Assert(t, fi.Name == "dir1", "wrong name: got %q, want %q", fi.Name, "dir1")
+	})
+	t.Run("Lstat/deep dir", func(t *testing.T) {
+		fi, err := src.Lstat("/" + bucketName + "/dir1/sub")
+		rtest.OK(t, err)
+		rtest.Assert(t, fi.Mode.IsDir(), "expected dir, got file")
+		rtest.Assert(t, fi.Name == "sub", "wrong name: got %q, want %q", fi.Name, "sub")
+	})
+
+	t.Run("Lstat/bucket-root", func(t *testing.T) {
+		fi, err := src.Lstat("/" + bucketName)
+		rtest.OK(t, err)
+		rtest.Assert(t, fi.Mode.IsDir(), "bucket root should be a dir")
+	})
+
+	t.Run("Lstat/notexist", func(t *testing.T) {
+		_, err := src.Lstat("/" + bucketName + "/notexist.txt")
+		rtest.Assert(t, errors.Is(err, os.ErrNotExist), "expected ErrNotExist, got %v", err)
+	})
+
+	t.Run("OpenFile/read", func(t *testing.T) {
+		f, err := src.OpenFile("/"+bucketName+"/file1.txt", 0, false)
+		rtest.OK(t, err)
+		defer f.Close()
+
+		got, err := io.ReadAll(f)
+		rtest.OK(t, err)
+		rtest.Equals(t, testObjects["file1.txt"], got)
+	})
+
+	t.Run("OpenFile/dir/readdirnames", func(t *testing.T) {
+		f, err := src.OpenFile("/"+bucketName+"/dir1", 0, false)
+		rtest.OK(t, err)
+		defer f.Close()
+
+		names, err := f.Readdirnames(-1)
+		rtest.OK(t, err)
+		sort.Strings(names)
+		rtest.Equals(t, []string{"file2.txt", "file3.txt", "sub"}, names)
+	})
+
+	t.Run("OpenFile/notexist", func(t *testing.T) {
+		_, err := src.OpenFile("/"+bucketName+"/notexist.txt", 0, false)
+		rtest.Assert(t, errors.Is(err, os.ErrNotExist), "expected ErrNotExist, got %v", err)
+	})
+
+	t.Run("MakeReadable/file", func(t *testing.T) {
+		f, err := src.OpenFile("/"+bucketName+"/file1.txt", 0, true)
+		rtest.OK(t, err)
+		defer f.Close()
+
+		rtest.OK(t, f.MakeReadable())
+		got, err := io.ReadAll(f)
+		rtest.OK(t, err)
+		rtest.Equals(t, testObjects["file1.txt"], got)
+	})
+
+	t.Run("MakeReadable/dir", func(t *testing.T) {
+		f, err := src.OpenFile("/"+bucketName+"/dir1", 0, true)
+		rtest.OK(t, err)
+		defer f.Close()
+
+		rtest.OK(t, f.MakeReadable())
+		names, err := f.Readdirnames(-1)
+		rtest.OK(t, err)
+		sort.Strings(names)
+		rtest.Equals(t, []string{"file2.txt", "file3.txt", "sub"}, names)
+	})
+
+	t.Run("ToNode/file", func(t *testing.T) {
+		f, err := src.OpenFile("/"+bucketName+"/file1.txt", 0, true)
+		rtest.OK(t, err)
+		defer f.Close()
+
+		node, err := f.ToNode(false, func(string, ...any) {})
+		rtest.OK(t, err)
+		rtest.Assert(t, node.Type == data.NodeTypeFile, "expected NodeTypeFile, got %v", node.Type)
+		rtest.Assert(t, node.Size == uint64(len(testObjects["file1.txt"])), "wrong node size: got %d, want %d", node.Size, len(testObjects["file1.txt"]))
+		rtest.Assert(t, node.Name == "file1.txt", "wrong node name: got %q", node.Name)
+	})
+
+	t.Run("ToNode/dir", func(t *testing.T) {
+		f, err := src.OpenFile("/"+bucketName+"/dir1", 0, true)
+		rtest.OK(t, err)
+		defer f.Close()
+
+		node, err := f.ToNode(false, func(string, ...any) {})
+		rtest.OK(t, err)
+		rtest.Assert(t, node.Type == data.NodeTypeDir, "expected NodeTypeDir, got %v", node.Type)
+		rtest.Assert(t, node.Name == "dir1", "wrong node name: got %q", node.Name)
+	})
+
+	t.Run("Stat/file", func(t *testing.T) {
+		f, err := src.OpenFile("/"+bucketName+"/dir1/file2.txt", 0, true)
+		rtest.OK(t, err)
+		defer f.Close()
+
+		fi, err := f.Stat()
+		rtest.OK(t, err)
+		rtest.Assert(t, fi.Size == int64(len(testObjects["dir1/file2.txt"])), "wrong stat size")
+		rtest.Assert(t, fi.Name == "file2.txt", "wrong stat name: got %q", fi.Name)
+		rtest.Assert(t, !fi.ModTime.IsZero(), "ModTime should not be zero for files")
+	})
+
+	t.Run("PathMethods", func(t *testing.T) {
+		rtest.Equals(t, "/", src.Separator())
+		rtest.Equals(t, "/a/b", src.Join("/a", "b"))
+		rtest.Assert(t, src.IsAbs("/a/b"), "expected /a/b to be absolute")
+		rtest.Assert(t, !src.IsAbs("a/b"), "expected a/b to be relative")
+
+		abs, err := src.Abs("a/b")
+		rtest.OK(t, err)
+		rtest.Equals(t, "/a/b", abs)
+
+		rtest.Equals(t, "/a/b", src.Clean("/a/b/"))
+		rtest.Equals(t, "b", src.Base("/a/b"))
+		rtest.Equals(t, "/a", src.Dir("/a/b"))
+		rtest.Equals(t, "", src.VolumeName("/a/b"))
+	})
+
+	t.Run("WarmingUp/many prefix", func(t *testing.T) {
+		s3SrcMany := &fs.S3Source{}
+		rtest.OK(t, s3SrcMany.WarmingUp([]string{"/" + bucketName + "/dir1", "/" + bucketName + "/dir2"}))
+
+		_, err := s3SrcMany.Lstat("/" + bucketName + "/dir1/file2.txt")
+		rtest.OK(t, err)
+
+		_, err = s3SrcMany.Lstat("/" + bucketName + "/dir1/sub/file4.txt")
+		rtest.OK(t, err)
+
+		_, err = s3SrcMany.Lstat("/" + bucketName + "/dir2/sub2/file5.txt")
+		rtest.OK(t, err)
+
+		_, err = s3SrcMany.Lstat("/" + bucketName + "/dir2/sub2/")
+		rtest.OK(t, err)
+
+		_, err = s3SrcMany.Lstat("/" + bucketName + "/file1.txt")
+		rtest.Assert(t, errors.Is(err, os.ErrNotExist), "file1.txt should not be visible with dir1 prefix, got err: %v", err)
+
+		_, err = s3SrcMany.Lstat("/" + bucketName + "/file5.txt")
+		rtest.Assert(t, errors.Is(err, os.ErrNotExist), "file5.txt should not be visible with dir2 prefix, got err: %v", err)
+	})
+}

--- a/internal/fs/fs_s3_test.go
+++ b/internal/fs/fs_s3_test.go
@@ -3,14 +3,11 @@ package fs_test
 import (
 	"context"
 	"errors"
-	"fmt"
 	"io"
 	"os"
 	"sort"
 	"testing"
-	"time"
 
-	"github.com/minio/minio-go/v7"
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/fs"
 	rtest "github.com/restic/restic/internal/test"
@@ -31,15 +28,6 @@ func TestS3SourceWithMinio(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	addr := s3testutil.FreeAddr(t)
-	key, secret := s3testutil.NewCredentials(t)
-	cleanup := s3testutil.RunMinio(ctx, t, rtest.TempDir(t), key, secret, addr)
-	defer cleanup()
-
-	bucketName := fmt.Sprintf("test-fs-s3-%d", time.Now().UnixNano())
-	client := s3testutil.NewClient(t, addr, key, secret)
-	rtest.OK(t, client.MakeBucket(ctx, bucketName, minio.MakeBucketOptions{}))
-
 	testObjects := map[string][]byte{
 		"file1.txt":           []byte("hello world"),
 		"dir1/file2.txt":      []byte("content of file2"),
@@ -47,11 +35,10 @@ func TestS3SourceWithMinio(t *testing.T) {
 		"dir1/sub/file4.txt":  []byte("content of file4"),
 		"dir2/sub2/file5.txt": []byte("content of file5"),
 	}
-	s3testutil.UploadObjects(t, ctx, client, bucketName, testObjects)
 
-	t.Setenv("AWS_ENDPOINT_URL", "http://"+addr)
-	t.Setenv("AWS_ACCESS_KEY_ID", key)
-	t.Setenv("AWS_SECRET_ACCESS_KEY", secret)
+	srv := s3testutil.StartMinio(ctx, t, "test-fs-s3", testObjects)
+	srv.SetAWSEnv(t)
+	bucketName := srv.Bucket
 
 	src := &fs.S3Source{}
 	rtest.OK(t, src.WarmingUp([]string{"/" + bucketName}))

--- a/internal/fs/fs_s3_test.go
+++ b/internal/fs/fs_s3_test.go
@@ -48,7 +48,7 @@ func TestS3SourceWithMinio(t *testing.T) {
 		"dir1/file2.txt":      []byte("content of file2"),
 		"dir1/file3.txt":      []byte("content of file3"),
 		"dir1/sub/file4.txt":  []byte("content of file4"),
-		"dir2/sub2/file5.txt": []byte("content of file4"),
+		"dir2/sub2/file5.txt": []byte("content of file5"),
 	}
 	s3testutil.UploadObjects(t, ctx, client, bucketName, testObjects)
 

--- a/internal/test/s3testutil/s3testutil.go
+++ b/internal/test/s3testutil/s3testutil.go
@@ -1,0 +1,132 @@
+// Package s3testutil provides shared helpers for starting a local minio
+// server and seeding it with test data. It is intended for use in test files
+// across multiple packages and must not be imported by production code.
+package s3testutil
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"io"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/minio/minio-go/v7"
+	"github.com/minio/minio-go/v7/pkg/credentials"
+)
+
+// FreeAddr returns a free TCP address on 127.0.0.1 that can be passed to
+// RunMinio. The port is released before returning, so there is a small race
+// window; this is acceptable for tests.
+func FreeAddr(t testing.TB) string {
+	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	addr := l.Addr().String()
+	if err := l.Close(); err != nil {
+		t.Fatal(err)
+	}
+	return addr
+}
+
+// NewCredentials returns a random access key and secret key suitable for
+// minio. Each value is a 20-character lowercase hex string.
+func NewCredentials(t testing.TB) (key, secret string) {
+	t.Helper()
+	buf := make([]byte, 10)
+
+	if _, err := io.ReadFull(rand.Reader, buf); err != nil {
+		t.Fatal(err)
+	}
+	key = hex.EncodeToString(buf)
+
+	if _, err := io.ReadFull(rand.Reader, buf); err != nil {
+		t.Fatal(err)
+	}
+	secret = hex.EncodeToString(buf)
+	return key, secret
+}
+
+// RunMinio starts a minio server listening on addr with the given credentials.
+// It creates config and root sub-directories under dir and blocks until the
+// server is reachable (up to 20 s). The returned function must be called to
+// stop the server.
+func RunMinio(ctx context.Context, t testing.TB, dir, key, secret, addr string) func() {
+	t.Helper()
+
+	for _, sub := range []string{"config", "root"} {
+		if err := os.MkdirAll(filepath.Join(dir, sub), 0700); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	cmd := exec.CommandContext(ctx, "minio",
+		"server",
+		"--address", addr,
+		"--config-dir", filepath.Join(dir, "config"),
+		filepath.Join(dir, "root"),
+	)
+	cmd.Env = append(os.Environ(),
+		"MINIO_ACCESS_KEY="+key,
+		"MINIO_SECRET_KEY="+secret,
+	)
+	cmd.Stderr = os.Stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatal(err)
+	}
+
+	var ok bool
+	for i := 0; i < 100; i++ {
+		time.Sleep(200 * time.Millisecond)
+		c, err := net.Dial("tcp", addr)
+		if err == nil {
+			ok = true
+			_ = c.Close()
+			break
+		}
+	}
+	if !ok {
+		t.Fatal("unable to connect to minio server")
+	}
+
+	return func() {
+		_ = cmd.Process.Kill()
+		_ = cmd.Wait()
+	}
+}
+
+// NewClient returns a *minio.Client connected to addr using plain HTTP and
+// the given credentials.
+func NewClient(t testing.TB, addr, key, secret string) *minio.Client {
+	t.Helper()
+	client, err := minio.New(addr, &minio.Options{
+		Creds:  credentials.NewStaticV4(key, secret, ""),
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+// UploadObjects uploads each entry in objects to bucket. The map key is the
+// S3 object key (relative path); the value is the object content.
+func UploadObjects(t testing.TB, ctx context.Context, client *minio.Client, bucket string, objects map[string][]byte) {
+	t.Helper()
+	for key, content := range objects {
+		_, err := client.PutObject(ctx, bucket, key,
+			bytes.NewReader(content), int64(len(content)),
+			minio.PutObjectOptions{})
+		if err != nil {
+			t.Fatalf("upload %q: %v", key, err)
+		}
+	}
+}

--- a/internal/test/s3testutil/s3testutil.go
+++ b/internal/test/s3testutil/s3testutil.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"io"
 	"net"
 	"os"
@@ -18,11 +19,60 @@ import (
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
+	rtest "github.com/restic/restic/internal/test"
 )
 
-// SkipIfNotFoundMinio skips the current test if the minio binary cannot be
-// found in PATH. It returns true when the test was skipped, so callers can
-// return early: if s3testutil.SkipIfNotFoundMinio(t) { return }.
+// MinioServer holds the connection information for a running local minio test
+// server, as returned by StartMinio.
+type MinioServer struct {
+	Addr   string        // host:port the server listens on (plain HTTP)
+	Key    string        // access key
+	Secret string        // secret key
+	Client *minio.Client // client connected to the server
+	Bucket string        // bucket created by StartMinio, empty if none
+}
+
+func StartMinio(ctx context.Context, t testing.TB, bucketPrefix string, objects map[string][]byte) *MinioServer {
+	t.Helper()
+
+	addr := freeAddr(t)
+	key, secret := newCredentials(t)
+	cleanup := runMinio(ctx, t, rtest.TempDir(t), key, secret, addr)
+	t.Cleanup(cleanup)
+
+	client, err := minio.New(addr, &minio.Options{
+		Creds:  credentials.NewStaticV4(key, secret, ""),
+		Secure: false,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	srv := &MinioServer{
+		Addr:   addr,
+		Key:    key,
+		Secret: secret,
+		Client: client,
+	}
+
+	if bucketPrefix != "" {
+		srv.Bucket = fmt.Sprintf("%s-%d", bucketPrefix, time.Now().UnixNano())
+		if err := srv.Client.MakeBucket(ctx, srv.Bucket, minio.MakeBucketOptions{}); err != nil {
+			t.Fatalf("create bucket %q: %v", srv.Bucket, err)
+		}
+		UploadObjects(t, ctx, srv.Client, srv.Bucket, objects)
+	}
+
+	return srv
+}
+
+func (s *MinioServer) SetAWSEnv(t *testing.T) {
+	t.Helper()
+	t.Setenv("AWS_ENDPOINT_URL", "http://"+s.Addr)
+	t.Setenv("AWS_ACCESS_KEY_ID", s.Key)
+	t.Setenv("AWS_SECRET_ACCESS_KEY", s.Secret)
+}
+
 func SkipIfNotFoundMinio(t testing.TB) bool {
 	t.Helper()
 	if _, err := exec.LookPath("minio"); err != nil {
@@ -32,10 +82,10 @@ func SkipIfNotFoundMinio(t testing.TB) bool {
 	return false
 }
 
-// FreeAddr returns a free TCP address on 127.0.0.1 that can be passed to
-// RunMinio. The port is released before returning, so there is a small race
+// freeAddr returns a free TCP address on 127.0.0.1 that can be passed to
+// runMinio. The port is released before returning, so there is a small race
 // window; this is acceptable for tests.
-func FreeAddr(t testing.TB) string {
+func freeAddr(t testing.TB) string {
 	t.Helper()
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
@@ -48,9 +98,9 @@ func FreeAddr(t testing.TB) string {
 	return addr
 }
 
-// NewCredentials returns a random access key and secret key suitable for
+// newCredentials returns a random access key and secret key suitable for
 // minio. Each value is a 20-character lowercase hex string.
-func NewCredentials(t testing.TB) (key, secret string) {
+func newCredentials(t testing.TB) (key, secret string) {
 	t.Helper()
 	buf := make([]byte, 10)
 
@@ -66,11 +116,11 @@ func NewCredentials(t testing.TB) (key, secret string) {
 	return key, secret
 }
 
-// RunMinio starts a minio server listening on addr with the given credentials.
+// runMinio starts a minio server listening on addr with the given credentials.
 // It creates config and root sub-directories under dir and blocks until the
 // server is reachable (up to 20 s). The returned function must be called to
 // stop the server.
-func RunMinio(ctx context.Context, t testing.TB, dir, key, secret, addr string) func() {
+func runMinio(ctx context.Context, t testing.TB, dir, key, secret, addr string) func() {
 	t.Helper()
 
 	for _, sub := range []string{"config", "root"} {
@@ -113,20 +163,6 @@ func RunMinio(ctx context.Context, t testing.TB, dir, key, secret, addr string) 
 		_ = cmd.Process.Kill()
 		_ = cmd.Wait()
 	}
-}
-
-// NewClient returns a *minio.Client connected to addr using plain HTTP and
-// the given credentials.
-func NewClient(t testing.TB, addr, key, secret string) *minio.Client {
-	t.Helper()
-	client, err := minio.New(addr, &minio.Options{
-		Creds:  credentials.NewStaticV4(key, secret, ""),
-		Secure: false,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-	return client
 }
 
 // UploadObjects uploads each entry in objects to bucket. The map key is the

--- a/internal/test/s3testutil/s3testutil.go
+++ b/internal/test/s3testutil/s3testutil.go
@@ -20,6 +20,18 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 )
 
+// SkipIfNotFoundMinio skips the current test if the minio binary cannot be
+// found in PATH. It returns true when the test was skipped, so callers can
+// return early: if s3testutil.SkipIfNotFoundMinio(t) { return }.
+func SkipIfNotFoundMinio(t testing.TB) bool {
+	t.Helper()
+	if _, err := exec.LookPath("minio"); err != nil {
+		t.Skip(err)
+		return true
+	}
+	return false
+}
+
 // FreeAddr returns a free TCP address on 127.0.0.1 that can be passed to
 // RunMinio. The port is released before returning, so there is a small race
 // window; this is acceptable for tests.


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

I want to do a backup with s3 in order to: 
- data storage in another data center in case of a failure in the current one 
- if a bug in the application erases a lot of files by mistake, then I will be able to restore the data at the time of the bug absence. 
- I'm doing a database backup at the same time, then I can restore the database and file storage data to consistency. 
I use restic because can take increment snapshots and deduplicate, which allows you to save storage space and roll back to the right place.

Previously, I tried to mount s3 as a file system using s3fs. But 
- it works very slowly 
- background memory 10% 
- if you accidentally perform any operation and cancel it, it will still be completed 
- use 100% CPU and a lot of memory when running 
I tested it on a storage with 500,000 files and a capacity of 150 GB.

In this pull request, I added a new format for the backup command for the path to s3 bucket and any of its internal parts of the tree. To do this, instead of the file path, specify the list `s3://bucket_name/maybe_deep_folder_or_file` 
`s3://` indicates that all files will be taken from s3. 
`bucket_name` is a required parameter. 
`maybe_deep_folder_or_file` is the path in the hierarchy whose internal tree we want to save

To run it at local, you need to:
1. create repository local
```bash
./restic -r ./test-repo init
```
2. build and run
```sh
make restic && RESTIC_PASSWORD=1234 AWS_ENDPOINT_URL=http://localhost:9000 AWS_ACCESS_KEY_ID=access_key AWS_SECRET_ACCESS_KEY=secret_key 
DEBUG_LOG=dubub.log ./restic -r ./test-repo backup s3://bucket_name_1 s3://bucket_name_2
```

Thanks

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://forum.restic.net/t/backup-of-an-s3-bucket/4852
https://forum.restic.net/t/creating-a-restic-backup-of-a-s3-bucket/10335

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
