### PR TITLE
Add space in error message

### DIFF
--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -210,7 +210,7 @@ func main() {
 		exitMessage = fmt.Sprintf("%+v", err)
 
 		if logBuffer.Len() > 0 {
-			exitMessage += "also, the following messages were logged by a library:\n"
+			exitMessage += " also, the following messages were logged by a library:\n"
 			sc := bufio.NewScanner(logBuffer)
 			for sc.Scan() {
 				exitMessage += fmt.Sprintln(sc.Text())


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

While trying to mount a restic backup, I've seen the following error message:

```
fusermount: exit status 1also, the following messages were logged by a library:
```

There's a space missing before the "also". This PR adds the missing space.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No discussion found.

Checklist
---------

- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.

This change is minuscule.