### PR TITLE
feature: parallel writes and --skip-zeros for dump --target

### DIFF
--- a/changelog/unreleased/pull-21787
+++ b/changelog/unreleased/pull-21787
@@ -1,0 +1,10 @@
+Enhancement: Parallel writes and `--skip-zeros` for `dump --target`
+
+Writing to an existing file with `dump --target` used to happen sequentially, which
+became a bottleneck when restoring to block devices. The `--target` flag now enables
+parallel file writes (not only blob loading), bringing a 2x+ speedup in some
+environments. Additionally, the new `--skip-zeros` flag prevents "zero blobs" from
+being written to the corresponding offsets, making the restoration of sparse block
+devices just as fast as restoring the real data on those devices.
+
+https://github.com/restic/restic/pull/21787

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -80,14 +80,14 @@ func splitPath(p string) []string {
 	return append(s, f)
 }
 
-func printFromTree(ctx context.Context, tree data.TreeNodeIterator, repo restic.BlobLoader, prefix string, pathComponents []string, d *dump.Dumper, canWriteArchiveFunc func() error) error {
+func printFromTree(ctx context.Context, tree data.TreeNodeIterator, repo restic.BlobLoader, prefix string, pathComponents []string, dumper dump.Dumper, canWriteArchiveFunc func() error) error {
 	// If we print / we need to assume that there are multiple nodes at that
 	// level in the tree.
 	if pathComponents[0] == "" {
 		if err := canWriteArchiveFunc(); err != nil {
 			return err
 		}
-		return d.DumpTree(ctx, tree, "/")
+		return dumper.DumpTree(ctx, tree, "/")
 	}
 
 	item := filepath.Join(prefix, pathComponents[0])
@@ -105,13 +105,13 @@ func printFromTree(ctx context.Context, tree data.TreeNodeIterator, repo restic.
 		if node.Name == pathComponents[0] {
 			switch {
 			case l == 1 && node.Type == data.NodeTypeFile:
-				return d.WriteNode(ctx, node)
+				return dumper.WriteNode(ctx, node)
 			case l > 1 && node.Type == data.NodeTypeDir:
 				subtree, err := data.LoadTree(ctx, repo, *node.Subtree)
 				if err != nil {
 					return errors.Wrapf(err, "cannot load subtree for %q", item)
 				}
-				return printFromTree(ctx, subtree, repo, item, pathComponents[1:], d, canWriteArchiveFunc)
+				return printFromTree(ctx, subtree, repo, item, pathComponents[1:], dumper, canWriteArchiveFunc)
 			case node.Type == data.NodeTypeDir:
 				if err := canWriteArchiveFunc(); err != nil {
 					return err
@@ -120,7 +120,7 @@ func printFromTree(ctx context.Context, tree data.TreeNodeIterator, repo restic.
 				if err != nil {
 					return err
 				}
-				return d.DumpTree(ctx, subtree, item)
+				return dumper.DumpTree(ctx, subtree, item)
 			case l > 1:
 				return fmt.Errorf("%q should be a dir, but is a %q", item, node.Type)
 			case node.Type != data.NodeTypeFile:
@@ -177,11 +177,13 @@ func runDump(ctx context.Context, opts DumpOptions, gopts global.Options, args [
 		return errors.Fatalf("loading tree for snapshot %q failed: %v", snapshotIDString, err)
 	}
 
-	outputFileWriter := term.OutputRaw()
+	outputWriter := term.OutputRaw()
 	canWriteArchiveFunc := checkStdoutArchive(term)
+	var file *os.File
 
 	if opts.Target != "" {
-		file, err := os.Create(opts.Target)
+		var err error
+		file, err = os.Create(opts.Target)
 		if err != nil {
 			return fmt.Errorf("cannot dump to file: %w", err)
 		}
@@ -189,12 +191,19 @@ func runDump(ctx context.Context, opts DumpOptions, gopts global.Options, args [
 			_ = file.Close()
 		}()
 
-		outputFileWriter = file
+		outputWriter = file
 		canWriteArchiveFunc = func() error { return nil }
 	}
 
-	d := dump.New(opts.Archive, repo, outputFileWriter)
-	err = printFromTree(ctx, tree, repo, "/", splittedPath, d, canWriteArchiveFunc)
+	seq := dump.NewSequentialDumper(opts.Archive, repo, outputWriter)
+
+	var dumper dump.Dumper = seq
+
+	if opts.Target != "" {
+		dumper = dump.NewParallelDumper(seq, file)
+	}
+
+	err = printFromTree(ctx, tree, repo, "/", splittedPath, dumper, canWriteArchiveFunc)
 	if err != nil {
 		return errors.Fatalf("cannot dump file: %v", err)
 	}

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -61,14 +61,16 @@ Exit status is 12 if the password is incorrect.
 // DumpOptions collects all options for the dump command.
 type DumpOptions struct {
 	data.SnapshotFilter
-	Archive string
-	Target  string
+	Archive   string
+	Target    string
+	SkipZeros bool
 }
 
 func (opts *DumpOptions) AddFlags(f *pflag.FlagSet) {
 	initSingleSnapshotFilter(f, &opts.SnapshotFilter)
 	f.StringVarP(&opts.Archive, "archive", "a", "tar", "set archive `format` as \"tar\" or \"zip\"")
 	f.StringVarP(&opts.Target, "target", "t", "", "write the output to target `path`")
+	f.BoolVar(&opts.SkipZeros, "skip-zeros", false, "do not write zero chunks (for optimization purposes)")
 }
 
 func splitPath(p string) []string {
@@ -133,7 +135,11 @@ func printFromTree(ctx context.Context, tree data.TreeNodeIterator, repo restic.
 
 func runDump(ctx context.Context, opts DumpOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	if len(args) != 2 {
-		return errors.Fatal("no file and no snapshot ID specified")
+		return errors.Fatal("both file and snapshot ID must be specified")
+	}
+
+	if opts.SkipZeros && opts.Target == "" {
+		return errors.Fatal("--target must be specified with --skip-zeros")
 	}
 
 	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, term)
@@ -200,7 +206,7 @@ func runDump(ctx context.Context, opts DumpOptions, gopts global.Options, args [
 	var dumper dump.Dumper = seq
 
 	if opts.Target != "" {
-		dumper = dump.NewParallelDumper(seq, file)
+		dumper = dump.NewParallelDumper(seq, file, opts.SkipZeros)
 	}
 
 	err = printFromTree(ctx, tree, repo, "/", splittedPath, dumper, canWriteArchiveFunc)

--- a/internal/dump/common.go
+++ b/internal/dump/common.go
@@ -2,6 +2,7 @@ package dump
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"path"
 
@@ -14,23 +15,41 @@ import (
 
 // A Dumper writes trees and files from a repository to a Writer
 // in an archive format.
-type Dumper struct {
+type Dumper interface {
+	WriteNode(ctx context.Context, node *data.Node) error
+	DumpTree(ctx context.Context, tree data.TreeNodeIterator, rootPath string) error
+}
+
+// SequentialDumper writes trees and files sequentially.
+type SequentialDumper struct {
 	cache  *bloblru.Cache
 	format string
 	repo   restic.Loader
-	w      io.Writer
+	writer io.Writer
 }
 
-func New(format string, repo restic.Loader, w io.Writer) *Dumper {
-	return &Dumper{
+type ParallelDumper struct {
+	seq       *SequentialDumper
+	writerAt  io.WriterAt
+}
+
+func NewSequentialDumper(format string, repo restic.Loader, writer io.Writer) *SequentialDumper {
+	return &SequentialDumper{
 		cache:  bloblru.New(64 << 20),
 		format: format,
 		repo:   repo,
-		w:      w,
+		writer: writer,
 	}
 }
 
-func (d *Dumper) DumpTree(ctx context.Context, tree data.TreeNodeIterator, rootPath string) error {
+func NewParallelDumper(seq *SequentialDumper, writerAt io.WriterAt) *ParallelDumper {
+	return &ParallelDumper{
+		seq:       seq,
+		writerAt:  writerAt,
+	}
+}
+
+func (d *SequentialDumper) DumpTree(ctx context.Context, tree data.TreeNodeIterator, rootPath string) error {
 	wg, ctx := errgroup.WithContext(ctx)
 
 	// ch is buffered to deal with variable download/write speeds.
@@ -108,11 +127,11 @@ func sendNodes(ctx context.Context, repo restic.BlobLoader, root *data.Node, ch 
 
 // WriteNode writes a file node's contents directly to d's Writer,
 // without caring about d's format.
-func (d *Dumper) WriteNode(ctx context.Context, node *data.Node) error {
-	return d.writeNode(ctx, d.w, node)
+func (d *SequentialDumper) WriteNode(ctx context.Context, node *data.Node) error {
+	return d.writeNode(ctx, d.writer, node)
 }
 
-func (d *Dumper) writeNode(ctx context.Context, w io.Writer, node *data.Node) error {
+func (d *SequentialDumper) writeNode(ctx context.Context, w io.Writer, node *data.Node) error {
 	wg, ctx := errgroup.WithContext(ctx)
 	limit := int(d.repo.Connections())
 	wg.SetLimit(1 + limit) // +1 for the writer.
@@ -159,5 +178,70 @@ loop:
 	}
 
 	close(blobs)
+	return wg.Wait()
+}
+
+func (p *ParallelDumper) WriteNode(ctx context.Context, node *data.Node) error {
+	return p.writeNode(ctx, p.writerAt, node)
+}
+
+func (p *ParallelDumper) DumpTree(ctx context.Context, tree data.TreeNodeIterator, rootPath string) error {
+	return p.seq.DumpTree(ctx, tree, rootPath)
+}
+
+type BlobTask struct {
+	id     restic.ID
+	offset int64
+}
+
+func (p *ParallelDumper) writeNode(ctx context.Context, w io.WriterAt, node *data.Node) error {
+	wg, ctx := errgroup.WithContext(ctx)
+	limit := int(p.seq.repo.Connections())
+	wg.SetLimit(limit)
+
+	taskChan := make(chan BlobTask, limit*2)
+
+	for i := 0; i < limit; i++ {
+		wg.Go(func() error {
+			for task := range taskChan {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				default:
+					blob, err := p.seq.cache.GetOrCompute(task.id, func() ([]byte, error) {
+						return p.seq.repo.LoadBlob(ctx, restic.DataBlob, task.id, nil)
+					})
+					if err != nil {
+						return err
+					}
+					if _, err := w.WriteAt(blob, task.offset); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		})
+	}
+
+	var currentOffset int64 = 0
+	for _, id := range node.Content {
+		size, found := p.seq.repo.LookupBlobSize(restic.DataBlob, id)
+		if !found {
+			return fmt.Errorf("blob %v not found", id)
+		}
+
+		select {
+		case taskChan <- BlobTask{
+			id:     id,
+			offset: currentOffset,
+		}:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+
+		currentOffset += int64(size)
+	}
+	close(taskChan)
+
 	return wg.Wait()
 }

--- a/internal/dump/common.go
+++ b/internal/dump/common.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/restic/restic/internal/bloblru"
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/walker"
 	"golang.org/x/sync/errgroup"
@@ -31,6 +32,7 @@ type SequentialDumper struct {
 type ParallelDumper struct {
 	seq       *SequentialDumper
 	writerAt  io.WriterAt
+	skipZeros bool
 }
 
 func NewSequentialDumper(format string, repo restic.Loader, writer io.Writer) *SequentialDumper {
@@ -42,10 +44,11 @@ func NewSequentialDumper(format string, repo restic.Loader, writer io.Writer) *S
 	}
 }
 
-func NewParallelDumper(seq *SequentialDumper, writerAt io.WriterAt) *ParallelDumper {
+func NewParallelDumper(seq *SequentialDumper, writerAt io.WriterAt, skipZeros bool) *ParallelDumper {
 	return &ParallelDumper{
 		seq:       seq,
 		writerAt:  writerAt,
+		skipZeros: skipZeros,
 	}
 }
 
@@ -228,6 +231,10 @@ func (p *ParallelDumper) writeNode(ctx context.Context, w io.WriterAt, node *dat
 		size, found := p.seq.repo.LookupBlobSize(restic.DataBlob, id)
 		if !found {
 			return fmt.Errorf("blob %v not found", id)
+		}
+		if p.skipZeros && (id == repository.ZeroChunk()) {
+			currentOffset += int64(size)
+			continue
 		}
 
 		select {

--- a/internal/dump/common_test.go
+++ b/internal/dump/common_test.go
@@ -96,7 +96,7 @@ func WriteTest(t *testing.T, format string, cd CheckDump) {
 			rtest.OK(t, err)
 
 			dst := &bytes.Buffer{}
-			d := New(format, repo, dst)
+			d := NewSequentialDumper(format, repo, dst)
 			if err := d.DumpTree(ctx, tree, tt.target); err != nil {
 				t.Fatalf("Dumper.Run error = %v", err)
 			}
@@ -109,7 +109,7 @@ func WriteTest(t *testing.T, format string, cd CheckDump) {
 			rtest.OK(t, err)
 			rtest.OK(t, be.Delete(ctx))
 			// use new dumper as the old one has the blobs cached
-			d = New(format, repo, dst)
+			d = NewSequentialDumper(format, repo, dst)
 			err = d.DumpTree(ctx, tree, tt.target)
 			rtest.Assert(t, err != nil, "expected error, got nil")
 		})

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -12,8 +12,8 @@ import (
 	"github.com/restic/restic/internal/errors"
 )
 
-func (d *Dumper) dumpTar(ctx context.Context, ch <-chan *data.Node) (err error) {
-	w := tar.NewWriter(d.w)
+func (d *SequentialDumper) dumpTar(ctx context.Context, ch <-chan *data.Node) (err error) {
+	w := tar.NewWriter(d.writer)
 
 	defer func() {
 		if err == nil {
@@ -48,7 +48,7 @@ func tarIdentifier(id uint32) int {
 	return int(id)
 }
 
-func (d *Dumper) dumpNodeTar(ctx context.Context, node *data.Node, w *tar.Writer) error {
+func (d *SequentialDumper) dumpNodeTar(ctx context.Context, node *data.Node, w *tar.Writer) error {
 	relPath, err := filepath.Rel("/", node.Path)
 	if err != nil {
 		return err

--- a/internal/dump/tar_test.go
+++ b/internal/dump/tar_test.go
@@ -133,7 +133,7 @@ func TestFieldTooLong(t *testing.T) {
 		},
 	}
 
-	d := Dumper{format: "tar"}
+	d := SequentialDumper{format: "tar"}
 	err := d.dumpNodeTar(context.Background(), &node, tar.NewWriter(io.Discard))
 
 	// We want a tar.ErrFieldTooLong that has the filename.

--- a/internal/dump/zip.go
+++ b/internal/dump/zip.go
@@ -9,8 +9,8 @@ import (
 	"github.com/restic/restic/internal/errors"
 )
 
-func (d *Dumper) dumpZip(ctx context.Context, ch <-chan *data.Node) (err error) {
-	w := zip.NewWriter(d.w)
+func (d *SequentialDumper) dumpZip(ctx context.Context, ch <-chan *data.Node) (err error) {
+	w := zip.NewWriter(d.writer)
 
 	defer func() {
 		if err == nil {
@@ -27,7 +27,7 @@ func (d *Dumper) dumpZip(ctx context.Context, ch <-chan *data.Node) (err error) 
 	return nil
 }
 
-func (d *Dumper) dumpNodeZip(ctx context.Context, node *data.Node, zw *zip.Writer) error {
+func (d *SequentialDumper) dumpNodeZip(ctx context.Context, node *data.Node, zw *zip.Writer) error {
 	relPath, err := filepath.Rel("/", node.Path)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
#4682 and #4692 introduced the `--target` flag of the `dump` command, which allows writing to an existing file. As mentioned in #4678, the primary objective of those changes was to provide a convenient way to restore to block devices.

This PR is an optimization of that feature, which is implemented via two things:

1. If `--target` is specified, file writes (not only blob loading) are now being done in parallel.
2. The `--skip-zeros` flag makes it so that "zero blobs" are not written to the corresponding offsets.

The parallelization by itself brings a 2x+ speedup in some environments, while `--skip-zeros` makes restoring sparse block devices just as fast as restoring the real data on those devices.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Unfortunately it wasn't, but as mentioned above it's an optimization of #4682 and #4692.

Furthermore, it's the next logical step in the issue discussed in #5250.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
