### PR TITLE
Add support for virtual device ids

### DIFF
--- a/internal/archiver/file_saver_test.go
+++ b/internal/archiver/file_saver_test.go
@@ -40,8 +40,9 @@ func startFileSaver(ctx context.Context, t testing.TB, _ fs.FS) (*fileSaver, *mo
 	}
 
 	saver := &mockSaver{saved: make(map[string]int)}
-	s := newFileSaver(ctx, wg, saver, pol, workers)
-	s.NodeFromFileInfo = func(snPath, filename string, meta ToNoder, ignoreXattrListError bool) (*data.Node, error) {
+	deviceIdMap := newMutableDeviceIdMapper().ReadOnlyMapper()
+	s := newFileSaver(ctx, wg, saver, pol, workers, deviceIdMap)
+	s.NodeFromFileInfo = func(snPath, filename string, meta ToNoder, deviceIdMap deviceIdMapper, ignoreXattrListError bool) (*data.Node, error) {
 		return meta.ToNode(ignoreXattrListError, t.Logf)
 	}
 

--- a/internal/archiver/virtual_device_id.go
+++ b/internal/archiver/virtual_device_id.go
@@ -1,0 +1,80 @@
+package archiver
+
+// Virtual device ID mapping: converts real device IDs into a stable virtual
+// numbering 1..n, where assignment order is determined by first-seen. This
+// keeps snapshot trees stable across runs regardless of which devices appear
+// or in what order.
+//
+// Concurrency: only the goroutine that created the mapper via
+// newMutableDeviceIdMapper() may call GetVirtualId on that mapper. For that
+// goroutine, GetVirtualId may allocate a new virtual ID for an unseen device.
+// All other goroutines must use the result of ReadOnlyMapper(). On the
+// read-only mapper, GetVirtualId returns (0, false) for any device ID not yet
+// seen by the mutable owner.
+//
+// See deviceIdMapper and newMutableDeviceIdMapper.
+
+import (
+	"sync"
+
+	"github.com/restic/restic/internal/debug"
+)
+
+// deviceIdMapper maps real device IDs to stable virtual IDs. Implementations
+// are either mutable (may assign new virtual IDs) or read-only (lookup only).
+type deviceIdMapper interface {
+	GetVirtualId(realDeviceID uint64) (uint64, bool)
+	ReadOnlyMapper() deviceIdMapper
+}
+
+// newMutableDeviceIdMapper returns a mapper that may assign new virtual IDs.
+// Only the creating goroutine may call GetVirtualId on the returned value.
+func newMutableDeviceIdMapper() deviceIdMapper {
+	m := &deviceIdMap{
+		count: 0,
+		cache: &vIdCache{},
+	}
+	m.cache.set(0, 0)
+	return m
+}
+
+// vIdCache is a concurrent read-only view of realID -> virtualID; GetVirtualId returns (0, false) when missing.
+type vIdCache sync.Map
+
+func (v *vIdCache) GetVirtualId(realDeviceID uint64) (uint64, bool) {
+	if id, ok := (*sync.Map)(v).Load(realDeviceID); ok {
+		return id.(uint64), true
+	}
+	return 0, false
+}
+
+func (v *vIdCache) set(realDeviceID uint64, virtualDeviceID uint64) {
+	(*sync.Map)(v).Store(realDeviceID, virtualDeviceID)
+}
+
+func (v *vIdCache) ReadOnlyMapper() deviceIdMapper {
+	return v
+}
+
+// deviceIdMap is the mutable mapper; only its owner goroutine may call GetVirtualId.
+type deviceIdMap struct {
+	count uint64
+	cache *vIdCache
+}
+
+// GetVirtualId returns the virtual ID for realDeviceID, allocating one (first-seen order) if needed.
+func (d *deviceIdMap) GetVirtualId(realDeviceID uint64) (uint64, bool) {
+	id, ok := d.cache.GetVirtualId(realDeviceID)
+	if !ok {
+		id = d.count + 1
+		d.cache.set(realDeviceID, id)
+		d.count = id
+		debug.Log("Mapped deviceId %v to virtualId %v", realDeviceID, id)
+	}
+	return id, true
+}
+
+// ReadOnlyMapper returns a concurrent-safe view for other goroutines; they must use this, not GetVirtualId on d.
+func (d *deviceIdMap) ReadOnlyMapper() deviceIdMapper {
+	return d.cache
+}

--- a/internal/archiver/virtual_device_id_test.go
+++ b/internal/archiver/virtual_device_id_test.go
@@ -1,0 +1,86 @@
+package archiver
+
+import (
+	"sync"
+	"testing"
+)
+
+func TestVirtualIdFirstSeenOrder(t *testing.T) {
+	m := newMutableDeviceIdMapper()
+
+	// Real 0 is pre-mapped to virtual 0
+	if vid, ok := m.GetVirtualId(0); !ok || vid != 0 {
+		t.Fatalf("real 0: got (%d, %v), want (0, true)", vid, ok)
+	}
+
+	// First-seen order: 100 -> 1, 200 -> 2, 100 again -> 1, 300 -> 3
+	cases := []struct {
+		realID uint64
+		want   uint64
+	}{
+		{100, 1},
+		{200, 2},
+		{100, 1},
+		{300, 3},
+	}
+	for _, c := range cases {
+		vid, ok := m.GetVirtualId(c.realID)
+		if !ok || vid != c.want {
+			t.Errorf("real %d: got (%d, %v), want (%d, true)", c.realID, vid, ok, c.want)
+		}
+	}
+}
+
+func TestReadOnlyMapperUnseenReturnsFalse(t *testing.T) {
+	m := newMutableDeviceIdMapper()
+	m.GetVirtualId(42)
+	ro := m.ReadOnlyMapper()
+
+	if vid, ok := ro.GetVirtualId(999); ok || vid != 0 {
+		t.Errorf("unseen 999: got (%d, %v), want (0, false)", vid, ok)
+	}
+}
+
+func TestReadOnlyMapperSeenReturnsId(t *testing.T) {
+	m := newMutableDeviceIdMapper()
+	vidOwner, _ := m.GetVirtualId(100)
+	ro := m.ReadOnlyMapper()
+
+	vidRo, ok := ro.GetVirtualId(100)
+	if !ok || vidRo != vidOwner {
+		t.Errorf("read-only for seen 100: got (%d, %v), want (%d, true)", vidRo, ok, vidOwner)
+	}
+}
+
+func TestReadOnlyMapperConcurrent(t *testing.T) {
+	m := newMutableDeviceIdMapper()
+	ro := m.ReadOnlyMapper()
+
+	var wg sync.WaitGroup
+	for i := 0; i < 10; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = ro.GetVirtualId(1)
+			_, _ = ro.GetVirtualId(999)
+		}()
+	}
+
+	m.GetVirtualId(1)
+	wg.Wait()
+}
+
+func TestReadOnlyMapperSeesUpdatesFromOwner(t *testing.T) {
+	m := newMutableDeviceIdMapper()
+	ro := m.ReadOnlyMapper()
+
+	if _, ok := ro.GetVirtualId(1); ok {
+		t.Error("read-only saw 1 before owner")
+	}
+
+	m.GetVirtualId(1)
+	vid, ok := ro.GetVirtualId(1)
+	if !ok || vid != 1 {
+		t.Errorf("after owner added 1: got (%d, %v), want (1, true)", vid, ok)
+	}
+}

