### PR TITLE
backend/sftp: add optional reconnect on transient SSH disconnects

### DIFF
--- a/changelog/unreleased/pull-0000-sftp-reconnect
+++ b/changelog/unreleased/pull-0000-sftp-reconnect
@@ -1,0 +1,25 @@
+Enhancement: add optional reconnect support for SFTP backend
+
+The SFTP backend can now automatically reconnect and retry operations when the
+underlying SSH connection drops during a backup. This is useful for unstable
+network links where transient disconnects would previously cause the entire
+backup to fail with errors like "ssh command exited: exit status 255" or
+"broken pipe".
+
+To enable, set the `sftp.reconnect` option to the maximum number of reconnect
+attempts allowed per session:
+
+    restic -o sftp.reconnect=5 -r sftp:user@host:/repo backup /data
+
+When a transient disconnect is detected, only one reconnect executes at a time
+regardless of the number of concurrent operations. The reconnect budget resets
+after 5 minutes of stable operation. Permanent errors (permission denied, not
+found, no space) are not retried.
+
+For best results, configure SSH client keepalive settings to detect dead
+connections promptly:
+
+    restic -o sftp.args="-o ServerAliveInterval=60 -o ServerAliveCountMax=3" \
+           -o sftp.reconnect=5 -r sftp:user@host:/repo backup /data
+
+https://github.com/restic/restic/pull/0000

--- a/changelog/unreleased/pull-5752
+++ b/changelog/unreleased/pull-5752
@@ -22,4 +22,5 @@ connections promptly:
     restic -o sftp.args="-o ServerAliveInterval=60 -o ServerAliveCountMax=3" \
            -o sftp.reconnect=5 -r sftp:user@host:/repo backup /data
 
