### PR TITLE
Fix typo in the Nix installation docs

### DIFF
--- a/doc/020_installation.rst
+++ b/doc/020_installation.rst
@@ -114,7 +114,7 @@ Nix & NixOS
 ===========
 
 If you are using `Nix / NixOS <https://nixos.org>`__,
-there is a package named ``restic`` avaliable in `nixpkgs <https://search.nixos.org/packages?query=restic>`__.
+there is a package named ``restic`` available in `nixpkgs <https://search.nixos.org/packages?query=restic>`__.
 You can install it by adding this to your ``configuration.nix``:
 
 .. code-block:: console


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Fix the typo "avaliable" in the Nix/NixOS installation docs.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

N/A, trivial documentation typo fix.

Checklist
---------

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.

Validation/testing note: Not run; documentation-only change.