### PR TITLE
mount: avoid duplicate index loading

### DIFF
--- a/changelog/unreleased/pull-5720
+++ b/changelog/unreleased/pull-5720
@@ -1,0 +1,7 @@
+Enhancement: speed up index loading in `restic mount`
+
+`restic mount` now loads the index once on startup and incrementally loads only
+new index files afterwards. In addition, `restic mount` now loads snapshots
+before printing that the repository is being served.
+
+https://github.com/restic/restic/pull/5720

--- a/internal/repository/index/master_index.go
+++ b/internal/repository/index/master_index.go
@@ -22,7 +22,7 @@ type MasterIndex struct {
 
 // NewMasterIndex creates a new master index.
 func NewMasterIndex() *MasterIndex {
-	mi := &MasterIndex{pendingBlobs: make(map[restic.BlobHandle]uint)}
+	mi := &MasterIndex{}
 	mi.clear()
 	return mi
 }
@@ -31,6 +31,11 @@ func (mi *MasterIndex) clear() {
 	// Always add an empty final index, such that MergeFinalIndexes can merge into this.
 	mi.idx = []*Index{NewIndex()}
 	mi.idx[0].Finalize()
+	mi.clearPendingBlobs()
+}
+
+func (mi *MasterIndex) clearPendingBlobs() {
+	mi.pendingBlobs = make(map[restic.BlobHandle]uint)
 }
 
 // Lookup queries all known Indexes for the ID and returns all matches.
@@ -265,10 +270,17 @@ func (mi *MasterIndex) Load(ctx context.Context, r restic.ListerLoaderUnpacked, 
 	if err != nil {
 		return err
 	}
-
+	loadedIDs, err := mi.prepareIncrementalLoad(ctx, indexList)
+	if err != nil {
+		return err
+	}
 	if p != nil {
 		var numIndexFiles uint64
-		err := indexList.List(ctx, restic.IndexFile, func(_ restic.ID, _ int64) error {
+		err := indexList.List(ctx, restic.IndexFile, func(id restic.ID, _ int64) error {
+			if loadedIDs.Has(id) {
+				// skip already loaded indexes
+				return nil
+			}
 			numIndexFiles++
 			return nil
 		})
@@ -280,6 +292,10 @@ func (mi *MasterIndex) Load(ctx context.Context, r restic.ListerLoaderUnpacked, 
 	}
 
 	err = ForAllIndexes(ctx, indexList, r, func(id restic.ID, idx *Index, err error) error {
+		if loadedIDs.Has(id) {
+			// skip already loaded indexes
+			return nil
+		}
 		if p != nil {
 			p.Add(1)
 		}
@@ -302,6 +318,37 @@ func (mi *MasterIndex) Load(ctx context.Context, r restic.ListerLoaderUnpacked, 
 	}
 
 	return mi.MergeFinalIndexes()
+}
+
+func (mi *MasterIndex) prepareIncrementalLoad(ctx context.Context, indexList restic.Lister) (restic.IDSet, error) {
+	mi.idxMutex.Lock()
+	// support incremental loading, while also ensuring that the result is identical to the result of a full load into a new MasterIndex
+	mi.clearPendingBlobs()
+	defer mi.idxMutex.Unlock()
+
+	// the first index is always final so this can't actually fail
+	loadedIDList, err := mi.idx[0].IDs()
+	if err != nil {
+		panic("internal error - failed to get index IDs")
+	}
+	loadedIDs := restic.NewIDSet(loadedIDList...)
+
+	indexFiles := restic.NewIDSet()
+	err = indexList.List(ctx, restic.IndexFile, func(id restic.ID, _ int64) error {
+		indexFiles.Insert(id)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(loadedIDs.Sub(indexFiles)) > 0 {
+		// indexes can only be removed by prune, which shouldn't happen concurrently, but behave correctly anyways
+		mi.clear()
+		loadedIDs = nil
+	}
+
+	return loadedIDs, nil
 }
 
 type MasterIndexRewriteOpts struct {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -709,9 +709,6 @@ func (r *Repository) LoadIndex(ctx context.Context, p restic.TerminalCounterFact
 func (r *Repository) loadIndexWithCallback(ctx context.Context, p restic.TerminalCounterFactory, cb func(id restic.ID, idx *index.Index, err error) error) error {
 	debug.Log("Loading index")
 
-	// reset in-memory index before loading it from the repository
-	r.clearIndex()
-
 	var bar *progress.Counter
 	if p != nil {
 		bar = p.NewCounterTerminalOnly("index files loaded")

--- a/internal/ui/progress/counter.go
+++ b/internal/ui/progress/counter.go
@@ -26,7 +26,9 @@ func NewCounter(interval time.Duration, total uint64, report Func) *Counter {
 	c.max.Store(total)
 	c.Updater = *NewUpdater(interval, func(runtime time.Duration, final bool) {
 		v, maxV := c.Get()
-		report(v, maxV, runtime, final)
+		if report != nil {
+			report(v, maxV, runtime, final)
+		}
 	})
 	return c
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Only report mountpoint readiness after the snapshots are actually loaded.
The repository index can now be loaded incrementally. Previously, the index was loaded twice. I've opted for properly implementing incremental reloading instead of just getting rid of the initial call to `LoadIndex`. This has the benefit of also providing fast reloads if the snapshots change at runtime.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Performance issues were reported in https://forum.restic.net/t/restic-mount-takes-5-minutes/10645/4
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