-https://github.com/restic/restic/pull/0000
+https://github.com/restic/restic/issues/353
+https://github.com/restic/restic/pull/5752

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -178,15 +178,44 @@ setting the arguments passed to the default SSH command (ignored when
 
 .. note:: Please be aware that SFTP servers close connections when no data is
           received by the client. This can happen when restic is processing huge
-          amounts of unchanged data. To avoid this issue add the following lines 
+          amounts of unchanged data. To avoid this issue add the following lines
           to the client's .ssh/config file:
 
 ::
 
     ServerAliveInterval 60
     ServerAliveCountMax 240
-          
-          
+
+Automatic reconnect on transient disconnects
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+On unstable network links, the SSH connection underlying the SFTP backend may
+drop mid-run, causing the backup to fail. The ``-o sftp.reconnect=N`` option
+enables automatic reconnect with up to ``N`` attempts:
+
+.. code-block:: console
+
+    $ restic -o sftp.reconnect=5 -r sftp:user@host:/srv/restic-repo backup /data
+
+When a transient disconnect is detected (e.g., "ssh command exited: exit
+status 255" or "broken pipe"), restic reconnects the SSH session and retries
+the interrupted operation. Only one reconnect executes at a time regardless of
+the number of concurrent uploads. The reconnect budget resets after 5 minutes
+of stable operation, so long-running backups over slightly flaky links will not
+exhaust the budget from widely-spaced, individually-recoverable disconnects.
+
+Permanent errors such as permission denied, file not found, and no space left
+on device are never retried.
+
+For best results, combine ``sftp.reconnect`` with SSH client keepalive settings
+to detect dead connections promptly:
+
+.. code-block:: console
+
+    $ restic -o sftp.args="-o ServerAliveInterval=60 -o ServerAliveCountMax=3" \
+             -o sftp.reconnect=5 -r sftp:user@host:/srv/restic-repo backup /data
+
+
 REST Server
 ***********
 

--- a/internal/backend/sftp/config.go
+++ b/internal/backend/sftp/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Args    string `option:"args"    help:"specify arguments for ssh"`
 
 	Connections uint `option:"connections" help:"set a limit for the number of concurrent connections (default: 5)"`
+	Reconnect   uint `option:"reconnect"   help:"set max reconnect attempts on transient SSH/SFTP disconnects (default: 0, disabled)"`
 }
 
 // NewConfig returns a new config with default options applied.

--- a/internal/backend/sftp/reconnect.go
+++ b/internal/backend/sftp/reconnect.go
@@ -1,0 +1,286 @@
+package sftp
+
+import (
+	"io"
+	"math/rand"
+	"os"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/errors"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/pkg/sftp"
+)
+
+// connState holds the per-connection state for an SFTP backend.
+// Each reconnect creates a new connState and tears down the old one.
+type connState struct {
+	client      *sftp.Client
+	cmd         *os.Process
+	result      <-chan error
+	posixRename bool
+	done        chan struct{} // closed on teardown to stop goroutines
+	closeOnce   sync.Once
+}
+
+// close tears down the connection. Safe to call multiple times.
+func (cs *connState) close() {
+	cs.closeOnce.Do(func() {
+		_ = cs.client.Close()
+
+		// Wait for the SSH process to exit. If it doesn't exit within
+		// closeTimeout, kill it and wait for the result.
+		select {
+		case <-cs.result:
+		case <-time.After(closeTimeout):
+			_ = cs.cmd.Kill()
+			<-cs.result
+		}
+
+		// Now that cmd.Wait() has completed, signal auxiliary goroutines
+		// (stderr reader) to stop.
+		close(cs.done)
+	})
+}
+
+// reconnectBudget tracks global reconnect attempts per backend instance.
+type reconnectBudget struct {
+	mu             sync.Mutex
+	attempts       uint
+	lastReconnect  time.Time
+	firstReconnect time.Time
+	maxElapsedTime time.Duration
+	stabilityReset time.Duration
+}
+
+const (
+	defaultMaxElapsedTime = 15 * time.Minute
+	defaultStabilityReset = 5 * time.Minute
+
+	reconnectInitialBackoff = 250 * time.Millisecond
+	reconnectMaxBackoff     = 15 * time.Second
+	reconnectBackoffFactor  = 2.0
+)
+
+var errBackendClosed = backoff.Permanent(errors.New("sftp: backend is closed"))
+
+func newReconnectBudget() reconnectBudget {
+	return reconnectBudget{
+		maxElapsedTime: defaultMaxElapsedTime,
+		stabilityReset: defaultStabilityReset,
+	}
+}
+
+// tryConsume checks if a reconnect attempt is allowed.
+func (b *reconnectBudget) tryConsume(maxAttempts uint) (bool, uint) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	now := time.Now()
+
+	// Reset counter if connection has been stable for stabilityReset.
+	if !b.lastReconnect.IsZero() && now.Sub(b.lastReconnect) > b.stabilityReset {
+		b.attempts = 0
+		b.firstReconnect = time.Time{}
+	}
+
+	if b.attempts >= maxAttempts {
+		return false, 0
+	}
+	if !b.firstReconnect.IsZero() && now.Sub(b.firstReconnect) > b.maxElapsedTime {
+		return false, 0
+	}
+
+	if b.firstReconnect.IsZero() {
+		b.firstReconnect = now
+	}
+	b.attempts++
+	b.lastReconnect = now
+	return true, b.attempts
+}
+
+// reconnectBackoff returns the backoff duration for the given attempt number
+// (1-based), using exponential backoff with full jitter.
+func reconnectBackoff(attempt uint) time.Duration {
+	dur := reconnectInitialBackoff
+	for i := uint(1); i < attempt; i++ {
+		dur = time.Duration(float64(dur) * reconnectBackoffFactor)
+		if dur > reconnectMaxBackoff {
+			dur = reconnectMaxBackoff
+			break
+		}
+	}
+	return time.Duration(rand.Int63n(int64(dur) + 1))
+}
+
+// conn returns the current connection state under lock.
+func (r *SFTP) conn() *connState {
+	r.connMu.Lock()
+	defer r.connMu.Unlock()
+	return r.cs
+}
+
+// ensureConnected reconnects after a transient disconnect. It uses
+// singleflight to coalesce concurrent reconnect requests.
+// preGen is the generation counter observed before the failing operation.
+func (r *SFTP) ensureConnected(preGen uint64) (*connState, error) {
+	v, err, _ := r.sfGroup.Do("reconnect", func() (interface{}, error) {
+		if r.closed.Load() {
+			return nil, errBackendClosed
+		}
+
+		// Another goroutine already reconnected.
+		if r.connGen.Load() != preGen {
+			return r.conn(), nil
+		}
+
+		ok, attempt := r.budget.tryConsume(r.Config.Reconnect)
+		if !ok {
+			debug.Log("reconnect budget exhausted (max %d attempts)", r.Config.Reconnect)
+			return nil, backoff.Permanent(errors.New("sftp: reconnect budget exhausted"))
+		}
+
+		delay := reconnectBackoff(attempt)
+		debug.Log("reconnecting (attempt %d/%d) after %v backoff", attempt, r.Config.Reconnect, delay)
+		time.Sleep(delay)
+
+		if r.closed.Load() {
+			return nil, errBackendClosed
+		}
+
+		// Tear down old connection.
+		r.connMu.Lock()
+		old := r.cs
+		r.cs = nil
+		r.connMu.Unlock()
+
+		if old != nil {
+			old.close()
+		}
+
+		cs, err := startClient(r.Config, r.errorLog)
+		if err != nil {
+			debug.Log("reconnect failed: %v", err)
+			return nil, err
+		}
+
+		if r.closed.Load() {
+			cs.close()
+			return nil, errBackendClosed
+		}
+
+		r.connMu.Lock()
+		r.cs = cs
+		r.connGen.Add(1)
+		r.connMu.Unlock()
+
+		debug.Log("reconnect succeeded (attempt %d/%d, gen %d)",
+			attempt, r.Config.Reconnect, r.connGen.Load())
+		return cs, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	if v == nil {
+		return nil, errBackendClosed
+	}
+	return v.(*connState), nil
+}
+
+// getConn returns a usable connection and its generation counter.
+// If the current connection is nil and reconnect is enabled, it joins
+// an in-progress reconnect via singleflight.
+func (r *SFTP) getConn() (*connState, uint64, error) {
+	r.connMu.Lock()
+	cs, gen := r.cs, r.connGen.Load()
+	r.connMu.Unlock()
+
+	if cs != nil {
+		return cs, gen, nil
+	}
+
+	if r.Config.Reconnect > 0 && !r.closed.Load() {
+		cs, err := r.ensureConnected(gen)
+		if err != nil {
+			return nil, 0, err
+		}
+		return cs, r.connGen.Load(), nil
+	}
+
+	return nil, 0, errBackendClosed
+}
+
+// withRetry runs fn with the current connection. On transient disconnect
+// with reconnect enabled, it reconnects and retries fn once.
+func (r *SFTP) withRetry(fn func(cs *connState) error) error {
+	cs, gen, err := r.getConn()
+	if err != nil {
+		return err
+	}
+
+	err = fn(cs)
+	if err == nil || r.Config.Reconnect == 0 || !isTransientDisconnect(err) {
+		return err
+	}
+
+	debug.Log("transient disconnect, attempting reconnect (gen %d): %v", gen, err)
+
+	newCS, reconnErr := r.ensureConnected(gen)
+	if reconnErr != nil {
+		return reconnErr
+	}
+
+	return fn(newCS)
+}
+
+// isTransientDisconnect returns true if the error indicates a transient
+// SSH/SFTP connection loss that may be recovered by reconnecting.
+func isTransientDisconnect(err error) bool {
+	if err == nil {
+		return false
+	}
+
+	// SFTP status errors (server-side SSH_FXP_STATUS responses).
+	var statusErr *sftp.StatusError
+	if errors.As(err, &statusErr) {
+		switch statusErr.FxCode() {
+		case sftp.ErrSSHFxConnectionLost, sftp.ErrSSHFxNoConnection:
+			return true
+		}
+	}
+
+	// Raw fxerr sentinels broadcast by pkg/sftp when the SSH pipe breaks.
+	// These are fxerr (uint32), not *StatusError.
+	if errors.Is(err, sftp.ErrSSHFxConnectionLost) ||
+		errors.Is(err, sftp.ErrSSHFxNoConnection) {
+		return true
+	}
+
+	if errors.Is(err, io.ErrUnexpectedEOF) {
+		return true
+	}
+
+	if errors.Is(err, syscall.EPIPE) ||
+		errors.Is(err, syscall.ECONNRESET) ||
+		errors.Is(err, syscall.ECONNABORTED) {
+		return true
+	}
+
+	// String fallbacks for SSH transport death indicators.
+	msg := err.Error()
+	if strings.Contains(msg, "ssh command exited: exit status 255") {
+		return true
+	}
+	if strings.Contains(msg, "broken pipe") ||
+		strings.Contains(msg, "connection reset by peer") ||
+		strings.Contains(msg, "connection lost") ||
+		strings.Contains(msg, "file already closed") {
+		return true
+	}
+
+	return false
+}

--- a/internal/backend/sftp/reconnect_test.go
+++ b/internal/backend/sftp/reconnect_test.go
@@ -1,0 +1,283 @@
+package sftp
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/pkg/sftp"
+	"github.com/restic/restic/internal/errors"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestIsTransientDisconnect(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		// Nil error
+		{name: "nil", err: nil, want: false},
+
+		// SFTP status errors — transient
+		{
+			name: "sftp_connection_lost",
+			err:  &sftp.StatusError{Code: uint32(sftp.ErrSSHFxConnectionLost)},
+			want: true,
+		},
+		{
+			name: "sftp_no_connection",
+			err:  &sftp.StatusError{Code: uint32(sftp.ErrSSHFxNoConnection)},
+			want: true,
+		},
+
+		// SFTP status errors — permanent
+		{
+			name: "sftp_permission_denied",
+			err:  &sftp.StatusError{Code: uint32(sftp.ErrSSHFxPermissionDenied)},
+			want: false,
+		},
+		{
+			name: "sftp_no_such_file",
+			err:  &sftp.StatusError{Code: uint32(sftp.ErrSSHFxNoSuchFile)},
+			want: false,
+		},
+		{
+			name: "sftp_failure",
+			err:  &sftp.StatusError{Code: uint32(sftp.ErrSSHFxFailure)},
+			want: false,
+		},
+		{
+			name: "sftp_op_unsupported",
+			err:  &sftp.StatusError{Code: uint32(sftp.ErrSSHFxOpUnsupported)},
+			want: false,
+		},
+
+		// io errors
+		{name: "unexpected_eof", err: io.ErrUnexpectedEOF, want: true},
+		{name: "regular_eof", err: io.EOF, want: false},
+
+		// Syscall errors
+		{name: "epipe", err: syscall.EPIPE, want: true},
+		{name: "econnreset", err: syscall.ECONNRESET, want: true},
+		{name: "econnaborted", err: syscall.ECONNABORTED, want: true},
+		{name: "enoent", err: syscall.ENOENT, want: false},
+		{name: "eacces", err: syscall.EACCES, want: false},
+
+		// SSH exit status 255 — transient
+		{
+			name: "ssh_exit_255",
+			err:  fmt.Errorf("ssh command exited: exit status 255"),
+			want: true,
+		},
+		{
+			name: "wrapped_ssh_exit_255",
+			err:  errors.Wrap(fmt.Errorf("ssh command exited: exit status 255"), "operation failed"),
+			want: true,
+		},
+
+		// SSH exit with other status codes — NOT transient
+		{
+			name: "ssh_exit_0",
+			err:  fmt.Errorf("ssh command exited: exit status 0"),
+			want: false,
+		},
+		{
+			name: "ssh_exit_1",
+			err:  fmt.Errorf("ssh command exited: exit status 1"),
+			want: false,
+		},
+		{
+			name: "ssh_exit_127",
+			err:  fmt.Errorf("ssh command exited: exit status 127"),
+			want: false,
+		},
+
+		// String-matched network errors
+		{name: "broken_pipe_msg", err: fmt.Errorf("write: broken pipe"), want: true},
+		{name: "conn_reset_msg", err: fmt.Errorf("read: connection reset by peer"), want: true},
+		{name: "connection_lost_msg", err: fmt.Errorf("Write foo: connection lost"), want: true},
+		{name: "file_already_closed_msg", err: fmt.Errorf("failed to send packet: write |1: file already closed"), want: true},
+
+		// Raw fxerr sentinel values (broadcastErr path in pkg/sftp)
+		{name: "fxerr_connection_lost", err: sftp.ErrSSHFxConnectionLost, want: true},
+		{name: "fxerr_no_connection", err: sftp.ErrSSHFxNoConnection, want: true},
+		{name: "wrapped_fxerr_connection_lost", err: fmt.Errorf("Write foo: %w", sftp.ErrSSHFxConnectionLost), want: true},
+		{name: "wrapped_fxerr_no_connection", err: fmt.Errorf("OpenFile foo: %w", sftp.ErrSSHFxNoConnection), want: true},
+
+		// Wrapped transient errors
+		{
+			name: "wrapped_epipe",
+			err:  fmt.Errorf("Save: %w", syscall.EPIPE),
+			want: true,
+		},
+		{
+			name: "wrapped_unexpected_eof",
+			err:  fmt.Errorf("Read: %w", io.ErrUnexpectedEOF),
+			want: true,
+		},
+
+		// Permanent errors that must not be classified as transient
+		{name: "os_not_exist", err: os.ErrNotExist, want: false},
+		{name: "os_permission", err: os.ErrPermission, want: false},
+		{name: "generic_error", err: fmt.Errorf("some other error"), want: false},
+		{name: "no_space", err: fmt.Errorf("sftp: no space left on device"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isTransientDisconnect(tt.err)
+			rtest.Equals(t, tt.want, got)
+		})
+	}
+}
+
+func TestReconnectBudget(t *testing.T) {
+	t.Run("basic_consumption", func(t *testing.T) {
+		b := newReconnectBudget()
+		ok, n := b.tryConsume(3)
+		rtest.Assert(t, ok, "attempt 1 should succeed")
+		rtest.Equals(t, uint(1), n)
+
+		ok, n = b.tryConsume(3)
+		rtest.Assert(t, ok, "attempt 2 should succeed")
+		rtest.Equals(t, uint(2), n)
+
+		ok, n = b.tryConsume(3)
+		rtest.Assert(t, ok, "attempt 3 should succeed")
+		rtest.Equals(t, uint(3), n)
+
+		ok, _ = b.tryConsume(3)
+		rtest.Assert(t, !ok, "attempt 4 should fail (budget exhausted)")
+	})
+
+	t.Run("zero_budget", func(t *testing.T) {
+		b := newReconnectBudget()
+		ok, _ := b.tryConsume(0)
+		rtest.Assert(t, !ok, "zero budget should always fail")
+	})
+
+	t.Run("stability_reset", func(t *testing.T) {
+		b := newReconnectBudget()
+		b.stabilityReset = 10 * time.Millisecond // short for testing
+
+		ok, _ := b.tryConsume(2)
+		rtest.Assert(t, ok, "attempt 1 should succeed")
+		ok, _ = b.tryConsume(2)
+		rtest.Assert(t, ok, "attempt 2 should succeed")
+		ok, _ = b.tryConsume(2)
+		rtest.Assert(t, !ok, "attempt 3 should fail")
+
+		// Wait for stability window.
+		time.Sleep(20 * time.Millisecond)
+
+		// Budget should be reset.
+		ok, _ = b.tryConsume(2)
+		rtest.Assert(t, ok, "after stability reset, attempt should succeed")
+		ok, _ = b.tryConsume(2)
+		rtest.Assert(t, ok, "after stability reset, second attempt should succeed")
+	})
+
+	t.Run("elapsed_time_limit", func(t *testing.T) {
+		b := newReconnectBudget()
+		b.maxElapsedTime = 10 * time.Millisecond // short for testing
+
+		ok, _ := b.tryConsume(100)
+		rtest.Assert(t, ok, "first attempt should succeed")
+
+		// Wait past max elapsed time.
+		time.Sleep(20 * time.Millisecond)
+
+		ok, _ = b.tryConsume(100)
+		rtest.Assert(t, !ok, "should fail after max elapsed time")
+	})
+}
+
+func TestReconnectBackoff(t *testing.T) {
+	// Attempt 1: backoff in [0, 250ms]
+	for i := 0; i < 100; i++ {
+		d := reconnectBackoff(1)
+		rtest.Assert(t, d >= 0 && d <= 250*time.Millisecond,
+			"attempt 1 backoff %v out of range", d)
+	}
+
+	// Attempt 2: backoff in [0, 500ms]
+	for i := 0; i < 100; i++ {
+		d := reconnectBackoff(2)
+		rtest.Assert(t, d >= 0 && d <= 500*time.Millisecond,
+			"attempt 2 backoff %v out of range", d)
+	}
+
+	// Attempt 3: backoff in [0, 1s]
+	for i := 0; i < 100; i++ {
+		d := reconnectBackoff(3)
+		rtest.Assert(t, d >= 0 && d <= time.Second,
+			"attempt 3 backoff %v out of range", d)
+	}
+
+	// Large attempt: backoff capped at [0, 15s]
+	for i := 0; i < 100; i++ {
+		d := reconnectBackoff(100)
+		rtest.Assert(t, d >= 0 && d <= 15*time.Second,
+			"attempt 100 backoff %v out of range", d)
+	}
+}
+
+func TestReconnectBudgetConcurrent(t *testing.T) {
+	b := newReconnectBudget()
+	maxAttempts := uint(10)
+
+	var consumed atomic.Int32
+	var wg sync.WaitGroup
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			ok, _ := b.tryConsume(maxAttempts)
+			if ok {
+				consumed.Add(1)
+			}
+		}()
+	}
+	wg.Wait()
+
+	rtest.Equals(t, int32(maxAttempts), consumed.Load())
+}
+
+func TestEnsureConnectedAfterClose(t *testing.T) {
+	r := &SFTP{
+		budget: newReconnectBudget(),
+		Config: Config{Reconnect: 5},
+	}
+	r.closed.Store(true)
+
+	_, err := r.ensureConnected(0)
+	rtest.Assert(t, err != nil, "ensureConnected should fail after Close()")
+	rtest.Assert(t, strings.Contains(err.Error(), "backend is closed"),
+		"error should indicate backend is closed, got: %v", err)
+}
+
+func TestWithRetryAfterClose(t *testing.T) {
+	r := &SFTP{
+		budget: newReconnectBudget(),
+		Config: Config{Reconnect: 5},
+	}
+	// conn_ is nil and closed is set — should get permanent error, not reconnect.
+	r.closed.Store(true)
+
+	called := false
+	err := r.withRetry(func(cs *connState) error {
+		called = true
+		return nil
+	})
+	rtest.Assert(t, !called, "fn should not be called after Close()")
+	rtest.Assert(t, err != nil, "withRetry should fail after Close()")
+	rtest.Assert(t, strings.Contains(err.Error(), "backend is closed"),
+		"error should indicate backend is closed, got: %v", err)
+}

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -80,11 +80,17 @@ func startClient(cfg Config, errorLog func(string, ...interface{})) (*connState,
 	// On early error, kill the subprocess (if started) and signal
 	// auxiliary goroutines to stop.
 	success := false
+	var waitCh <-chan error // set once the wait goroutine is running
 	defer func() {
 		if !success {
 			if cmd.Process != nil {
 				_ = cmd.Process.Kill()
-				_ = cmd.Wait()
+				if waitCh != nil {
+					// The wait goroutine owns cmd.Wait(); drain it.
+					<-waitCh
+				} else {
+					_ = cmd.Wait()
+				}
 			}
 			close(done)
 		}
@@ -122,6 +128,7 @@ func startClient(cfg Config, errorLog func(string, ...interface{})) (*connState,
 
 	// wait in a different goroutine
 	ch := make(chan error, 1)
+	waitCh = ch
 	go func() {
 		err := cmd.Wait()
 		debug.Log("ssh command exited, err %v", err)
@@ -691,12 +698,21 @@ func (r *SFTP) deleteRecursive(ctx context.Context, cs *connState, name string) 
 // Delete removes all data in the backend.
 // Delete is not retried on disconnect because deleteRecursive is not
 // idempotent — already-deleted files would cause errors on retry.
+// On transient disconnect it triggers a reconnect so that the outer
+// retry backend's next attempt gets a fresh connection.
 func (r *SFTP) Delete(ctx context.Context) error {
-	cs, _, err := r.getConn()
+	cs, gen, err := r.getConn()
 	if err != nil {
 		return err
 	}
-	return r.deleteRecursive(ctx, cs, r.p)
+	err = r.deleteRecursive(ctx, cs, r.p)
+	if err != nil && r.Config.Reconnect > 0 && isTransientDisconnect(err) {
+		debug.Log("Delete: transient disconnect, triggering reconnect (gen %d): %v", gen, err)
+		if _, reconnErr := r.ensureConnected(gen); reconnErr != nil {
+			return reconnErr
+		}
+	}
+	return err
 }
 
 // Warmup not implemented

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/restic/restic/internal/backend"
@@ -26,17 +28,23 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/pkg/sftp"
 	"golang.org/x/sync/errgroup"
+	"golang.org/x/sync/singleflight"
 )
 
 // SFTP is a backend in a directory accessed via SFTP.
 type SFTP struct {
-	c *sftp.Client
 	p string
 
-	cmd    *exec.Cmd
-	result <-chan error
+	// Connection state, guarded by connMu.
+	connMu sync.Mutex
+	cs *connState
+	closed atomic.Bool // set by Close(); prevents reconnect after shutdown
 
-	posixRename bool
+	// Reconnect coordination.
+	connGen  atomic.Uint64
+	sfGroup  singleflight.Group
+	budget   reconnectBudget
+	errorLog func(string, ...interface{})
 
 	layout.Layout
 	Config
@@ -51,7 +59,7 @@ func NewFactory() location.Factory {
 	return location.NewLimitedBackendFactory("sftp", ParseConfig, location.NoPassword, limiter.WrapBackendConstructor(Create), limiter.WrapBackendConstructor(Open))
 }
 
-func startClient(cfg Config, errorLog func(string, ...interface{})) (*SFTP, error) {
+func startClient(cfg Config, errorLog func(string, ...interface{})) (*connState, error) {
 	program, args, err := buildSSHCommand(cfg)
 	if err != nil {
 		return nil, err
@@ -68,9 +76,28 @@ func startClient(cfg Config, errorLog func(string, ...interface{})) (*SFTP, erro
 		return nil, errors.Wrap(err, "cmd.StderrPipe")
 	}
 
+	done := make(chan struct{})
+	// On early error, kill the subprocess (if started) and signal
+	// auxiliary goroutines to stop.
+	success := false
+	defer func() {
+		if !success {
+			if cmd.Process != nil {
+				_ = cmd.Process.Kill()
+				_ = cmd.Wait()
+			}
+			close(done)
+		}
+	}()
+
 	go func() {
 		sc := bufio.NewScanner(stderr)
 		for sc.Scan() {
+			select {
+			case <-done:
+				return
+			default:
+			}
 			errorLog("subprocess %v: %v\n", program, sc.Text())
 		}
 	}()
@@ -99,7 +126,11 @@ func startClient(cfg Config, errorLog func(string, ...interface{})) (*SFTP, erro
 		err := cmd.Wait()
 		debug.Log("ssh command exited, err %v", err)
 		for {
-			ch <- errors.Wrap(err, "ssh command exited")
+			select {
+			case ch <- errors.Wrap(err, "ssh command exited"):
+			case <-done:
+				return
+			}
 		}
 	}()
 
@@ -120,26 +151,14 @@ func startClient(cfg Config, errorLog func(string, ...interface{})) (*SFTP, erro
 	}
 
 	_, posixRename := client.HasExtension("posix-rename@openssh.com")
-	return &SFTP{
-		c:           client,
-		cmd:         cmd,
+	success = true
+	return &connState{
+		client:      client,
+		cmd:         cmd.Process,
 		result:      ch,
 		posixRename: posixRename,
-		Layout:      layout.NewDefaultLayout(cfg.Path, path.Join),
+		done:        done,
 	}, nil
-}
-
-// clientError returns an error if the client has exited. Otherwise, nil is
-// returned immediately.
-func (r *SFTP) clientError() error {
-	select {
-	case err := <-r.result:
-		debug.Log("client has exited with err %v", err)
-		return backoff.Permanent(err)
-	default:
-	}
-
-	return nil
 }
 
 // Open opens an sftp backend as described by the config by running
@@ -147,27 +166,37 @@ func (r *SFTP) clientError() error {
 func Open(_ context.Context, cfg Config, errorLog func(string, ...interface{})) (*SFTP, error) {
 	debug.Log("open backend with config %#v", cfg)
 
-	sftp, err := startClient(cfg, errorLog)
+	cs, err := startClient(cfg, errorLog)
 	if err != nil {
 		debug.Log("unable to start program: %v", err)
 		return nil, err
 	}
 
-	return open(sftp, cfg)
+	be := &SFTP{
+		cs:    cs,
+		Layout:   layout.NewDefaultLayout(cfg.Path, path.Join),
+		errorLog: errorLog,
+		budget:   newReconnectBudget(),
+	}
+
+	return openBackend(be, cfg)
 }
 
-func open(sftp *SFTP, cfg Config) (*SFTP, error) {
-	fi, err := sftp.c.Stat(sftp.Layout.Filename(backend.Handle{Type: backend.ConfigFile}))
+func openBackend(be *SFTP, cfg Config) (*SFTP, error) {
+	cs := be.conn()
+	fi, err := cs.client.Stat(be.Layout.Filename(backend.Handle{Type: backend.ConfigFile}))
 	m := util.DeriveModesFromFileInfo(fi, err)
 	debug.Log("using (%03O file, %03O dir) permissions", m.File, m.Dir)
 
-	sftp.Config = cfg
-	sftp.p = cfg.Path
-	sftp.Modes = m
-	return sftp, nil
+	be.Config = cfg
+	be.p = cfg.Path
+	be.Modes = m
+	return be, nil
 }
 
 func (r *SFTP) mkdirAllDataSubdirs(ctx context.Context, nconn uint) error {
+	cs := r.conn()
+
 	// Run multiple MkdirAll calls concurrently. These involve multiple
 	// round-trips and we do a lot of them, so this whole operation can be slow
 	// on high-latency links.
@@ -181,10 +210,10 @@ func (r *SFTP) mkdirAllDataSubdirs(ctx context.Context, nconn uint) error {
 			// round trip, not counting duplicate parent creations causes by
 			// concurrency. MkdirAll first does Stat, then recursive MkdirAll
 			// on the parent, so calls typically take three round trips.
-			if err := r.c.Mkdir(d); err == nil {
+			if err := cs.client.Mkdir(d); err == nil {
 				return nil
 			}
-			return errors.Wrapf(r.c.MkdirAll(d), "MkdirAll %v", d)
+			return errors.Wrapf(cs.client.MkdirAll(d), "MkdirAll %v", d)
 		})
 	}
 
@@ -241,33 +270,44 @@ func buildSSHCommand(cfg Config) (cmd string, args []string, err error) {
 // Create creates an sftp backend as described by the config by running "ssh"
 // with the appropriate arguments (or cfg.Command, if set).
 func Create(ctx context.Context, cfg Config, errorLog func(string, ...interface{})) (*SFTP, error) {
-	sftp, err := startClient(cfg, errorLog)
+	cs, err := startClient(cfg, errorLog)
 	if err != nil {
 		debug.Log("unable to start program: %v", err)
 		return nil, err
 	}
 
-	sftp.Modes = util.DefaultModes
+	be := &SFTP{
+		cs:    cs,
+		Layout:   layout.NewDefaultLayout(cfg.Path, path.Join),
+		Modes:    util.DefaultModes,
+		errorLog: errorLog,
+		budget:   newReconnectBudget(),
+	}
 
 	// test if config file already exists
-	_, err = sftp.c.Lstat(sftp.Layout.Filename(backend.Handle{Type: backend.ConfigFile}))
+	_, err = cs.client.Lstat(be.Layout.Filename(backend.Handle{Type: backend.ConfigFile}))
 	if err == nil {
 		return nil, errors.New("config file already exists")
 	}
 
 	// create paths for data and refs
-	if err = sftp.mkdirAllDataSubdirs(ctx, cfg.Connections); err != nil {
+	if err = be.mkdirAllDataSubdirs(ctx, cfg.Connections); err != nil {
 		return nil, err
 	}
 
 	// repurpose existing connection
-	return open(sftp, cfg)
+	return openBackend(be, cfg)
 }
 
 func (r *SFTP) Properties() backend.Properties {
+	cs := r.conn()
+	posixRename := false
+	if cs != nil {
+		posixRename = cs.posixRename
+	}
 	return backend.Properties{
 		Connections:      r.Config.Connections,
-		HasAtomicReplace: r.posixRename,
+		HasAtomicReplace: posixRename,
 	}
 }
 
@@ -301,39 +341,57 @@ func setFileReadonly(client *sftp.Client, path string, mode os.FileMode) error {
 
 // Save stores data in the backend at the handle.
 func (r *SFTP) Save(_ context.Context, h backend.Handle, rd backend.RewindReader) error {
-	if err := r.clientError(); err != nil {
+	return r.saveWithRetry(h, rd)
+}
+
+// saveWithRetry performs a Save with one reconnect retry on transient disconnect.
+func (r *SFTP) saveWithRetry(h backend.Handle, rd backend.RewindReader) error {
+	cs, gen, err := r.getConn()
+	if err != nil {
 		return err
 	}
 
+	err = r.doSave(cs, h, rd)
+	if err == nil || r.Config.Reconnect == 0 || !isTransientDisconnect(err) {
+		return err
+	}
+
+	debug.Log("transient disconnect during Save, attempting reconnect (gen %d): %v", gen, err)
+
+	newCS, reconnErr := r.ensureConnected(gen)
+	if reconnErr != nil {
+		return reconnErr
+	}
+
+	if err := rd.Rewind(); err != nil {
+		return errors.Wrap(err, "Rewind")
+	}
+
+	return r.doSave(newCS, h, rd)
+}
+
+// doSave performs a single Save attempt with the given connection state.
+func (r *SFTP) doSave(cs *connState, h backend.Handle, rd backend.RewindReader) error {
 	filename := r.Filename(h)
 	tmpFilename := filename + "-restic-temp-" + tempSuffix()
 	dirname := r.Dirname(h)
 
 	// create new file
-	f, err := r.c.OpenFile(tmpFilename, os.O_CREATE|os.O_EXCL|os.O_WRONLY)
+	f, err := cs.client.OpenFile(tmpFilename, os.O_CREATE|os.O_EXCL|os.O_WRONLY)
 
 	if r.IsNotExist(err) {
 		// error is caused by a missing directory, try to create it
-		mkdirErr := r.c.MkdirAll(r.Dirname(h))
+		mkdirErr := cs.client.MkdirAll(r.Dirname(h))
 		if mkdirErr != nil {
 			debug.Log("error creating dir %v: %v", r.Dirname(h), mkdirErr)
 		} else {
 			// try again
-			f, err = r.c.OpenFile(tmpFilename, os.O_CREATE|os.O_EXCL|os.O_WRONLY)
+			f, err = cs.client.OpenFile(tmpFilename, os.O_CREATE|os.O_EXCL|os.O_WRONLY)
 		}
 	}
 
 	if err != nil {
 		return errors.Wrapf(err, "OpenFile %v", tmpFilename)
-	}
-
-	// pkg/sftp doesn't allow creating with a mode.
-	// Chmod while the file is still empty.
-	if err == nil {
-		err = f.Chmod(r.Modes.File)
-		if err != nil {
-			return errors.Wrapf(err, "Chmod %v", tmpFilename)
-		}
 	}
 
 	defer func() {
@@ -342,18 +400,29 @@ func (r *SFTP) Save(_ context.Context, h backend.Handle, rd backend.RewindReader
 		}
 
 		// Try not to leave a partial file behind.
-		rmErr := r.c.Remove(f.Name())
+		rmErr := cs.client.Remove(f.Name())
 		if rmErr != nil {
 			debug.Log("sftp: failed to remove broken file %v: %v",
 				f.Name(), rmErr)
 		}
 	}()
 
+	// pkg/sftp doesn't allow creating with a mode.
+	// Chmod while the file is still empty.
+	err = f.Chmod(r.Modes.File)
+	if err != nil {
+		return errors.Wrapf(err, "Chmod %v", tmpFilename)
+	}
+
 	// save data, make sure to use the optimized sftp upload method
 	wbytes, err := f.ReadFromWithConcurrency(rd, 0)
 	if err != nil {
 		_ = f.Close()
-		err = r.checkNoSpace(dirname, rd.Length(), err)
+		// Skip checkNoSpace on transient disconnects — the connection is
+		// dead and StatVFS would also fail.
+		if !isTransientDisconnect(err) {
+			err = r.checkNoSpace(cs, dirname, rd.Length(), err)
+		}
 		return errors.Wrapf(err, "Write %v", tmpFilename)
 	}
 
@@ -368,33 +437,37 @@ func (r *SFTP) Save(_ context.Context, h backend.Handle, rd backend.RewindReader
 	}
 
 	// Prefer POSIX atomic rename if available.
-	if r.posixRename {
-		err = r.c.PosixRename(tmpFilename, filename)
+	if cs.posixRename {
+		err = cs.client.PosixRename(tmpFilename, filename)
 	} else {
-		err = r.c.Rename(tmpFilename, filename)
+		err = cs.client.Rename(tmpFilename, filename)
 	}
-	err = setFileReadonly(r.c, filename, r.Modes.File)
+	if err != nil {
+		return errors.Wrapf(err, "Rename %v", tmpFilename)
+	}
+
+	err = setFileReadonly(cs.client, filename, r.Modes.File)
 	if err != nil {
 		return errors.Errorf("sftp setFileReadonly: %v", err)
 	}
 
-	return errors.Wrapf(err, "Rename %v", tmpFilename)
+	return nil
 }
 
 // checkNoSpace checks if err was likely caused by lack of available space
 // on the remote, and if so, makes it permanent.
-func (r *SFTP) checkNoSpace(dir string, size int64, origErr error) error {
+func (r *SFTP) checkNoSpace(cs *connState, dir string, size int64, origErr error) error {
 	// The SFTP protocol has a message for ENOSPC,
 	// but pkg/sftp doesn't export it and OpenSSH's sftp-server
 	// sends FX_FAILURE instead.
 
 	e, ok := origErr.(*sftp.StatusError)
-	_, hasExt := r.c.HasExtension("statvfs@openssh.com")
+	_, hasExt := cs.client.HasExtension("statvfs@openssh.com")
 	if !ok || e.FxCode() != sftp.ErrSSHFxFailure || !hasExt {
 		return origErr
 	}
 
-	fsinfo, err := r.c.StatVFS(dir)
+	fsinfo, err := cs.client.StatVFS(dir)
 	if err != nil {
 		debug.Log("sftp: StatVFS returned %v", err)
 		return origErr
@@ -409,32 +482,37 @@ func (r *SFTP) checkNoSpace(dir string, size int64, origErr error) error {
 // Load runs fn with a reader that yields the contents of the file at h at the
 // given offset.
 func (r *SFTP) Load(ctx context.Context, h backend.Handle, length int, offset int64, fn func(rd io.Reader) error) error {
-	if err := r.clientError(); err != nil {
-		return err
-	}
+	return r.withRetry(func(cs *connState) error {
+		return util.DefaultLoad(ctx, h, length, offset, r.openReaderWith(cs), func(rd io.Reader) error {
+			if length == 0 || !feature.Flag.Enabled(feature.BackendErrorRedesign) {
+				return fn(rd)
+			}
 
-	return util.DefaultLoad(ctx, h, length, offset, r.openReader, func(rd io.Reader) error {
-		if length == 0 || !feature.Flag.Enabled(feature.BackendErrorRedesign) {
-			return fn(rd)
-		}
+			// there is no direct way to efficiently check whether the file is too short
+			// rd is already a LimitedReader which can be used to track the number of bytes read
+			err := fn(rd)
 
-		// there is no direct way to efficiently check whether the file is too short
-		// rd is already a LimitedReader which can be used to track the number of bytes read
-		err := fn(rd)
+			// check the underlying reader to be agnostic to however fn() handles the returned error
+			_, rderr := rd.Read([]byte{0})
+			if rderr == io.EOF && rd.(*util.LimitedReadCloser).N != 0 {
+				// file is too short
+				return fmt.Errorf("%w: %v", errTooShort, err)
+			}
 
-		// check the underlying reader to be agnostic to however fn() handles the returned error
-		_, rderr := rd.Read([]byte{0})
-		if rderr == io.EOF && rd.(*util.LimitedReadCloser).N != 0 {
-			// file is too short
-			return fmt.Errorf("%w: %v", errTooShort, err)
-		}
-
-		return err
+			return err
+		})
 	})
 }
 
-func (r *SFTP) openReader(_ context.Context, h backend.Handle, length int, offset int64) (io.ReadCloser, error) {
-	f, err := r.c.Open(r.Filename(h))
+// openReaderWith returns an openReader function bound to the given connState.
+func (r *SFTP) openReaderWith(cs *connState) func(ctx context.Context, h backend.Handle, length int, offset int64) (io.ReadCloser, error) {
+	return func(_ context.Context, h backend.Handle, length int, offset int64) (io.ReadCloser, error) {
+		return r.doOpenReader(cs, h, length, offset)
+	}
+}
+
+func (r *SFTP) doOpenReader(cs *connState, h backend.Handle, length int, offset int64) (io.ReadCloser, error) {
+	f, err := cs.client.Open(r.Filename(h))
 	if err != nil {
 		return nil, errors.Wrapf(err, "Open %v", r.Filename(h))
 	}
@@ -458,48 +536,60 @@ func (r *SFTP) openReader(_ context.Context, h backend.Handle, length int, offse
 
 // Stat returns information about a blob.
 func (r *SFTP) Stat(_ context.Context, h backend.Handle) (backend.FileInfo, error) {
-	if err := r.clientError(); err != nil {
-		return backend.FileInfo{}, err
-	}
-
-	fi, err := r.c.Lstat(r.Filename(h))
-	if err != nil {
-		return backend.FileInfo{}, errors.Wrapf(err, "Lstat %v", r.Filename(h))
-	}
-
-	return backend.FileInfo{Size: fi.Size(), Name: h.Name}, nil
+	var fi backend.FileInfo
+	err := r.withRetry(func(cs *connState) error {
+		osfi, err := cs.client.Lstat(r.Filename(h))
+		if err != nil {
+			return errors.Wrapf(err, "Lstat %v", r.Filename(h))
+		}
+		fi = backend.FileInfo{Size: osfi.Size(), Name: h.Name}
+		return nil
+	})
+	return fi, err
 }
 
 // Remove removes the content stored at name.
 func (r *SFTP) Remove(_ context.Context, h backend.Handle) error {
-	if err := r.clientError(); err != nil {
-		return err
-	}
-
-	return errors.Wrapf(r.c.Remove(r.Filename(h)), "Remove %v", r.Filename(h))
+	return r.withRetry(func(cs *connState) error {
+		return errors.Wrapf(cs.client.Remove(r.Filename(h)), "Remove %v", r.Filename(h))
+	})
 }
 
 // List runs fn for each file in the backend which has the type t. When an
 // error occurs (or fn returns an error), List stops and returns it.
+//
+// List does not retry internally (restarting would deliver duplicates to fn).
+// On transient disconnect it triggers a reconnect so that the outer retry
+// backend's next attempt gets a fresh connection.
 func (r *SFTP) List(ctx context.Context, t backend.FileType, fn func(backend.FileInfo) error) error {
-	if err := r.clientError(); err != nil {
+	cs, gen, err := r.getConn()
+	if err != nil {
 		return err
 	}
 
 	basedir, subdirs := r.Basedir(t)
-	walker := r.c.Walk(basedir)
+	walker := cs.client.Walk(basedir)
 	for {
 		ok := walker.Step()
 		if !ok {
 			break
 		}
 
-		if walker.Err() != nil {
-			if r.IsNotExist(walker.Err()) {
+		if walkErr := walker.Err(); walkErr != nil {
+			if r.IsNotExist(walkErr) {
 				debug.Log("ignoring non-existing directory")
 				return nil
 			}
-			return errors.Wrapf(walker.Err(), "Walk %v", basedir)
+			err := errors.Wrapf(walkErr, "Walk %v", basedir)
+			// Trigger reconnect so the outer retry backend's next
+			// attempt gets a fresh connection.
+			if r.Config.Reconnect > 0 && isTransientDisconnect(walkErr) {
+				debug.Log("List: transient disconnect, triggering reconnect (gen %d): %v", gen, err)
+				if _, reconnErr := r.ensureConnected(gen); reconnErr != nil {
+					return reconnErr
+				}
+			}
+			return err
 		}
 
 		if walker.Path() == basedir {
@@ -548,27 +638,23 @@ func (r *SFTP) Close() error {
 		return nil
 	}
 
-	err := errors.Wrap(r.c.Close(), "Close")
-	debug.Log("Close returned error %v", err)
+	r.closed.Store(true)
 
-	// wait for closeTimeout before killing the process
-	select {
-	case err := <-r.result:
-		return err
-	case <-time.After(closeTimeout):
+	r.connMu.Lock()
+	cs := r.cs
+	r.cs = nil
+	r.connMu.Unlock()
+
+	if cs == nil {
+		return nil
 	}
 
-	if err := r.cmd.Process.Kill(); err != nil {
-		return err
-	}
-
-	// get the error, but ignore it
-	<-r.result
+	cs.close()
 	return nil
 }
 
-func (r *SFTP) deleteRecursive(ctx context.Context, name string) error {
-	entries, err := r.c.ReadDir(name)
+func (r *SFTP) deleteRecursive(ctx context.Context, cs *connState, name string) error {
+	entries, err := cs.client.ReadDir(name)
 	if err != nil {
 		return errors.Wrapf(err, "ReadDir %v", name)
 	}
@@ -580,12 +666,12 @@ func (r *SFTP) deleteRecursive(ctx context.Context, name string) error {
 
 		itemName := path.Join(name, fi.Name())
 		if fi.IsDir() {
-			err := r.deleteRecursive(ctx, itemName)
+			err := r.deleteRecursive(ctx, cs, itemName)
 			if err != nil {
 				return err
 			}
 
-			err = r.c.RemoveDirectory(itemName)
+			err = cs.client.RemoveDirectory(itemName)
 			if err != nil {
 				return errors.Wrapf(err, "RemoveDirectory %v", itemName)
 			}
@@ -593,7 +679,7 @@ func (r *SFTP) deleteRecursive(ctx context.Context, name string) error {
 			continue
 		}
 
-		err := r.c.Remove(itemName)
+		err := cs.client.Remove(itemName)
 		if err != nil {
 			return errors.Wrapf(err, "Remove %v", itemName)
 		}
@@ -603,8 +689,14 @@ func (r *SFTP) deleteRecursive(ctx context.Context, name string) error {
 }
 
 // Delete removes all data in the backend.
+// Delete is not retried on disconnect because deleteRecursive is not
+// idempotent — already-deleted files would cause errors on retry.
 func (r *SFTP) Delete(ctx context.Context) error {
-	return r.deleteRecursive(ctx, r.p)
+	cs, _, err := r.getConn()
+	if err != nil {
+		return err
+	}
+	return r.deleteRecursive(ctx, cs, r.p)
 }
 
 // Warmup not implemented


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds optional automatic reconnect support for the SFTP backend via `-o sftp.reconnect=N`, where N is the maximum number of reconnect attempts allowed per session (default 0, disabled).

I was facing the same issues as discussed in #353, also with Hetzner. I reached out to their support and they looked in their logs and they see a whole bunch of this:

```
2026-02-26T08:12:13.533402+00:00 [info]: Accepted publickey for <redacted> from
<redacted> port 35188 ssh2: ED25519
SHA256:<redacted>
2026-02-26T08:24:19.269730+00:00 [info]: Timeout, client not responding from
user <redacted> <redacted> port 35188
```

This meant that my initial backup never succeeded (I've now waited for over a month of daily backups).
I've never had this issue before with B2 or anywhere else so....not sure what the root cause is.

On the restic side I just saw that it disconnects and never reconnects, causing the entire backup to fail. With this option enabled, restic detects transient disconnects, reconnects the SSH session, and retries the interrupted operation.

_Full disclosure / AI usage_: While I'm an experienced software developer (or at least I like to think so :) ) I'm not a Go person. I reviewed everything manually to the best of my abilities but in the end I had help by Claude.

I tried to incorporate the early feedback from another older PR:

- Opt-in: Reconnect is disabled by default
- Concurrency concerns: Concurrent uploads that all hit a disconnect trigger exactly one reconnect
- Exponential backoff with jitter
- The reconnect counter resets after 5 minutes of stable operation. My initial backup ran for hours and without this reset it'd still never finish

Save, Load, Stat, and Remove retry once after reconnect. List and Delete trigger a reconnect on transient failure but do not retry internally (List to avoid delivering duplicate entries, Delete because recursive deletion is not idempotent). The outer retry backend handles the next attempt with a fresh connection (I believe).


Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Yes, it (hopefully) closes #353

This supersedes the draft in #4058, addressing the feedback from that PR (see above)


Checklist
---------       

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
