### PR TITLE
docs: clarify backup scheduling scope and common patterns

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -664,15 +664,72 @@ snapshot.
 Scheduling backups
 ******************
 
-Restic does not have a built-in way of scheduling backups, as it's a tool
-that runs when executed rather than a daemon. There are plenty of different
-ways to schedule backup runs on various different platforms, e.g. systemd
-and cron on Linux/BSD and Task Scheduler in Windows, depending on one's
-needs and requirements. If you don't want to implement your own scheduling,
-you can use `resticprofile <https://github.com/creativeprojects/resticprofile/#resticprofile>`__.
+.. admonition:: Design note
 
-When scheduling restic to run recurringly, please make sure to detect already
-running instances before starting the backup.
+   Restic intentionally does not provide built-in scheduling or job management.
+   It is designed to run when executed, rather than as a daemon. Scheduling and
+   orchestration are therefore considered out of scope and are delegated to the
+   operating system or external tools.
+
+   This design keeps the restic core simpler, more reliable, and easier to audit,
+   while allowing it to integrate cleanly into a wide range of environments.
+
+Scheduling mechanisms
+=====================
+
+Backup scheduling depends on the platform and environment:
+
+- On Unix-like systems (e.g. BSD, Linux and macOS), ``systemd`` timers are generally preferred when available,
+  as they provide better error handling, logging, dependency management, and
+  integration with the system lifecycle.
+- ``cron`` remains a widely supported and portable option, especially on
+  minimal or non-systemd systems.
+- On Windows, Task Scheduler can be used to run restic commands at defined
+  intervals.
+
+The choice of scheduler depends on the operating system and local constraints,
+rather than on restic itself.
+
+External orchestration tools
+============================
+
+Several community-maintained tools exist to orchestrate restic backups by
+combining configuration, scheduling, hooks, and retention policies. These tools
+are optional and not required to use restic.
+
+Using such tools can reduce boilerplate for some setups, but they are not part
+of restic itself and are not required for correct operation.
+
+.. note::
+
+   Restic is not affiliated with, nor does it endorse, any third-party
+   orchestration or automation tools, even if such tools are mentioned explicitly in the
+   documentation.
+
+If you don't want to implement your own scheduling, you can use third-party
+orchestration tools such as `resticprofile <https://creativeprojects.github.io/resticprofile/>`__.
+
+Avoiding concurrent runs
+========================
+
+.. caution::
+
+   Avoid running overlapping scheduled restic commands against the same
+   repository.
+
+   While the repository format supports concurrent access, some
+   operations require exclusive locks and overlapping runs can cause lock
+   contention, failed backups, or additional maintenance work.
+
+When scheduling restic to run automatically, use mechanisms that prevent overlapping executions.
+Common strategies include:
+
+- ensuring that scheduled jobs cannot overlap
+- using simple locking mechanisms (for example, lock files)
+- relying on the scheduler's own guarantees (such as systemd unit semantics).
+
+See :ref:`locks-design` for details.
+
 
 Space requirements
 ******************

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -709,23 +709,26 @@ of restic itself and are not required for correct operation.
 If you don't want to implement your own scheduling, you can use third-party
 orchestration tools such as `resticprofile <https://creativeprojects.github.io/resticprofile/>`__.
 
-Avoiding concurrent runs
-========================
+Avoiding lock conflicts
+=======================
 
 .. caution::
 
-   Avoid running overlapping scheduled restic commands against the same
-   repository.
+   Avoid running scheduled maintenance commands that require exclusive
+   repository access while other restic commands are using the same repository.
 
-   While the repository format supports concurrent access, some
-   operations require exclusive locks and overlapping runs can cause lock
-   contention, failed backups, or additional maintenance work.
+   Restic allows concurrent access to a repository. For example, ``backup`` and
+   commands that only read from the repository can run at the same time. The
+   ``check``, ``forget`` and ``prune`` commands require exclusive access and
+   will conflict with other running restic commands.
 
-When scheduling restic to run automatically, use mechanisms that prevent overlapping executions.
+When scheduling restic to run automatically, make sure that exclusive
+maintenance commands do not overlap with backups or other repository operations.
 Common strategies include:
 
-- ensuring that scheduled jobs cannot overlap
-- using simple locking mechanisms (for example, lock files)
+- scheduling maintenance jobs in a separate time window
+- using ``--retry-lock`` so a command waits for a conflicting lock to clear
+- using scheduler-level locking or dependency mechanisms
 - relying on the scheduler's own guarantees (such as systemd unit semantics on Linux).
 
 See :ref:`locks-design` for details.

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -679,11 +679,11 @@ Scheduling mechanisms
 
 Backup scheduling depends on the platform and environment:
 
-- On Unix-like systems (e.g. BSD, Linux and macOS), ``systemd`` timers are generally preferred when available,
+- On Linux systems that use ``systemd``, ``systemd`` timers are generally preferred when available,
   as they provide better error handling, logging, dependency management, and
   integration with the system lifecycle.
-- ``cron`` remains a widely supported and portable option, especially on
-  minimal or non-systemd systems.
+- On Unix-like systems without ``systemd`` (including BSD and macOS), ``cron`` remains a widely
+  supported and portable option. On macOS, ``launchd`` is another common native option.
 - On Windows, Task Scheduler can be used to run restic commands at defined
   intervals.
 
@@ -726,7 +726,7 @@ Common strategies include:
 
 - ensuring that scheduled jobs cannot overlap
 - using simple locking mechanisms (for example, lock files)
-- relying on the scheduler's own guarantees (such as systemd unit semantics).
+- relying on the scheduler's own guarantees (such as systemd unit semantics on Linux).
 
 See :ref:`locks-design` for details.
 

--- a/doc/design.rst
+++ b/doc/design.rst
@@ -591,6 +591,8 @@ As can be seen from the output of the program ``sha256sum``, the hash
 matches the plaintext hash from the map included in the tree above, so
 the correct data has been returned.
 
+.. _locks-design:
+
 Locks
 =====
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR rewrites and clarifies the *Scheduling backups* section of the
documentation.

It makes the design intent explicit by explaining that scheduling and job
management are intentionally out of scope for restic and are delegated to the
operating system or external tools. The section is restructured to:

- clarify why restic does not provide built-in scheduling or job management,
- describe common scheduling mechanisms in a platform-agnostic way,
- explain the role of optional third-party orchestration tools without implying
  endorsement or affiliation,
- document best practices to avoid overlapping scheduled runs and lock
  contention.

The goal is to reduce confusion for new users, set correct expectations, and
provide safer guidance for automated backups without expanding restic's scope.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Yes. This topic was discussed in the context of documentation improvements and backup job/scheduling expectations in:

- #5506 
    - (see https://github.com/restic/restic/issues/5506#issuecomment-3694178643)
- #5507 
    - (see https://github.com/restic/restic/issues/5507#issuecomment-3694213191)

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
