### PR TITLE
Enhancement: restic find - more integration tests

### DIFF
--- a/cmd/restic/cmd_find_integration_test.go
+++ b/cmd/restic/cmd_find_integration_test.go
@@ -204,9 +204,6 @@ func TestFindPackfile(t *testing.T) {
 			record.ObjectType, record.SnapshotID, sn1.String())
 		backupPath = filepath.ToSlash(backupPath)[2:] // take the offending drive mapping away
 		rtest.Assert(t, strings.Contains(record.Path, backupPath), "expected %q as part of %q", backupPath, record.Path)
-		// Windows response:
-		//expected "C:/Users/RUNNER~1/AppData/Local/Temp/restic-test-3529440698/testdata/0/0/9" as part of
-		//         "/C/Users/RUNNER~1/AppData/Local/Temp/restic-test-3529440698/testdata/0/0/9"
 
 		return nil
 	})
@@ -272,5 +269,8 @@ func TestFindPackID(t *testing.T) {
 
 	rtest.Equals(t, record.ObjectType, "tree")
 	rtest.Equals(t, record.SnapshotID, sn1.String())
-	rtest.Equals(t, filepath.ToSlash(record.Path), filepath.ToSlash(dir009))
+	// windows path are messy, so we get rid of the messy bits at the start
+	// exp: "/C/Users/RUNNER~1/AppData/Local/Temp/restic-test-2921201257/testdata/0/0/9"
+	// got: "C:/Users/RUNNER~1/AppData/Local/Temp/restic-test-2921201257/testdata/0/0/9"
+	rtest.Equals(t, filepath.ToSlash(record.Path)[2:], filepath.ToSlash(dir009)[2:])
 }


### PR DESCRIPTION
Added three more tests
- TestFindOldestNewest() to find a file in the repository where the ModTime of the file is within the specified range of options `--oldest`, `--newest'
- TestFindBlobID() which finds the the data blob with a given ID
- TestFindPackID() which finds all (data) blobs in a given packfile

Note: there should be more tests once PR #5664 has been applied, which will test
      option `--pack` and option `--show-pack-id`

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
see above
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
#5670
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
~~- [ ] I have added documentation for relevant changes (in the manual).~~
~~- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
No visible changes for the user
- [x] I'm done! This pull request is ready for review.
