### PR TITLE
Add flake.nix for NixCI

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1773821835,
+        "narHash": "sha256-TJ3lSQtW0E2JrznGVm8hOQGVpXjJyXY2guAxku2O9A4=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b40629efe5d6ec48dd1efba650c797ddbd39ace0",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,39 @@
+{
+  description = "restic - Backup program that is fast, efficient and secure";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = import nixpkgs { inherit system; };
+    in
+    {
+      packages.${system} = {
+        default = pkgs.buildGoModule {
+          pname = "restic";
+          version = "dev";
+          src = self;
+          subPackages = [ "cmd/restic" ];
+          vendorHash = "sha256-ULyz3M9RDztoVbeuEb5RjIzS51/GN+7/bKR6QBCM7Fg=";
+          # Integration tests require permissions not available in the Nix build sandbox
+          doCheck = false;
+        };
+      };
+
+      devShells.${system} = {
+        default = pkgs.mkShell {
+          buildInputs = [
+            pkgs.go
+          ];
+        };
+      };
+
+      checks.${system} = {
+        package = self.packages.${system}.default;
+        devShell = self.devShells.${system}.default;
+      };
+    };
+}


### PR DESCRIPTION
Adds a Nix flake that builds restic from source with a development shell.

Hi! I saw that you scheduled a demo on https://nix-ci.com but it failed
because had no flake.nix so I decided to make you one so you can really try    
it out.    
You can see it passing here: https://staging.nix-ci.com/gh:NorfairKing:restic/your-first-flake/f242555060501540624d13634f65502a2c6f2808           
                                                                         
Please let me know if you have any feedback!

