### PR TITLE
Show progress for `restic stats`

### DIFF
--- a/changelog/unreleased/issue-5689
+++ b/changelog/unreleased/issue-5689
@@ -1,0 +1,8 @@
+Enhancement: Show progress bar for `restic stats`
+
+Previously, running `restic stats` would only give progress updates for loading the index.
+Now it displays progress for how many snapshots, files, and blobs were processed so far.
+This lets users better understand if the command is working as expected or where it is hanging.
+
+https://github.com/restic/restic/issues/5689
+https://github.com/restic/restic/pull/55555

--- a/changelog/unreleased/issue-5689
+++ b/changelog/unreleased/issue-5689
@@ -5,4 +5,4 @@ Now it displays progress for how many snapshots, files, and blobs were processed
 This lets users better understand if the command is working as expected or where it is hanging.
 
 https://github.com/restic/restic/issues/5689
-https://github.com/restic/restic/pull/55555
+https://github.com/restic/restic/pull/5705

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -388,12 +388,14 @@ func newStatsProgress(term ui.Terminal, snapshotCount uint64) *statsProgress {
 }
 
 func (s *statsProgress) printProgress(runtime time.Duration, final bool) {
+	s.m.Lock()
+
 	progressBase := s.processedSnapshotCount
 	if progressBase > 0 && !final {
 		progressBase--
 	}
 
-	status := fmt.Sprintf("[%s] %s Snapshot %v / %v", ui.FormatDuration(runtime), ui.FormatPercent(progressBase, s.snapshotCount), s.processedSnapshotCount, s.snapshotCount)
+	status := fmt.Sprintf("[%s] %s  %d / %d snapshots", ui.FormatDuration(runtime), ui.FormatPercent(progressBase, s.snapshotCount), s.processedSnapshotCount, s.snapshotCount)
 
 	if s.processedFileCount > 0 {
 		status += fmt.Sprintf(", %v files", s.processedFileCount)
@@ -404,6 +406,7 @@ func (s *statsProgress) printProgress(runtime time.Duration, final bool) {
 	}
 
 	status += fmt.Sprintf(", %s", ui.FormatBytes(s.processedSize))
+	s.m.Unlock()
 
 	if final {
 		s.term.SetStatus(nil)

--- a/cmd/restic/cmd_stats_test.go
+++ b/cmd/restic/cmd_stats_test.go
@@ -68,23 +68,23 @@ func TestStatsProgress(t *testing.T) {
 
 	progress := newStatsProgress(term, 2)
 	progress.printProgress(0*time.Second, false)
-	rtest.Equals(t, []string{"[0:00] 0.00% Snapshot 0 / 2, 0 B"}, term.Output)
+	rtest.Equals(t, []string{"[0:00] 0.00%  0 / 2 snapshots, 0 B"}, term.Output)
 
 	progress.processSnapshot()
 	progress.update(1, 2, 3)
 	progress.printProgress(5*time.Second, false)
 	// Output differs from the previous one because the progress is based on the number of processed snapshots,
-	// Snapshot 1/2 means processing the snapshot 1 currently
-	rtest.Equals(t, []string{"[0:05] 0.00% Snapshot 1 / 2, 1 files, 2 blobs, 3 B"}, term.Output)
+	// 1/2 snapshots means processing the snapshot 1 currently
+	rtest.Equals(t, []string{"[0:05] 0.00%  1 / 2 snapshots, 1 files, 2 blobs, 3 B"}, term.Output)
 
 	progress.processSnapshot()
 	progress.printProgress(10*time.Second, false)
-	rtest.Equals(t, []string{"[0:10] 50.00% Snapshot 2 / 2, 0 B"}, term.Output)
+	rtest.Equals(t, []string{"[0:10] 50.00%  2 / 2 snapshots, 0 B"}, term.Output)
 
 	progress.update(4, 5, 6)
 	progress.printProgress(15*time.Second, false)
-	rtest.Equals(t, []string{"[0:15] 50.00% Snapshot 2 / 2, 4 files, 5 blobs, 6 B"}, term.Output)
+	rtest.Equals(t, []string{"[0:15] 50.00%  2 / 2 snapshots, 4 files, 5 blobs, 6 B"}, term.Output)
 
 	progress.printProgress(20*time.Second, true)
-	rtest.Equals(t, []string{"[0:20] 100.00% Snapshot 2 / 2, 4 files, 5 blobs, 6 B"}, term.Output)
+	rtest.Equals(t, []string{"[0:20] 100.00%  2 / 2 snapshots, 4 files, 5 blobs, 6 B"}, term.Output)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

`restic stats` now displays progress for how many snapshots, files, and blobs were processed so far.
This lets users better understand if the command is working as expected or where it is hanging.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
Closes #5689

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

~~- [ ] I have added tests for all code changes.~~
~~- [ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
