### PR TITLE
Bugfix: ``restic find --pack <tree-pack>`` did not produce output for tree packs

### DIFF
--- a/changelog/unreleased/pull-5664
+++ b/changelog/unreleased/pull-5664
@@ -1,0 +1,6 @@
+Bugfix: restic find --pack <tree-pack> did not produce output for tree packs
+
+`restic find --pack` now produces output for a tree related packfile.
+
+https://github.com/restic/restic/issues/5280
+https://github.com/restic/restic/pull/5664

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -450,6 +450,9 @@ func (f *Finder) packsToBlobs(ctx context.Context, packs []string) error {
 	if f.blobIDs == nil {
 		f.blobIDs = make(map[string]struct{})
 	}
+	if f.treeIDs == nil {
+		f.treeIDs = make(map[string]struct{})
+	}
 
 	debug.Log("Looking for packs...")
 	err := f.repo.List(ctx, restic.PackFile, func(id restic.ID, size int64) error {
@@ -470,7 +473,11 @@ func (f *Finder) packsToBlobs(ctx context.Context, packs []string) error {
 			return err
 		}
 		for _, b := range blobs {
-			f.blobIDs[b.ID.String()] = struct{}{}
+			if b.Type == restic.DataBlob {
+				f.blobIDs[b.ID.String()] = struct{}{}
+			} else if b.Type == restic.TreeBlob {
+				f.treeIDs[b.ID.String()] = struct{}{}
+			}
 		}
 		// Stop searching when all packs have been found
 		if len(packIDs) == 0 {
@@ -557,7 +564,7 @@ func (f *Finder) findObjectPack(id string, t restic.BlobType) {
 
 	blobs := f.repo.LookupBlob(t, rid)
 	if len(blobs) == 0 {
-		f.printer.S("Object %s not found in the index", rid.Str())
+		f.printer.S("Object %s with type %s not found in the index", t.String(), rid.Str())
 		return
 	}
 

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -473,10 +473,13 @@ func (f *Finder) packsToBlobs(ctx context.Context, packs []string) error {
 			return err
 		}
 		for _, b := range blobs {
-			if b.Type == restic.DataBlob {
+			switch b.Type {
+			case restic.DataBlob:
 				f.blobIDs[b.ID.String()] = struct{}{}
-			} else if b.Type == restic.TreeBlob {
+			case restic.TreeBlob:
 				f.treeIDs[b.ID.String()] = struct{}{}
+			default:
+				panic(fmt.Sprintf("unknown type %v in blob list", b.Type.String()))
 			}
 		}
 		// Stop searching when all packs have been found

--- a/cmd/restic/cmd_find_integration_test.go
+++ b/cmd/restic/cmd_find_integration_test.go
@@ -3,10 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"runtime"
 	"strings"
 	"testing"
 	"time"
+	"path/filepath"
 
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
@@ -199,15 +199,11 @@ func TestFindPackfile(t *testing.T) {
 		lastIndex := len(jsonResult) - 1
 		record := jsonResult[lastIndex]
 		rtest.Assert(t, record.ObjectType == "tree" && record.SnapshotID == sn1.String(),
-			"expexted a tree record with known snapshot id, but got type=%s and snapID=%s instead of %s",
+			"expected a tree record with known snapshot id, but got type=%s and snapID=%s instead of %s",
 			record.ObjectType, record.SnapshotID, sn1.String())
-		// for windows only: convert \\ to /
-		backupPath = strings.ReplaceAll(backupPath, `\\`, "/")
+		backupPath = filepath.ToSlash(backupPath)
+		rtest.Assert(t, strings.Contains(record.Path, backupPath), "expected %q as part of %q", backupPath, record.Path)
 
-		// I give up on Windows stuff
-		if runtime.GOOS != "windows" {
-			rtest.Assert(t, strings.Contains(record.Path, backupPath), "expected %q as part of %q", backupPath, record.Path)
-		}
 		return nil
 	})
 	rtest.OK(t, err)

--- a/cmd/restic/cmd_find_integration_test.go
+++ b/cmd/restic/cmd_find_integration_test.go
@@ -3,10 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
-	"path/filepath"
 
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"

--- a/cmd/restic/cmd_find_integration_test.go
+++ b/cmd/restic/cmd_find_integration_test.go
@@ -3,12 +3,15 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/restic/restic/internal/global"
+	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/ui"
 )
 
 func testRunFind(t testing.TB, wantJSON bool, opts FindOptions, gopts global.Options, pattern string) []byte {
@@ -140,4 +143,72 @@ func TestFindInvalidTimeRange(t *testing.T) {
 	err := runFind(context.TODO(), FindOptions{Oldest: "2026-01-01", Newest: "2020-01-01"}, env.gopts, []string{"quack"}, env.gopts.Term)
 	rtest.Assert(t, err != nil && err.Error() == "Fatal: --oldest must specify a time before --newest",
 		"unexpected error message: %v", err)
+}
+
+// JsonOutput is the struct `restic find --json` produces
+type JSONOutput struct {
+	ObjectType string    `json:"object_type"`
+	ID         string    `json:"id"`
+	Path       string    `json:"path"`
+	ParentTree string    `json:"parent_tree,omitempty"`
+	SnapshotID string    `json:"snapshot"`
+	Time       time.Time `json:"time,omitempty"`
+}
+
+func TestFindPackfile(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+
+	// backup
+	backupPath := env.testdata + "/0/0/9"
+	testRunBackup(t, "", []string{backupPath}, BackupOptions{}, env.gopts)
+	sn1 := testListSnapshots(t, env.gopts, 1)[0]
+
+	// do all the testing wrapped inside withTermStatus()
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
+		printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
+		_, repo, unlock, err := openWithReadLock(ctx, gopts, false, printer)
+		rtest.OK(t, err)
+		defer unlock()
+
+		// load master index
+		rtest.OK(t, repo.LoadIndex(ctx, printer))
+
+		packID := restic.ID{}
+		done := false
+		err = repo.ListBlobs(ctx, func(pb restic.PackedBlob) {
+			if !done && pb.Type == restic.TreeBlob {
+				packID = pb.PackID
+				done = true
+			}
+		})
+
+		rtest.OK(t, err)
+		rtest.Assert(t, !packID.IsNull(), "expected a tree packfile ID")
+		findOptions := FindOptions{PackID: true}
+		results := testRunFind(t, true, findOptions, env.gopts, packID.String())
+
+		// get the json records
+		jsonResult := []JSONOutput{}
+		rtest.OK(t, json.Unmarshal(results, &jsonResult))
+		rtest.Assert(t, len(jsonResult) > 0, "expected at least one tree record in the packfile")
+
+		// look at the last record
+		lastIndex := len(jsonResult) - 1
+		record := jsonResult[lastIndex]
+		rtest.Assert(t, record.ObjectType == "tree" && record.SnapshotID == sn1.String(),
+			"expexted a tree record with known snapshot id, but got type=%s and snapID=%s instead of %s",
+			record.ObjectType, record.SnapshotID, sn1.String())
+		// for windows only: convert \\ to /
+		backupPath = strings.ReplaceAll(backupPath, `\\`, "/")
+
+		// I give up on Windows stuff
+		if runtime.GOOS != "windows" {
+			rtest.Assert(t, strings.Contains(record.Path, backupPath), "expected %q as part of %q", backupPath, record.Path)
+		}
+		return nil
+	})
+	rtest.OK(t, err)
 }

--- a/cmd/restic/cmd_find_integration_test.go
+++ b/cmd/restic/cmd_find_integration_test.go
@@ -201,7 +201,7 @@ func TestFindPackfile(t *testing.T) {
 		rtest.Assert(t, record.ObjectType == "tree" && record.SnapshotID == sn1.String(),
 			"expected a tree record with known snapshot id, but got type=%s and snapID=%s instead of %s",
 			record.ObjectType, record.SnapshotID, sn1.String())
-		backupPath = filepath.ToSlash(backupPath)[:2] // take the offending drive mapping away
+		backupPath = filepath.ToSlash(backupPath)[2:] // take the offending drive mapping away
 		rtest.Assert(t, strings.Contains(record.Path, backupPath), "expected %q as part of %q", backupPath, record.Path)
 		// Windows response:
 		//expected "C:/Users/RUNNER~1/AppData/Local/Temp/restic-test-3529440698/testdata/0/0/9" as part of

--- a/cmd/restic/cmd_find_integration_test.go
+++ b/cmd/restic/cmd_find_integration_test.go
@@ -201,8 +201,11 @@ func TestFindPackfile(t *testing.T) {
 		rtest.Assert(t, record.ObjectType == "tree" && record.SnapshotID == sn1.String(),
 			"expected a tree record with known snapshot id, but got type=%s and snapID=%s instead of %s",
 			record.ObjectType, record.SnapshotID, sn1.String())
-		backupPath = filepath.ToSlash(backupPath)
+		backupPath = filepath.ToSlash(backupPath)[:2] // take the offending drive mapping away
 		rtest.Assert(t, strings.Contains(record.Path, backupPath), "expected %q as part of %q", backupPath, record.Path)
+		// Windows response:
+		//expected "C:/Users/RUNNER~1/AppData/Local/Temp/restic-test-3529440698/testdata/0/0/9" as part of
+		//         "/C/Users/RUNNER~1/AppData/Local/Temp/restic-test-3529440698/testdata/0/0/9"
 
 		return nil
 	})


### PR DESCRIPTION
cmd/restic/cmd_find.go: now produces output for both data-blob and tree-blob packfiles.
In ``func packsToBlobs()`` the blob type is now checked and the blob is either inserted into ``f.blobIDs`` or ``f.treeIDs``.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR fixes a bug in ``restic find --pack``.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Yes, in https://github.com/restic/restic/issues/5280

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
