### PR TITLE
docs: add systemd scheduling example

### DIFF
--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -421,11 +421,6 @@ Create the file ``/etc/systemd/system/restic-backup.service``:
 The service runs exactly one backup operation and exits. If the command fails,
 systemd will record the failure in the journal.
 
-.. tip:: This is a minimal example.
-   You may want to add further options to control
-   resource usage, logging, or other aspects of the execution environment.
-   See the "See also" section below for more information.
-
 Directive reference
 -------------------
 
@@ -497,8 +492,6 @@ The timer will trigger the associated backup service according to the defined
 schedule.
 If the system was powered off at the scheduled time, the backup will be run at
 the next boot.
-
-.. note:: Enable the timer unit, not the service unit.
 
 Directive reference
 -------------------

--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -540,3 +540,25 @@ To open these manuals on the system:
    $ man systemd.timer
    $ man systemd.time
 
+
+Going further
+=============
+
+The above example is minimal and non-exhaustive. Depending on your use case, you
+may need to consider additional aspects such as monitoring, alerting, and
+maintenance.
+
+Adding alerting and monitoring is strongly recommended to detect failed backups
+and other issues. Consider using systemd's built-in mechanisms (for example,
+service and timer status, exit codes, and the journal), or external monitoring
+tools to track backup health.
+
+.. note::
+   Maintenance commands such as ``restic check`` or ``restic prune`` should be
+   scheduled separately, depending on the use case.
+
+.. important::
+   Regularly verify your backups by checking and restoring data. Automated
+   backups alone are not sufficient; testing restores is the only reliable way
+   to ensure that your backups work as expected.
+   

--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -378,7 +378,7 @@ executed in a controlled and predictable way. In particular, care must be taken
 to avoid running multiple restic processes concurrently against the same
 repository, which can lead to lock contention or failed backups.
 
-This example demonstrates a minimal setup for scheduling restic backups
+This example demonstrates a minimal approach to scheduling restic backups
 using systemd units and timers.
 
 Prerequisites
@@ -424,12 +424,11 @@ systemd will record the failure in the journal.
 Directive reference
 -------------------
 
-The options used above are standard systemd unit directives. They are documented
-in the systemd manual pages (see below).
+The options used above are standard systemd unit directives. 
 
 ``Description=``
    A human-readable name shown by ``systemctl status`` and in the journal.
-   Optional but recommended.
+   Optional.
 
 ``Type=oneshot``
    Declares that this service runs a command and exits. Recommended for restic
@@ -496,12 +495,11 @@ the next boot.
 Directive reference
 -------------------
 
-The options used above are standard systemd timer directives. They are
-documented in the systemd manual pages (see below).
+The options used above are standard systemd timer directives.
 
 ``Description=``
    A human-readable name shown by ``systemctl status`` and in the journal.
-   Optional but recommended.
+   Optional.
 
 ``OnCalendar=``
    Specifies when the timer should trigger. The value uses systemd's calendar

--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -448,26 +448,24 @@ in the systemd manual pages (see below).
 ``ExecStart=``
    The command to execute. Required.
 
-See also (systemd documentation)
---------------------------------
+.. seealso::
 
-Manual pages:
+   `systemd.unit(5) <https://manpages.debian.org/stable/systemd/systemd.unit.5.en.html>`__
+      Unit file syntax and common directives.
 
-- `systemd.unit(5) <https://manpages.debian.org/stable/systemd/systemd.unit.5.en.html>`__ (``[UNIT] SECTION OPTIONS`` and ``[INSTALL] SECTION OPTIONS``)
-- `systemd.service(5) <https://manpages.debian.org/stable/systemd/systemd.service.5.en.html>`__ (service behavior, ``Type=``, ``ExecStart=``)
-- `systemd.exec(5) <https://manpages.debian.org/stable/systemd/systemd.exec.5.en.html>`__ (execution environment, ``EnvironmentFile=``, resource limits, I/O scheduling)
-- `systemd.special(7) <https://manpages.debian.org/stable/systemd/systemd.special.7.en.html>`__ (special targets such as ``network-online.target``)
-- `systemd.directives(7) <https://manpages.debian.org/stable/systemd/systemd.directives.7.en.html>`__ (index of directives and where they are documented)
+   `systemd.service(5) <https://manpages.debian.org/stable/systemd/systemd.service.5.en.html>`__
+      Service unit behavior, including ``Type=`` and ``ExecStart=``.
 
-To open these manuals on the system:
+   `systemd.exec(5) <https://manpages.debian.org/stable/systemd/systemd.exec.5.en.html>`__
+      Execution environment configuration, including ``EnvironmentFile=`` and
+      resource control options.
 
-.. code-block:: console
+   `systemd.special(7) <https://manpages.debian.org/stable/systemd/systemd.special.7.en.html>`__
+      Special systemd targets.
 
