### PR TITLE
Fix a typo in the contributing docs

### DIFF
--- a/doc/090_participating.rst
+++ b/doc/090_participating.rst
@@ -166,7 +166,7 @@ The classical helpers for integration tests are, amongst others:
 - ``testListSnapshots(t, env.gopts, <n>)``: check that there are <n> snapshots in the repository
 - ``testRunCheck(t, env.gopts)``: check that the repository is sound and happy
 - the above mentioned ``rtest.OK()``, ``rtest.Equals()``, ``rtest.Assert()`` helpers
-- ``withCaptureStdout()`` and ``withTermStatus()`` wrappers: both functions are found in ``cmd/restic/integration_helpers_test.go`` for creating an enviroment where one can analyze the output created by the ``testRunXXX()`` command, particularly when checking JSON output
+- ``withCaptureStdout()`` and ``withTermStatus()`` wrappers: both functions are found in ``cmd/restic/integration_helpers_test.go`` for creating an environment where one can analyze the output created by the ``testRunXXX()`` command, particularly when checking JSON output
 
 Integration tests test the overall workings of a command. Integration tests are used for commands and
 are stored in the same directory ``cmd/restic``. The recommended naming convention is


### PR DESCRIPTION
## Summary
- Fix the "enviroment" typo in the contributing guide.

## Related issue
- N/A (trivial docs wording fix)

## Guideline alignment
- Docs-only change with no behavior impact.
- Followed https://github.com/restic/restic/blob/master/CONTRIBUTING.md
- This file is not one of the autogenerated man-page sources called out in CONTRIBUTING.

## Validation
- Not run; docs-only change.