### PR TITLE
clarify pack ID in decryption error

### DIFF
--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -1280,7 +1280,7 @@ func (b *packBlobIterator) Next() (packBlobValue, error) {
 	nonce, ciphertext := buf[:b.key.NonceSize()], buf[b.key.NonceSize():]
 	plaintext, err := b.key.Open(ciphertext[:0], nonce, ciphertext, nil)
 	if err != nil {
-		err = fmt.Errorf("decrypting blob %v from %v failed: %w", h, b.packID.Str(), err)
+		err = fmt.Errorf("decrypting blob %v from pack %v failed: %w", h, b.packID.String(), err)
 	}
 	if err == nil && entry.IsCompressed() {
 		// DecodeAll will allocate a slice if it is not large enough since it
@@ -1288,16 +1288,16 @@ func (b *packBlobIterator) Next() (packBlobValue, error) {
 		b.decode, err = b.dec.DecodeAll(plaintext, b.decode[:0])
 		plaintext = b.decode
 		if err != nil {
-			err = fmt.Errorf("decompressing blob %v from %v failed: %w", h, b.packID.Str(), err)
+			err = fmt.Errorf("decompressing blob %v from pack %v failed: %w", h, b.packID.String(), err)
 		}
 	}
 	if err == nil {
 		id := restic.Hash(plaintext)
 		if !id.Equal(entry.ID) {
-			debug.Log("read blob %v/%v from %v: wrong data returned, hash is %v",
-				h.Type, h.ID, b.packID.Str(), id)
-			err = fmt.Errorf("read blob %v from %v: wrong data returned, hash is %v",
-				h, b.packID.Str(), id)
+			debug.Log("read blob %v/%v from pack %v: wrong data returned, hash is %v",
+				h.Type, h.ID, b.packID.String(), id)
+			err = fmt.Errorf("read blob %v from pack %v: wrong data returned, hash is %v",
+				h, b.packID.String(), id)
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Include full pack ID in decryption error message. In addition, the error message now says that it is a pack file.

The error message now looks like this:
`decrypting blob <data/9c308c02> from pack ef51560cae5a0751e935070c86f760ba6672c6db2df7a88f9c6f93f19a27de16 failed: ciphertext verification failed`

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://forum.restic.net/t/better-error-messaging-for-fatal-decrypting-blob-failed-nonce-is-invalid/10507/3
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- ~~[ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I'm done! This pull request is ready for review.
