### PR TITLE
mount: check for more requisite mountpoint conditions

### DIFF
--- a/changelog/unreleased/pull-5718
+++ b/changelog/unreleased/pull-5718
@@ -1,4 +1,4 @@
-Change: check for more requisite mountpoint conditions
+Enhancement: stricter early mountpoint validation in `mount`
 
 `restic mount` accepted parameters that would lead to a FUSE mount operation
 failing after having done computationally intensive work to prepare the mount.

--- a/changelog/unreleased/pull-5718
+++ b/changelog/unreleased/pull-5718
@@ -1,0 +1,9 @@
+Change: check for more requisite mountpoint conditions
+
+`restic mount` accepted parameters that would lead to a FUSE mount operation
+failing after having done computationally intensive work to prepare the mount.
+The `mountpoint` argument supplied must now refer to the name of a directory
+that the current user can access and write to, otherwise `restic mount` will
+exit with an error before interacting with the repository.
+
+https://github.com/restic/restic/pull/5718

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"golang.org/x/sys/unix"
 
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/debug"
@@ -35,8 +36,8 @@ func newMountCommand(globalOptions *global.Options) *cobra.Command {
 		Use:   "mount [flags] mountpoint",
 		Short: "Mount the repository",
 		Long: `
-The "mount" command mounts the repository via fuse to a directory. This is a
-read-only mount.
+The "mount" command mounts the repository via fuse over a writeable directory.
+The repository will be mounted read-only.
 
 Snapshot Directories
 ====================
@@ -133,9 +134,19 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 
 	// Check the existence of the mount point at the earliest stage to
 	// prevent unnecessary computations while opening the repository.
-	if _, err := os.Stat(mountpoint); errors.Is(err, os.ErrNotExist) {
+	mountpoint_stat, err := os.Stat(mountpoint)
+	if errors.Is(err, os.ErrNotExist) {
 		printer.P("Mountpoint %s doesn't exist", mountpoint)
-		return err
+		return errors.Fatal("invalid mountpoint")
+	} else if !mountpoint_stat.IsDir() {
+		printer.P("Mountpoint %s is not a directory", mountpoint)
+		return errors.Fatal("invalid mountpoint")
+	}
+
+	err = unix.Access(mountpoint, unix.W_OK|unix.X_OK)
+	if err != nil {
+		printer.P("Mountpoint %s is not writeable or not excutable", mountpoint)
+		return errors.Fatal("inaccessible mountpoint")
 	}
 
 	debug.Log("start mount")

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -134,11 +134,11 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 
 	// Check the existence of the mount point at the earliest stage to
 	// prevent unnecessary computations while opening the repository.
-	mountpoint_stat, err := os.Stat(mountpoint)
+	stat, err := os.Stat(mountpoint)
 	if errors.Is(err, os.ErrNotExist) {
 		printer.P("Mountpoint %s doesn't exist", mountpoint)
 		return errors.Fatal("invalid mountpoint")
-	} else if !mountpoint_stat.IsDir() {
+	} else if !stat.IsDir() {
 		printer.P("Mountpoint %s is not a directory", mountpoint)
 		return errors.Fatal("invalid mountpoint")
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Esp. with large repositories, `restic mount` may waste a lot of time and resources on preparing for a fuse mount that ultimately cannot succeed due conditions that are not checked for.

In order to be able to mount a repository over a mountpoint target directory via FUSE, that target directory needs to be both writeable and executable for the UID performing the mount, which this patch ensures.

FUSE does allow for mounting over a target path that refers to a regular (writeable) file, but the result is not accessible via chdir(), so we prevent that as well, and accept only directory inodes as the intended target mountpoint path.


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.

Checklist
---------
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