--- a/internal/feature/registry.go
+++ b/internal/feature/registry.go
@@ -9,6 +9,7 @@ const (
 	DeprecateLegacyIndex    FlagName = "deprecate-legacy-index"
 	DeprecateS3LegacyLayout FlagName = "deprecate-s3-legacy-layout"
 	DeviceIDForHardlinks    FlagName = "device-id-for-hardlinks"
+	VirtualDeviceId         FlagName = "virtual-device-id"
 	ExplicitS3AnonymousAuth FlagName = "explicit-s3-anonymous-auth"
 	SafeForgetKeepTags      FlagName = "safe-forget-keep-tags"
 	S3Restore               FlagName = "s3-restore"
@@ -20,6 +21,7 @@ func init() {
 		DeprecateLegacyIndex:    {Type: Stable, Description: "disable support for index format used by restic 0.1.0. Use `restic repair index` to update the index if necessary."},
 		DeprecateS3LegacyLayout: {Type: Stable, Description: "disable support for S3 legacy layout used up to restic 0.7.0. Use restic 0.17.3 to migrate if necessary."},
 		DeviceIDForHardlinks:    {Type: Alpha, Description: "store deviceID only for hardlinks to reduce metadata changes for example when using btrfs subvolumes. Will be removed in a future restic version after repository format 3 is available"},
+		VirtualDeviceId:         {Type: Alpha, Description: "Use a virtual DeviceID, generated in lexographic order during backup"},
 		ExplicitS3AnonymousAuth: {Type: Stable, Description: "forbid anonymous S3 authentication unless `-o s3.unsafe-anonymous-auth=true` is set"},
 		SafeForgetKeepTags:      {Type: Stable, Description: "prevent deleting all snapshots if the tag passed to `forget --keep-tags tagname` does not exist"},
 		S3Restore:               {Type: Alpha, Description: "restore S3 objects from cold storage classes when `-o s3.enable-restore=true` is set"},


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR addresses the issue of two backups, identical except for coming from different btrfs snapshots, produce blob changes due to the device_id changing. While the `device-id-for-hardlinks` flag address this for regular files, this behavior still persists for hard links. This PR provides a mechanism that addresses this problem for all files. It can be used with, or without the `device-id-for-hardlinks` flag

## Basic algorithm
The actual device id doesn't matter in itself. It's just used to keep inodes from different devices from conflicting. So, as long as we can keep the device id stable for all files on a device, and stable between runs, we can use any numbering scheme we want. Next, the backup logic is designed to always visit files in the same order for a given set of files to backup. Putting this together, and we can have a very simple algorithm: The first device_id that we see when backing files up gets an id of 1. The next device gets an id of 2, and so on. As long as backing up remains in the same order, every file will always get the same value.

## Implementation
The core logic is quite simple to manage, with a lot of piping to pass the data around. At its core, the Savepoint() logic is single-threaded. It eventually calls down into `nodeFromFileInfo`. Here, we add the logic to rewrite the device id to the virtual device id, and also cache the virtual id for future calls. The only complication is that the file uploader workers also need this mapping. The code is designed such that the workers get a read-only implementation of the mapping, and only the saveTree() enumeration does the writing. This ensures deterministic ordering and greatly increases the performance. sync.Map() is specifically built for this type of scenario and is quite fast (10ns / op).

## What if the virtual device id is wrong?
The algorithm will definitely ensure consistency within a backup. E.g. if the device_id is 142, then all nodes will have a device_id of 1 after the re-mapping. If there is a mismatch between device ids between different backups, this is already what happens today for the snapshot scenarios mentioned, so this is no different than today's behavior (where extra metadata is uploaded every backup for all the nodes with different device ids) This could happen if the user changes backup paths between different backups, or perhaps if the only file in a block device were removed between scans. Even with this user behavior, the system would re-stabilize once the backup paths become consistent across runs, and in the meantime the only real side effect is extra metadata uploading.

## Test plan
1. Existing unit tests pass
2. Created a unit test for the virtual device id behavior
3. Created a unit test to ensure that the code behaves well with `device-id-for-hardlinks`
4. Manually tested the various conditions with a test script (see the first comment in the PR for details)

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://github.com/restic/restic/issues/3041
That thread is very long (and old now), but should hopefully address any remaining difficulties

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
