### PR TITLE
fix for S3 restore failing with 202 Accepted for cold storage

### DIFF
--- a/changelog/unreleased/issue-5659
+++ b/changelog/unreleased/issue-5659
@@ -1,0 +1,14 @@
+Bugfix: Fix S3 DEEP_ARCHIVE restore failing with "202 Accepted"
+
+When restoring from S3 Glacier or DEEP_ARCHIVE storage classes using the
+experimental `s3-restore` feature, restic incorrectly treated the HTTP 202
+Accepted response as an error. This caused the restore to fail immediately
+with the message "202 Accepted" instead of waiting for the objects to become
+available.
+
+Restic now correctly recognizes HTTP 202 Accepted as a successful restore
+initiation and waits for the objects to transition from cold storage before
+proceeding with the restore.
+
+https://github.com/restic/restic/issues/5659
+https://github.com/restic/restic/pull/5660

--- a/internal/backend/s3/s3.go
+++ b/internal/backend/s3/s3.go
@@ -499,6 +499,10 @@ func (be *Backend) requestRestore(ctx context.Context, filename string) (bool, e
 	if err := be.client.RestoreObject(ctx, be.cfg.Bucket, filename, "", opts); err != nil {
 		var e minio.ErrorResponse
 		if errors.As(err, &e) {
+			// HTTP 202 Accepted means the restore request was successfully initiated
+			if e.StatusCode == 202 {
+				return true, nil
+			}
 			switch e.Code {
 			case "InvalidObjectState":
 				return false, nil


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

S3 Glacier/DEEP_ARCHIVE restore fails with "202 Accepted" instead of waiting for objects to become available.

When using the experimental S3 cold storage restore feature (RESTIC_FEATURES=s3-restore), restoring objects from GLACIER or DEEP_ARCHIVE storage classes fails immediately with the message "202 Accepted" instead of waiting for the objects to become available. With `202 Accepted` "error" originating from `be.client.RestoreObject` (minio.Client) call in s3.go `requestRestore`.

Adding a handler for `StatusCode == 202` solves the issue:
```go
	if err := be.client.RestoreObject(ctx, be.cfg.Bucket, filename, "", opts); err != nil {
		var e minio.ErrorResponse
		if errors.As(err, &e) {
			// HTTP 202 Accepted means the restore request was successfully initiated
			if e.StatusCode == 202 {
				return true, nil
			}
			switch e.Code {
			case "InvalidObjectState":
				return false, nil
			case "RestoreAlreadyInProgress":
				return true, nil
			}
		}
		return false, err
	}
```

Tested with the number of days from 1 to 7, the issue is reproducible. Important note - on each execution one of the packs moves to "RestoreAlreadyInProgress" state. So, with just one pack to restore, a second attempt to restore will start waiting. With two packs to restore, the third attempt to restore will start waiting etc. Gets really difficult when you need to restore 176 packs.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #5659

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
     No, but I can if requested. It will require mocking minio.Client though.
- [ ] I have added documentation for relevant changes (in the manual).
     No, but I don't think it's needed
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
