### PR TITLE
Have `backup -vv` mention compressed size of added files

### DIFF
--- a/internal/ui/backup/text.go
+++ b/internal/ui/backup/text.go
@@ -104,8 +104,8 @@ func (b *TextProgress) CompleteItem(messageType, item string, s archiver.ItemSta
 			item, d.Seconds(), ui.FormatBytes(s.DataSize),
 			ui.FormatBytes(s.DataSizeInRepo), ui.FormatBytes(s.TreeSizeInRepo))
 	case "file new":
-		b.VV("new       %v, saved in %.3fs (%v added)", item,
-			d.Seconds(), ui.FormatBytes(s.DataSize))
+		b.VV("new       %v, saved in %.3fs (%v added, %v stored)", item,
+			d.Seconds(), ui.FormatBytes(s.DataSize), ui.FormatBytes(s.DataSizeInRepo))
 	case "file unchanged":
 		b.VV("unchanged %v", item)
 	case "file modified":


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------


Compressed size is already shown for modified files, but the added files message wasn't updated when compression was implemented in restic.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No, I thought it was simple enough to just send a PR

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- (not planned, though I could) I have added tests for all code changes.
- (not planned) I have added documentation for relevant changes (in the manual).
- (last time I contributed somethig similar, I was told this kind of feature is too small) There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review (though I'm happy to do any of the above if it helps)

