### PR TITLE
man: add note about append-only mode to restic-unlock.1

### DIFF
--- a/cmd/restic/cmd_unlock.go
+++ b/cmd/restic/cmd_unlock.go
@@ -19,6 +19,8 @@ func newUnlockCommand(globalOptions *global.Options) *cobra.Command {
 		Long: `
 The "unlock" command removes stale locks that have been created by other restic processes.
 
+Removing locks works even with repositories served in append-only mode from restic's rest-server.
+
 EXIT STATUS
 ===========
 


### PR DESCRIPTION


What does this PR change? What problem does it solve?
-----------------------------------------------------
Since restic unlock _removes_ locks, a user reading about append-only might wonder whether this mode prevents removal of locks, too. This change explicitly mentions in the man page that the deletion of locks is an allowed exception.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #5653 

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
