### PR TITLE
Enhancement: restic cat - add type `full-tree`

### DIFF
--- a/changelog/unreleased/pull-5678
+++ b/changelog/unreleased/pull-5678
@@ -1,0 +1,10 @@
+Enhancement: add new type `tree-full` to `restic cat`
+
+`restic cat tree-full <snapshot-id[:subfolder]> generates JSON output for all
+participating tree blobs for the selected snapshot or a subfolder thereof. This
+will help when troubleshooting problems and relating directory names to JSON
+nodes in the repository,
+
+https://github.com/restic/restic/pull/5679
+https://github.com/restic/restic/pull/5678
+https://github.com/restic/restic/issues/5674

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -22,7 +22,7 @@ var catAllowedCmds = []string{"config", "index", "snapshot", "key", "masterkey",
 
 func newCatCommand(globalOptions *global.Options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "cat [flags] [masterkey|config|pack ID|blob ID|snapshot ID|index ID|key ID|lock ID|tree snapshot:subfolder|full-tree snapshot:subfolder]",
+		Use:   "cat [flags] [masterkey|config|pack ID|blob ID|snapshot ID|index ID|key ID|lock ID|tree snapshot[:subfolder]|full-tree snapshot[:subfolder]]",
 		Short: "Print internal objects to stdout",
 		Long: `
 The "cat" command is used to print internal objects to stdout.

--- a/cmd/restic/cmd_cat_integration_test.go
+++ b/cmd/restic/cmd_cat_integration_test.go
@@ -1,0 +1,47 @@
+package main
+
+import (
+	"context"
+	"path"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/restic/restic/internal/global"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func testRunCat(t testing.TB, gopts global.Options, tpe string, ID string) []byte {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		gopts.Quiet = true
+		return runCat(ctx, gopts, []string{tpe, ID}, gopts.Term)
+	})
+	rtest.OK(t, err)
+	return buf.Bytes()
+}
+
+func TestFullTree(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9")}, opts, env.gopts)
+	testRunCheck(t, env.gopts)
+	sn := testListSnapshots(t, env.gopts, 1)[0]
+	snapID := sn.String()
+
+	// gather the tree blobs from the repository: run 'restic list blobs'
+	treeIDs := testRunListTreeBlobs(t, env.gopts)
+
+	outString := string(testRunCat(t, env.gopts, "full-tree", snapID))
+
+	rtest.Assert(t, strings.Contains(outString, `"root"`), "expected to find string 'root', but did not see it")
+	rtest.Assert(t, strings.Contains(outString, snapID), "expected to find %q, but did not see it", snapID)
+	backupPath := path.Join("0", "0", "9")
+	rtest.Assert(t, strings.Contains(outString, backupPath), "expected to find %q, but did not see it", backupPath)
+	for _, treeID := range treeIDs {
+		rtest.Assert(t, strings.Contains(outString, treeID), "expected treeID %s in output string, got nothing", treeID)
+	}
+}

--- a/doc/view_repository.rst
+++ b/doc/view_repository.rst
@@ -361,6 +361,87 @@ Example::
 
 .. _cat_blob:
 
