### PR TITLE
implement restic backup --exclude-no-dump

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -85,6 +85,7 @@ type BackupOptions struct {
 	ExcludeCaches     bool
 	ExcludeLargerThan string
 	ExcludeCloudFiles bool
+	ExcludeNoDump     bool
 	Stdin             bool
 	StdinFilename     string
 	StdinCommand      bool
@@ -142,6 +143,9 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 	}
 	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		f.BoolVar(&opts.ExcludeCloudFiles, "exclude-cloud-files", false, "excludes online-only cloud files (such as OneDrive, iCloud drive, …)")
+	}
+	if runtime.GOOS == "linux" {
+		f.BoolVar(&opts.ExcludeNoDump, "exclude-no-dump", false, "excludes directories and files marked with the `no dump` attribute)")
 	}
 	f.BoolVar(&opts.SkipIfUnchanged, "skip-if-unchanged", false, "skip snapshot creation if identical to parent snapshot")
 
@@ -377,6 +381,14 @@ func collectRejectFuncs(opts BackupOptions, targets []string, fs fs.FS, warnf fu
 			return nil, err
 		}
 
+		funcs = append(funcs, f)
+	}
+
+	if opts.ExcludeNoDump {
+		f, err := archiver.RejectByNoDump(warnf)
+		if err != nil {
+			return nil, err
+		}
 		funcs = append(funcs, f)
 	}
 

--- a/internal/archiver/attributes_linux.go
+++ b/internal/archiver/attributes_linux.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package archiver
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// isNoDump returns whether the "no dump" Linux file attribute is set on path.
+// See CHATTR(1) for more information about Linux file attributes.
+func isNoDump(path string) (bool, error) {
+	statx := &unix.Statx_t{}
+
+	if err := unix.Statx(0, path, unix.AT_NO_AUTOMOUNT|unix.AT_SYMLINK_NOFOLLOW, 0, statx); err != nil {
+		return false, err
+	}
+
+	return statx.Attributes&unix.STATX_ATTR_NODUMP != 0, nil
+}

--- a/internal/archiver/attributes_other.go
+++ b/internal/archiver/attributes_other.go
@@ -1,0 +1,9 @@
+//go:build !linux
+
+package archiver
+
+// isNoDump returns whether the "no dump" Linux file attribute is set on path.
+// See CHATTR(1) for more information about Linux file attributes.
+func isNoDump(path string) (bool, error) {
+	return false, nil
+}

--- a/internal/archiver/exclude.go
+++ b/internal/archiver/exclude.go
@@ -334,3 +334,16 @@ func RejectCloudFiles(warnf func(msg string, args ...interface{})) (RejectFunc, 
 		return false
 	}, nil
 }
+
+// RejectByNoDump returns a func which on Linux rejects files with the "no dump"
+// Linux file attribute is set.  On other OSes it rejects no files.
+func RejectByNoDump(warnf func(string, ...any)) (RejectFunc, error) {
+	return func(item string, _ *fs.ExtendedFileInfo, _ fs.FS) bool {
+		rv, err := isNoDump(item)
+		if err != nil {
+			warnf("item %v: error getting attributes: %v", item, err)
+		}
+
+		return rv
+	}, nil
+}

--- a/internal/archiver/exclude_linux_test.go
+++ b/internal/archiver/exclude_linux_test.go
@@ -1,0 +1,60 @@
+//go:build linux
+
+package archiver
+
+import (
+	"os"
+	"testing"
+
+	"golang.org/x/sys/unix"
+
+	"github.com/restic/restic/internal/test"
+)
+
+func TestRejectByNoDump(t *testing.T) {
+	tempDir := test.TempDir(t)
+
+	items := []struct {
+		path   string
+		dir    bool
+		noDump bool
+	}{
+		{"/no-dump", true, true},
+		{"/normal", true, false},
+		{"/normal/no-dump", false, true},
+		{"/normal/normal", false, false},
+	}
+
+	for _, item := range items {
+		if item.dir {
+			test.OK(t, os.Mkdir(tempDir+item.path, 0700))
+		} else {
+			test.OK(t, os.WriteFile(tempDir+item.path, nil, 0600))
+		}
+
+		if item.noDump {
+			test.OK(t, setNoDump(tempDir+item.path))
+		}
+	}
+
+	reject, err := RejectByNoDump(nil)
+	test.OK(t, err)
+
+	for _, item := range items {
+		rejected := reject(tempDir+item.path, nil, nil)
+		if rejected != item.noDump {
+			t.Errorf("inclusion status of %s is wrong: want %v, got %v", item.path, item.noDump, rejected)
+		}
+	}
+}
+
+// setNoDump sets the "no dump" Linux file attribute on path (file or directory).
+func setNoDump(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	return unix.IoctlSetPointerInt(int(f.Fd()), unix.FS_IOC_SETFLAGS, 0x40 /* FS_NODUMP_FL */)
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR implements `restic backup --exclude-no-dump` (Linux only), which may be used to exclude all directories and files that have the "no dump" Linux file attribute set.  See [CHATTR(1)](https://www.man7.org/linux/man-pages/man1/chattr.1.html) for more details on Linux file attributes.

On non-Linux systems, the `--exclude-no-dump` option is not available.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #4208

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
