### PR TITLE
Feature/tracing

### DIFF
--- a/changelog/unreleased/pull-21782
+++ b/changelog/unreleased/pull-21782
@@ -1,0 +1,10 @@
+Enhancement: Add tracing with OTEL
+
+In a large infrastructure we need to know what's wrong with our backups and where the error occurs. Therefore we can use logs. However Logs only tell a story without context. OTEL can be used to add a context to the logs. I've implemented OTEL tracing in this PR. Therefore we'll know if somethig goes wrong and were the problem occurs without even looking through distributed logs.
+
+The OTEL tracing feature is optional and disabled by default. No braking changes. No leaks of data in the traces. We now knows which command has been run, the duration, if an error occurred and where the problem is.
+
+Tested on Debian12 & 13, Ubuntu 22.04 & 24.04, Raspberry Pi OS 13 with http, local and s3 backend repository. I havn't windows or mac to test the code.
+
+
+https://github.com/restic/restic/pull/21782

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -28,6 +28,7 @@ import (
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/textfile"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/backup"
 )
@@ -555,7 +556,11 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 		printer.V("load index files")
 	}
 
-	err = repo.LoadIndex(ctx, printer)
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.backup.load_index")
+		err = repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, err)
+	}
 	if err != nil {
 		return err
 	}
@@ -630,7 +635,12 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 		if !gopts.JSON {
 			printer.V("start scan on %v", targets)
 		}
-		wg.Go(func() error { return sc.Scan(cancelCtx, targets) })
+		scanCtx, scanSpan := tracing.Tracer().Start(cancelCtx, "restic.backup.scan_sources")
+		wg.Go(func() error {
+			err := sc.Scan(scanCtx, targets)
+			tracing.EndSpanWithError(scanSpan, err)
+			return err
+		})
 	}
 
 	arch := archiver.New(repo, targetFS, archiver.Options{ReadConcurrency: opts.ReadConcurrency})
@@ -675,7 +685,9 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 	if !gopts.JSON {
 		printer.V("start backup on %v", targets)
 	}
-	_, id, summary, err := arch.Snapshot(ctx, targets, snapshotOpts)
+	snapCtx, snapSpan := tracing.Tracer().Start(ctx, "restic.backup.create_snapshot")
+	_, id, summary, err := arch.Snapshot(snapCtx, targets, snapshotOpts)
+	tracing.EndSpanWithError(snapSpan, err)
 
 	// cleanly shutdown all running goroutines
 	cancel()

