### PR TITLE
Bugfix: `restic check`: add missing finalizeSnapshotFilter()

### DIFF
--- a/changelog/unreleased/issue-3326
+++ b/changelog/unreleased/issue-3326
@@ -5,4 +5,5 @@ via the standard snapshot filter, (`--tag`, `--host`, `--path` or specifying
 snapshot IDs directly) and will be used for checking the packfiles used by these snapshots.
 
 https://github.com/restic/restic/issues/3326
-https://github.com/restic/restic/pull/5213
+https://github.com/restic/restic/pull/5469
+https://github.com/restic/restic/pull/5644

--- a/changelog/unreleased/pull-5469
+++ b/changelog/unreleased/pull-5469
@@ -1,0 +1,6 @@
+Bugfix: add missing finalizeSnapshotFilter() to `restic check`
+
+When applying PR#5469, the finalizeSnapshotFilter() was omitted in the code.
+
+https://github.com/restic/restic/pull/5644
+https://github.com/restic/restic/pull/5469

--- a/changelog/unreleased/pull-5469
+++ b/changelog/unreleased/pull-5469
@@ -1,6 +1,0 @@
-Bugfix: add missing finalizeSnapshotFilter() to `restic check`
-
-When applying PR#5469, the finalizeSnapshotFilter() was omitted in the code.
-
-https://github.com/restic/restic/pull/5644
-https://github.com/restic/restic/pull/5469

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -48,6 +48,7 @@ Exit status is 12 if the password is incorrect.
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			finalizeSnapshotFilter(&opts.SnapshotFilter)
 			summary, err := runCheck(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 			if globalOptions.JSON {
 				if err != nil && summary.NumErrors == 0 {


### PR DESCRIPTION
add missing finalizeSnapshotFilter() to cmd.RunE()

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->
Fix oversight of missing finalizeSnapshotFilter().

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
no
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

~~- [ ] I have added tests for all code changes.~~
~~- [ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
