### PR TITLE
docs: remove outdated CentOS 6/7 installation instructions

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -150,8 +150,8 @@ On openSUSE (leap 15.0 and greater, and tumbleweed), you can install restic usin
 
     # zypper install restic
 
-RHEL & CentOS
-=============
+RHEL & CentOS Stream
+====================
 
 For RHEL / CentOS Stream 8 & 9 restic can be installed from the EPEL repository:
 
@@ -159,26 +159,6 @@ For RHEL / CentOS Stream 8 & 9 restic can be installed from the EPEL repository:
 
     $ dnf install epel-release
     $ dnf install restic
-
-For RHEL7/CentOS there is a copr repository available, you can try the following:
-
-.. code-block:: console
-
-    $ yum install yum-plugin-copr
-    $ yum copr enable copart/restic
-    $ yum install restic
-
-If that doesn't work, you can try adding the repository directly, for CentOS6 use:
-
-.. code-block:: console
-
-    $ yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/copart/restic/repo/epel-6/copart-restic-epel-6.repo
-
-For CentOS7 use:
-
-.. code-block:: console
-
-    $ yum-config-manager --add-repo https://copr.fedorainfracloud.org/coprs/copart/restic/repo/epel-7/copart-restic-epel-7.repo
 
 Solus
 =====

--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -153,7 +153,7 @@ On openSUSE (leap 15.0 and greater, and tumbleweed), you can install restic usin
 RHEL & CentOS Stream
 ====================
 
-For RHEL / CentOS Stream 8 & 9 restic can be installed from the EPEL repository:
+For supported RHEL / CentOS Stream releases, restic can be installed from the EPEL repository:
 
 .. code-block:: console
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Remove outdated installation instructions for CentOS 6 and CentOS 7.
CentOS 6 has been EOL since November 2020 and CentOS 7 since June 2024.
The copr repository links referenced in the documentation are no longer available.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #5218

Checklist
---------
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.