-   $ man systemd.unit
-   $ man systemd.service
-   $ man systemd.exec
-   $ man systemd.special
-   $ man systemd.directives
+   `systemd.directives(7) <https://manpages.debian.org/stable/systemd/systemd.directives.7.en.html>`__
+      Index of systemd directives and the manual pages documenting them.
+
 
 Timer unit
 ==========
@@ -525,20 +523,15 @@ documented in the systemd manual pages (see below).
    Makes the timer start at boot when it is enabled. Required if you want the
    timer to run automatically.
 
-See also (systemd documentation)
---------------------------------
+.. seealso::
 
-Manual pages:
+   `systemd.timer(5) <https://manpages.debian.org/stable/systemd/systemd.timer.5.en.html>`__
+      Documentation for systemd timer units, including ``OnCalendar=`` and
+      ``Persistent=``.
 
-- `systemd.timer(5) <https://manpages.debian.org/stable/systemd/systemd.timer.5.en.html>`__ (timer units, ``OnCalendar=``, ``Persistent=``)
-- `systemd.time(7) <https://manpages.debian.org/stable/systemd/systemd.time.7.en.html>`__ (calendar event expressions)
+   `systemd.time(7) <https://manpages.debian.org/stable/systemd/systemd.time.7.en.html>`__
+      Calendar event expressions used by ``OnCalendar=``.
 
-To open these manuals on the system:
-
-.. code-block:: console
-
-   $ man systemd.timer
-   $ man systemd.time
 
 
 Going further

--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -419,7 +419,7 @@ Create the file ``/etc/systemd/system/restic-backup.service``:
    ExecStart=/usr/bin/restic backup /data
 
 The service runs exactly one backup operation and exits. If the command fails,
-systemd will record the failure in the journal. 
+systemd will record the failure in the journal.
 
 .. tip:: This is a minimal example.
    You may want to add further options to control

--- a/doc/080_examples.rst
+++ b/doc/080_examples.rst
@@ -468,3 +468,75 @@ To open these manuals on the system:
    $ man systemd.exec
    $ man systemd.special
    $ man systemd.directives
+
+Timer unit
+==========
+
+To schedule the backup periodically, create a corresponding timer unit.
+
+Create the file ``/etc/systemd/system/restic-backup.timer``:
+
+.. code-block:: ini
+
+   [Unit]
+   Description=Run restic backup daily
+
+   [Timer]
+   OnCalendar=daily
+   Persistent=true
+
+   [Install]
+   WantedBy=timers.target
+
+Enable and start the timer:
+
+.. code-block:: console
+
+   # systemctl daemon-reload
+   # systemctl enable --now restic-backup.timer
+
+The timer will trigger the associated backup service according to the defined
+schedule.
+If the system was powered off at the scheduled time, the backup will be run at
+the next boot.
+
+.. note:: Enable the timer unit, not the service unit.
+
+Directive reference
+-------------------
+
+The options used above are standard systemd timer directives. They are
+documented in the systemd manual pages (see below).
+
+``Description=``
+   A human-readable name shown by ``systemctl status`` and in the journal.
+   Optional but recommended.
+
+``OnCalendar=``
+   Specifies when the timer should trigger. The value uses systemd's calendar
+   event syntax (for example ``daily``). See ``systemd.time(7)`` for
+   details and examples of calendar event expressions. Required.
+
+``Persistent=``
+   When set to ``true``, systemd will catch up on missed runs after the system
+   was powered off at the scheduled time. Optional but recommended for backups.
+
+``WantedBy=timers.target``
+   Makes the timer start at boot when it is enabled. Required if you want the
+   timer to run automatically.
+
+See also (systemd documentation)
+--------------------------------
+
+Manual pages:
+
+- `systemd.timer(5) <https://manpages.debian.org/stable/systemd/systemd.timer.5.en.html>`__ (timer units, ``OnCalendar=``, ``Persistent=``)
+- `systemd.time(7) <https://manpages.debian.org/stable/systemd/systemd.time.7.en.html>`__ (calendar event expressions)
+
+To open these manuals on the system:
+
+.. code-block:: console
+
+   $ man systemd.timer
+   $ man systemd.time
+


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds a complete and minimal example showing how to schedule restic
backups using systemd service and timer units.

The documentation explains:
- how to run restic as a one-shot systemd service,
- how to schedule backups using a systemd timer,
- which systemd directives are used and why,
- where to find the relevant systemd documentation,
- and which additional aspects (monitoring, maintenance, restore testing)
  should be considered beyond the minimal example.

The goal is to provide a clear, systemd-native reference example without
introducing external tools, wrappers, or prescriptive workflows, while helping
users avoid common pitfalls when automating backups.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Yes. Related aspects were discussed in
https://github.com/restic/restic/issues/5507 and
https://github.com/restic/restic/issues/5507#issuecomment-3694213191.

That discussion clarified that scheduling and job orchestration are intentionally
out of scope for restic itself, and should be handled by the operating system or
external tools.

This PR follows that guidance by improving the documentation around common and
systemd-native scheduling patterns, without introducing any notion of jobs,
policy, or orchestration into restic itself.


<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
