### PR TITLE
ui: don't rewrite unchanged lines in status bar

### DIFF
--- a/changelog/unreleased/issue-5562
+++ b/changelog/unreleased/issue-5562
@@ -1,0 +1,10 @@
+Enhancement: Do not rewrite unchanged lines every frame in status bar
+
+Status bars were entirely rewritten every frame if any of its content has updated.
+This behavior had made any user interaction (such as selection) with status bar
+impossible in certain terminal emulators, even with the unchanged lines.
+Now it writes changed lines only at status bar update, thereby improving 
+user experience in those terminal emulators.
+
+https://github.com/restic/restic/issues/5562
+https://github.com/restic/restic/pull/5648

--- a/internal/terminal/terminal_posix.go
+++ b/internal/terminal/terminal_posix.go
@@ -11,6 +11,8 @@ const (
 	PosixControlMoveCursorHome = "\r"
 	// PosixControlMoveCursorUp moves cursor up one line
 	PosixControlMoveCursorUp = "\x1b[1A"
+	// PosixControlMoveCursorDown moves cursor down one line
+	PosixControlMoveCursorDown = "\x1b[1B"
 	// PosixControlClearLine clears the current line
 	PosixControlClearLine = "\x1b[2K"
 )
@@ -30,6 +32,17 @@ func PosixClearCurrentLine(wr io.Writer, _ uintptr) error {
 func PosixMoveCursorUp(wr io.Writer, _ uintptr, n int) error {
 	data := []byte(PosixControlMoveCursorHome)
 	data = append(data, bytes.Repeat([]byte(PosixControlMoveCursorUp), n)...)
+	_, err := wr.Write(data)
+	if err != nil {
+		return fmt.Errorf("write failed: %w", err)
+	}
+	return nil
+}
+
+// PosixMoveCursorDown moves the cursor to the line n lines below the current one.
+func PosixMoveCursorDown(wr io.Writer, _ uintptr, n int) error {
+	data := []byte(PosixControlMoveCursorHome)
+	data = append(data, bytes.Repeat([]byte(PosixControlMoveCursorDown), n)...)
 	_, err := wr.Write(data)
 	if err != nil {
 		return fmt.Errorf("write failed: %w", err)

--- a/internal/terminal/terminal_unix.go
+++ b/internal/terminal/terminal_unix.go
@@ -20,6 +20,11 @@ func MoveCursorUp(_ uintptr) func(io.Writer, uintptr, int) error {
 	return PosixMoveCursorUp
 }
 
+// MoveCursorDown moves the cursor to the line n lines below the current one.
+func MoveCursorDown(_ uintptr) func(io.Writer, uintptr, int) error {
+	return PosixMoveCursorDown
+}
+
 // CanUpdateStatus returns true if status lines can be printed, the process
 // output is not redirected to a file or pipe.
 func CanUpdateStatus(fd uintptr) bool {

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -26,7 +26,7 @@ type Terminal struct {
 	errWriter        io.Writer
 	msg              chan message
 	status           chan status
-	lastStatusLen    int
+	lastStatus       []string
 	inputIsTerminal  bool
 	outputIsTerminal bool
 	canUpdateStatus  bool
@@ -219,12 +219,11 @@ func findUnchangedLines(curr, last []string) []bool {
 // run listens on the channels and updates the terminal screen.
 func (t *Terminal) run(ctx context.Context) {
 	var status []string
-	var lastWrittenStatus []string
 	for {
 		select {
 		case <-ctx.Done():
 			if !terminal.IsProcessBackground(t.fd) {
-				t.writeStatus([]string{}, nil)
+				t.writeStatus([]string{}, false)
 			}
 
 			return
@@ -255,8 +254,7 @@ func (t *Terminal) run(ctx context.Context) {
 				continue
 			}
 
-			t.writeStatus(status, nil)
-			lastWrittenStatus = append([]string{}, status...)
+			t.writeStatus(status, false)
 		case stat := <-t.status:
 			status = append(status[:0], stat.lines...)
 
@@ -265,28 +263,29 @@ func (t *Terminal) run(ctx context.Context) {
 				continue
 			}
 
-			if !slices.Equal(status, lastWrittenStatus) {
-				unchangedLines := findUnchangedLines(status, lastWrittenStatus)
-				t.writeStatus(status, unchangedLines)
-				// Copy the status slice to avoid aliasing
-				lastWrittenStatus = append([]string{}, status...)
-			}
+			t.writeStatus(status, true)
 		}
 	}
 }
 
-func (t *Terminal) writeStatus(status []string, unchanged []bool) {
-	statusLen := len(status)
-	status = append([]string{}, status...)
-	for i := len(status); i < t.lastStatusLen; i++ {
-		// clear no longer used status lines
-		status = append(status, "")
-		if i > 0 {
-			// all lines except the last one must have a line break
-			status[i-1] = status[i-1] + "\n"
+func (t *Terminal) writeStatus(status []string, skipUnchanged bool) {
+	var unchanged []bool
+	if skipUnchanged {
+		if slices.Equal(status, t.lastStatus) {
+			return
 		}
+		unchanged = findUnchangedLines(status, t.lastStatus)
 	}
-	t.lastStatusLen = statusLen
+
+	lastStatusLen := len(t.lastStatus)
+	// Copy the status slice to avoid aliasing
+	t.lastStatus = append([]string{}, status...)
+
+	// Extend to clear no longer used status lines
+	status = append([]string{}, status...)
+	for i := len(status); i < lastStatusLen; i++ {
+		status = append(status, "")
+	}
 
 	for i, line := range status {
 		if unchanged != nil && i < len(unchanged) && unchanged[i] {
@@ -307,6 +306,13 @@ func (t *Terminal) writeStatus(status []string, unchanged []bool) {
 		_, err := t.wr.Write([]byte(line))
 		if err != nil {
 			_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
+		}
+		// all lines except the last one must be followed by a line break
+		if i < len(status)-1 {
+			_, err := t.wr.Write([]byte("\n"))
+			if err != nil {
+				_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
+			}
 		}
 	}
 
@@ -399,9 +405,6 @@ func sanitizeLines(lines []string, width int) []string {
 		line = ui.Quote(line)
 		if width > 0 {
 			line = ui.Truncate(line, width-2)
-		}
-		if i < len(lines)-1 { // Last line gets no line break.
-			line += "\n"
 		}
 		lines[i] = line
 	}

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -238,7 +238,7 @@ func (t *Terminal) run(ctx context.Context) {
 				continue
 			}
 			if err := t.clearCurrentLine(t.wr, t.fd); err != nil {
-				_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
+				t.logWriteErr(err)
 				continue
 			}
 
@@ -250,7 +250,7 @@ func (t *Terminal) run(ctx context.Context) {
 			}
 
 			if _, err := io.WriteString(dst, msg.line); err != nil {
-				_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
+				t.logWriteErr(err)
 				continue
 			}
 
@@ -265,6 +265,12 @@ func (t *Terminal) run(ctx context.Context) {
 
 			t.writeStatus(status, true)
 		}
+	}
+}
+
+func (t *Terminal) logWriteErr(err error) {
+	if err != nil {
+		_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
 	}
 }
 
@@ -292,34 +298,24 @@ func (t *Terminal) writeStatus(status []string, skipUnchanged bool) {
 			// don't write unchanged lines every frame
 			if i < len(status)-1 {
 				// just move the cursor down to the next line
-				if err := t.moveCursorDown(t.wr, t.fd, 1); err != nil {
-					_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
-				}
+				t.logWriteErr(t.moveCursorDown(t.wr, t.fd, 1))
 			}
 			continue
 		}
 
-		if err := t.clearCurrentLine(t.wr, t.fd); err != nil {
-			_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
-		}
+		t.logWriteErr(t.clearCurrentLine(t.wr, t.fd))
 
 		_, err := t.wr.Write([]byte(line))
-		if err != nil {
-			_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
-		}
+		t.logWriteErr(err)
 		// all lines except the last one must be followed by a line break
 		if i < len(status)-1 {
 			_, err := t.wr.Write([]byte("\n"))
-			if err != nil {
-				_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
-			}
+			t.logWriteErr(err)
 		}
 	}
 
 	if len(status) > 0 {
-		if err := t.moveCursorUp(t.wr, t.fd, len(status)-1); err != nil {
-			_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
-		}
+		t.logWriteErr(t.moveCursorUp(t.wr, t.fd, len(status)-1))
 	}
 }
 
@@ -344,17 +340,15 @@ func (t *Terminal) runWithoutStatus(ctx context.Context) {
 				dst = t.wr
 			}
 
-			if _, err := io.WriteString(dst, msg.line); err != nil {
-				_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
-			}
+			_, err := io.WriteString(dst, msg.line)
+			t.logWriteErr(err)
 
 		case stat := <-t.status:
 			if !slices.Equal(stat.lines, lastStatus) {
 				for _, line := range stat.lines {
 					// Ensure that each message ends with exactly one newline.
-					if _, err := fmt.Fprintln(t.wr, strings.TrimRight(line, "\n")); err != nil {
-						_, _ = fmt.Fprintf(t.errWriter, "write failed: %v\n", err)
-					}
+					_, err := fmt.Fprintln(t.wr, strings.TrimRight(line, "\n"))
+					t.logWriteErr(err)
 				}
 				// Copy the status slice to avoid aliasing
 				lastStatus = append([]string{}, stat.lines...)

--- a/internal/ui/termstatus/status.go
+++ b/internal/ui/termstatus/status.go
@@ -204,18 +204,6 @@ func (t *Terminal) Run(ctx context.Context) {
 	t.runWithoutStatus(ctx)
 }
 
-func findUnchangedLines(curr, last []string) []bool {
-	unchanged := make([]bool, len(curr))
-
-	for i := range min(len(curr), len(last)) {
-		if curr[i] == last[i] {
-			unchanged[i] = true
-		}
-	}
-
-	return unchanged
-}
-
 // run listens on the channels and updates the terminal screen.
 func (t *Terminal) run(ctx context.Context) {
 	var status []string
@@ -317,6 +305,18 @@ func (t *Terminal) writeStatus(status []string, skipUnchanged bool) {
 	if len(status) > 0 {
 		t.logWriteErr(t.moveCursorUp(t.wr, t.fd, len(status)-1))
 	}
+}
+
+func findUnchangedLines(curr, last []string) []bool {
+	unchanged := make([]bool, len(curr))
+
+	for i := range min(len(curr), len(last)) {
+		if curr[i] == last[i] {
+			unchanged[i] = true
+		}
+	}
+
+	return unchanged
 }
 
 // runWithoutStatus listens on the channels and just prints out the messages,

--- a/internal/ui/termstatus/status_test.go
+++ b/internal/ui/termstatus/status_test.go
@@ -91,8 +91,8 @@ func TestSanitizeLines(t *testing.T) {
 	}{
 		{[]string{""}, 80, []string{""}},
 		{[]string{"too long test line"}, 10, []string{"too long"}},
-		{[]string{"too long test line", "text"}, 10, []string{"too long\n", "text"}},
-		{[]string{"too long test line", "second long test line"}, 10, []string{"too long\n", "second l"}},
+		{[]string{"too long test line", "text"}, 10, []string{"too long", "text"}},
+		{[]string{"too long test line", "second long test line"}, 10, []string{"too long", "second l"}},
 	}
 
 	for _, test := range tests {

--- a/internal/ui/termstatus/status_test.go
+++ b/internal/ui/termstatus/status_test.go
@@ -50,6 +50,37 @@ func TestSetStatus(t *testing.T) {
 	rtest.Equals(t, exp, buf.String())
 }
 
+func TestSetStatusUnchangedLines(t *testing.T) {
+	buf, term, cancel := setupStatusTest()
+
+	const (
+		cl   = terminal.PosixControlClearLine
+		home = terminal.PosixControlMoveCursorHome
+		up   = terminal.PosixControlMoveCursorUp
+		down = terminal.PosixControlMoveCursorDown
+	)
+
+	clearLn := home + cl
+	stepDown := home + down
+
+	term.SetStatus([]string{"line1", "line2", "line3"})
+	exp := clearLn + "line1\n" + clearLn + "line2\n" + clearLn + "line3" + home + up + up
+
+	term.SetStatus([]string{"line1", "line2", "line3-changed"})
+	exp += stepDown + stepDown + clearLn + "line3-changed" + home + up + up
+
+	term.SetStatus([]string{"line1", "line2", "line3-changed"})
+
+	term.SetStatus([]string{"line1", "line2-new", "line3-changed"})
+	exp += stepDown + clearLn + "line2-new\n" + home + up + up
+
+	cancel()
+	exp += clearLn + "\n" + clearLn + "\n" + clearLn + "" + home + up + up
+
+	<-term.closed
+	rtest.Equals(t, exp, buf.String())
+}
+
 func setupStatusTest() (*bytes.Buffer, *Terminal, context.CancelFunc) {
 	buf := &bytes.Buffer{}
 	term := New(nil, buf, buf, false)
@@ -58,6 +89,7 @@ func setupStatusTest() (*bytes.Buffer, *Terminal, context.CancelFunc) {
 	term.fd = ^uintptr(0)
 	term.clearCurrentLine = terminal.PosixClearCurrentLine
 	term.moveCursorUp = terminal.PosixMoveCursorUp
+	term.moveCursorDown = terminal.PosixMoveCursorDown
 
 	ctx, cancel := context.WithCancel(context.Background())
 	go term.Run(ctx)

--- a/internal/ui/termstatus/status_test.go
+++ b/internal/ui/termstatus/status_test.go
@@ -20,31 +20,32 @@ func TestSetStatus(t *testing.T) {
 		cl   = terminal.PosixControlClearLine
 		home = terminal.PosixControlMoveCursorHome
 		up   = terminal.PosixControlMoveCursorUp
+
+		clearLn = home + cl
 	)
 
 	term.SetStatus([]string{"first"})
-	exp := home + cl + "first" + home
+	exp := clearLn + "first" + home
 
 	term.SetStatus([]string{""})
-	exp += home + cl + "" + home
+	exp += clearLn + "" + home
 
 	term.SetStatus([]string{})
-	exp += home + cl + "" + home
+	exp += clearLn + "" + home
 
 	// already empty status
 	term.SetStatus([]string{})
 
 	term.SetStatus([]string{"foo", "bar", "baz"})
-	exp += home + cl + "foo\n" + home + cl + "bar\n" +
-		home + cl + "baz" + home + up + up
+	exp += clearLn + "foo\n" + clearLn + "bar\n" + clearLn + "baz" + home + up + up
 
 	term.SetStatus([]string{"quux", "needs\nquote"})
-	exp += home + cl + "quux\n" +
-		home + cl + "\"needs\\nquote\"\n" +
-		home + cl + home + up + up // Clear third line
+	exp += clearLn + "quux\n" +
+		clearLn + "\"needs\\nquote\"\n" +
+		clearLn + home + up + up // Clear third line
 
 	cancel()
-	exp += home + cl + "\n" + home + cl + home + up // Status cleared
+	exp += clearLn + "\n" + clearLn + "" + home + up // Status cleared
 
 	<-term.closed
 	rtest.Equals(t, exp, buf.String())
@@ -58,10 +59,10 @@ func TestSetStatusUnchangedLines(t *testing.T) {
 		home = terminal.PosixControlMoveCursorHome
 		up   = terminal.PosixControlMoveCursorUp
 		down = terminal.PosixControlMoveCursorDown
-	)
 
-	clearLn := home + cl
-	stepDown := home + down
+		clearLn  = home + cl
+		stepDown = home + down
+	)
 
 	term.SetStatus([]string{"line1", "line2", "line3"})
 	exp := clearLn + "line1\n" + clearLn + "line2\n" + clearLn + "line3" + home + up + up


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Previously, status bars were entirely rewritten every frame if any of its content has updated.
This behavior had made any user interaction (such as selection) with status bar
impossible in certain terminal emulators, even on the unchanged lines.
Now it writes only changed lines at status bar update, thereby improving 
user experience in those terminal emulators.

It is tested in Ubuntu.24.04.3 with st 0.9.3.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Closes #5562

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
