### PR TITLE
mount: Ensure a hard link count > 0 for all files

### DIFF
--- a/changelog/unreleased/pull-21784
+++ b/changelog/unreleased/pull-21784
@@ -1,0 +1,9 @@
+Bugfix: Support exporting a `restic mount` of a Windows system via Samba
+
+A repository mounted using `restic mount` on a POSIX system, could not use
+Samba to export files from restic backups of Windows systems. Backups of
+other systems were not affected. This has been fixed.
+
+https://github.com/restic/restic/pull/21784
+https://github.com/restic/restic/issues/2034
+https://github.com/restic/restic/issues/4382

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -55,7 +55,8 @@ func (f *file) Attr(_ context.Context, a *fuse.Attr) error {
 	a.Size = f.node.Size
 	a.Blocks = (f.node.Size + blockSize - 1) / blockSize
 	a.BlockSize = blockSize
-	a.Nlink = uint32(f.node.Links)
+	// present a link count > 0 to keep over-eager stat() .st_nlink checks (e.g., from Samba's smbd) happy
+	a.Nlink = max(uint32(1), uint32(f.node.Links))
 
 	if !f.root.cfg.OwnerIsRoot {
 		a.Uid = f.node.UID

--- a/internal/fuse/file.go
+++ b/internal/fuse/file.go
@@ -55,7 +55,9 @@ func (f *file) Attr(_ context.Context, a *fuse.Attr) error {
 	a.Size = f.node.Size
 	a.Blocks = (f.node.Size + blockSize - 1) / blockSize
 	a.BlockSize = blockSize
-	// present a link count > 0 to keep over-eager stat() .st_nlink checks (e.g., from Samba's smbd) happy
+	// Windows (and other non-POSIX) backups may store a link count of 0.
+	// FUSE must still report a positive nlink so tools that validate stat()
+	// (e.g. Samba) accept the file.
 	a.Nlink = max(uint32(1), uint32(f.node.Links))
 
 	if !f.root.cfg.OwnerIsRoot {

--- a/internal/fuse/fuse_test.go
+++ b/internal/fuse/fuse_test.go
@@ -5,6 +5,7 @@ package fuse
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"math/rand"
 	"os"
 	"strings"
@@ -274,6 +275,28 @@ func TestBlocks(t *testing.T) {
 			rtest.OK(t, err)
 			rtest.Equals(t, c.blocks, a.Blocks)
 		}
+	}
+}
+
+// Windows (and other non-POSIX) backups may store a link count of 0; FUSE
+// must still report a positive nlink so tools that validate stat() (e.g.
+// Samba) accept the file.
+func TestFileAttrNlink(t *testing.T) {
+	root := &Root{}
+	for _, tc := range []struct {
+		links uint64
+		want  uint32
+	}{
+		{0, 1},
+		{1, 1},
+		{42, 42},
+	} {
+		t.Run(fmt.Sprintf("links_%d", tc.links), func(t *testing.T) {
+			f := &file{root: root, node: &data.Node{Links: tc.links}}
+			var a fuse.Attr
+			rtest.OK(t, f.Attr(context.TODO(), &a))
+			rtest.Equals(t, tc.want, a.Nlink)
+		})
 	}
 }
 


### PR DESCRIPTION
When using `restic mount` to serve a repository via a POSIX host's file system, all files backed up from Windows systems will show up on the mounting host with a (hard)link count of 0.

While this is not a problem in general and most programs do not even register this strange value, some others (such as Samba's smbd(8)) will go the extra mile and check a file's stat() results for various properties (such as a positive non-zero link count), and refuse to operate if any of the reported values appear off.

Since other inode properties absent from non-POSIX backup sources are also "faked up" (e.g., the inode number) during mount and work fine in general, the chances of this change to be in any way harmful are probably rather slim.

What does this PR change? What problem does it solve?
-----------------------------------------------------
This makes it possible to serve up a `restic mount`-provided repository via the Samba project's `smbd`. Without it, accessing a regular file backed up from a Windows source host will cause the smb client to croak with the NT status equivalent of ENOENT.

To work around this with this patch, the fuse layer will ensure a minimal link count of 1 for all files it presents to the mounting host.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No, merely on IRC.

Checklist
---------

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