+full-tree snapshot[:subfolder]
+------------------------------
+
+``restic cat full-tree`` prints all subfolder information or selected parts of
+a given snapshot.
+
+Example::
+
+    # Print all subfolders within a snapshot
+    $ restic -r /srv/restic-repo cat full-tree 6e552abe3f7efb5146cb3489ac4ded7b640466f95d920fbb70bfeabb43711508
+    {
+      "snapshot": "6e552abe3f7efb5146cb3489ac4ded7b640466f95d920fbb70bfeabb43711508",
+      "root": "d23fd30c1341bf523df423cd763170bfd2e96da1167f8d47d7d4a1c185cdaf47",
+      "subdirecories": [
+        {
+          "subtree": "eb34dc1976a21dc61ee5f45e4abfbf07ae237c30d3c1d75973001882a7231f3f",
+          "path": "/home"
+        },
+        {
+          "subtree": "8f0d4ca5f73db0efe6dbce43b8784967f8c83678e195ac1959c46c7c776ec001",
+          "path": "/home/user"
+        },
+        ...
+        {
+          "subtree": "e077db3f444b60686570a23f7822f70a3d6bd0db5a0a2ab38fbb066881c441be",
+          "path": "/home/user/restic/testdata/0/for_cmd_ls"
+        }
+      ]
+    }
+
+Select the subfolder of interest and the print the contents of this subfolder with
+``restic cat blob ID``.
+
+Example::
+
+    # Print the contents of blob e077db3f444b60686570a23f7822f70a3d6bd0db5a0a2ab38fbb066881c441be
+    $ restic -r /srv/restic-repo blob e077db3f444b60686570a23f7822f70a3d6bd0db5a0a2ab38fbb066881c441be
+    {
+      "nodes": [
+        {
+          "name": "cmd_key.go",
+          "type": "file",
+          "mode": 436,
+          "mtime": "2026-05-22T17:17:00.001977314+01:00",
+          "atime": "2026-05-22T17:17:00.001977314+01:00",
+          "ctime": "2026-05-24T15:40:18.715037751+01:00",
+          "uid": 1000,
+          "gid": 1000,
+          "user": "myuser",
+          "group": "mygroup",
+          "inode": 3036011,
+          "device_id": 66310,
+          "size": 589,
+          "links": 1,
+          "content": [
+            "7f625e20f590535f397be3be4962e7eae49e534d0204ffe5708ba2c943b7782b"
+          ]
+        },
+        ...
+        {
+          "name": "python.py",
+          "type": "file",
+          "mode": 420,
+          "mtime": "2025-01-28T04:28:21Z",
+          "atime": "2025-01-28T04:28:21Z",
+          "ctime": "2026-04-05T13:19:55.554804617+01:00",
+          "uid": 1000,
+          "gid": 1000,
+          "user": "myuser",
+          "group": "mygroup",
+          "inode": 3036991,
+          "device_id": 66310,
+          "size": 113,
+          "links": 1,
+          "content": [
+            "5dfb8bc8a35175bf011d10ac7bc3a6b8d42b7743ac188be8c1bf0b215f9b7bf5"
+          ]
+        }
+      ]
+    }
+
 blob ID
 -------
 

--- a/doc/view_repository.rst
+++ b/doc/view_repository.rst
@@ -364,8 +364,10 @@ Example::
 full-tree snapshot[:subfolder]
 ------------------------------
 
-``restic cat full-tree`` prints all subfolder information or selected parts of
-a given snapshot.
+If one is interested in the blob contents of the subfolder
+``/home/user/restic/testdata/0/for_cmd_ls`` but does not know the tree ID for the
+subfolder, one has to descend from the top of the tree step by step down to the subfolder
+in question. ``restic cat full-tree`` does this in one step when the snapshot ID is given.
 
 Example::
 


### PR DESCRIPTION
Create a topologically sorted list of tree nodes ID and names belonging to a snapshot or a subfolder of a snaphot

Added keyword "full-tree" to the list of acceptable types Moved the code validateCatArgs() up to check for simple errors as soon as possible.

Output is JSON only, like the rest of the ``cat`` command.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR creates a list of tree blobs which constitute all - or a selected subset of - tree blobs for a given snapshot. In the past, I was always struggling to see these details without doing repeated ``restic list`` and ``restic cat``.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->
Added the type ``full-tree``and created a function ``buildFullTree()`` which calls ``ẁalker.Walk()`` with appropriate parameters.
The result is gathered in a struct, which is then converted to a JSON structure of the form
```
{
  "snapshot": "774ebacda7f3fb8f92589773c023d8aa0fd21cd04c76d86309baf5e11aaa2f90",
  "root": "17c020f49e3a6f26f8a0a1312042a6a4d93430b956f13beea9426adf4880146a",
  "subdirecories": [
    {
      "subtree": "4f743fe78398e0a8c0ded6ac464df455c319b1a02d6cd2a2313b87c886c1b5f7",
      "path": "/home"
    },
		...
    {
      "subtree": "6409bed28d08898b849ecc4fdf338cdb0d67358619c99e6f6c3b402b1895baf8",
      "path": "/home/wplapper/restic/testdata/0/0/9"
    }
  ]
}
``` 

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