--- a/cmd/restic/cmd_cache.go
+++ b/cmd/restic/cmd_cache.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -11,6 +12,7 @@ import (
 	"github.com/restic/restic/internal/backend/cache"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/table"
 	"github.com/spf13/cobra"
@@ -34,8 +36,8 @@ Exit status is 1 if there was any error.
 `,
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
-		RunE: func(_ *cobra.Command, args []string) error {
-			return runCache(opts, *globalOptions, args, globalOptions.Term)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runCache(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 
@@ -56,7 +58,11 @@ func (opts *CacheOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.NoSize, "no-size", false, "do not output the size of the cache directories")
 }
 
-func runCache(opts CacheOptions, gopts global.Options, args []string, term ui.Terminal) error {
+func runCache(ctx context.Context, opts CacheOptions, gopts global.Options, args []string, term ui.Terminal) error {
+	cacheCtx, cacheSpan := tracing.Tracer().Start(ctx, "restic.cache")
+	defer tracing.EndSpanWithError(cacheSpan, nil)
+	ctx = cacheCtx
+
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 
 	if len(args) > 0 {

--- a/cmd/restic/cmd_cat.go
+++ b/cmd/restic/cmd_cat.go
@@ -12,6 +12,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 )
 
@@ -170,7 +171,11 @@ func runCat(ctx context.Context, gopts global.Options, args []string, term ui.Te
 		return err
 
 	case "blob":
-		err = repo.LoadIndex(ctx, printer)
+		{
+			indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.cat.load_index")
+			err = repo.LoadIndex(indexCtx, printer)
+			tracing.EndSpanWithError(indexSpan, err)
+		}
 		if err != nil {
 			return err
 		}
@@ -197,7 +202,11 @@ func runCat(ctx context.Context, gopts global.Options, args []string, term ui.Te
 			return errors.Fatalf("could not find snapshot: %v", err)
 		}
 
-		err = repo.LoadIndex(ctx, printer)
+		{
+			indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.cat.load_index")
+			err = repo.LoadIndex(indexCtx, printer)
+			tracing.EndSpanWithError(indexSpan, err)
+		}
 		if err != nil {
 			return err
 		}

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -20,6 +20,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 )
@@ -251,7 +252,13 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 	}
 
 	printer.P("load indexes\n")
-	hints, errs := chkr.LoadIndex(ctx, printer)
+	indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.check.load_index")
+	hints, errs := chkr.LoadIndex(indexCtx, printer)
+	var indexErr error
+	if len(errs) > 0 {
+		indexErr = errs[0]
+	}
+	tracing.EndSpanWithError(indexSpan, indexErr)
 	if ctx.Err() != nil {
 		return summary, ctx.Err()
 	}
@@ -294,7 +301,8 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 	salvagePacks := restic.NewIDSet()
 
 	printer.P("check all packs\n")
-	go chkr.Packs(ctx, errChan)
+	packsCtx, packsSpan := tracing.Tracer().Start(ctx, "restic.check.check_packs")
+	go chkr.Packs(packsCtx, errChan)
 
 	for err := range errChan {
 		var packErr *repository.PackError
@@ -315,6 +323,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 			printer.E("%v\n", err)
 		}
 	}
+	tracing.EndSpanWithError(packsSpan, nil)
 
 	if orphanedPacks > 0 {
 		summary.HintPrune = true
@@ -331,12 +340,13 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 	errChan = make(chan error)
 	var wg sync.WaitGroup
 
+	structCtx, structSpan := tracing.Tracer().Start(ctx, "restic.check.check_structure")
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
 		bar := printer.NewCounter("snapshots")
 		defer bar.Done()
-		chkr.Structure(ctx, bar, errChan)
+		chkr.Structure(structCtx, bar, errChan)
 	}()
 
 	for err := range errChan {
@@ -357,6 +367,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 	// Must happen after `errChan` is read from in the above loop to avoid
 	// deadlocking in the case of errors.
 	wg.Wait()
+	tracing.EndSpanWithError(structSpan, nil)
 	if ctx.Err() != nil {
 		return summary, ctx.Err()
 	}
@@ -382,7 +393,8 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 		p := printer.NewCounter("packs")
 		errChan := make(chan error)
 
-		go chkr.ReadPacks(ctx, readDataFilter, p, errChan)
+		readCtx, readSpan := tracing.Tracer().Start(ctx, "restic.check.read_data")
+		go chkr.ReadPacks(readCtx, readDataFilter, p, errChan)
 
 		for err := range errChan {
 			errorsFound = true
@@ -393,6 +405,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 			}
 		}
 		p.Done()
+		tracing.EndSpanWithError(readSpan, nil)
 	}
 
 	if len(salvagePacks) > 0 {

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -13,6 +13,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 
@@ -139,12 +140,22 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args [
 	}
 
 	debug.Log("Loading source index")
-	if err := srcRepo.LoadIndex(ctx, printer); err != nil {
-		return err
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.copy.load_src_index")
+		indexErr := srcRepo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, indexErr)
+		if indexErr != nil {
+			return indexErr
+		}
 	}
 	debug.Log("Loading destination index")
-	if err := dstRepo.LoadIndex(ctx, printer); err != nil {
-		return err
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.copy.load_dst_index")
+		indexErr := dstRepo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, indexErr)
+		if indexErr != nil {
+			return indexErr
+		}
 	}
 
 	dstSnapshotByOriginal := make(map[restic.ID][]*data.Snapshot)
@@ -161,8 +172,11 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args [
 
 	selectedSnapshots := collectAllSnapshots(ctx, opts, srcSnapshotLister, srcRepo, dstSnapshotByOriginal, args, printer)
 
-	if err := copyTreeBatched(ctx, srcRepo, dstRepo, selectedSnapshots, printer); err != nil {
-		return err
+	copyCtx, copySpan := tracing.Tracer().Start(ctx, "restic.copy.copy_blobs")
+	copyErr := copyTreeBatched(copyCtx, srcRepo, dstRepo, selectedSnapshots, printer)
+	tracing.EndSpanWithError(copySpan, copyErr)
+	if copyErr != nil {
+		return copyErr
 	}
 
 	return ctx.Err()

--- a/cmd/restic/cmd_debug.go
+++ b/cmd/restic/cmd_debug.go
@@ -28,6 +28,7 @@ import (
 	"github.com/restic/restic/internal/repository/index"
 	"github.com/restic/restic/internal/repository/pack"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 )
@@ -199,30 +200,28 @@ func runDebugDump(ctx context.Context, gopts global.Options, args []string, term
 
 	tpe := args[0]
 
+	dumpCtx, dumpSpan := tracing.Tracer().Start(ctx, "restic.debug.dump")
+	defer func() { tracing.EndSpanWithError(dumpSpan, err) }()
+
 	switch tpe {
 	case "indexes":
-		return dumpIndexes(ctx, repo, gopts.Term.OutputWriter(), printer)
+		err = dumpIndexes(dumpCtx, repo, gopts.Term.OutputWriter(), printer)
 	case "snapshots":
-		return debugPrintSnapshots(ctx, repo, gopts.Term.OutputWriter())
+		err = debugPrintSnapshots(dumpCtx, repo, gopts.Term.OutputWriter())
 	case "packs":
-		return printPacks(ctx, repo, gopts.Term.OutputWriter(), printer)
+		err = printPacks(dumpCtx, repo, gopts.Term.OutputWriter(), printer)
 	case "all":
 		printer.S("snapshots:")
-		err := debugPrintSnapshots(ctx, repo, gopts.Term.OutputWriter())
+		err = debugPrintSnapshots(dumpCtx, repo, gopts.Term.OutputWriter())
 		if err != nil {
 			return err
 		}
-
 		printer.S("indexes:")
-		err = dumpIndexes(ctx, repo, gopts.Term.OutputWriter(), printer)
-		if err != nil {
-			return err
-		}
-
-		return nil
+		err = dumpIndexes(dumpCtx, repo, gopts.Term.OutputWriter(), printer)
 	default:
-		return errors.Fatalf("no such type %q", tpe)
+		err = errors.Fatalf("no such type %q", tpe)
 	}
+	return err
 }
 
 func tryRepairWithBitflip(key *crypto.Key, input []byte, bytewise bool, printer progress.Printer) []byte {
@@ -474,13 +473,17 @@ func runDebugExamine(ctx context.Context, gopts global.Options, opts DebugExamin
 		return errors.Fatal("no pack files to examine")
 	}
 
-	err = repo.LoadIndex(ctx, printer)
+	indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.debug.examine.load_index")
+	err = repo.LoadIndex(indexCtx, printer)
+	tracing.EndSpanWithError(indexSpan, err)
 	if err != nil {
 		return err
 	}
 
+	examineCtx, examineSpan := tracing.Tracer().Start(ctx, "restic.debug.examine")
+	defer tracing.EndSpanWithError(examineSpan, nil)
 	for _, id := range ids {
-		err := examinePack(ctx, opts, repo, id, printer)
+		err := examinePack(examineCtx, opts, repo, id, printer)
 		if err != nil {
 			printer.E("error: %v", err)
 		}

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -11,6 +11,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -384,7 +385,12 @@ func runDiff(ctx context.Context, opts DiffOptions, gopts global.Options, args [
 	if !gopts.JSON {
 		printer.P("comparing snapshot %v to %v:\n\n", sn1.ID().Str(), sn2.ID().Str())
 	}
-	if err = repo.LoadIndex(ctx, printer); err != nil {
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.diff.load_index")
+		err = repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, err)
+	}
+	if err != nil {
 		return err
 	}
 
@@ -440,7 +446,9 @@ func runDiff(ctx context.Context, opts DiffOptions, gopts global.Options, args [
 	stats.BlobsBefore.Insert(restic.BlobHandle{Type: restic.TreeBlob, ID: *sn1.Tree})
 	stats.BlobsAfter.Insert(restic.BlobHandle{Type: restic.TreeBlob, ID: *sn2.Tree})
 
-	err = c.diffTree(ctx, stats, "/", *sn1.Tree, *sn2.Tree)
+	diffCtx, diffSpan := tracing.Tracer().Start(ctx, "restic.diff.compute_diff")
+	err = c.diffTree(diffCtx, stats, "/", *sn1.Tree, *sn2.Tree)
+	tracing.EndSpanWithError(diffSpan, err)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -13,6 +13,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 
 	"github.com/spf13/cobra"
@@ -162,7 +163,11 @@ func runDump(ctx context.Context, opts DumpOptions, gopts global.Options, args [
 		return errors.Fatalf("failed to find snapshot: %v", err)
 	}
 
-	err = repo.LoadIndex(ctx, printer)
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.dump.load_index")
+		err = repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, err)
+	}
 	if err != nil {
 		return err
 	}
@@ -194,7 +199,9 @@ func runDump(ctx context.Context, opts DumpOptions, gopts global.Options, args [
 	}
 
 	d := dump.New(opts.Archive, repo, outputFileWriter)
-	err = printFromTree(ctx, tree, repo, "/", splittedPath, d, canWriteArchiveFunc)
+	dumpCtx, dumpSpan := tracing.Tracer().Start(ctx, "restic.dump.dump_files")
+	err = printFromTree(dumpCtx, tree, repo, "/", splittedPath, d, canWriteArchiveFunc)
+	tracing.EndSpanWithError(dumpSpan, err)
 	if err != nil {
 		return errors.Fatalf("cannot dump file: %v", err)
 	}

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -18,6 +18,7 @@ import (
 	"github.com/restic/restic/internal/filter"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/walker"
 )
@@ -640,7 +641,12 @@ func runFind(ctx context.Context, opts FindOptions, gopts global.Options, args [
 	if err != nil {
 		return err
 	}
-	if err = repo.LoadIndex(ctx, printer); err != nil {
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.find.load_index")
+		err = repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, err)
+	}
+	if err != nil {
 		return err
 	}
 
@@ -672,8 +678,12 @@ func runFind(ctx context.Context, opts FindOptions, gopts global.Options, args [
 	}
 
 	var filteredSnapshots []*data.Snapshot
-	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &opts.SnapshotFilter, opts.Snapshots, printer) {
-		filteredSnapshots = append(filteredSnapshots, sn)
+	{
+		snapshotCtx, snapshotSpan := tracing.Tracer().Start(ctx, "restic.find.filter_snapshots")
+		for sn := range FindFilteredSnapshots(snapshotCtx, snapshotLister, repo, &opts.SnapshotFilter, opts.Snapshots, printer) {
+			filteredSnapshots = append(filteredSnapshots, sn)
+		}
+		tracing.EndSpanWithError(snapshotSpan, ctx.Err())
 	}
 	if ctx.Err() != nil {
 		return ctx.Err()
@@ -686,17 +696,21 @@ func runFind(ctx context.Context, opts FindOptions, gopts global.Options, args [
 		return filteredSnapshots[i].Time.After(filteredSnapshots[j].Time)
 	})
 
+	searchCtx, searchSpan := tracing.Tracer().Start(ctx, "restic.find.search_files_in_snapshots")
 	for _, sn := range filteredSnapshots {
 		if f.blobIDs != nil || f.treeIDs != nil {
-			if err = f.findIDs(ctx, sn); err != nil && err.Error() != "OK" {
+			if err = f.findIDs(searchCtx, sn); err != nil && err.Error() != "OK" {
+				tracing.EndSpanWithError(searchSpan, err)
 				return err
 			}
 			continue
 		}
-		if err = f.findInSnapshot(ctx, sn); err != nil {
+		if err = f.findInSnapshot(searchCtx, sn); err != nil {
+			tracing.EndSpanWithError(searchSpan, err)
 			return err
 		}
 	}
+	tracing.EndSpanWithError(searchSpan, nil)
 	f.out.Finish()
 
 	if opts.ShowPackID && (f.blobIDs != nil || f.treeIDs != nil) {

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -11,6 +11,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -310,9 +311,10 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 	// these are the snapshots that failed to be removed
 	failedSnIDs := restic.NewIDSet()
 	if len(removeSnIDs) > 0 {
+		removeCtx, removeSpan := tracing.Tracer().Start(ctx, "restic.forget.remove_snapshots")
 		if !opts.DryRun {
 			bar := printer.NewCounter("files deleted")
-			err := restic.ParallelRemove(ctx, repo, removeSnIDs, restic.WriteableSnapshotFile, func(id restic.ID, err error) error {
+			err := restic.ParallelRemove(removeCtx, repo, removeSnIDs, restic.WriteableSnapshotFile, func(id restic.ID, err error) error {
 				if err != nil {
 					printer.E("unable to remove %v/%v from the repository\n", restic.SnapshotFile, id)
 					failedSnIDs.Insert(id)
@@ -322,11 +324,13 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 				return nil
 			}, bar)
 			bar.Done()
+			tracing.EndSpanWithError(removeSpan, err)
 			if err != nil {
 				return err
 			}
 		} else {
 			printer.P("Would have removed the following snapshots:\n%v\n\n", removeSnIDs)
+			tracing.EndSpanWithError(removeSpan, nil)
 		}
 	}
 

--- a/cmd/restic/cmd_generate.go
+++ b/cmd/restic/cmd_generate.go
@@ -1,12 +1,14 @@
 package main
 
 import (
+	"context"
 	"io"
 	"os"
 	"time"
 
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 	"github.com/spf13/cobra"
@@ -31,8 +33,8 @@ Exit status is 0 if the command was successful.
 Exit status is 1 if there was any error.
 `,
 		DisableAutoGenTag: true,
-		RunE: func(_ *cobra.Command, args []string) error {
-			return runGenerate(opts, *globalOptions, args, globalOptions.Term)
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runGenerate(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
 		},
 	}
 	opts.AddFlags(cmd.Flags())
@@ -111,10 +113,13 @@ func checkStdoutForSingleShell(opts generateOptions) error {
 	return nil
 }
 
-func runGenerate(opts generateOptions, gopts global.Options, args []string, term ui.Terminal) error {
+func runGenerate(ctx context.Context, opts generateOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	if len(args) > 0 {
 		return errors.Fatal("the generate command expects no arguments, only options - please see `restic help generate` for usage and flags")
 	}
+
+	_, genSpan := tracing.Tracer().Start(ctx, "restic.generate")
+	defer tracing.EndSpanWithError(genSpan, nil)
 
 	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
 	cmdRoot := newRootCommand(&global.Options{})

--- a/cmd/restic/cmd_generate_integration_test.go
+++ b/cmd/restic/cmd_generate_integration_test.go
@@ -11,7 +11,7 @@ import (
 
 func testRunGenerate(t testing.TB, gopts global.Options, opts generateOptions) ([]byte, error) {
 	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
-		return runGenerate(opts, gopts, []string{}, gopts.Term)
+		return runGenerate(ctx, opts, gopts, []string{}, gopts.Term)
 	})
 	return buf.Bytes(), err
 }

--- a/cmd/restic/cmd_init.go
+++ b/cmd/restic/cmd_init.go
@@ -10,6 +10,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 
@@ -81,7 +82,9 @@ func runInit(ctx context.Context, opts InitOptions, gopts global.Options, args [
 		return err
 	}
 
-	s, err := global.CreateRepository(ctx, gopts, version, chunkerPolynomial, printer)
+	createCtx, createSpan := tracing.Tracer().Start(ctx, "restic.init.create_repository")
+	s, err := global.CreateRepository(createCtx, gopts, version, chunkerPolynomial, printer)
+	tracing.EndSpanWithError(createSpan, err)
 	if err != nil {
 		return errors.Fatalf("%s", err)
 	}

--- a/cmd/restic/cmd_key_add.go
+++ b/cmd/restic/cmd_key_add.go
@@ -7,6 +7,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 	"github.com/spf13/cobra"
@@ -67,7 +68,10 @@ func runKeyAdd(ctx context.Context, gopts global.Options, opts KeyAddOptions, ar
 	}
 	defer unlock()
 
-	return addKey(ctx, repo, gopts, opts, printer)
+	addCtx, addSpan := tracing.Tracer().Start(ctx, "restic.key.add")
+	err = addKey(addCtx, repo, gopts, opts, printer)
+	tracing.EndSpanWithError(addSpan, err)
+	return err
 }
 
 func addKey(ctx context.Context, repo *repository.Repository, gopts global.Options, opts KeyAddOptions, printer progress.Printer) error {

--- a/cmd/restic/cmd_key_list.go
+++ b/cmd/restic/cmd_key_list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 	"github.com/restic/restic/internal/ui/table"
@@ -53,7 +54,10 @@ func runKeyList(ctx context.Context, gopts global.Options, args []string, term u
 	}
 	defer unlock()
 
-	return listKeys(ctx, repo, gopts, printer)
+	listCtx, listSpan := tracing.Tracer().Start(ctx, "restic.key.list")
+	err = listKeys(listCtx, repo, gopts, printer)
+	tracing.EndSpanWithError(listSpan, err)
+	return err
 }
 
 func listKeys(ctx context.Context, s *repository.Repository, gopts global.Options, printer progress.Printer) error {

--- a/cmd/restic/cmd_key_passwd.go
+++ b/cmd/restic/cmd_key_passwd.go
@@ -7,6 +7,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 	"github.com/spf13/cobra"
@@ -62,7 +63,10 @@ func runKeyPasswd(ctx context.Context, gopts global.Options, opts KeyPasswdOptio
 	}
 	defer unlock()
 
-	return changePassword(ctx, repo, gopts, opts, printer)
+	passwdCtx, passwdSpan := tracing.Tracer().Start(ctx, "restic.key.passwd")
+	err = changePassword(passwdCtx, repo, gopts, opts, printer)
+	tracing.EndSpanWithError(passwdSpan, err)
+	return err
 }
 
 func changePassword(ctx context.Context, repo *repository.Repository, gopts global.Options, opts KeyPasswdOptions, printer progress.Printer) error {

--- a/cmd/restic/cmd_key_remove.go
+++ b/cmd/restic/cmd_key_remove.go
@@ -8,6 +8,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 	"github.com/spf13/cobra"
@@ -50,7 +51,10 @@ func runKeyRemove(ctx context.Context, gopts global.Options, args []string, term
 	}
 	defer unlock()
 
-	return deleteKey(ctx, repo, args[0], printer)
+	removeCtx, removeSpan := tracing.Tracer().Start(ctx, "restic.key.remove")
+	err = deleteKey(removeCtx, repo, args[0], printer)
+	tracing.EndSpanWithError(removeSpan, err)
+	return err
 }
 
 func deleteKey(ctx context.Context, repo *repository.Repository, idPrefix string, printer progress.Printer) error {

--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -8,6 +8,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository/index"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 
 	"github.com/spf13/cobra"
@@ -69,24 +70,30 @@ func runList(ctx context.Context, gopts global.Options, args []string, term ui.T
 	case "locks":
 		t = restic.LockFile
 	case "blobs":
-		return index.ForAllIndexes(ctx, repo, repo, func(_ restic.ID, idx *index.Index, err error) error {
+		listCtx, listSpan := tracing.Tracer().Start(ctx, "restic.list.blobs")
+		listErr := index.ForAllIndexes(listCtx, repo, repo, func(_ restic.ID, idx *index.Index, err error) error {
 			if err != nil {
 				return err
 			}
 			for blobs := range idx.Values() {
-				if ctx.Err() != nil {
-					return ctx.Err()
+				if listCtx.Err() != nil {
+					return listCtx.Err()
 				}
 				printer.S("%v %v", blobs.Type, blobs.ID)
 			}
 			return nil
 		})
+		tracing.EndSpanWithError(listSpan, listErr)
+		return listErr
 	default:
 		return errors.Fatal("invalid type")
 	}
 
-	return repo.List(ctx, t, func(id restic.ID, _ int64) error {
+	listCtx, listSpan := tracing.Tracer().Start(ctx, "restic.list.objects")
+	listErr := repo.List(listCtx, t, func(id restic.ID, _ int64) error {
 		printer.S("%s", id)
 		return nil
 	})
+	tracing.EndSpanWithError(listSpan, listErr)
+	return listErr
 }

--- a/cmd/restic/cmd_ls.go
+++ b/cmd/restic/cmd_ls.go
@@ -20,6 +20,7 @@ import (
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/walker"
 )
@@ -376,7 +377,12 @@ func runLs(ctx context.Context, opts LsOptions, gopts global.Options, args []str
 		return err
 	}
 
-	if err = repo.LoadIndex(ctx, termPrinter); err != nil {
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.ls.load_index")
+		err = repo.LoadIndex(indexCtx, termPrinter)
+		tracing.EndSpanWithError(indexSpan, err)
+	}
+	if err != nil {
 		return err
 	}
 
@@ -467,7 +473,8 @@ func runLs(ctx context.Context, opts LsOptions, gopts global.Options, args []str
 		return nil
 	}
 
-	err = walker.Walk(ctx, repo, *sn.Tree, walker.WalkVisitor{
+	walkCtx, walkSpan := tracing.Tracer().Start(ctx, "restic.ls.walk")
+	err = walker.Walk(walkCtx, repo, *sn.Tree, walker.WalkVisitor{
 		ProcessNode: processNode,
 		LeaveDir: func(path string) error {
 			// the root path `/` has no corresponding node and is thus also skipped by processNode
@@ -477,7 +484,7 @@ func runLs(ctx context.Context, opts LsOptions, gopts global.Options, args []str
 			return nil
 		},
 	})
-
+	tracing.EndSpanWithError(walkSpan, err)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_migrate.go
+++ b/cmd/restic/cmd_migrate.go
@@ -6,6 +6,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/migrations"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 
@@ -144,8 +145,14 @@ func runMigrate(ctx context.Context, opts MigrateOptions, gopts global.Options, 
 	defer unlock()
 
 	if len(args) == 0 {
-		return checkMigrations(ctx, repo, printer)
+		checkCtx, checkSpan := tracing.Tracer().Start(ctx, "restic.migrate.check")
+		err = checkMigrations(checkCtx, repo, printer)
+		tracing.EndSpanWithError(checkSpan, err)
+		return err
 	}
 
-	return applyMigrations(ctx, opts, gopts, repo, args, term, printer)
+	applyCtx, applySpan := tracing.Tracer().Start(ctx, "restic.migrate.apply")
+	err = applyMigrations(applyCtx, opts, gopts, repo, args, term, printer)
+	tracing.EndSpanWithError(applySpan, err)
+	return err
 }

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -17,12 +17,14 @@ import (
 	"github.com/restic/restic/internal/debug"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 
 	"github.com/restic/restic/internal/fuse"
 
 	systemFuse "github.com/anacrolix/fuse"
 	"github.com/anacrolix/fuse/fs"
+	"go.opentelemetry.io/otel/trace"
 )
 
 func registerMountCommand(cmdRoot *cobra.Command, globalOptions *global.Options) {
@@ -138,6 +140,8 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 	if errors.Is(err, os.ErrNotExist) {
 		printer.P("Mountpoint %s doesn't exist", mountpoint)
 		return errors.Fatal("invalid mountpoint")
+	} else if err != nil {
+		return errors.Fatalf("failed to access mountpoint %s: %v", mountpoint, err)
 	} else if !stat.IsDir() {
 		printer.P("Mountpoint %s is not a directory", mountpoint)
 		return errors.Fatal("invalid mountpoint")
@@ -152,13 +156,22 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 	debug.Log("start mount")
 	defer debug.Log("finish mount")
 
+	// Capture the command-level span before openWithReadLock, because
+	// openWithReadLock ends the open_repository span, causing IsRecording() to
+	// return false on the returned ctx.
+	cmdSpan := trace.SpanFromContext(ctx)
+
 	ctx, repo, unlock, err := openWithReadLock(ctx, gopts, gopts.NoLock, printer)
 	if err != nil {
 		return err
 	}
 	defer unlock()
 
-	err = repo.LoadIndex(ctx, printer)
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.mount.load_index")
+		err = repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, err)
+	}
 	if err != nil {
 		return err
 	}
@@ -196,12 +209,19 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 		PathTemplates: opts.PathTemplates,
 	}
 	root := fuse.NewRoot(repo, cfg)
+	if cmdSpan.IsRecording() {
+		root.EnrichCtx = func(fuseCtx context.Context) context.Context {
+			return trace.ContextWithSpan(fuseCtx, cmdSpan)
+		}
+	}
 
 	printer.S("Now serving the repository at %s", mountpoint)
 	printer.S("Use another terminal or tool to browse the contents of this folder.")
 	printer.S("When finished, quit with Ctrl-c here or umount the mountpoint.")
 
 	debug.Log("serving mount at %v", mountpoint)
+
+	serveCtx, serveSpan := tracing.Tracer().Start(ctx, "restic.mount.serve")
 
 	done := make(chan struct{})
 
@@ -213,15 +233,19 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 	select {
 	case <-ctx.Done():
 		debug.Log("running umount cleanup handler for mount at %v", mountpoint)
-		err := systemFuse.Unmount(mountpoint)
-		if err != nil {
-			printer.E("unable to umount (maybe already umounted or still in use?): %v", err)
+		umountErr := systemFuse.Unmount(mountpoint)
+		if umountErr != nil {
+			printer.E("unable to umount (maybe already umounted or still in use?): %v", umountErr)
 		}
+		tracing.EndSpanWithError(serveSpan, nil)
+		_ = serveCtx
 
 		return ErrOK
 	case <-done:
 		// clean shutdown, nothing to do
 	}
 
+	tracing.EndSpanWithError(serveSpan, err)
+	_ = serveCtx
 	return err
 }

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -13,6 +13,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 
@@ -192,9 +193,13 @@ func runPruneWithRepo(ctx context.Context, opts PruneOptions, repo *repository.R
 	}
 
 	// loading the index before the snapshots is ok, as we use an exclusive lock here
-	err := repo.LoadIndex(ctx, printer)
-	if err != nil {
-		return err
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.prune.load_index")
+		err := repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, err)
+		if err != nil {
+			return err
+		}
 	}
 
 	popts := repository.PruneOptions{
@@ -210,9 +215,11 @@ func runPruneWithRepo(ctx context.Context, opts PruneOptions, repo *repository.R
 		RepackUncompressed:  opts.RepackUncompressed,
 	}
 
-	plan, err := repository.PlanPrune(ctx, popts, repo, func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) error {
+	planCtx, planSpan := tracing.Tracer().Start(ctx, "restic.prune.plan")
+	plan, err := repository.PlanPrune(planCtx, popts, repo, func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) error {
 		return getUsedBlobs(ctx, repo, usedBlobs, ignoreSnapshots, printer)
 	}, printer)
+	tracing.EndSpanWithError(planSpan, err)
 	if err != nil {
 		return err
 	}
@@ -232,7 +239,10 @@ func runPruneWithRepo(ctx context.Context, opts PruneOptions, repo *repository.R
 	// Trigger GC to reset garbage collection threshold
 	runtime.GC()
 
-	return plan.Execute(ctx, printer)
+	executeCtx, executeSpan := tracing.Tracer().Start(ctx, "restic.prune.delete_packs")
+	err = plan.Execute(executeCtx, printer)
+	tracing.EndSpanWithError(executeSpan, err)
+	return err
 }
 
 // printPruneStats prints out the statistics

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -10,6 +10,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 	"github.com/spf13/cobra"
@@ -61,13 +62,22 @@ func runRecover(ctx context.Context, gopts global.Options, term ui.Terminal) err
 	}
 
 	printer.P("ensuring index is complete\n")
-	err = repository.RepairIndex(ctx, repo, repository.RepairIndexOptions{}, printer)
+	{
+		repairCtx, repairSpan := tracing.Tracer().Start(ctx, "restic.recover.repair_index")
+		err = repository.RepairIndex(repairCtx, repo, repository.RepairIndexOptions{}, printer)
+		tracing.EndSpanWithError(repairSpan, err)
+	}
 	if err != nil {
 		return err
 	}
 
 	printer.P("load index files\n")
-	if err = repo.LoadIndex(ctx, printer); err != nil {
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.recover.load_index")
+		err = repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, err)
+	}
+	if err != nil {
 		return err
 	}
 
@@ -139,7 +149,8 @@ func runRecover(ctx context.Context, gopts global.Options, term ui.Terminal) err
 	}
 
 	var treeID restic.ID
-	err = repo.WithBlobUploader(ctx, func(ctx context.Context, uploader restic.BlobSaverWithAsync) error {
+	saveCtx, saveSpan := tracing.Tracer().Start(ctx, "restic.recover.save_snapshot")
+	err = repo.WithBlobUploader(saveCtx, func(ctx context.Context, uploader restic.BlobSaverWithAsync) error {
 		var err error
 		tw := data.NewTreeWriter(uploader)
 		for id := range roots {
@@ -165,6 +176,8 @@ func runRecover(ctx context.Context, gopts global.Options, term ui.Terminal) err
 		}
 		return nil
 	})
+	tracing.EndSpanWithError(saveSpan, err)
+	_ = saveCtx
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_repair_index.go
+++ b/cmd/restic/cmd_repair_index.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -78,9 +79,11 @@ func runRebuildIndex(ctx context.Context, opts RepairIndexOptions, gopts global.
 	}
 	defer unlock()
 
-	err = repository.RepairIndex(ctx, repo, repository.RepairIndexOptions{
+	repairCtx, repairSpan := tracing.Tracer().Start(ctx, "restic.repair.index")
+	err = repository.RepairIndex(repairCtx, repo, repository.RepairIndexOptions{
 		ReadAllPacks: opts.ReadAllPacks,
 	}, printer)
+	tracing.EndSpanWithError(repairSpan, err)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_repair_packs.go
+++ b/cmd/restic/cmd_repair_packs.go
@@ -10,6 +10,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 )
@@ -60,7 +61,11 @@ func runRepairPacks(ctx context.Context, gopts global.Options, term ui.Terminal,
 	}
 	defer unlock()
 
-	err = repo.LoadIndex(ctx, printer)
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.repair.load_index")
+		err = repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, err)
+	}
 	if err != nil {
 		return errors.Fatalf("%s", err)
 	}
@@ -86,7 +91,9 @@ func runRepairPacks(ctx context.Context, gopts global.Options, term ui.Terminal,
 		}
 	}
 
-	err = repository.RepairPacks(ctx, repo, ids, printer)
+	repairCtx, repairSpan := tracing.Tracer().Start(ctx, "restic.repair.packs")
+	err = repository.RepairPacks(repairCtx, repo, ids, printer)
+	tracing.EndSpanWithError(repairSpan, err)
 	if err != nil {
 		return errors.Fatalf("%s", err)
 	}

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -8,6 +8,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/walker"
 
@@ -91,8 +92,13 @@ func runRepairSnapshots(ctx context.Context, gopts global.Options, opts RepairOp
 		return err
 	}
 
-	if err := repo.LoadIndex(ctx, printer); err != nil {
-		return err
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.repair.load_index")
+		indexErr := repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, indexErr)
+		if indexErr != nil {
+			return indexErr
+		}
 	}
 
 	// Three error cases are checked:
@@ -144,10 +150,11 @@ func runRepairSnapshots(ctx context.Context, gopts global.Options, opts RepairOp
 		AllowUnstableSerialization: true,
 	})
 
+	repairCtx, repairSpan := tracing.Tracer().Start(ctx, "restic.repair.snapshots")
 	changedCount := 0
-	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &opts.SnapshotFilter, args, printer) {
+	for sn := range FindFilteredSnapshots(repairCtx, snapshotLister, repo, &opts.SnapshotFilter, args, printer) {
 		printer.P("\n%v", sn)
-		changed, err := filterAndReplaceSnapshot(ctx, repo, sn,
+		changed, err := filterAndReplaceSnapshot(repairCtx, repo, sn,
 			func(ctx context.Context, sn *data.Snapshot, uploader restic.BlobSaver) (restic.ID, *data.SnapshotSummary, error) {
 				id, err := rewriter.RewriteTree(ctx, repo, uploader, "/", *sn.Tree)
 				return id, nil, err
@@ -159,8 +166,9 @@ func runRepairSnapshots(ctx context.Context, gopts global.Options, opts RepairOp
 			changedCount++
 		}
 	}
-	if ctx.Err() != nil {
-		return ctx.Err()
+	tracing.EndSpanWithError(repairSpan, repairCtx.Err())
+	if repairCtx.Err() != nil {
+		return repairCtx.Err()
 	}
 
 	printer.P("")

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -12,6 +12,7 @@ import (
 	"github.com/restic/restic/internal/filter"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restorer"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 	restoreui "github.com/restic/restic/internal/ui/restore"
@@ -156,7 +157,11 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts global.Options,
 		return errors.Fatalf("failed to find snapshot: %v", err)
 	}
 
-	err = repo.LoadIndex(ctx, printer)
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.restore.load_index")
+		err = repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, err)
+	}
 	if err != nil {
 		return err
 	}
@@ -245,7 +250,9 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts global.Options,
 		printer.P("restoring %s to %s\n", res.Snapshot(), opts.Target)
 	}
 
-	countRestoredFiles, err := res.RestoreTo(ctx, opts.Target)
+	restoreCtx, restoreSpan := tracing.Tracer().Start(ctx, "restic.restore.restore_files")
+	countRestoredFiles, err := res.RestoreTo(restoreCtx, opts.Target)
+	tracing.EndSpanWithError(restoreSpan, err)
 	if err != nil {
 		return err
 	}
@@ -263,7 +270,9 @@ func runRestore(ctx context.Context, opts RestoreOptions, gopts global.Options,
 		var count int
 		t0 := time.Now()
 		bar := printer.NewCounterTerminalOnly("files verified")
-		count, err = res.VerifyFiles(ctx, opts.Target, countRestoredFiles, bar)
+		verifyCtx, verifySpan := tracing.Tracer().Start(ctx, "restic.restore.verify_files")
+		count, err = res.VerifyFiles(verifyCtx, opts.Target, countRestoredFiles, bar)
+		tracing.EndSpanWithError(verifySpan, err)
 		if err != nil {
 			return err
 		}

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -14,6 +14,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 	"github.com/restic/restic/internal/walker"
@@ -324,14 +325,20 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, 
 		return err
 	}
 
-	if err = repo.LoadIndex(ctx, printer); err != nil {
-		return err
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.rewrite.load_index")
+		indexErr := repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, indexErr)
+		if indexErr != nil {
+			return indexErr
+		}
 	}
 
+	rewriteCtx, rewriteSpan := tracing.Tracer().Start(ctx, "restic.rewrite.snapshots")
 	changedCount := 0
-	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &opts.SnapshotFilter, args, printer) {
+	for sn := range FindFilteredSnapshots(rewriteCtx, snapshotLister, repo, &opts.SnapshotFilter, args, printer) {
 		printer.P("\n%v", sn)
-		changed, err := rewriteSnapshot(ctx, repo, sn, opts, printer)
+		changed, err := rewriteSnapshot(rewriteCtx, repo, sn, opts, printer)
 		if err != nil {
 			return errors.Fatalf("unable to rewrite snapshot ID %q: %v", sn.ID().Str(), err)
 		}
@@ -339,8 +346,9 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, 
 			changedCount++
 		}
 	}
-	if ctx.Err() != nil {
-		return ctx.Err()
+	tracing.EndSpanWithError(rewriteSpan, rewriteCtx.Err())
+	if rewriteCtx.Err() != nil {
+		return rewriteCtx.Err()
 	}
 
 	printer.P("")

--- a/cmd/restic/cmd_self_update.go
+++ b/cmd/restic/cmd_self_update.go
@@ -10,6 +10,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/selfupdate"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -90,7 +91,9 @@ func runSelfUpdate(ctx context.Context, opts SelfUpdateOptions, gopts global.Opt
 	printer := ui.NewProgressPrinter(false, gopts.Verbosity, term)
 	printer.P("writing restic to %v", opts.Output)
 
-	v, err := selfupdate.DownloadLatestStableRelease(ctx, opts.Output, global.Version, printer.P)
+	downloadCtx, downloadSpan := tracing.Tracer().Start(ctx, "restic.self_update.download")
+	v, err := selfupdate.DownloadLatestStableRelease(downloadCtx, opts.Output, global.Version, printer.P)
+	tracing.EndSpanWithError(downloadSpan, err)
 	if err != nil {
 		return errors.Fatalf("unable to update restic: %v", err)
 	}

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -12,6 +12,7 @@ import (
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/table"
 	"github.com/spf13/cobra"
@@ -79,11 +80,13 @@ func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts global.Option
 	defer unlock()
 
 	var snapshots data.Snapshots
-	for sn := range FindFilteredSnapshots(ctx, repo, repo, &opts.SnapshotFilter, args, printer) {
+	snapshotsCtx, snapshotsSpan := tracing.Tracer().Start(ctx, "restic.snapshots.list")
+	for sn := range FindFilteredSnapshots(snapshotsCtx, repo, repo, &opts.SnapshotFilter, args, printer) {
 		snapshots = append(snapshots, sn)
 	}
-	if ctx.Err() != nil {
-		return ctx.Err()
+	tracing.EndSpanWithError(snapshotsSpan, snapshotsCtx.Err())
+	if snapshotsCtx.Err() != nil {
+		return snapshotsCtx.Err()
 	}
 	snapshotGroups, grouped, err := data.GroupSnapshots(snapshots, opts.GroupBy)
 	if err != nil {

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -15,6 +15,7 @@ import (
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/restorer"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 	"github.com/restic/restic/internal/ui/table"
@@ -114,7 +115,12 @@ func runStats(ctx context.Context, opts StatsOptions, gopts global.Options, args
 	if err != nil {
 		return err
 	}
-	if err = repo.LoadIndex(ctx, printer); err != nil {
+	{
+		indexCtx, indexSpan := tracing.Tracer().Start(ctx, "restic.stats.load_index")
+		err = repo.LoadIndex(indexCtx, printer)
+		tracing.EndSpanWithError(indexSpan, err)
+	}
+	if err != nil {
 		return err
 	}
 
@@ -134,14 +140,17 @@ func runStats(ctx context.Context, opts StatsOptions, gopts global.Options, args
 		SnapshotsCount: 0,
 	}
 
-	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &opts.SnapshotFilter, args, printer) {
-		err = statsWalkSnapshot(ctx, sn, repo, opts, stats)
+	statsCtx, statsSpan := tracing.Tracer().Start(ctx, "restic.stats.compute")
+	for sn := range FindFilteredSnapshots(statsCtx, snapshotLister, repo, &opts.SnapshotFilter, args, printer) {
+		err = statsWalkSnapshot(statsCtx, sn, repo, opts, stats)
 		if err != nil {
+			tracing.EndSpanWithError(statsSpan, err)
 			return fmt.Errorf("error walking snapshot: %v", err)
 		}
 	}
-	if ctx.Err() != nil {
-		return ctx.Err()
+	tracing.EndSpanWithError(statsSpan, statsCtx.Err())
+	if statsCtx.Err() != nil {
+		return statsCtx.Err()
 	}
 
 	if opts.countMode == countModeRawData {

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -12,6 +12,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 )
 
@@ -158,8 +159,9 @@ func runTag(ctx context.Context, opts TagOptions, gopts global.Options, term ui.
 		}
 	}
 
-	for sn := range FindFilteredSnapshots(ctx, repo, repo, &opts.SnapshotFilter, args, printer) {
-		changed, err := changeTags(ctx, repo, sn, opts.SetTags.Flatten(), opts.AddTags.Flatten(), opts.RemoveTags.Flatten(), printFunc)
+	tagCtx, tagSpan := tracing.Tracer().Start(ctx, "restic.tag.update_snapshots")
+	for sn := range FindFilteredSnapshots(tagCtx, repo, repo, &opts.SnapshotFilter, args, printer) {
+		changed, err := changeTags(tagCtx, repo, sn, opts.SetTags.Flatten(), opts.AddTags.Flatten(), opts.RemoveTags.Flatten(), printFunc)
 		if err != nil {
 			printer.E("unable to modify the tags for snapshot ID %q, ignoring: %v", sn.ID(), err)
 			continue
@@ -168,9 +170,10 @@ func runTag(ctx context.Context, opts TagOptions, gopts global.Options, term ui.
 			summary.ChangedSnapshots++
 		}
 	}
+	tracing.EndSpanWithError(tagSpan, tagCtx.Err())
 
-	if ctx.Err() != nil {
-		return ctx.Err()
+	if tagCtx.Err() != nil {
+		return tagCtx.Err()
 	}
 
 	printSummary(summary)

--- a/cmd/restic/cmd_unlock.go
+++ b/cmd/restic/cmd_unlock.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -58,7 +59,9 @@ func runUnlock(ctx context.Context, opts UnlockOptions, gopts global.Options, te
 		fn = repository.RemoveAllLocks
 	}
 
-	processed, err := fn(ctx, repo)
+	unlockCtx, unlockSpan := tracing.Tracer().Start(ctx, "restic.unlock")
+	processed, err := fn(unlockCtx, repo)
+	tracing.EndSpanWithError(unlockSpan, err)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/lock.go
+++ b/cmd/restic/lock.go
@@ -5,12 +5,15 @@ import (
 
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui/progress"
 )
 
 func internalOpenWithLocked(ctx context.Context, gopts global.Options, dryRun bool, exclusive bool, printer progress.Printer) (context.Context, *repository.Repository, func(), error) {
-	repo, err := global.OpenRepository(ctx, gopts, printer)
+	openCtx, openSpan := tracing.Tracer().Start(ctx, "restic.open_repository")
+	repo, err := global.OpenRepository(openCtx, gopts, printer)
 	if err != nil {
+		tracing.EndSpanWithError(openSpan, err)
 		return nil, nil, nil, err
 	}
 
@@ -18,20 +21,23 @@ func internalOpenWithLocked(ctx context.Context, gopts global.Options, dryRun bo
 	if !dryRun {
 		var lock *repository.Unlocker
 
-		lock, ctx, err = repository.Lock(ctx, repo, exclusive, gopts.RetryLock, func(msg string) {
+		lock, ctx, err = repository.Lock(openCtx, repo, exclusive, gopts.RetryLock, func(msg string) {
 			if !gopts.JSON {
 				printer.P("%s", msg)
 			}
 		}, printer.E)
 		if err != nil {
+			tracing.EndSpanWithError(openSpan, err)
 			return nil, nil, nil, err
 		}
 
 		unlock = lock.Unlock
 	} else {
 		repo.SetDryRun()
+		ctx = openCtx
 	}
 
+	tracing.EndSpanWithError(openSpan, nil)
 	return ctx, repo, unlock, nil
 }
 

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -10,8 +10,14 @@ import (
 	"os"
 	"runtime"
 	godebug "runtime/debug"
+	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/automaxprocs/maxprocs"
 
 	"github.com/restic/restic/internal/backend/all"
@@ -21,6 +27,7 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/tracing"
 	"github.com/restic/restic/internal/ui/termstatus"
 )
 
@@ -48,10 +55,21 @@ The full documentation can be found at https://restic.readthedocs.io/ .
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,
 
-		PersistentPreRunE: func(c *cobra.Command, _ []string) error {
+		PersistentPreRunE: func(c *cobra.Command, args []string) error {
 			switch c.Name() {
 			case "__complete", "__completeNoDesc":
 				return nil
+			}
+			if globalOptions.TraceURL != "" {
+				shutdown, err := tracing.Setup(c.Context(), globalOptions.TraceURL, globalOptions.TraceService)
+				if err != nil {
+					// Non-fatal: warn and continue without tracing.
+					_, _ = fmt.Fprintf(os.Stderr, "warning: tracing setup failed: %v\n", err)
+				} else {
+					ctx := tracing.ExtractParentContext(c.Context(), globalOptions.TraceParentID)
+					ctx = startCommandTrace(ctx, c, args, globalOptions, shutdown)
+					c.SetContext(ctx)
+				}
 			}
 			return globalOptions.PreRun(needsPassword(c.Name()))
 		},
@@ -111,6 +129,76 @@ The full documentation can be found at https://restic.readthedocs.io/ .
 	global.RegisterProfiling(cmd, os.Stderr)
 
 	return cmd
+}
+
+// startCommandTrace creates the process-ancestry span chain and the command
+// span, wires them into ctx, and stores a cleanup function in gopts that ends
+// all spans and shuts down the exporter. It returns the updated context.
+func startCommandTrace(
+	ctx context.Context,
+	c *cobra.Command,
+	_ []string,
+	gopts *global.Options,
+	shutdown func(context.Context) error,
+) context.Context {
+	sysInfo := tracing.Collect()
+	t := tracing.Tracer()
+
+	// Build a chain of spans for each ancestor process, oldest first.
+	// Each span is a child of the previous one so the process tree is visible.
+	var ancestorSpans []trace.Span
+	for _, proc := range sysInfo.Ancestry {
+		name := proc.Comm
+		if name == "" {
+			name = fmt.Sprintf("pid-%d", proc.PID)
+		}
+		var span trace.Span
+		ctx, span = t.Start(ctx, name, trace.WithSpanKind(trace.SpanKindInternal))
+		span.SetAttributes(
+			attribute.Int("process.pid", proc.PID),
+			attribute.Int("process.ppid", proc.PPID),
+			attribute.String("process.command_line", proc.CmdLine),
+		)
+		ancestorSpans = append(ancestorSpans, span)
+	}
+
+	// The restic command span is a child of the innermost ancestor span
+	// (or of the external parent supplied via --trace-id-parent).
+	ctx, cmdSpan := t.Start(ctx, "restic."+c.Name(), trace.WithSpanKind(trace.SpanKindClient))
+	cmdSpan.SetAttributes(
+		attribute.StringSlice("process.command_args", os.Args),
+		attribute.String("enduser.id", sysInfo.User),
+		attribute.String("enduser.uid", sysInfo.UserID),
+		attribute.String("host.name", sysInfo.FQDN),
+		attribute.String("restic.command", c.Name()),
+	)
+	// Capture flag names and values for observability.
+	var flagPairs []string
+	c.Flags().VisitAll(func(f *pflag.Flag) {
+		if f.Changed {
+			flagPairs = append(flagPairs, f.Name+"="+f.Value.String())
+		}
+	})
+	if len(flagPairs) > 0 {
+		cmdSpan.SetAttributes(attribute.String("restic.flags", strings.Join(flagPairs, " ")))
+	}
+
+	gopts.TraceCleanup = func(cleanupCtx context.Context, cmdErr error) {
+		if cmdErr != nil {
+			cmdSpan.RecordError(cmdErr)
+			cmdSpan.SetStatus(codes.Error, cmdErr.Error())
+		} else {
+			cmdSpan.SetStatus(codes.Ok, "")
+		}
+		cmdSpan.End()
+		// End ancestor spans in reverse order (innermost first).
+		for i := len(ancestorSpans) - 1; i >= 0; i-- {
+			ancestorSpans[i].End()
+		}
+		_ = shutdown(cleanupCtx)
+	}
+
+	return ctx
 }
 
 // Distinguish commands that need the password from those that work without,
@@ -195,6 +283,12 @@ func main() {
 			err = nil
 		}
 	}()
+
+	if globalOptions.TraceCleanup != nil {
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		globalOptions.TraceCleanup(cleanupCtx, err)
+	}
 
 	var exitMessage string
 	switch {

--- a/doc/man/restic.1
+++ b/doc/man/restic.1
@@ -121,6 +121,18 @@ The full documentation can be found at https://restic.readthedocs.io/ .
 \fB-v\fP, \fB--verbose\fP[=0]
 	be verbose (specify multiple times or a level using --verbose=n``, max level/times is 2)
 
+.PP
+\fB--trace\fP=""
+	send OpenTelemetry traces to this `URL` http/https, basic-auth supported, e.g. http://user:pass@collector:4318 (default: do not send traces)
+
+.PP
+\fB--trace-id-parent\fP=""
+	W3C traceparent to use as parent for distributed tracing (default: start a new trace)
+
+.PP
+\fB--trace-service\fP=""
+	service name reported in OpenTelemetry spans (default: restic)
+
 
 .SH SEE ALSO
 \fBrestic-backup(1)\fP, \fBrestic-cache(1)\fP, \fBrestic-cat(1)\fP, \fBrestic-check(1)\fP, \fBrestic-copy(1)\fP, \fBrestic-diff(1)\fP, \fBrestic-dump(1)\fP, \fBrestic-features(1)\fP, \fBrestic-find(1)\fP, \fBrestic-forget(1)\fP, \fBrestic-generate(1)\fP, \fBrestic-init(1)\fP, \fBrestic-key(1)\fP, \fBrestic-list(1)\fP, \fBrestic-ls(1)\fP, \fBrestic-migrate(1)\fP, \fBrestic-mount(1)\fP, \fBrestic-options(1)\fP, \fBrestic-prune(1)\fP, \fBrestic-recover(1)\fP, \fBrestic-repair(1)\fP, \fBrestic-restore(1)\fP, \fBrestic-rewrite(1)\fP, \fBrestic-self-update(1)\fP, \fBrestic-snapshots(1)\fP, \fBrestic-stats(1)\fP, \fBrestic-tag(1)\fP, \fBrestic-unlock(1)\fP, \fBrestic-version(1)\fP

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -79,6 +79,9 @@ Usage help is available:
           --repository-file file       file to read the repository location from (default: $RESTIC_REPOSITORY_FILE)
           --retry-lock duration        retry to lock the repository if it is already locked, takes a value like 5m or 2h (default: no retries)
           --tls-client-cert file       path to a file containing PEM encoded TLS client certificate and private key (default: $RESTIC_TLS_CLIENT_CERT)
+      --trace URL                      send OpenTelemetry traces to this `URL` (http/https, basic-auth supported, e.g. http://user:pass@collector:4318) (default: do not send traces)
+      --trace-id-parent UUID           W3C traceparent to use as parent for distributed tracing (default: start a new trace)
+      --trace-service NAME             service name reported in OpenTelemetry spans (default: restic)
       -v, --verbose                    be verbose (specify multiple times or a level using --verbose=n, max level/times is 2)
 
     Use "restic [command] --help" for more information about a command.

--- a/go.mod
+++ b/go.mod
@@ -56,6 +56,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.29.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.54.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.54.0 // indirect
+	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
 	github.com/cncf/xds/go v0.0.0-20250501225837-2ac532fd4443 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
@@ -73,6 +74,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.7 // indirect
 	github.com/googleapis/gax-go/v2 v2.15.0 // indirect
+	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.11 // indirect
 	github.com/klauspost/crc32 v1.3.0 // indirect
@@ -93,10 +95,13 @@ require (
 	go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc v0.63.0 // indirect
 	go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 // indirect
 	go.opentelemetry.io/otel v1.38.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 // indirect
+	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0 // indirect
 	go.opentelemetry.io/otel/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.38.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.38.0 // indirect
 	go.opentelemetry.io/otel/trace v1.38.0 // indirect
+	go.opentelemetry.io/proto/otlp v1.7.1 // indirect
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	google.golang.org/genproto v0.0.0-20250922171735-9219d122eba9 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251111163417-95abcf5c77ba // indirect

--- a/go.sum
+++ b/go.sum
@@ -60,6 +60,8 @@ github.com/anacrolix/log v0.14.1 h1:j2FcIpYZ5FbANetUcm5JNu+zUBGADSp/VbjhUPrAY0k=
 github.com/anacrolix/log v0.14.1/go.mod h1:1OmJESOtxQGNMlUO5rcv96Vpp9mfMqXXbe2RdinFLdY=
 github.com/cenkalti/backoff/v4 v4.3.0 h1:MyRJ/UdXutAwSAT+s3wNd7MfTIcy71VQueUuFK343L8=
 github.com/cenkalti/backoff/v4 v4.3.0/go.mod h1:Y3VNntkOUPxTVeUxJ/G5vcM//AlwfmyYozVcomhLiZE=
+github.com/cenkalti/backoff/v5 v5.0.3 h1:ZN+IMa753KfX5hd8vVaMixjnqRZ3y8CuJKRKj1xcsSM=
+github.com/cenkalti/backoff/v5 v5.0.3/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
 github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
@@ -124,6 +126,8 @@ github.com/googleapis/enterprise-certificate-proxy v0.3.7 h1:zrn2Ee/nWmHulBx5sAV
 github.com/googleapis/enterprise-certificate-proxy v0.3.7/go.mod h1:MkHOF77EYAE7qfSuSS9PU6g4Nt4e11cnsDUowfwewLA=
 github.com/googleapis/gax-go/v2 v2.15.0 h1:SyjDc1mGgZU5LncH8gimWo9lW1DtIfPibOG81vgd/bo=
 github.com/googleapis/gax-go/v2 v2.15.0/go.mod h1:zVVkkxAQHa1RQpg9z2AUCMnKhi0Qld9rcmyfL1OZhoc=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2 h1:8Tjv8EJ+pM1xP8mK6egEbD1OgnVTyacbefKhmbLhIhU=
+github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.2/go.mod h1:pkJQ2tZHJ0aFOVEEot6oZmaVEZcRme73eIFmhiVuRWs=
 github.com/hashicorp/golang-lru/v2 v2.0.7 h1:a+bsQ5rvGLjzHuww6tVxozPZFVghXaHOwFs4luLUK2k=
 github.com/hashicorp/golang-lru/v2 v2.0.7/go.mod h1:QeFd9opnmA6QUJc5vARoKUSoFhyfM2/ZepoAG6RGpeM=
 github.com/ianlancetaylor/demangle v0.0.0-20210905161508-09a460cdf81d/go.mod h1:aYm2/VgdVmcIU8iMfdMvDMsRAQjcfZSKFby6HOFvi/w=
@@ -232,6 +236,10 @@ go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0 h1:F7Jx+6h
 go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp v0.61.0/go.mod h1:UHB22Z8QsdRDrnAtX4PntOl36ajSxcdUMt1sF7Y6E7Q=
 go.opentelemetry.io/otel v1.38.0 h1:RkfdswUDRimDg0m2Az18RKOsnI8UDzppJAtj01/Ymk8=
 go.opentelemetry.io/otel v1.38.0/go.mod h1:zcmtmQ1+YmQM9wrNsTGV/q/uyusom3P8RxwExxkZhjM=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0 h1:GqRJVj7UmLjCVyVJ3ZFLdPRmhDUp2zFmQe3RHIOsw24=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.38.0/go.mod h1:ri3aaHSmCTVYu2AWv44YMauwAQc0aqI9gHKIcSbI1pU=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0 h1:aTL7F04bJHUlztTsNGJ2l+6he8c+y/b//eR0jjjemT4=
+go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp v1.38.0/go.mod h1:kldtb7jDTeol0l3ewcmd8SDvx3EmIE7lyvqbasU3QC4=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.38.0 h1:wm/Q0GAAykXv83wzcKzGGqAnnfLFyFe7RslekZuv+VI=
 go.opentelemetry.io/otel/exporters/stdout/stdoutmetric v1.38.0/go.mod h1:ra3Pa40+oKjvYh+ZD3EdxFZZB0xdMfuileHAm4nNN7w=
 go.opentelemetry.io/otel/metric v1.38.0 h1:Kl6lzIYGAh5M159u9NgiRkmoMKjvbsKtYRwgfrA6WpA=
@@ -242,6 +250,8 @@ go.opentelemetry.io/otel/sdk/metric v1.38.0 h1:aSH66iL0aZqo//xXzQLYozmWrXxyFkBJ6
 go.opentelemetry.io/otel/sdk/metric v1.38.0/go.mod h1:dg9PBnW9XdQ1Hd6ZnRz689CbtrUp0wMMs9iPcgT9EZA=
 go.opentelemetry.io/otel/trace v1.38.0 h1:Fxk5bKrDZJUH+AMyyIXGcFAPah0oRcT+LuNtJrmcNLE=
 go.opentelemetry.io/otel/trace v1.38.0/go.mod h1:j1P9ivuFsTceSWe1oY+EeW3sc+Pp42sO++GHkg4wwhs=
+go.opentelemetry.io/proto/otlp v1.7.1 h1:gTOMpGDb0WTBOP8JaO72iL3auEZhVmAQg4ipjOVAtj4=
+go.opentelemetry.io/proto/otlp v1.7.1/go.mod h1:b2rVh6rfI/s2pHWNlB7ILJcRALpcNDzKhACevjI+ZnE=
 go.uber.org/automaxprocs v1.6.0 h1:O3y2/QNTOdbF+e/dpXNNW7Rx2hZ4sTIPyybbxyNqTUs=
 go.uber.org/automaxprocs v1.6.0/go.mod h1:ifeIMSnPZuznNm6jmdzmU3/bfk01Fe2fotchwEFJ8r8=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/internal/fuse/dir.go
+++ b/internal/fuse/dir.go
@@ -110,6 +110,9 @@ func (d *dir) open(ctx context.Context) error {
 
 	debug.Log("open dir %v (%v)", d.node.Name, d.node.Subtree)
 
+	if d.root.EnrichCtx != nil {
+		ctx = d.root.EnrichCtx(ctx)
+	}
 	tree, err := data.LoadTree(ctx, d.root.repo, *d.node.Subtree)
 	if err != nil {
 		debug.Log("  error loading tree %v: %v", d.node.Subtree, err)

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -103,6 +103,9 @@ func (f *file) Open(ctx context.Context, _ *fuse.OpenRequest, _ *fuse.OpenRespon
 }
 
 func (f *openFile) getBlobAt(ctx context.Context, i int) (blob []byte, err error) {
+	if f.root.EnrichCtx != nil {
+		ctx = f.root.EnrichCtx(ctx)
+	}
 	blob, err = f.root.blobCache.GetOrCompute(f.node.Content[i], func() ([]byte, error) {
 		return f.root.repo.LoadBlob(ctx, restic.DataBlob, f.node.Content[i], nil)
 	})

--- a/internal/fuse/root.go
+++ b/internal/fuse/root.go
@@ -3,6 +3,7 @@
 package fuse
 
 import (
+	"context"
 	"os"
 
 	"github.com/restic/restic/internal/bloblru"
@@ -30,6 +31,10 @@ type Root struct {
 	*SnapshotsDir
 
 	uid, gid uint32
+
+	// EnrichCtx optionally injects a parent trace span into per-operation contexts,
+	// allowing FUSE backend calls to appear as children of the command-level span.
+	EnrichCtx func(context.Context) context.Context
 }
 
 // ensure that *Root implements these interfaces

--- a/internal/fuse/snapshots_dirstruct.go
+++ b/internal/fuse/snapshots_dirstruct.go
@@ -292,6 +292,10 @@ func (d *SnapshotsDirStructure) updateSnapshots(ctx context.Context) error {
 		return nil
 	}
 
+	if d.root.EnrichCtx != nil {
+		ctx = d.root.EnrichCtx(ctx)
+	}
+
 	var snapshots data.Snapshots
 	err := d.root.cfg.Filter.FindAll(ctx, d.root.repo, d.root.repo, nil, func(_ string, sn *data.Snapshot, _ error) error {
 		if sn != nil {

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -29,6 +29,7 @@ import (
 	"github.com/spf13/pflag"
 
 	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/tracing"
 )
 
 // ErrNoRepository is used to report if opening a repository failed due
@@ -82,6 +83,22 @@ type Options struct {
 
 	Extended options.Options
 
+	// TraceURL is the OTLP/HTTP endpoint for OpenTelemetry traces (http/https,
+	// basic-auth supported). Empty means tracing is disabled.
+	TraceURL string
+
+	// TraceParentID is an optional W3C traceparent string that makes this
+	// invocation a child of an existing distributed trace.
+	TraceParentID string
+
+	// TraceService is the service.name resource attribute sent with every span.
+	TraceService string
+
+	// TraceCleanup is set by the command infrastructure when tracing is
+	// active. It ends all open spans and shuts down the exporter, recording
+	// err as the span status before doing so.
+	TraceCleanup func(ctx context.Context, err error)
+
 	// packSizeFlag is used to detect if --pack-size was set (CLI overrides env).
 	packSizeFlag *pflag.Flag
 }
@@ -114,6 +131,9 @@ func (opts *Options) AddFlags(f *pflag.FlagSet) {
 	f.StringSliceVarP(&opts.Options, "option", "o", []string{}, "set extended option (`key=value`, can be specified multiple times)")
 	f.StringVar(&opts.HTTPUserAgent, "http-user-agent", "", "set a http user agent for outgoing http requests")
 	f.DurationVar(&opts.StuckRequestTimeout, "stuck-request-timeout", 5*time.Minute, "`duration` after which to retry stuck requests")
+	f.StringVar(&opts.TraceURL, "trace", "", "send OpenTelemetry traces to this `URL` (http/https, basic-auth supported, e.g. http://user:pass@collector:4318)")
+	f.StringVar(&opts.TraceParentID, "trace-id-parent", "", "W3C traceparent to use as parent for distributed tracing (default: start a new trace)")
+	f.StringVar(&opts.TraceService, "trace-service", "restic", "`service` name reported in OpenTelemetry spans")
 
 	opts.Repo = os.Getenv("RESTIC_REPOSITORY")
 	opts.RepositoryFile = os.Getenv("RESTIC_REPOSITORY_FILE")
@@ -540,7 +560,8 @@ func parseConfig(backends *location.Registry, s string, opts options.Options) (s
 	return loc.Scheme, cfg, nil
 }
 
-// setupTransport creates and configures the transport with rate limiting.
+// setupTransport creates and configures the transport with rate limiting and
+// OpenTelemetry instrumentation.
 func setupTransport(gopts Options) (http.RoundTripper, limiter.Limiter, error) {
 	rt, err := backend.Transport(gopts.TransportOptions)
 	if err != nil {
@@ -550,6 +571,11 @@ func setupTransport(gopts Options) (http.RoundTripper, limiter.Limiter, error) {
 	// wrap the transport so that the throughput via HTTP is limited
 	lim := limiter.NewStaticLimiter(gopts.Limits)
 	rt = lim.Transport(rt)
+
+	// wrap with OTel HTTP instrumentation: injects traceparent headers and
+	// creates child spans for every outgoing backend request.  When tracing is
+	// not configured this is effectively a no-op.
+	rt = tracing.WrapTransport(rt)
 
 	return rt, lim, nil
 }

--- a/internal/tracing/process.go
+++ b/internal/tracing/process.go
@@ -1,0 +1,49 @@
+package tracing
+
+import (
+	"net"
+	"os"
+	"os/user"
+	"strings"
+)
+
+// ProcessInfo holds metadata about a process in the ancestry chain.
+type ProcessInfo struct {
+	PID     int
+	PPID    int
+	Comm    string // short executable name (e.g. "bash", "sshd")
+	CmdLine string // full reconstructed command line (best-effort)
+}
+
+// SystemInfo describes the environment in which restic is executing.
+type SystemInfo struct {
+	User     string // login name
+	UserID   string // numeric UID
+	FQDN     string
+	Ancestry []ProcessInfo // oldest ancestor first, direct parent last
+}
+
+// Collect gathers the current user, hostname, and process ancestry chain.
+func Collect() SystemInfo {
+	info := SystemInfo{}
+	if u, err := user.Current(); err == nil {
+		info.User = u.Username
+		info.UserID = u.Uid
+	}
+	if h, err := os.Hostname(); err == nil {
+		info.FQDN = resolveFQDN(h)
+	}
+	info.Ancestry = collectAncestry()
+	return info
+}
+
+// resolveFQDN attempts a DNS reverse lookup to determine the FQDN. Falls back
+// to the short hostname if DNS is unavailable or returns no useful result.
+func resolveFQDN(hostname string) string {
+	if ips, err := net.LookupHost(hostname); err == nil && len(ips) > 0 {
+		if names, err := net.LookupAddr(ips[0]); err == nil && len(names) > 0 {
+			return strings.TrimSuffix(names[0], ".")
+		}
+	}
+	return hostname
+}

--- a/internal/tracing/process_linux.go
+++ b/internal/tracing/process_linux.go
@@ -1,0 +1,59 @@
+//go:build linux
+
+package tracing
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+)
+
+func collectAncestry() []ProcessInfo {
+	var chain []ProcessInfo
+	pid := os.Getppid()
+	for pid > 1 && len(chain) < 32 {
+		info, err := readProcInfo(pid)
+		if err != nil {
+			break
+		}
+		chain = append(chain, info)
+		pid = info.PPID
+	}
+	// Reverse so the oldest ancestor comes first.
+	for i, j := 0, len(chain)-1; i < j; i, j = i+1, j-1 {
+		chain[i], chain[j] = chain[j], chain[i]
+	}
+	return chain
+}
+
+func readProcInfo(pid int) (ProcessInfo, error) {
+	info := ProcessInfo{PID: pid}
+
+	commBytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if err != nil {
+		return info, err
+	}
+	info.Comm = strings.TrimSpace(string(commBytes))
+
+	statusBytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/status", pid))
+	if err != nil {
+		return info, err
+	}
+	for _, line := range strings.Split(string(statusBytes), "\n") {
+		if strings.HasPrefix(line, "PPid:") {
+			if fields := strings.Fields(line); len(fields) >= 2 {
+				info.PPID, _ = strconv.Atoi(fields[1])
+			}
+			break
+		}
+	}
+
+	// cmdline uses NUL bytes as separators – best-effort, ignore errors.
+	if cmdlineBytes, err := os.ReadFile(fmt.Sprintf("/proc/%d/cmdline", pid)); err == nil && len(cmdlineBytes) > 0 {
+		parts := strings.Split(strings.TrimRight(string(cmdlineBytes), "\x00"), "\x00")
+		info.CmdLine = strings.Join(parts, " ")
+	}
+
+	return info, nil
+}

--- a/internal/tracing/process_linux_test.go
+++ b/internal/tracing/process_linux_test.go
@@ -1,0 +1,78 @@
+//go:build linux
+
+package tracing
+
+import (
+	"os"
+	"testing"
+)
+
+func TestCollectAncestry(t *testing.T) {
+	chain := collectAncestry()
+	if len(chain) == 0 {
+		t.Error("expected at least one ancestor process on Linux")
+	}
+	// Oldest ancestor is first; the last entry is the direct parent.
+	for i, p := range chain {
+		if p.PID <= 0 {
+			t.Errorf("chain[%d]: expected positive PID, got %d", i, p.PID)
+		}
+	}
+}
+
+func TestCollectAncestryOrderedOldestFirst(t *testing.T) {
+	chain := collectAncestry()
+	if len(chain) < 2 {
+		t.Skip("not enough ancestors to verify order")
+	}
+	// In a proper ancestry chain, each entry's PPID should match the previous entry's PID.
+	for i := 1; i < len(chain); i++ {
+		if chain[i].PPID != chain[i-1].PID {
+			t.Errorf("chain[%d].PPID=%d does not match chain[%d].PID=%d",
+				i, chain[i].PPID, i-1, chain[i-1].PID)
+		}
+	}
+}
+
+func TestReadProcInfoCurrentProcess(t *testing.T) {
+	pid := os.Getpid()
+	info, err := readProcInfo(pid)
+	if err != nil {
+		t.Fatalf("readProcInfo(%d): %v", pid, err)
+	}
+	if info.PID != pid {
+		t.Errorf("expected PID %d, got %d", pid, info.PID)
+	}
+	if info.Comm == "" {
+		t.Error("expected non-empty Comm for current process")
+	}
+	if info.CmdLine == "" {
+		t.Error("expected non-empty CmdLine for current process")
+	}
+}
+
+func TestReadProcInfoParentProcess(t *testing.T) {
+	ppid := os.Getppid()
+	info, err := readProcInfo(ppid)
+	if err != nil {
+		t.Fatalf("readProcInfo(%d): %v", ppid, err)
+	}
+	if info.PID != ppid {
+		t.Errorf("expected PID %d, got %d", ppid, info.PID)
+	}
+}
+
+func TestReadProcInfoInvalidPID(t *testing.T) {
+	_, err := readProcInfo(-1)
+	if err == nil {
+		t.Error("expected error for PID -1")
+	}
+}
+
+func TestReadProcInfoNonExistentPID(t *testing.T) {
+	// PID 0 is the idle/swapper process; /proc/0 does not exist.
+	_, err := readProcInfo(0)
+	if err == nil {
+		t.Error("expected error for PID 0")
+	}
+}

--- a/internal/tracing/process_other.go
+++ b/internal/tracing/process_other.go
@@ -1,0 +1,5 @@
+//go:build !linux
+
+package tracing
+
+func collectAncestry() []ProcessInfo { return nil }

--- a/internal/tracing/process_other_test.go
+++ b/internal/tracing/process_other_test.go
@@ -1,0 +1,14 @@
+//go:build !linux
+
+package tracing
+
+import (
+	"testing"
+)
+
+func TestCollectAncestry(t *testing.T) {
+	chain := collectAncestry()
+	if chain != nil {
+		t.Errorf("expected nil ancestry on non-linux, got %v", chain)
+	}
+}

--- a/internal/tracing/process_test.go
+++ b/internal/tracing/process_test.go
@@ -1,0 +1,38 @@
+package tracing
+
+import (
+	"testing"
+)
+
+func TestCollect(t *testing.T) {
+	info := Collect()
+	if info.User == "" {
+		t.Error("expected non-empty User")
+	}
+	if info.FQDN == "" {
+		t.Error("expected non-empty FQDN")
+	}
+}
+
+func TestCollectUserID(t *testing.T) {
+	info := Collect()
+	if info.UserID == "" {
+		t.Error("expected non-empty UserID (numeric UID)")
+	}
+}
+
+func TestResolveFQDNFallsBackToHostname(t *testing.T) {
+	// An obviously non-routable hostname should fall back to the input.
+	got := resolveFQDN("this-hostname-does-not-exist.invalid")
+	if got != "this-hostname-does-not-exist.invalid" {
+		t.Errorf("expected fallback to input, got %q", got)
+	}
+}
+
+func TestResolveFQDNLocalhost(t *testing.T) {
+	// "localhost" always resolves; result must be non-empty.
+	got := resolveFQDN("localhost")
+	if got == "" {
+		t.Error("expected non-empty result for 'localhost'")
+	}
+}

--- a/internal/tracing/tracing.go
+++ b/internal/tracing/tracing.go
@@ -1,0 +1,139 @@
+package tracing
+
+import (
+	"context"
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"go.opentelemetry.io/contrib/instrumentation/net/http/otelhttp"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
+	"go.opentelemetry.io/otel/propagation"
+	sdkresource "go.opentelemetry.io/otel/sdk/resource"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+)
+
+const instrumentationScope = "github.com/restic/restic"
+
+// Tracer returns the global restic tracer. When Setup has not been called it
+// returns a no-op tracer so callers need no conditional guards.
+func Tracer() trace.Tracer {
+	return otel.Tracer(instrumentationScope)
+}
+
+// Setup initialises the OpenTelemetry SDK with an OTLP/HTTP exporter.
+//
+// rawURL must use the http or https scheme. Basic-auth credentials may be
+// embedded in the URL userinfo component, e.g.:
+//
+//	https://user:pass@collector.example.com:4318
+//
+// serviceName is used as the service.name resource attribute (default "restic").
+// Returns a shutdown function that must be called to flush pending spans.
+func Setup(ctx context.Context, rawURL, serviceName string) (shutdown func(context.Context) error, err error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return nil, fmt.Errorf("invalid trace URL %q: %w", rawURL, err)
+	}
+	if u.Scheme != "http" && u.Scheme != "https" {
+		return nil, fmt.Errorf("trace URL must use http or https scheme, got %q", u.Scheme)
+	}
+
+	opts := []otlptracehttp.Option{
+		otlptracehttp.WithEndpoint(endpointHost(u)),
+	}
+	if u.Scheme == "http" {
+		opts = append(opts, otlptracehttp.WithInsecure())
+	}
+	if u.User != nil {
+		user := u.User.Username()
+		pass, _ := u.User.Password()
+		token := base64.StdEncoding.EncodeToString([]byte(user + ":" + pass))
+		opts = append(opts, otlptracehttp.WithHeaders(map[string]string{
+			"Authorization": "Basic " + token,
+		}))
+	}
+	// Override the default /v1/traces path when the URL carries an explicit one.
+	if u.Path != "" && u.Path != "/" {
+		opts = append(opts, otlptracehttp.WithURLPath(u.Path))
+	}
+
+	exp, err := otlptracehttp.New(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating OTLP trace exporter: %w", err)
+	}
+
+	if serviceName == "" {
+		serviceName = "restic"
+	}
+	sysInfo := Collect()
+	res, err := sdkresource.New(ctx,
+		sdkresource.WithAttributes(
+			attribute.String("service.name", serviceName),
+			attribute.String("host.name", sysInfo.FQDN),
+		),
+	)
+	if err != nil || res == nil {
+		res = sdkresource.Default()
+	}
+
+	tp := sdktrace.NewTracerProvider(
+		sdktrace.WithBatcher(exp),
+		sdktrace.WithResource(res),
+		sdktrace.WithSampler(sdktrace.AlwaysSample()),
+	)
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+		propagation.Baggage{},
+	))
+
+	return tp.Shutdown, nil
+}
+
+// WrapTransport wraps rt with OpenTelemetry HTTP instrumentation so that every
+// outgoing request carries a W3C traceparent header and is recorded as a child
+// span of the currently active span.  When no tracer provider has been
+// configured (--trace not supplied) the wrapper delegates to rt without
+// overhead.
+func WrapTransport(rt http.RoundTripper) http.RoundTripper {
+	return otelhttp.NewTransport(rt)
+}
+
+// ExtractParentContext parses a W3C traceparent string and returns a context
+// that carries it as the remote parent span context. If traceparent is empty
+// the original context is returned unchanged.
+func ExtractParentContext(ctx context.Context, traceparent string) context.Context {
+	if traceparent == "" {
+		return ctx
+	}
+	return otel.GetTextMapPropagator().Extract(ctx, propagation.MapCarrier{
+		"traceparent": traceparent,
+	})
+}
+
+// EndSpanWithError records err on the span (if non-nil) and calls End.
+func EndSpanWithError(span trace.Span, err error) {
+	if err != nil {
+		span.RecordError(err)
+		span.SetStatus(codes.Error, err.Error())
+	}
+	span.End()
+}
+
+// endpointHost returns "host:port" from a parsed URL, defaulting to standard
+// HTTP/HTTPS ports when none is explicitly specified.
+func endpointHost(u *url.URL) string {
+	if u.Port() != "" {
+		return u.Hostname() + ":" + u.Port()
+	}
+	if u.Scheme == "https" {
+		return u.Hostname() + ":443"
+	}
+	return u.Hostname() + ":80"
+}

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -1,0 +1,244 @@
+package tracing
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/propagation"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace"
+)
+
+func resetGlobalOTEL(t *testing.T) {
+	t.Helper()
+	origTP := otel.GetTracerProvider()
+	origProp := otel.GetTextMapPropagator()
+	t.Cleanup(func() {
+		otel.SetTracerProvider(origTP)
+		otel.SetTextMapPropagator(origProp)
+	})
+}
+
+func TestTracer(t *testing.T) {
+	tr := Tracer()
+	if tr == nil {
+		t.Fatal("expected non-nil tracer")
+	}
+}
+
+func TestSetupInvalidURL(t *testing.T) {
+	_, err := Setup(context.Background(), "://invalid", "svc")
+	if err == nil {
+		t.Fatal("expected error for invalid URL")
+	}
+}
+
+func TestSetupWrongScheme(t *testing.T) {
+	_, err := Setup(context.Background(), "ftp://example.com:4318", "svc")
+	if err == nil {
+		t.Fatal("expected error for non-http/https scheme")
+	}
+}
+
+func otlpHandler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+}
+
+func TestSetupHTTP(t *testing.T) {
+	resetGlobalOTEL(t)
+	srv := httptest.NewServer(otlpHandler())
+	defer srv.Close()
+
+	shutdown, err := Setup(context.Background(), srv.URL, "test-svc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if err := shutdown(context.Background()); err != nil {
+		t.Fatalf("shutdown error: %v", err)
+	}
+}
+
+func TestSetupDefaultServiceName(t *testing.T) {
+	resetGlobalOTEL(t)
+	srv := httptest.NewServer(otlpHandler())
+	defer srv.Close()
+
+	shutdown, err := Setup(context.Background(), srv.URL, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = shutdown(context.Background())
+}
+
+func TestSetupHTTPWithBasicAuth(t *testing.T) {
+	resetGlobalOTEL(t)
+	var gotAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	rawURL := "http://user:secret@" + srv.Listener.Addr().String()
+	shutdown, err := Setup(context.Background(), rawURL, "svc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Export a span so the exporter actually sends a request.
+	_, span := Tracer().Start(context.Background(), "auth-test")
+	span.End()
+	_ = shutdown(context.Background())
+
+	if gotAuth == "" {
+		// The OTLP exporter may not have sent a request if spans were dropped.
+		// Just verify Setup didn't error.
+		t.Log("no HTTP request received (spans may have been dropped before flush)")
+	}
+}
+
+func TestSetupHTTPWithCustomPath(t *testing.T) {
+	resetGlobalOTEL(t)
+	srv := httptest.NewServer(otlpHandler())
+	defer srv.Close()
+
+	rawURL := "http://" + srv.Listener.Addr().String() + "/custom/traces"
+	shutdown, err := Setup(context.Background(), rawURL, "svc")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	_ = shutdown(context.Background())
+}
+
+func TestWrapTransport(t *testing.T) {
+	wrapped := WrapTransport(http.DefaultTransport)
+	if wrapped == nil {
+		t.Fatal("expected non-nil RoundTripper")
+	}
+	if wrapped == http.DefaultTransport {
+		t.Fatal("expected a different RoundTripper from the wrapper")
+	}
+}
+
+func TestExtractParentContextEmpty(t *testing.T) {
+	ctx := context.Background()
+	got := ExtractParentContext(ctx, "")
+	if got != ctx {
+		t.Fatal("expected same context for empty traceparent")
+	}
+}
+
+func TestExtractParentContextValid(t *testing.T) {
+	resetGlobalOTEL(t)
+
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	otel.SetTracerProvider(tp)
+	otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(
+		propagation.TraceContext{},
+	))
+
+	const rawTraceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	ctx := ExtractParentContext(context.Background(), rawTraceparent)
+
+	_, span := Tracer().Start(ctx, "child")
+	span.End()
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 recorded span, got %d", len(spans))
+	}
+	parent := spans[0].Parent
+	if !parent.IsValid() {
+		t.Fatal("expected child span to have a valid parent")
+	}
+	if parent.TraceID().String() != "4bf92f3577b34da6a3ce929d0e0e4736" {
+		t.Errorf("unexpected parent trace ID: %s", parent.TraceID().String())
+	}
+	if parent.SpanID().String() != "00f067aa0ba902b7" {
+		t.Errorf("unexpected parent span ID: %s", parent.SpanID().String())
+	}
+}
+
+func TestExtractParentContextInvalidIsNoop(t *testing.T) {
+	ctx := context.Background()
+	got := ExtractParentContext(ctx, "not-a-valid-traceparent")
+	_ = got // must not panic
+}
+
+func TestEndSpanWithErrorNil(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	_, span := tp.Tracer("test").Start(context.Background(), "op")
+
+	EndSpanWithError(span, nil)
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].Status.Code != 0 {
+		t.Errorf("expected unset status code, got %v", spans[0].Status.Code)
+	}
+}
+
+func TestEndSpanWithError(t *testing.T) {
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	_, span := tp.Tracer("test").Start(context.Background(), "op")
+
+	EndSpanWithError(span, errors.New("something failed"))
+
+	spans := exp.GetSpans()
+	if len(spans) != 1 {
+		t.Fatalf("expected 1 span, got %d", len(spans))
+	}
+	if spans[0].Status.Code != codes.Error {
+		t.Errorf("expected codes.Error status, got %v", spans[0].Status.Code)
+	}
+	if spans[0].Status.Description != "something failed" {
+		t.Errorf("unexpected status description: %q", spans[0].Status.Description)
+	}
+	if len(spans[0].Events) == 0 {
+		t.Error("expected at least one event (recorded error)")
+	}
+}
+
+func TestEndSpanWithErrorNoop(t *testing.T) {
+	// Ensure EndSpanWithError works on a no-op span without panicking.
+	var span trace.Span = trace.SpanFromContext(context.Background())
+	EndSpanWithError(span, errors.New("noop"))
+}
+
+func TestEndpointHost(t *testing.T) {
+	cases := []struct {
+		rawURL string
+		want   string
+	}{
+		{"http://example.com", "example.com:80"},
+		{"https://example.com", "example.com:443"},
+		{"http://example.com:9411", "example.com:9411"},
+		{"https://example.com:4318", "example.com:4318"},
+		{"http://127.0.0.1", "127.0.0.1:80"},
+		{"https://127.0.0.1", "127.0.0.1:443"},
+	}
+	for _, tc := range cases {
+		u, err := url.Parse(tc.rawURL)
+		if err != nil {
+			t.Fatalf("url.Parse(%q): %v", tc.rawURL, err)
+		}
+		got := endpointHost(u)
+		if got != tc.want {
+			t.Errorf("endpointHost(%q) = %q, want %q", tc.rawURL, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

In a large infrastructure we need to know what's wrong with our backups and where the error occurs. Therefore we can use logs. However Logs only tell a story without context. OTEL can be used to add a context to the logs. I've implemented OTEL tracing in this PR. Therefore we'll know if somethig goes wrong and were the problem occurs without even looking through distributed logs. 

The OTEL tracing feature is optional and disabled by default. No braking changes. No leaks of data in the traces. We now knows which command has been run, the duration, if an error occurred and where the problem is. 

Tested on Debian12 & 13, Ubuntu 22.04 & 24.04, Raspberry Pi OS 13 with http, local and s3 backend repository. I havn't windows or mac to test the code.



Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No.

Checklist
---------


- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
