### PR TITLE
docs: document backup progress bar fields

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -48,9 +48,23 @@ some of the data was duplicate and restic was able to efficiently reduce it.
 The data compression also managed to compress the data down to 1.103 GiB.
 
 If you don't pass the ``--verbose`` option, restic will print less data. You'll
-still get a nice live status display. Be aware that the live status shows the
-processed files and not the transferred data. Transferred volume might be lower
-(due to de-duplication) or higher.
+still get a nice live status display that looks like this:
+
+.. code-block:: console
+
+    [0:34] 2.96%  867 files 5.046 GiB, total 307867 files 170.438 GiB, 0 errors ETA 18:35
+
+The progress bar shows, from left to right: elapsed time, progress in percent,
+the number of files already processed and their size on the local filesystem,
+followed by the total expected file count and size for the whole backup (these
+totals come from the initial scan used for progress estimation, which can be
+disabled with ``--no-scan``). Next is a counter for the number of files that
+caused errors (these are logged above the progress bar), and finally an
+estimated time of completion. The file paths displayed below the progress bar
+are the files currently being read by restic.
+
+Be aware that the live status shows the processed files and not the transferred
+data. Transferred volume might be lower (due to de-duplication) or higher.
 
 On Windows, the ``--use-fs-snapshot`` option will use Windows' Volume Shadow Copy
 Service (VSS) when creating backups. Restic will transparently create a VSS


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Document the backup progress bar by adding an example of the live status
display and explaining each field: elapsed time, progress percentage,
processed files and their size on the local filesystem, total expected
files and size (from the initial scan), error count, and ETA.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #4258

Checklist
---------
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.