### PR TITLE
feat: Add --exclude-verbatim and --exclude-file-verbatim options

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -346,9 +346,11 @@ the exclude options are:
 
 -  ``--exclude`` Specify one or more times to exclude one or more items
 -  ``--iexclude`` Same as ``--exclude`` but ignores the case of paths
+-  ``--exclude-verbatim`` Same as ``--exclude`` but treats entry as a literal path
 -  ``--exclude-caches`` Specify once to exclude a folder's content if it contains `the special CACHEDIR.TAG file <https://bford.info/cachedir/>`__, but keep ``CACHEDIR.TAG``.
 -  ``--exclude-file`` Specify one or more times to exclude items listed in a given file
 -  ``--iexclude-file`` Same as ``--exclude-file`` but ignores cases like in ``--iexclude``
+-  ``--exclude-file-verbatim`` Same as ``--exclude-file`` but treats entries as literal paths
 -  ``--exclude-if-present foo`` Specify one or more times to exclude a folder's content if it contains a file called ``foo`` (optionally having a given header, no wildcards for the file name supported)
 -  ``--exclude-larger-than size`` Specify once to exclude files larger than the given size
 -  ``--exclude-cloud-files`` Specify once to exclude online-only cloud files (such as OneDrive Files On-Demand, iCloud drive), currently only supported on Windows and macOS

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -341,9 +341,10 @@ the unwanted files from affected snapshots by rewriting them using the
 
     modified 1 snapshots
 
-The options ``--exclude``, ``--exclude-file``, ``--iexclude`` and
-``--iexclude-file`` are supported. They behave the same way as for the backup
-command, see :ref:`backup-excluding-files` for details.
+The options ``--exclude``, ``--exclude-file``, ``--iexclude``,
+``--iexclude-file``, ``--exclude-verbatim`` and ``--exclude-file-verbatim`` are
+supported. They behave the same way as for the backup command, see
+:ref:`backup-excluding-files` for details.
 
 The options ``--include``, ``--include-file``, ``--iinclude`` and
 ``--iinclude-file`` are supported as well.

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -79,6 +79,9 @@ ignore the casing of paths.
 There are also ``--include-file``, ``--exclude-file``, ``--iinclude-file`` and
 ``--iexclude-file`` flags that read the include and exclude patterns from a file.
 
+If paths needs to be treated literally rather than as a pattern, you can use
+``--exclude-verbatim`` or ``--exclude-file-verbatim``.
+
 Restoring symbolic links on Windows is only possible when the user has the
 ``SeCreateSymbolicLinkPrivilege`` privilege or is running as administrator. This is a
 restriction of Windows, not restic.

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -115,8 +115,10 @@ command:
       -e, --exclude pattern                        exclude a pattern (can be specified multiple times)
           --exclude-caches                         excludes cache directories that are marked with a CACHEDIR.TAG file. See https://bford.info/cachedir/ for the Cache Directory Tagging Standard
           --exclude-file file                      read exclude patterns from a file (can be specified multiple times)
+          --exclude-file-verbatim file             same as --exclude-file but treats entries as literal paths
           --exclude-if-present filename[:header]   takes filename[:header], exclude contents of directories containing filename (except filename itself) if header of that file is as provided (can be specified multiple times)
           --exclude-larger-than size               max size of the files to be backed up (allowed suffixes: k/K, m/M, g/G, t/T)
+          --exclude-verbatim path                  same as --exclude but treats entry as a literal path
           --files-from file                        read the files to backup from file (can be combined with file args; can be specified multiple times)
           --files-from-raw file                    read the files to backup from file (can be combined with file args; can be specified multiple times)
           --files-from-verbatim file               read the files to backup from file (can be combined with file args; can be specified multiple times)

--- a/internal/filter/exclude.go
+++ b/internal/filter/exclude.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"fmt"
 	"os"
+	"slices"
 	"strings"
 
 	"github.com/restic/restic/internal/debug"
