### PR TITLE
Enhancement: restic diff --diff-hosts comparison

### DIFF
--- a/changelog/unreleased/pull-5709
+++ b/changelog/unreleased/pull-5709
@@ -1,0 +1,11 @@
+Enhancement: `restic diff` is now able to compare two different hosts
+
+In the past you could only compare two different snapshots and get an overview
+over differences.
+
+You can now compare snapshots from two different hosts, which can be further filtered
+by subfolder. The output shows common data blobs together with their size, and
+the data blobs used only by host A and host B.
+
+https://github.com/restic/restic/pull/5709
+https://forum.restic.net/t/how-to-check-deduplication-across-sources/10512

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -65,10 +65,16 @@ Exit status is 12 if the password is incorrect.
 // DiffOptions collects all options for the diff command.
 type DiffOptions struct {
 	ShowMetadata bool
+
+	// for 2-host comparison
+	hostA string
+	hostB string
 }
 
 func (opts *DiffOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.ShowMetadata, "metadata", false, "print changes in metadata")
+	f.StringVar(&opts.hostA, "host-A", "", "gather `host-A` snapsshots")
+	f.StringVar(&opts.hostB, "host-B", "", "gather `host-B` snapsshots")
 }
 
 func loadSnapshot(ctx context.Context, be restic.Lister, repo restic.LoaderUnpacked, desc string) (*data.Snapshot, string, error) {
@@ -354,12 +360,103 @@ func (c *Comparer) diffTree(ctx context.Context, stats *DiffStatsContainer, pref
 	return ctx.Err()
 }
 
-func runDiff(ctx context.Context, opts DiffOptions, gopts global.Options, args []string, term ui.Terminal) error {
-	if len(args) != 2 {
-		return errors.Fatalf("specify two snapshot IDs")
+func deleteTreeBlobs(set restic.BlobSet) {
+	for blob := range set {
+		if blob.Type == restic.TreeBlob {
+			delete(set, blob)
+		}
+	}
+}
+
+func countAndSizeHosts(repo restic.Repository, set restic.BlobSet) (int, uint64) {
+	setCount := len(set)
+	size := uint64(0)
+	for blob := range set {
+		bsize, exist := repo.LookupBlobSize(blob.Type, blob.ID)
+		if exist {
+			size += uint64(bsize)
+		}
 	}
 
-	printer := progress.NewTerminalPrinter(gopts.JSON, gopts.Verbosity, term)
+	return setCount, size
+}
+
+// runHostDiff: compare two different host snapshots in the same repository and
+// find commonality and differences
+func runHostDiff(ctx context.Context, opts DiffOptions, gopts global.Options,
+	repo restic.Repository, printer restic.Printer, be restic.Lister) error {
+
+	treeHostA := restic.IDs{}
+	treeHostB := restic.IDs{}
+	countOtherTrees := 0
+	printer.P("loading all snapshots...\n")
+	err := data.ForAllSnapshots(ctx, repo, repo, nil,
+		func(id restic.ID, sn *data.Snapshot, err error) error {
+			if err != nil {
+				debug.Log("failed to load snapshot %v (error %v)", id, err)
+				return err
+			}
+			switch sn.Hostname {
+				case opts.hostA:
+					treeHostA = append(treeHostA, *sn.Tree)
+				case opts.hostB:
+					treeHostB = append(treeHostB, *sn.Tree)
+				default:
+					countOtherTrees++
+			}
+			return nil
+		})
+	if err != nil {
+		return errors.Fatalf("failed loading snapshot: %v", err)
+	}
+
+	// both sets of used blobs are materialized as restic.BlobSets
+	barA := printer.NewCounter("snapshots host A")
+	barA.SetMax(uint64(len(treeHostA)))
+	blobsHostA := restic.NewBlobSet()
+	if err := data.FindUsedBlobs(ctx, repo, treeHostA, blobsHostA, barA); err != nil {
+		return err
+	}
+	barA.Done()
+
+	barB := printer.NewCounter("snapshots host B")
+	barB.SetMax(uint64(len(treeHostB)))
+	blobsHostB := restic.NewBlobSet()
+	if err := data.FindUsedBlobs(ctx, repo, treeHostB, blobsHostB, barB); err != nil {
+		return err
+	}
+	barB.Done()
+
+	// remove referenced tree blobs
+	deleteTreeBlobs(blobsHostA)
+	deleteTreeBlobs(blobsHostB)
+
+	// create result sets
+	common := blobsHostA.Intersect(blobsHostB)
+	onlyA := blobsHostA.Sub(blobsHostB)
+	onlyB := blobsHostB.Sub(blobsHostA)
+
+	// count and size
+	commonCount, commonSize := countAndSizeHosts(repo, common)
+	onlyACount, onlyASize := countAndSizeHosts(repo, onlyA)
+	onlyBCount, onlyBSize := countAndSizeHosts(repo, onlyB)
+	allCount := commonCount + onlyACount + onlyBCount
+	allSize := commonSize + onlyASize = onlyBSize
+
+	printer.P("%7d common data blobs with %12s", commonCount, ui.FormatBytes(commonSize))
+	printer.P("%7d only host A blobs with %12s %5d snapshots", onlyACount, ui.FormatBytes(onlyASize), len(treeHostA))
+	printer.P("%7d only host B blobs with %12s %5d snapshots", onlyBCount, ui.FormatBytes(onlyBSize), len(treeHostB))
+	printer.P("%7d accounted   blobs with %12s %5d snapshots", allCount, ui.FormatBytes(allSize), len(treeHostA)+len(treeHostB))
+	if countOtherTrees > 0 {
+		printer.P("%-43s %5d snapshots", "  other", countOtherTrees)
+	}
+
+	return nil
+}
+
+func runDiff(ctx context.Context, opts DiffOptions, gopts global.Options, args []string, term ui.Terminal) error {
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
+>>>>>>> f5722d152 (restic diff - compare snapshots from two hosts)
 
 	ctx, repo, unlock, err := openWithReadLock(ctx, gopts, gopts.NoLock, printer)
 	if err != nil {
@@ -372,6 +469,19 @@ func runDiff(ctx context.Context, opts DiffOptions, gopts global.Options, args [
 	if err != nil {
 		return err
 	}
+
+	if err = repo.LoadIndex(ctx, printer); err != nil {
+		return err
+	}
+
+	if opts.hostA != "" && opts.hostB != "" {
+		return runHostDiff(ctx, opts, gopts, repo, printer, be)
+	}
+
+	if len(args) != 2 {
+		return errors.Fatalf("specify two snapshot IDs")
+	}
+
 	sn1, subfolder1, err := loadSnapshot(ctx, be, repo, args[0])
 	if err != nil {
 		return err
@@ -384,9 +494,6 @@ func runDiff(ctx context.Context, opts DiffOptions, gopts global.Options, args [
 
 	if !gopts.JSON {
 		printer.P("comparing snapshot %v to %v:\n\n", sn1.ID().Str(), sn2.ID().Str())
-	}
-	if err = repo.LoadIndex(ctx, printer); err != nil {
-		return err
 	}
 
 	if sn1.Tree == nil {

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -22,7 +22,7 @@ func newDiffCommand(globalOptions *global.Options) *cobra.Command {
 	var opts DiffOptions
 
 	cmd := &cobra.Command{
-		Use:   "diff [flags] snapshotID snapshotID or diff --diff-hosts host1 host2",
+		Use:   "diff [flags] snapshotID snapshotID | diff [flags] --diff-hosts host1 host2",
 		Short: "Show differences between two snapshots",
 		Long: `
 The "diff" command shows differences from the first to the second snapshot. The
@@ -376,7 +376,7 @@ func countAndSizeHosts(repo restic.Repository, set restic.AssociatedBlobSet) (in
 	setCount := set.Len()
 	size := uint64(0)
 	for blob := range set.Keys() {
-		bsize, exist := repo.LookupBlobSize(blob.Type, blob.ID)
+		bsize, exist := repo.LookupBlobSize(blob)
 		if exist {
 			size += uint64(bsize)
 		}
@@ -386,7 +386,7 @@ func countAndSizeHosts(repo restic.Repository, set restic.AssociatedBlobSet) (in
 }
 
 func gatherHostData(ctx context.Context, repo restic.Repository, hostname string,
-	opts DiffOptions, printer progress.Printer, be restic.Lister,
+	opts DiffOptions, printer restic.Printer, be restic.Lister,
 ) (restic.AssociatedBlobSet, int, error) {
 	trees := restic.IDs{}
 
@@ -395,8 +395,16 @@ func gatherHostData(ctx context.Context, repo restic.Repository, hostname string
 		Tags:  opts.SnapshotFilter.Tags,
 		Paths: opts.SnapshotFilter.Paths,
 	}
-	for sn := range FindFilteredSnapshots(ctx, be, repo, hostFilter, nil, printer) {
+
+	err := hostFilter.FindAll(ctx, be, repo, nil, func(_ string, sn *data.Snapshot, err error) error {
+		if err != nil {
+			return err
+		}
 		trees = append(trees, *sn.Tree)
+		return nil
+	})
+	if err != nil {
+		return nil, 0, err
 	}
 
 	bar := printer.NewCounter(fmt.Sprintf("snapshots %s", hostname))
@@ -429,7 +437,7 @@ type StatDiffHosts struct {
 // No attempt is made to translate the common data blobs back to pathnames.
 func runHostDiff(ctx context.Context, opts DiffOptions, gopts global.Options,
 	repo restic.Repository, be restic.Lister,
-	left string, right string, printer progress.Printer,
+	left string, right string, printer restic.Printer,
 ) error {
 
 	blobsLeft, lenTreesLeft, err := gatherHostData(ctx, repo, left, opts, printer, be)
@@ -480,8 +488,7 @@ func runHostDiff(ctx context.Context, opts DiffOptions, gopts global.Options,
 }
 
 func runDiff(ctx context.Context, opts DiffOptions, gopts global.Options, args []string, term ui.Terminal) error {
-	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
->>>>>>> f5722d152 (restic diff - compare snapshots from two hosts)
+	printer := progress.NewTerminalPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	ctx, repo, unlock, err := openWithReadLock(ctx, gopts, gopts.NoLock, printer)
 	if err != nil {

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"path"
 	"reflect"
 
@@ -21,7 +22,7 @@ func newDiffCommand(globalOptions *global.Options) *cobra.Command {
 	var opts DiffOptions
 
 	cmd := &cobra.Command{
-		Use:   "diff [flags] snapshotID snapshotID",
+		Use:   "diff [flags] snapshotID snapshotID or diff --diff-hosts host1 host2",
 		Short: "Show differences between two snapshots",
 		Long: `
 The "diff" command shows differences from the first to the second snapshot. The
@@ -42,6 +43,10 @@ To only compare files in specific subfolders, you can use the
 "snapshotID:subfolder" syntax, where "subfolder" is a path within the
 snapshot tree as shown by "restic ls".
 
+The --diff-hosts option allows to compare commonalities and differences between
+two hosts in the same repository. The comparison can further be filtered by the
+use of --path and --tag.
+
 EXIT STATUS
 ===========
 
@@ -54,6 +59,7 @@ Exit status is 12 if the password is incorrect.
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			finalizeSnapshotFilter(&opts.SnapshotFilter)
 			return runDiff(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
@@ -65,16 +71,14 @@ Exit status is 12 if the password is incorrect.
 // DiffOptions collects all options for the diff command.
 type DiffOptions struct {
 	ShowMetadata bool
-
-	// for 2-host comparison
-	hostA string
-	hostB string
+	diffHosts    bool
+	data.SnapshotFilter
 }
 
 func (opts *DiffOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.ShowMetadata, "metadata", false, "print changes in metadata")
-	f.StringVar(&opts.hostA, "host-A", "", "gather `host-A` snapsshots")
-	f.StringVar(&opts.hostB, "host-B", "", "gather `host-B` snapsshots")
+	f.BoolVar(&opts.diffHosts, "diff-hosts", false, "show differences between 2 hosts in repository")
+	initMultiSnapshotFilter(f, &opts.SnapshotFilter, false)
 }
 
 func loadSnapshot(ctx context.Context, be restic.Lister, repo restic.LoaderUnpacked, desc string) (*data.Snapshot, string, error) {
@@ -360,18 +364,18 @@ func (c *Comparer) diffTree(ctx context.Context, stats *DiffStatsContainer, pref
 	return ctx.Err()
 }
 
-func deleteTreeBlobs(set restic.BlobSet) {
-	for blob := range set {
+func deleteTreeBlobs(set restic.AssociatedBlobSet) {
+	for blob := range set.Keys() {
 		if blob.Type == restic.TreeBlob {
-			delete(set, blob)
+			set.Delete(blob)
 		}
 	}
 }
 
-func countAndSizeHosts(repo restic.Repository, set restic.BlobSet) (int, uint64) {
-	setCount := len(set)
+func countAndSizeHosts(repo restic.Repository, set restic.AssociatedBlobSet) (int, uint64) {
+	setCount := set.Len()
 	size := uint64(0)
-	for blob := range set {
+	for blob := range set.Keys() {
 		bsize, exist := repo.LookupBlobSize(blob.Type, blob.ID)
 		if exist {
 			size += uint64(bsize)
@@ -381,53 +385,63 @@ func countAndSizeHosts(repo restic.Repository, set restic.BlobSet) (int, uint64)
 	return setCount, size
 }
 
+func gatherHostData(ctx context.Context, repo restic.Repository, hostname string,
+	opts DiffOptions, printer progress.Printer, be restic.Lister,
+) (restic.AssociatedBlobSet, int, error) {
+	trees := restic.IDs{}
+
+	hostFilter := &data.SnapshotFilter{
+		Hosts: []string{hostname},
+		Tags:  opts.SnapshotFilter.Tags,
+		Paths: opts.SnapshotFilter.Paths,
+	}
+	for sn := range FindFilteredSnapshots(ctx, be, repo, hostFilter, nil, printer) {
+		trees = append(trees, *sn.Tree)
+	}
+
+	bar := printer.NewCounter(fmt.Sprintf("snapshots %s", hostname))
+	bar.SetMax(uint64(len(trees)))
+	blobsHost := repo.NewAssociatedBlobSet()
+	if err := data.FindUsedBlobs(ctx, repo, trees, blobsHost, bar); err != nil {
+		return nil, 0, err
+	}
+	bar.Done()
+
+	return blobsHost, len(trees), nil
+}
+
+type StatDiffHosts struct {
+	MessageType            string `json:"message_type"` // "host_differences"
+	HostA                  string `json:"host_A"`
+	HostB                  string `json:"host_B"`
+	HostASnapshotCount     int    `json:"host_A_snapcount"`
+	HostBSnapshotCount     int    `json:"host_B_snapcount"`
+	CommonDataBlobCount    int    `json:"common_blob_count"`
+	CommonDataBlobSize     uint64 `json:"common_blob_size"`
+	HostAOnlyDataBlobCount int    `json:"host_A_only_blob_count"`
+	HostAOnlyDataBlobSize  uint64 `json:"host_A_only_blob_size"`
+	HostBOnlyDataBlobCount int    `json:"host_B_only_blob_count"`
+	HostBOnlyDataBlobSize  uint64 `json:"host_B_only_blob_size"`
+}
+
 // runHostDiff: compare two different host snapshots in the same repository and
-// find commonality and differences
+// find commonality and differences. Only data blobs are checked for commonality.
+// No attempt is made to translate the common data blobs back to pathnames.
 func runHostDiff(ctx context.Context, opts DiffOptions, gopts global.Options,
-	repo restic.Repository, printer restic.Printer, be restic.Lister) error {
+	repo restic.Repository, be restic.Lister,
+	hostA string, hostB string, printer progress.Printer,
+) error {
 
-	treeHostA := restic.IDs{}
-	treeHostB := restic.IDs{}
-	countOtherTrees := 0
-	printer.P("loading all snapshots...\n")
-	err := data.ForAllSnapshots(ctx, repo, repo, nil,
-		func(id restic.ID, sn *data.Snapshot, err error) error {
-			if err != nil {
-				debug.Log("failed to load snapshot %v (error %v)", id, err)
-				return err
-			}
-			switch sn.Hostname {
-				case opts.hostA:
-					treeHostA = append(treeHostA, *sn.Tree)
-				case opts.hostB:
-					treeHostB = append(treeHostB, *sn.Tree)
-				default:
-					countOtherTrees++
-			}
-			return nil
-		})
+	blobsHostA, lenTreesA, err := gatherHostData(ctx, repo, hostA, opts, printer, be)
 	if err != nil {
-		return errors.Fatalf("failed loading snapshot: %v", err)
-	}
-
-	// both sets of used blobs are materialized as restic.BlobSets
-	barA := printer.NewCounter("snapshots host A")
-	barA.SetMax(uint64(len(treeHostA)))
-	blobsHostA := restic.NewBlobSet()
-	if err := data.FindUsedBlobs(ctx, repo, treeHostA, blobsHostA, barA); err != nil {
 		return err
 	}
-	barA.Done()
-
-	barB := printer.NewCounter("snapshots host B")
-	barB.SetMax(uint64(len(treeHostB)))
-	blobsHostB := restic.NewBlobSet()
-	if err := data.FindUsedBlobs(ctx, repo, treeHostB, blobsHostB, barB); err != nil {
+	blobsHostB, lenTreesB, err := gatherHostData(ctx, repo, hostB, opts, printer, be)
+	if err != nil {
 		return err
 	}
-	barB.Done()
 
-	// remove referenced tree blobs
+	// remove referenced `tree` blobs
 	deleteTreeBlobs(blobsHostA)
 	deleteTreeBlobs(blobsHostB)
 
@@ -440,15 +454,33 @@ func runHostDiff(ctx context.Context, opts DiffOptions, gopts global.Options,
 	commonCount, commonSize := countAndSizeHosts(repo, common)
 	onlyACount, onlyASize := countAndSizeHosts(repo, onlyA)
 	onlyBCount, onlyBSize := countAndSizeHosts(repo, onlyB)
-	allCount := commonCount + onlyACount + onlyBCount
-	allSize := commonSize + onlyASize = onlyBSize
 
-	printer.P("%7d common data blobs with %12s", commonCount, ui.FormatBytes(commonSize))
-	printer.P("%7d only host A blobs with %12s %5d snapshots", onlyACount, ui.FormatBytes(onlyASize), len(treeHostA))
-	printer.P("%7d only host B blobs with %12s %5d snapshots", onlyBCount, ui.FormatBytes(onlyBSize), len(treeHostB))
-	printer.P("%7d accounted   blobs with %12s %5d snapshots", allCount, ui.FormatBytes(allSize), len(treeHostA)+len(treeHostB))
-	if countOtherTrees > 0 {
-		printer.P("%-43s %5d snapshots", "  other", countOtherTrees)
+	if !gopts.JSON {
+		printer.S("   host A: %s    host B: %s", hostA, hostB)
+		printer.S("%7d common data blobs with %12s", commonCount, ui.FormatBytes(commonSize))
+		printer.S("%7d only host A blobs with %12s in %5d snapshots", onlyACount, ui.FormatBytes(onlyASize), lenTreesA)
+		printer.S("%7d only host B blobs with %12s in %5d snapshots", onlyBCount, ui.FormatBytes(onlyBSize), lenTreesB)
+		return nil
+	}
+
+	statsDiffHosts := StatDiffHosts{
+		MessageType:            "host_differences",
+		HostA:                  hostA,
+		HostB:                  hostB,
+		HostASnapshotCount:     lenTreesA,
+		HostBSnapshotCount:     lenTreesB,
+		CommonDataBlobCount:    commonCount,
+		CommonDataBlobSize:     commonSize,
+		HostAOnlyDataBlobCount: onlyACount,
+		HostAOnlyDataBlobSize:  onlyASize,
+		HostBOnlyDataBlobCount: onlyBCount,
+		HostBOnlyDataBlobSize:  onlyBSize,
+	}
+
+	err = json.NewEncoder(gopts.Term.OutputWriter()).Encode(statsDiffHosts)
+	if err != nil {
+		printer.E("JSON encode failed: %v", err)
+		return err
 	}
 
 	return nil
@@ -474,8 +506,11 @@ func runDiff(ctx context.Context, opts DiffOptions, gopts global.Options, args [
 		return err
 	}
 
-	if opts.hostA != "" && opts.hostB != "" {
-		return runHostDiff(ctx, opts, gopts, repo, printer, be)
+	if opts.diffHosts {
+		if len(args) != 2 {
+			return errors.Fatalf("specify two host names")
+		}
+		return runHostDiff(ctx, opts, gopts, repo, be, args[0], args[1], printer)
 	}
 
 	if len(args) != 2 {

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -410,18 +410,18 @@ func gatherHostData(ctx context.Context, repo restic.Repository, hostname string
 	return blobsHost, len(trees), nil
 }
 
+type CountItem struct {
+	Hostname      string `json:"hostname,omitempty"`
+	SnapshotCount int    `json:"snapshot_count,omitempty"`
+	DataBlobCount int    `json:"data_blob_count"`
+	DataBlobSize  uint64 `json:"data_blob_size"`
+}
+
 type StatDiffHosts struct {
-	MessageType            string `json:"message_type"` // "host_differences"
-	HostA                  string `json:"host_A"`
-	HostB                  string `json:"host_B"`
-	HostASnapshotCount     int    `json:"host_A_snapcount"`
-	HostBSnapshotCount     int    `json:"host_B_snapcount"`
-	CommonDataBlobCount    int    `json:"common_blob_count"`
-	CommonDataBlobSize     uint64 `json:"common_blob_size"`
-	HostAOnlyDataBlobCount int    `json:"host_A_only_blob_count"`
-	HostAOnlyDataBlobSize  uint64 `json:"host_A_only_blob_size"`
-	HostBOnlyDataBlobCount int    `json:"host_B_only_blob_count"`
-	HostBOnlyDataBlobSize  uint64 `json:"host_B_only_blob_size"`
+	MessageType string    `json:"message_type"` // "host_differences"
+	LeftStats   CountItem `json:"left_stats"`
+	RightStats  CountItem `json:"right_stats"`
+	CommonStats CountItem `json:"common_stats"`
 }
 
 // runHostDiff: compare two different host snapshots in the same repository and
@@ -429,52 +429,45 @@ type StatDiffHosts struct {
 // No attempt is made to translate the common data blobs back to pathnames.
 func runHostDiff(ctx context.Context, opts DiffOptions, gopts global.Options,
 	repo restic.Repository, be restic.Lister,
-	hostA string, hostB string, printer progress.Printer,
+	left string, right string, printer progress.Printer,
 ) error {
 
-	blobsHostA, lenTreesA, err := gatherHostData(ctx, repo, hostA, opts, printer, be)
+	blobsLeft, lenTreesLeft, err := gatherHostData(ctx, repo, left, opts, printer, be)
 	if err != nil {
 		return err
 	}
-	blobsHostB, lenTreesB, err := gatherHostData(ctx, repo, hostB, opts, printer, be)
+	blobsRight, lenTreesRight, err := gatherHostData(ctx, repo, right, opts, printer, be)
 	if err != nil {
 		return err
 	}
 
 	// remove referenced `tree` blobs
-	deleteTreeBlobs(blobsHostA)
-	deleteTreeBlobs(blobsHostB)
+	deleteTreeBlobs(blobsLeft)
+	deleteTreeBlobs(blobsRight)
 
 	// create result sets
-	common := blobsHostA.Intersect(blobsHostB)
-	onlyA := blobsHostA.Sub(blobsHostB)
-	onlyB := blobsHostB.Sub(blobsHostA)
+	common := blobsLeft.Intersect(blobsRight)
+	onlyLeft := blobsLeft.Sub(blobsRight)
+	onlyRight := blobsRight.Sub(blobsLeft)
 
 	// count and size
 	commonCount, commonSize := countAndSizeHosts(repo, common)
-	onlyACount, onlyASize := countAndSizeHosts(repo, onlyA)
-	onlyBCount, onlyBSize := countAndSizeHosts(repo, onlyB)
+	onlyLeftCount, onlyLeftSize := countAndSizeHosts(repo, onlyLeft)
+	onlyRightCount, onlyRightSize := countAndSizeHosts(repo, onlyRight)
 
 	if !gopts.JSON {
-		printer.S("   host A: %s    host B: %s", hostA, hostB)
+		printer.S("   host A: %s    host B: %s", left, right)
 		printer.S("%7d common data blobs with %12s", commonCount, ui.FormatBytes(commonSize))
-		printer.S("%7d only host A blobs with %12s in %5d snapshots", onlyACount, ui.FormatBytes(onlyASize), lenTreesA)
-		printer.S("%7d only host B blobs with %12s in %5d snapshots", onlyBCount, ui.FormatBytes(onlyBSize), lenTreesB)
+		printer.S("%7d only host A blobs with %12s in %5d snapshots", onlyLeftCount, ui.FormatBytes(onlyLeftSize), lenTreesLeft)
+		printer.S("%7d only host B blobs with %12s in %5d snapshots", onlyRightCount, ui.FormatBytes(onlyRightSize), lenTreesRight)
 		return nil
 	}
 
 	statsDiffHosts := StatDiffHosts{
-		MessageType:            "host_differences",
-		HostA:                  hostA,
-		HostB:                  hostB,
-		HostASnapshotCount:     lenTreesA,
-		HostBSnapshotCount:     lenTreesB,
-		CommonDataBlobCount:    commonCount,
-		CommonDataBlobSize:     commonSize,
-		HostAOnlyDataBlobCount: onlyACount,
-		HostAOnlyDataBlobSize:  onlyASize,
-		HostBOnlyDataBlobCount: onlyBCount,
-		HostBOnlyDataBlobSize:  onlyBSize,
+		MessageType: "host_differences",
+		LeftStats:   CountItem{left, lenTreesLeft, onlyLeftCount, onlyLeftSize},
+		RightStats:  CountItem{right, lenTreesRight, onlyRightCount, onlyRightSize},
+		CommonStats: CountItem{"", 0, commonCount, commonSize},
 	}
 
 	err = json.NewEncoder(gopts.Term.OutputWriter()).Encode(statsDiffHosts)

--- a/cmd/restic/cmd_diff_integration_test.go
+++ b/cmd/restic/cmd_diff_integration_test.go
@@ -244,10 +244,10 @@ func TestDiffHostsJSON(t *testing.T) {
 
 	rtest.Assert(t, statsDiffHosts.MessageType == "host_differences", "expected `host_differences`, got %q",
 		statsDiffHosts.MessageType)
-	rtest.Assert(t, statsDiffHosts.HostASnapshotCount == 1 && statsDiffHosts.HostBSnapshotCount == 1,
+	rtest.Assert(t, statsDiffHosts.HostAStats.SnapshotCount == 1 && statsDiffHosts.HostBStats.SnapshotCount == 1,
 		"expected one snapshot per host, got hostA=%d and hostB=%d snapshots",
-		statsDiffHosts.HostASnapshotCount, statsDiffHosts.HostBSnapshotCount)
-	rtest.Assert(t, statsDiffHosts.CommonDataBlobCount == 1 && statsDiffHosts.CommonDataBlobSize == 1<<18,
+		statsDiffHosts.HostAStats.SnapshotCount, statsDiffHosts.HostBStats.SnapshotCount)
+	rtest.Assert(t, statsDiffHosts.CommonStats.DataBlobCount == 1 && statsDiffHosts.CommonStats.DataBlobSize == 1<<18,
 		"expected common data blob count == 1 and datablobsize == 256KiB, got %d and %d",
-		statsDiffHosts.CommonDataBlobCount, statsDiffHosts.CommonDataBlobSize)
+		statsDiffHosts.CommonStats.DataBlobCount, statsDiffHosts.CommonStats.DataBlobSize)
 }

--- a/cmd/restic/cmd_diff_integration_test.go
+++ b/cmd/restic/cmd_diff_integration_test.go
@@ -244,9 +244,9 @@ func TestDiffHostsJSON(t *testing.T) {
 
 	rtest.Assert(t, statsDiffHosts.MessageType == "host_differences", "expected `host_differences`, got %q",
 		statsDiffHosts.MessageType)
-	rtest.Assert(t, statsDiffHosts.HostAStats.SnapshotCount == 1 && statsDiffHosts.HostBStats.SnapshotCount == 1,
-		"expected one snapshot per host, got hostA=%d and hostB=%d snapshots",
-		statsDiffHosts.HostAStats.SnapshotCount, statsDiffHosts.HostBStats.SnapshotCount)
+	rtest.Assert(t, statsDiffHosts.LeftStats.SnapshotCount == 1 && statsDiffHosts.RightStats.SnapshotCount == 1,
+		"expected one snapshot per host, got left host=%d and right host=%d snapshots",
+		statsDiffHosts.LeftStats.SnapshotCount, statsDiffHosts.RightStats.SnapshotCount)
 	rtest.Assert(t, statsDiffHosts.CommonStats.DataBlobCount == 1 && statsDiffHosts.CommonStats.DataBlobSize == 1<<18,
 		"expected common data blob count == 1 and datablobsize == 256KiB, got %d and %d",
 		statsDiffHosts.CommonStats.DataBlobCount, statsDiffHosts.CommonStats.DataBlobSize)

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -644,6 +644,58 @@ The characters left of the file path show what has changed for this file:
 | ``?`` | bitrot detected       |
 +-------+-----------------------+
 
+You can also compare the snapshots from two different hosts in the same repository to
+find commonalities in backups of these two hosts: this is meant to check for
+deduplication of data between hosts.
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo diff --diff-hosts host-A host-B
+    host A: host-A    host B: host-B
+    14267 common data blobs with  901.712 MiB
+    37232 only host A blobs with    5.894 GiB in    19 snapshots
+     8212 only host B blobs with    5.199 GiB in    52 snapshots
+
+The same comparison in JSON mode creates:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo diff --diff-hosts host-A host-B --json | jq
+    {
+      "message_type": "host_differences",
+      "host_A": "host-A",
+      "host_B": "host-B",
+      "host_A_snapcount": 19,
+      "host_B_snapcount": 52,
+      "common_blob_count": 14267,
+      "common_blob_size": 945513854,
+      "host_A_only_blob_count": 37232,
+      "host_A_only_blob_size": 6328153473,
+      "host_B_only_blob_count": 8212,
+      "host_B_only_blob_size": 5582446694
+    }
+
+If you want to select a shared path between the two hosts and an compare the
+commonalities between then you can use a filter ``--path <shared_pathname>``:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo diff --diff-hosts host-A host-B --json --path /home | jq
+    {
+      "message_type": "host_differences",
+      "host_A": "host-A",
+      "host_B": "host-B",
+      "host_A_snapcount": 19,
+      "host_B_snapcount": 52,
+      "common_blob_count": 14267,
+      "common_blob_size": 945513854,
+      "host_A_only_blob_count": 37232,
+      "host_A_only_blob_size": 6328153473,
+      "host_B_only_blob_count": 8212,
+      "host_B_only_blob_size": 5582446694
+    }
+
+
 Backing up special items and metadata
 *************************************
 

--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -469,6 +469,34 @@ DiffStat object
 +----------------+-------------------------------------------+--------+
 
 .. _find:
+The ``diff --diff-hosts`` command uses the JSON line format with the following message type.
+
+diff --diff-hosts
+^^^^^^^^^^^^^^^^^
+
++------------------+-------------------------------+---------------------+
+| ``message_type`` | Always "host_differences"     | string              |
++------------------+-------------------------------+---------------------+
+| ``left_stats``   | Statistics for host ``left``  | `CountItem object`_ |
++------------------+-------------------------------+---------------------+
+| ``right_stats``  | Statistics for host ``right`` | `CountItem object`_ |
++------------------+-------------------------------+---------------------+
+| ``common_stats`` | Statistics for common data    | `CountItem object`_ |
++------------------+-------------------------------+---------------------+
+
+.. _CountItem object:
+
+CountItem object
+
++---------------------+-------------------------------+--------+
+| ``hostname``        | Hostname                      | string |
++---------------------+-------------------------------+--------+
+| ``snapshot_count``  | Number of snapshots           | int    |
++---------------------+-------------------------------+--------+
+| ``data_blob_count`` | Data blob count               | int    |
++---------------------+-------------------------------+--------+
+| ``data_blob_size``  | Data blob size                | uint64 |
++---------------------+-------------------------------+--------+
 
 find
 ----

--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -468,7 +468,7 @@ DiffStat object
 | ``bytes``      | Number of bytes                           | uint64 |
 +----------------+-------------------------------------------+--------+
 
-.. _find:
+
 The ``diff --diff-hosts`` command uses the JSON line format with the following message type.
 
 diff --diff-hosts
@@ -497,6 +497,8 @@ CountItem object
 +---------------------+-------------------------------+--------+
 | ``data_blob_size``  | Data blob size                | uint64 |
 +---------------------+-------------------------------+--------+
+
+.. _find:
 
 find
 ----


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Discussion on the forum: https://forum.restic.net/t/how-to-check-deduplication-across-sources/10512


<!--
Describe the changes and their purpose here, as detailed as needed.
-->
    This is the first commit of a row of commits to enable host based
    diffing of a repository. The basic idea behind is to find out how much
    deduplication helped in a case where two hosts with a set of common files
    have been backup up into the same repository.
    
    New in cmd/restic/cmd_diff.go:
    the option `--diff-hosts`
    the data.SnapshotFilter to allow further filtering of the comparison
    
    Helpers:
    - deleteTreeBlobs() to remove tree blobs from any comparison
    - countAndSizeHosts() to count and size the various AssociatedBlobSet's.
    - gatherHostData() to collect data for a host and a given filterSet
    
    A new JSON struct StatDiffHosts to collect the host statistics
    
    and a new function runHostDiff() which orchestrates the whole lot.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://forum.restic.net/t/how-to-check-deduplication-across-sources/10512
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
