### PR TITLE
mount: refresh latest symlink after snapshot reload

### DIFF
--- a/changelog/unreleased/issue-5722
+++ b/changelog/unreleased/issue-5722
@@ -1,0 +1,8 @@
+Bugfix: refresh `latest` symlink targets in `mount`
+
+`restic mount` could keep showing an outdated `latest` symlink after a newer
+snapshot was added to the repository. Restic now refreshes cached snapshot
+directory entries when the mounted snapshot tree changes, so `latest` points to
+the newest snapshot without remounting.
+
+https://github.com/restic/restic/issues/5722

--- a/internal/fuse/fuse_test.go
+++ b/internal/fuse/fuse_test.go
@@ -246,6 +246,53 @@ func TestStableNodeObjects(t *testing.T) {
 	testStableLookup(t, dir, "file-2")
 }
 
+func TestSnapshotsDirReloadUpdatesLatestSymlink(t *testing.T) {
+	repo := repository.TestRepository(t)
+	root := NewRoot(repo, Config{TimeTemplate: time.RFC3339})
+
+	first := data.TestCreateSnapshot(t, repo, time.Unix(1700000000, 0).UTC(), 0)
+
+	snapshotsDir, err := root.Lookup(context.TODO(), "snapshots")
+	rtest.OK(t, err)
+
+	latestNode, err := snapshotsDir.(fs.NodeStringLookuper).Lookup(context.TODO(), "latest")
+	rtest.OK(t, err)
+
+	latestLink := latestNode.(*snapshotLink)
+	target, err := latestLink.Readlink(context.TODO(), nil)
+	rtest.OK(t, err)
+	rtest.Equals(t, first.Time.Format(time.RFC3339), target)
+
+	second := data.TestCreateSnapshot(t, repo, first.Time.Add(time.Second), 0)
+	root.SnapshotsDir.dirStruct.lastCheck = time.Time{}
+
+	latestNode, err = snapshotsDir.(fs.NodeStringLookuper).Lookup(context.TODO(), "latest")
+	rtest.OK(t, err)
+
+	target, err = latestNode.(*snapshotLink).Readlink(context.TODO(), nil)
+	rtest.OK(t, err)
+	rtest.Equals(t, second.Time.Format(time.RFC3339), target)
+}
+
+func TestTreeCacheGenerationForgetIsolation(t *testing.T) {
+	cache := newTreeCache()
+
+	lookupLatest := func(generation uint64) fs.Node {
+		node, err := cache.lookupOrCreateAtGeneration(generation, "latest", func(forget forgetFn) (fs.Node, error) {
+			return &snapshotLink{forget: forget}, nil
+		})
+		rtest.OK(t, err)
+		return node
+	}
+
+	oldNode := lookupLatest(1)
+	currentNode := lookupLatest(2)
+	rtest.Assert(t, oldNode != currentNode, "cache should be invalidated across generations")
+
+	oldNode.(fs.NodeForgetter).Forget()
+	rtest.Assert(t, currentNode == lookupLatest(2), "stale forget removed the current generation cache entry")
+}
+
 // Test reporting of fuse.Attr.Blocks in multiples of 512.
 func TestBlocks(t *testing.T) {
 	root := &Root{}

--- a/internal/fuse/snapshots_dir.go
+++ b/internal/fuse/snapshots_dir.go
@@ -61,7 +61,7 @@ func (d *SnapshotsDir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 	debug.Log("ReadDirAll()")
 
 	// update snapshots
-	meta, err := d.dirStruct.UpdatePrefix(ctx, d.prefix)
+	meta, _, err := d.dirStruct.UpdatePrefix(ctx, d.prefix)
 	if err != nil {
 		return nil, unwrapCtxCanceled(err)
 	} else if meta == nil {
@@ -104,14 +104,14 @@ func (d *SnapshotsDir) ReadDirAll(ctx context.Context) ([]fuse.Dirent, error) {
 func (d *SnapshotsDir) Lookup(ctx context.Context, name string) (fs.Node, error) {
 	debug.Log("Lookup(%s)", name)
 
-	meta, err := d.dirStruct.UpdatePrefix(ctx, d.prefix)
+	meta, generation, err := d.dirStruct.UpdatePrefix(ctx, d.prefix)
 	if err != nil {
 		return nil, unwrapCtxCanceled(err)
 	} else if meta == nil {
 		return nil, syscall.ENOENT
 	}
 
-	return d.cache.lookupOrCreate(name, func(forget forgetFn) (fs.Node, error) {
+	return d.cache.lookupOrCreateAtGeneration(generation, name, func(forget forgetFn) (fs.Node, error) {
 		entry := meta.names[name]
 		if entry == nil {
 			return nil, syscall.ENOENT

--- a/internal/fuse/snapshots_dirstruct.go
+++ b/internal/fuse/snapshots_dirstruct.go
@@ -40,8 +40,9 @@ type SnapshotsDirStructure struct {
 	// that way we don't need path processing special cases when using the entries tree
 	entries map[string]*MetaDirData
 
-	hash      [sha256.Size]byte // Hash at last check.
-	lastCheck time.Time
+	generation uint64
+	hash       [sha256.Size]byte // Hash at last check.
+	lastCheck  time.Time
 }
 
 // NewSnapshotsDirStructure returns a new directory structure for snapshots.
@@ -334,16 +335,17 @@ func (d *SnapshotsDirStructure) updateSnapshots(ctx context.Context) error {
 	d.lastCheck = time.Now()
 	d.hash = hash
 	d.makeDirs(snapshots)
+	d.generation++
 	return nil
 }
 
-func (d *SnapshotsDirStructure) UpdatePrefix(ctx context.Context, prefix string) (*MetaDirData, error) {
+func (d *SnapshotsDirStructure) UpdatePrefix(ctx context.Context, prefix string) (*MetaDirData, uint64, error) {
 	err := d.updateSnapshots(ctx)
 	if err != nil {
-		return nil, err
+		return nil, 0, err
 	}
 
 	d.mutex.Lock()
 	defer d.mutex.Unlock()
-	return d.entries[prefix], nil
+	return d.entries[prefix], d.generation, nil
 }

--- a/internal/fuse/tree_cache.go
+++ b/internal/fuse/tree_cache.go
@@ -9,8 +9,9 @@ import (
 )
 
 type treeCache struct {
-	nodes map[string]fs.Node
-	m     sync.Mutex
+	nodes      map[string]fs.Node
+	generation uint64
+	m          sync.Mutex
 }
 
 type forgetFn func()
@@ -22,17 +23,30 @@ func newTreeCache() *treeCache {
 }
 
 func (t *treeCache) lookupOrCreate(name string, create func(forget forgetFn) (fs.Node, error)) (fs.Node, error) {
+	return t.lookupOrCreateAtGeneration(0, name, create)
+}
+
+func (t *treeCache) lookupOrCreateAtGeneration(generation uint64, name string, create func(forget forgetFn) (fs.Node, error)) (fs.Node, error) {
 	t.m.Lock()
 	defer t.m.Unlock()
+
+	if t.generation != generation {
+		t.nodes = map[string]fs.Node{}
+		t.generation = generation
+	}
 
 	if node, ok := t.nodes[name]; ok {
 		return node, nil
 	}
 
+	cacheGeneration := generation
 	node, err := create(func() {
 		t.m.Lock()
 		defer t.m.Unlock()
 
+		if t.generation != cacheGeneration {
+			return
+		}
 		delete(t.nodes, name)
 	})
 	if err != nil {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Closes #5722.

`restic mount` caches `SnapshotsDir` lookups, so after the snapshot tree reloads the existing `latest` symlink node can still point to the old target. This patch adds a generation counter to the snapshot directory structure and invalidates the cached `SnapshotsDir` entries when that generation changes, so `latest` is refreshed after new snapshots are added without remounting.

Validation: `go test ./internal/fuse -count=1`

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #5722.

Checklist
---------
- [x] I have added tests for all code changes.
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
