### PR TITLE
PR dead: Bugfix: restic find --json --show-pack-id: suppress text output in JSON mode

### DIFF
--- a/changelog/unreleased/pull-5666
+++ b/changelog/unreleased/pull-5666
@@ -1,0 +1,8 @@
+Bugfix: restic find --json --show-pack-id suppresses some output in JSON mode.
+
+When calling `restic find` with both options `--json --show-pack-id` in the past
+it has generated JSON output as well as text output regarding packfiles.
+The generation of text output is now suppressed in JSON mode.
+
+https://github.com/restic/restic/issues/5280
+https://github.com/restic/restic/pull/5666

--- a/changelog/unreleased/pull-5666
+++ b/changelog/unreleased/pull-5666
@@ -1,4 +1,4 @@
-Bugfix: restic find --json --show-pack-id suppresses some output in JSON mode.
+Bugfix: restic find --json --show-pack-id suppresses some output in JSON mode
 
 When calling `restic find` with both options `--json --show-pack-id` in the past
 it has generated JSON output as well as text output regarding packfiles.

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -685,7 +685,7 @@ func runFind(ctx context.Context, opts FindOptions, gopts global.Options, args [
 	}
 	f.out.Finish()
 
-	if opts.ShowPackID && (f.blobIDs != nil || f.treeIDs != nil) {
+	if !gopts.JSON && opts.ShowPackID && (f.blobIDs != nil || f.treeIDs != nil) {
 		f.findObjectsPacks()
 	}
 


### PR DESCRIPTION
cmd/restic/cmd_find.go:
Suppress "normal" output of f.findObjectsPacks() in JSON mode.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
It fixes mixed output in JSON mode. It actually suppresses the execution of the call to ``f.findObjectsPacks()``.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Yes, in https://github.com/restic/restic/issues/5280
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

~~- [ ] I have added tests for all code changes.~~
~~- [ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
