### PR TITLE
feat: Add support for setting `--ignore-ctime` and `--ignore-inode` via environment variables

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -134,22 +134,8 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 	f.StringVar(&opts.TimeStamp, "time", "", "`time` of the backup (ex. '2012-11-01 22:08:41') (default: now)")
 	f.BoolVar(&opts.WithAtime, "with-atime", false, "store the atime for all files and directories")
 
-	// Use environment to set the default value if available
-	ignoreInodeDefault := false
-	if v := os.Getenv("RESTIC_IGNORE_INODE"); v != "" {
-		if b, err := strconv.ParseBool(v); err == nil {
-			ignoreInodeDefault = b
-		}
-	}
-	ignoreCtimeDefault := false
-	if v := os.Getenv("RESTIC_IGNORE_CTIME"); v != "" {
-		if b, err := strconv.ParseBool(v); err == nil {
-			ignoreCtimeDefault = b
-		}
-	}
-
-	f.BoolVar(&opts.IgnoreInode, "ignore-inode", ignoreInodeDefault, "ignore inode number and ctime changes when checking for modified files")
-	f.BoolVar(&opts.IgnoreCtime, "ignore-ctime", ignoreCtimeDefault, "ignore ctime changes when checking for modified files")
+	f.BoolVar(&opts.IgnoreInode, "ignore-inode", false, "ignore inode number and ctime changes when checking for modified files")
+	f.BoolVar(&opts.IgnoreCtime, "ignore-ctime", false, "ignore ctime changes when checking for modified files")
 	f.BoolVarP(&opts.DryRun, "dry-run", "n", false, "do not upload or write any data, just show what would be done")
 	f.BoolVar(&opts.NoScan, "no-scan", false, "do not run scanner to estimate size of backup")
 	if runtime.GOOS == "windows" {
@@ -163,6 +149,10 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 	// parse read concurrency from env, on error the default value will be used
 	readConcurrency, _ := strconv.ParseUint(os.Getenv("RESTIC_READ_CONCURRENCY"), 10, 32)
 	opts.ReadConcurrency = uint(readConcurrency)
+
+	// parse read inode and ctime from env, on error the default value will be used
+	opts.IgnoreInode, _ := strconv.ParseBool(os.Getenv("RESTIC_IGNORE_INODE"))
+	opts.IgnoreCtime, _ := strconv.ParseBool(os.Getenv("RESTIC_IGNORE_CTIME"))
 
 	// parse host from env, if not exists or empty the default value will be used
 	if host := os.Getenv("RESTIC_HOST"); host != "" {

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -133,8 +133,23 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 	f.StringArrayVar(&opts.FilesFromRaw, "files-from-raw", nil, "read the files to backup from `file` (can be combined with file args; can be specified multiple times)")
 	f.StringVar(&opts.TimeStamp, "time", "", "`time` of the backup (ex. '2012-11-01 22:08:41') (default: now)")
 	f.BoolVar(&opts.WithAtime, "with-atime", false, "store the atime for all files and directories")
-	f.BoolVar(&opts.IgnoreInode, "ignore-inode", false, "ignore inode number and ctime changes when checking for modified files")
-	f.BoolVar(&opts.IgnoreCtime, "ignore-ctime", false, "ignore ctime changes when checking for modified files")
+
+	// Use environment to set the default value if available
+	ignoreInodeDefault := false
+	if v := os.Getenv("RESTIC_IGNORE_INODE"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			ignoreInodeDefault = b
+		}
+	}
+	ignoreCtimeDefault := false
+	if v := os.Getenv("RESTIC_IGNORE_CTIME"); v != "" {
+		if b, err := strconv.ParseBool(v); err == nil {
+			ignoreCtimeDefault = b
+		}
+	}
+
+	f.BoolVar(&opts.IgnoreInode, "ignore-inode", ignoreInodeDefault, "ignore inode number and ctime changes when checking for modified files")
+	f.BoolVar(&opts.IgnoreCtime, "ignore-ctime", ignoreCtimeDefault, "ignore ctime changes when checking for modified files")
 	f.BoolVarP(&opts.DryRun, "dry-run", "n", false, "do not upload or write any data, just show what would be done")
 	f.BoolVar(&opts.NoScan, "no-scan", false, "do not run scanner to estimate size of backup")
 	if runtime.GOOS == "windows" {

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -133,7 +133,6 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 	f.StringArrayVar(&opts.FilesFromRaw, "files-from-raw", nil, "read the files to backup from `file` (can be combined with file args; can be specified multiple times)")
 	f.StringVar(&opts.TimeStamp, "time", "", "`time` of the backup (ex. '2012-11-01 22:08:41') (default: now)")
 	f.BoolVar(&opts.WithAtime, "with-atime", false, "store the atime for all files and directories")
-
 	f.BoolVar(&opts.IgnoreInode, "ignore-inode", false, "ignore inode number and ctime changes when checking for modified files")
 	f.BoolVar(&opts.IgnoreCtime, "ignore-ctime", false, "ignore ctime changes when checking for modified files")
 	f.BoolVarP(&opts.DryRun, "dry-run", "n", false, "do not upload or write any data, just show what would be done")

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -133,8 +133,8 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 	f.StringArrayVar(&opts.FilesFromRaw, "files-from-raw", nil, "read the files to backup from `file` (can be combined with file args; can be specified multiple times)")
 	f.StringVar(&opts.TimeStamp, "time", "", "`time` of the backup (ex. '2012-11-01 22:08:41') (default: now)")
 	f.BoolVar(&opts.WithAtime, "with-atime", false, "store the atime for all files and directories")
-	f.BoolVar(&opts.IgnoreInode, "ignore-inode", false, "ignore inode number and ctime changes when checking for modified files")
-	f.BoolVar(&opts.IgnoreCtime, "ignore-ctime", false, "ignore ctime changes when checking for modified files")
+	f.BoolVar(&opts.IgnoreInode, "ignore-inode", false, "ignore inode number and ctime changes when checking for modified files (default: $RESTIC_IGNORE_INODE or false)")
+	f.BoolVar(&opts.IgnoreCtime, "ignore-ctime", false, "ignore ctime changes when checking for modified files (default: $RESTIC_IGNORE_CTIME or false)")
 	f.BoolVarP(&opts.DryRun, "dry-run", "n", false, "do not upload or write any data, just show what would be done")
 	f.BoolVar(&opts.NoScan, "no-scan", false, "do not run scanner to estimate size of backup")
 	if runtime.GOOS == "windows" {

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -150,8 +150,8 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 	opts.ReadConcurrency = uint(readConcurrency)
 
 	// parse read inode and ctime from env, on error the default value will be used
-	opts.IgnoreInode, _ := strconv.ParseBool(os.Getenv("RESTIC_IGNORE_INODE"))
-	opts.IgnoreCtime, _ := strconv.ParseBool(os.Getenv("RESTIC_IGNORE_CTIME"))
+	opts.IgnoreInode, _ = strconv.ParseBool(os.Getenv("RESTIC_IGNORE_INODE"))
+	opts.IgnoreCtime, _ = strconv.ParseBool(os.Getenv("RESTIC_IGNORE_CTIME"))
 
 	// parse host from env, if not exists or empty the default value will be used
 	if host := os.Getenv("RESTIC_HOST"); host != "" {

--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -41,6 +41,8 @@ environment variables, which are listed below.
     RESTIC_PROGRESS_FPS                 Frames per second by which the progress bar is updated
     RESTIC_PACK_SIZE                    Target size for pack files
     RESTIC_READ_CONCURRENCY             Concurrency for file reads
+    RESTIC_IGNORE_CTIME                 Ignore ctime changes when comparing files (replaces --ignore-ctime)
+    RESTIC_IGNORE_INODE                 Ignore inode changes when comparing files (replaces --ignore-inode)
 
     TMPDIR                              Location for temporary files (except Windows)
     TMP                                 Location for temporary files (only Windows)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

`volsync` does not allow passing CLI args to `restic`, thus the only option is to set `--ignore-ctime` and `--ignore-inode` via environment variables

This PR adds environment variables for the `ignore-ctime` and `ignore-inode` options. The environment variables are used as the default value for the CLI option, and can be overwritten by providing the CLI flag directly.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #5738

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