@@ -48,6 +49,51 @@ func RejectByInsensitivePattern(patterns []string, warnf func(msg string, args .
 	return func(item string) bool {
 		return rejFunc(strings.ToLower(item))
 	}
+}
+
+// RejectByPath returns a RejectByNameFunc which rejects files by literal path.
+func RejectByPath(paths []string, warnf func(msg string, args ...interface{})) RejectByNameFunc {
+	return func(item string) bool {
+		if slices.Contains(paths, item) {
+			debug.Log("path %q excluded by an exclude pattern", item)
+			return true
+		}
+
+		return false
+	}
+}
+
+// readLines reads all lines from the named file and returns them as a
+// string slice.
+//
+// If filename is empty, readLines returns an empty slice.
+func readLines(filename string) ([]string, error) {
+	if filename == "" {
+		return nil, nil
+	}
+
+	var (
+		data []byte
+		err  error
+	)
+
+	data, err = textfile.Read(filename)
+
+	if err != nil {
+		return nil, err
+	}
+
+	var lines []string
+
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+	return lines, nil
 }
 
 // readPatternsFromFiles reads all files and returns the list of
@@ -100,19 +146,24 @@ func readPatternsFromFiles(files []string) ([]string, error) {
 type ExcludePatternOptions struct {
 	Excludes                []string
 	InsensitiveExcludes     []string
+	ExcludesVerbatim        []string
 	ExcludeFiles            []string
 	InsensitiveExcludeFiles []string
+	ExcludeFilesVerbatim    []string
 }
 
 func (opts *ExcludePatternOptions) Add(f *pflag.FlagSet) {
 	f.StringArrayVarP(&opts.Excludes, "exclude", "e", nil, "exclude a `pattern` (can be specified multiple times)")
 	f.StringArrayVar(&opts.InsensitiveExcludes, "iexclude", nil, "same as --exclude `pattern` but ignores the casing of filenames")
+	f.StringArrayVar(&opts.ExcludesVerbatim, "exclude-verbatim", nil, "same as --exclude but treats entry as a literal `path`")
 	f.StringArrayVar(&opts.ExcludeFiles, "exclude-file", nil, "read exclude patterns from a `file` (can be specified multiple times)")
 	f.StringArrayVar(&opts.InsensitiveExcludeFiles, "iexclude-file", nil, "same as --exclude-file but ignores casing of `file`names in patterns")
+	f.StringArrayVar(&opts.ExcludeFilesVerbatim, "exclude-file-verbatim", nil, "same as --exclude-`file` but treats entries as literal paths")
 }
 
 func (opts *ExcludePatternOptions) Empty() bool {
-	return len(opts.Excludes) == 0 && len(opts.InsensitiveExcludes) == 0 && len(opts.ExcludeFiles) == 0 && len(opts.InsensitiveExcludeFiles) == 0
+	return len(opts.Excludes) == 0 && len(opts.InsensitiveExcludes) == 0 && len(opts.ExcludesVerbatim) == 0 &&
+		len(opts.ExcludeFiles) == 0 && len(opts.InsensitiveExcludeFiles) == 0 && len(opts.ExcludeFilesVerbatim) == 0
 }
 
 func (opts ExcludePatternOptions) CollectPatterns(warnf func(msg string, args ...interface{})) ([]RejectByNameFunc, error) {
@@ -144,6 +195,15 @@ func (opts ExcludePatternOptions) CollectPatterns(warnf func(msg string, args ..
 		opts.InsensitiveExcludes = append(opts.InsensitiveExcludes, excludes...)
 	}
 
+	for _, filename := range opts.ExcludeFilesVerbatim {
+		excludes, err := readLines(filename)
+		if err != nil {
+			return nil, err
+		}
+
+		opts.ExcludesVerbatim = append(opts.ExcludesVerbatim, excludes...)
+	}
+
 	if len(opts.InsensitiveExcludes) > 0 {
 		if err := ValidatePatterns(opts.InsensitiveExcludes); err != nil {
 			return nil, errors.Fatalf("--iexclude: %s", err)
@@ -159,5 +219,10 @@ func (opts ExcludePatternOptions) CollectPatterns(warnf func(msg string, args ..
 
 		fs = append(fs, RejectByPattern(opts.Excludes, warnf))
 	}
+
+	if len(opts.ExcludesVerbatim) > 0 {
+		fs = append(fs, RejectByPath(opts.ExcludesVerbatim, warnf))
+	}
+
 	return fs, nil
 }

--- a/internal/filter/exclude_test.go
+++ b/internal/filter/exclude_test.go
@@ -57,3 +57,30 @@ func TestRejectByInsensitivePattern(t *testing.T) {
 		})
 	}
 }
+
+func TestRejectByLiteralPath(t *testing.T) {
+	var tests = []struct {
+		filename string
+		reject   bool
+	}{
+		{filename: "/home/user/foo.go", reject: true},
+		{filename: "/home/user/foo.c", reject: false},
+		{filename: "/home/user/foobar", reject: false},
+		{filename: "/home/user/f*bar", reject: true},
+		{filename: "/home/user/foodir/bar", reject: false},
+		{filename: "/home/user/foodir/*", reject: true},
+	}
+
+	paths := []string{"/home/user/foo.go", "/home/user/f*bar", "/home/user/foodir/*"}
+
+	for _, tc := range tests {
+		t.Run("", func(t *testing.T) {
+			reject := RejectByPath(paths, nil)
+			res := reject(tc.filename)
+			if res != tc.reject {
+				t.Fatalf("wrong result for filename %v: want %v, got %v",
+					tc.filename, tc.reject, res)
+			}
+		})
+	}
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

There was previously no way to treat excluded paths literally rather than as a pattern.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Partly addresses #4867.

Checklist
---------

- [X] I have added tests for all code changes.
- [X] I have added documentation for relevant changes (in the manual).
- [X] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.