### PR TITLE
docs: fix Nix installation typo

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -114,7 +114,7 @@ Nix & NixOS
 ===========
 
 If you are using `Nix / NixOS <https://nixos.org>`__,
-there is a package named ``restic`` avaliable in `nixpkgs <https://search.nixos.org/packages?query=restic>`__.
+there is a package named ``restic`` available in `nixpkgs <https://search.nixos.org/packages?query=restic>`__.
 You can install it by adding this to your ``configuration.nix``:
 
 .. code-block:: console


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
It fixes a typo in the Nix & NixOS installation docs by changing `avaliable` to `available` in `doc/020_installation.rst`.

Summary
- fix a typo in the Nix installation documentation

Related issue
- N/A; trivial documentation typo fix.

Guideline alignment
- Followed https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches and kept this to a single documentation file with no behavior change.

Validation/testing note
- Not run; documentation-only change.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No. This is a trivial documentation typo fix.

Checklist
---------
- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in changelog/unreleased/ that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I am done. This pull request is ready for review.
