### PR TITLE
CI: prevent backends from importing internal/restic package

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -6,6 +6,8 @@ linters:
     - asciicheck
     # ensure that http response bodies are closed
     - bodyclose
+    # restrict imports from other restic packages for internal/backend (cache exempt)
+    - depguard
     - copyloopvar
     # make sure all errors returned by functions are handled
     - errcheck
@@ -24,6 +26,20 @@ linters:
     # find unused variables, functions, structs, types, etc.
     - unused
   settings:
+    depguard:
+      rules:
+        # Prevent backend packages from importing the internal/restic package to keep the architectural layers intact.
+        backend-imports:
+          files:
+            - "**/internal/backend/**"
+            - "!**/internal/backend/cache/**"
+            - "!**/internal/backend/test/**"
+            - "!**/*_test.go"
+          deny:
+            - pkg: "github.com/restic/restic/internal/restic"
+              desc: "internal/restic should not be imported to keep the architectural layers intact"
+            - pkg: "github.com/restic/restic/internal/repository"
+              desc: "internal/repository should not be imported to keep the architectural layers intact"
     importas:
       alias:
         - pkg: github.com/restic/restic/internal/test


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The architectural layers in restic are `internal/data` above `internal/restic` / `internal/repository`  above `internal/backend`. Make sure that individual backends cannot break that rule. The cache needs an exception as it interacts more significantly with the repository.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Noticed the layering issue while taking a quick look at https://github.com/restic/restic/pull/5362 .
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- ~~[ ] I have added tests for all code changes.~~
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I'm done! This pull request is ready for review.
