### PR TITLE
fail if RESTIC_READ_CONCURRENCY or RESTIC_COMPRESSION are invalid

### DIFF
--- a/changelog/unreleased/issue-4759
+++ b/changelog/unreleased/issue-4759
@@ -1,0 +1,10 @@
+Bugfix: Return error if environment variables contain invalid values
+
+If the value of one of the environment variables `RESTIC_COMPRESSION`, `RESTIC_PACK_SIZE`
+or `RESTIC_READ_CONCURRENCY` could not be parsed, then restic ignored their value.
+Now, the restic commands fail with an error, unless they were overwritten with their
+corresponding command-line option.
+
+https://github.com/restic/restic/issues/4759
+https://github.com/restic/restic/pull/5592
+https://github.com/restic/restic/pull/5700

--- a/changelog/unreleased/pull-5592
+++ b/changelog/unreleased/pull-5592
@@ -1,7 +1,0 @@
-Bugfix: Return error if `RESTIC_PACK_SIZE` contains invalid value
-
-If the environment variable `RESTIC_PACK_SIZE` could not be parsed, then
-restic ignored its value. Now, the restic commands fail with an error, unless
-the command-line option `--pack-size` was specified.
-
-https://github.com/restic/restic/pull/5592


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Return an error if `RESTIC_READ_CONCURRENCY` or `RESTIC_COMPRESSION` cannot be parsed and they haven't been overwritten via their command line option.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Follow-up to https://github.com/restic/restic/pull/5592
Fixes https://github.com/restic/restic/issues/4759
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
