### PR TITLE
Enhancement: Allow stripping path components during restore

### DIFF
--- a/changelog/unreleased/issue-5639
+++ b/changelog/unreleased/issue-5639
@@ -1,0 +1,10 @@
+Enhancement: Allow stripping directories when restoring
+
+Restic restore always restored the full backed up path to a target location.
+For example restoring `/home/work/foo` to `/home/restores` would create `/home/restores/home/work/foo`.
+Restic now, much like `tar` permits trimming the structure on restore allowing to skip first N levels of directories using the `--strip-components` option.
+This way you can now restore  `/home/work/foo` to `/home/restores/foo` using `--strip-components=2`.
+Pathnames with fewer elements will be silently skipped.
+
+https://github.com/restic/restic/issues/5639
+https://github.com/restic/restic/pull/5681

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -73,6 +73,7 @@ type RestoreOptions struct {
 	ExcludeXattrPattern []string
 	IncludeXattrPattern []string
 	OwnershipByName     bool
+	StripComponents     int
 }
 
 func (opts *RestoreOptions) AddFlags(f *pflag.FlagSet) {
@@ -90,6 +91,7 @@ func (opts *RestoreOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.Verify, "verify", false, "verify restored files content")
 	f.Var(&opts.Overwrite, "overwrite", "overwrite behavior, one of (always|if-changed|if-newer|never)")
 	f.BoolVar(&opts.Delete, "delete", false, "delete files from target directory if they do not exist in snapshot. Use '--dry-run -vv' to check what would be deleted")
+	f.IntVar(&opts.StripComponents, "strip-components", 0, "number of leading path components to strip when restoring")
 	if runtime.GOOS != "windows" {
 		f.BoolVar(&opts.OwnershipByName, "ownership-by-name", false, "restore file ownership by user name and group name (except POSIX ACLs)")
 	}
@@ -178,6 +180,7 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts global.Options,
 		Overwrite:       opts.Overwrite,
 		Delete:          opts.Delete,
 		OwnershipByName: opts.OwnershipByName,
+		StripComponents: opts.StripComponents,
 	})
 
 	totalErrors := 0

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -88,6 +88,17 @@ disk space. Note that the exact location of the holes can differ from those in
 the original file, as their location is determined while restoring and is not
 stored explicitly.
 
+Much like ``tar`` restic has a ``--strip-components`` option to remove leading path elements
+when restoring files. For example, to restore everything below the ``work`` directory
+and place it directly into the target directory, use:
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo restore 79766175 --target /tmp/restore-work --strip-components 1 --include /work/foo
+    enter password for repository:
+    restoring <Snapshot of [/home/user/work] at 2015-05-08 21:40:19.884408621 +0200 CEST> to /tmp/restore-work
+
+This will restore the file ``foo`` to ``/tmp/restore-work/foo``. Note that pathnames with fewer elements than specified will be silently skipped.
+
 Restoring extended file attributes
 ----------------------------------
 

--- a/internal/restorer/restorer.go
+++ b/internal/restorer/restorer.go
@@ -46,6 +46,7 @@ type Options struct {
 	Overwrite       OverwriteBehavior
 	Delete          bool
 	OwnershipByName bool
+	StripComponents int
 }
 
 type OverwriteBehavior int
@@ -143,7 +144,7 @@ func (res *Restorer) traverseTree(ctx context.Context, target string, treeID res
 			return err
 		}
 	}
-	childFilenames, hasRestored, err := res.traverseTreeInner(ctx, target, location, treeID, visitor)
+	childFilenames, hasRestored, err := res.traverseTreeInner(ctx, target, location, treeID, visitor, res.opts.StripComponents)
 	if err != nil {
 		return err
 	}
@@ -154,7 +155,7 @@ func (res *Restorer) traverseTree(ctx context.Context, target string, treeID res
 	return err
 }
 
-func (res *Restorer) traverseTreeInner(ctx context.Context, target, location string, treeID restic.ID, visitor treeVisitor) (filenames []string, hasRestored bool, err error) {
+func (res *Restorer) traverseTreeInner(ctx context.Context, target, location string, treeID restic.ID, visitor treeVisitor, stripComponents int) (filenames []string, hasRestored bool, err error) {
 	debug.Log("%v %v %v", target, location, treeID)
 	tree, err := data.LoadTree(ctx, res.repo, treeID)
 	if err != nil {
@@ -215,6 +216,13 @@ func (res *Restorer) traverseTreeInner(ctx context.Context, target, location str
 		selectedForRestore, childMayBeSelected := res.SelectFilter(nodeLocation, node.Type == data.NodeTypeDir)
 		debug.Log("SelectFilter returned %v %v for %q", selectedForRestore, childMayBeSelected, nodeLocation)
 
+		skipNode := stripComponents > 0
+		if skipNode {
+			nodeTarget = target
+			nodeLocation = location
+			selectedForRestore = false
+		}
+
 		if selectedForRestore {
 			hasRestored = true
 		}
@@ -237,7 +245,7 @@ func (res *Restorer) traverseTreeInner(ctx context.Context, target, location str
 			var childFilenames []string
 
 			if childMayBeSelected {
-				childFilenames, childHasRestored, err = res.traverseTreeInner(ctx, nodeTarget, nodeLocation, *node.Subtree, visitor)
+				childFilenames, childHasRestored, err = res.traverseTreeInner(ctx, nodeTarget, nodeLocation, *node.Subtree, visitor, stripComponents-1)
 				err = res.sanitizeError(nodeLocation, err)
 				if err != nil {
 					return nil, hasRestored, err
@@ -250,7 +258,7 @@ func (res *Restorer) traverseTreeInner(ctx context.Context, target, location str
 
 			// metadata need to be restore when leaving the directory in both cases
 			// selected for restore or any child of any subtree have been restored
-			if (selectedForRestore || childHasRestored) && visitor.leaveDir != nil {
+			if (selectedForRestore || childHasRestored) && !skipNode && visitor.leaveDir != nil {
 				err = res.sanitizeError(nodeLocation, visitor.leaveDir(node, nodeTarget, nodeLocation, childFilenames))
 				if err != nil {
 					return nil, hasRestored, err


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Added support for stripping leading path components when restoring
files and directories, similar to tar’s --strip-components option.

Previously, restic always restored the full original path under the target
directory. For example, restoring /home/work/foo to /home/restores
would result in /home/restores/home/work/foo.

With this change, users can specify --strip-components=N to skip the
first N directory levels during restore. Pathnames with fewer elements will be silently skipped.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #5639

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
