### PR TITLE
restore: tune fileswriter

### DIFF
--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -79,12 +79,10 @@ func newFileRestorer(dst string,
 	workerCount := int(connections)
 
 	return &fileRestorer{
-		idx:         idx,
-		blobsLoader: blobsLoader,
-		startWarmup: startWarmup,
-		// use a large number of buckets to minimize bucket contention in filesWriter
-		// buckets are relatively cheap, so we can afford to have a lot of them
-		filesWriter:          newFilesWriter(1024, allowRecursiveDelete),
+		idx:                  idx,
+		blobsLoader:          blobsLoader,
+		startWarmup:          startWarmup,
+		filesWriter:          newFilesWriter(workerCount, allowRecursiveDelete),
 		zeroChunk:            repository.ZeroChunk(),
 		sparse:               sparse,
 		progress:             progress,

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -219,6 +219,8 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 	wg, ctx := errgroup.WithContext(ctx)
 	downloadCh := make(chan *packInfo)
 
+	// close all files when finished
+	defer r.filesWriter.flush()
 	worker := func() error {
 		for pack := range downloadCh {
 			if err := r.downloadPack(ctx, pack); err != nil {

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -79,10 +79,12 @@ func newFileRestorer(dst string,
 	workerCount := int(connections)
 
 	return &fileRestorer{
-		idx:                  idx,
-		blobsLoader:          blobsLoader,
-		startWarmup:          startWarmup,
-		filesWriter:          newFilesWriter(workerCount, allowRecursiveDelete),
+		idx:         idx,
+		blobsLoader: blobsLoader,
+		startWarmup: startWarmup,
+		// use a large number of buckets to minimize bucket contention in filesWriter
+		// buckets are relatively cheap, so we can afford to have a lot of them
+		filesWriter:          newFilesWriter(1024, allowRecursiveDelete),
 		zeroChunk:            repository.ZeroChunk(),
 		sparse:               sparse,
 		progress:             progress,

--- a/internal/restorer/fileswriter_test.go
+++ b/internal/restorer/fileswriter_test.go
@@ -30,6 +30,8 @@ func TestFilesWriterBasic(t *testing.T) {
 	rtest.OK(t, w.writeToFile(f2, []byte{2}, 1, -1, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
 
+	w.flush()
+
 	buf, err := os.ReadFile(f1)
 	rtest.OK(t, err)
 	rtest.Equals(t, []byte{1, 1}, buf)
@@ -51,11 +53,13 @@ func TestFilesWriterRecursiveOverwrite(t *testing.T) {
 	err := w.writeToFile(path, []byte{1}, 0, 2, false)
 	rtest.Assert(t, errors.Is(err, notEmptyDirError()), "unexpected error got %v", err)
 	rtest.Equals(t, 0, len(w.buckets[0].files))
+	w.flush()
 
 	// must replace directory
 	w = newFilesWriter(1, true)
 	rtest.OK(t, w.writeToFile(path, []byte{1, 1}, 0, 2, false))
 	rtest.Equals(t, 0, len(w.buckets[0].files))
+	w.flush()
 
 	buf, err := os.ReadFile(path)
 	rtest.OK(t, err)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Increase the number of buckets in the fileswriter to reduce possible lock contention. In addition, keep file handles cached to not have to open and close each file for every blob written. While both changes should improve performance, my local tests rather looked like they fall into the category of micro optimizations. They might be more useful when restoring to remote filesystems.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Stumbled across the current behavior while investigating https://github.com/restic/restic/pull/5553 .
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
