### PR TITLE
docs: clarify double-asterisk wildcard behavior in exclude patterns

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -378,6 +378,7 @@ This instructs restic to exclude files matching the following criteria:
 
 Patterns use the syntax of the Go function
 `filepath.Match <https://pkg.go.dev/path/filepath#Match>`__
+with the addition of the double-asterisk (``**``) wildcard,
 and are tested against the full path of a file/dir to be saved,
 even if restic is passed a relative path to save. Empty lines and lines
 starting with a ``#`` are ignored.
@@ -407,6 +408,38 @@ The ``**`` must be positioned between path separators. The pattern
 * ``/dir1/foo/dir2/bar/file``
 * ``/foo/bar/file``
 * ``/tmp/foo/bar``
+
+For example, given the following directory structure::
+
+    /home/user/repos
+    ├── repo1
+    │   ├── target
+    │   └── src
+    ├── repo2_workspace
+    │   ├── project1
+    │   │   ├── target
+    │   │   └── src
+    │   └── project2
+    │       ├── target
+    │       └── src
+    └── repo3
+        ├── bin
+        └── src
+
+Using ``--exclude '/home/user/repos/**/target'`` will exclude all ``target``
+directories at any depth, resulting in the following backup::
+
+    /home/user/repos
+    ├── repo1
+    │   └── src
+    ├── repo2_workspace
+    │   ├── project1
+    │   │   └── src
+    │   └── project2
+    │       └── src
+    └── repo3
+        ├── bin
+        └── src
 
 Spaces in patterns listed in an exclude file can be specified verbatim. That is,
 in order to exclude a file named ``foo bar star.txt``, put that just as it reads

--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -101,7 +101,7 @@ Restic handles globbing and expansion in the following ways:
 -  Environment variables are not expanded in the file read via ``--files-from``
 -  ``*`` is expanded for paths read via ``--files-from``
 -  e.g. For backup sources given to restic as arguments on the shell, neither glob expansion nor shell variable replacement is done. If restic is called as ``restic backup '*' '$HOME'``, it will try to backup the literal file(s)/dir(s) ``*`` and ``$HOME``
--  Double-asterisk ``**`` only works in exclude patterns as this is a custom extension built into restic; the shell must not expand it
+-  Double-asterisk ``**`` matches across zero or more subdirectories in exclude patterns (e.g. ``foo/**/bar``). This is a custom extension beyond Go's ``filepath.Match``; make sure the shell does not expand it (e.g. by quoting the pattern). See :ref:`backup-excluding-files` for details
 
 
 How can I specify encryption passwords automatically?


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Clarify the double-asterisk (`**`) wildcard documentation:

- Update the FAQ entry to explain what `**` does (matches across zero or more
  subdirectories) instead of only stating it is a "custom extension", and add
  a reference to the Excluding Files section for details.
- Clarify in the Excluding Files section that exclude patterns extend Go's
  `filepath.Match` with the `**` wildcard.
- Add a visual before/after directory tree example showing how `**` works
  in practice.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #3043

Checklist
---------
- [ ] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.