### PR TITLE
docs: add warning for capability-based non-root backups

### DIFF
--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -319,6 +319,18 @@ Note that when using a systemd unit to run restic, you can use
 Using file capabilities
 =======================
 
+.. warning::
+
+   Granting ``CAP_DAC_READ_SEARCH`` to the restic binary allows any process
+   executing that binary to bypass standard file permission checks for reading
+   and directory traversal. In practice, anyone who can execute this binary can
+   read most of the system, regardless of their user ID.
+
+   Ensure that only a dedicated backup user (and root) can execute the
+   capability-enabled restic binary, and treat that account as highly privileged.
+
+   See: `capabilities(7) <https://man7.org/linux/man-pages/man7/capabilities.7.html>`_
+
 Alternatively, the capability can be granted to a file. First we
 create a new user called ``restic`` that is going to create
 the backups:


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds a prominent warning to the "Full backup without root" example in the
documentation.

The example relies on the Linux capability `CAP_DAC_READ_SEARCH`, which allows any
process executing the capability-enabled restic binary to bypass standard file
permission checks for reading and directory traversal. This is a powerful privilege
that was not previously made explicit.

The added warning clarifies the security implications of this setup and points
readers to the relevant Linux documentation, helping users better understand the
trade-offs of capability-based non-root backups.


<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Discussed in #5506, specifically in https://github.com/restic/restic/issues/5506#issuecomment-3694178643.


<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
