### PR TITLE
Add macOS backup exclusion support

### DIFF
--- a/changelog/unreleased/issue-2180
+++ b/changelog/unreleased/issue-2180
@@ -1,0 +1,8 @@
+Enhancement: Support excluding files marked by macOS as excluded from backups
+
+The `backup` command now supports `--exclude-macos-backup` on macOS. When set,
+restic excludes files and directories marked by macOS as excluded from system
+backups via Backup Core, such as application cache data that Time Machine would
+skip.
+
+https://github.com/restic/restic/issues/2180

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -77,31 +77,32 @@ Exit status is 12 if the password is incorrect.
 type BackupOptions struct {
 	filter.ExcludePatternOptions
 
-	Parent            string
-	GroupBy           data.SnapshotGroupByOptions
-	Force             bool
-	ExcludeOtherFS    bool
-	ExcludeIfPresent  []string
-	ExcludeCaches     bool
-	ExcludeLargerThan string
-	ExcludeCloudFiles bool
-	Stdin             bool
-	StdinFilename     string
-	StdinCommand      bool
-	Tags              data.TagLists
-	Host              string
-	FilesFrom         []string
-	FilesFromVerbatim []string
-	FilesFromRaw      []string
-	TimeStamp         string
-	WithAtime         bool
-	IgnoreInode       bool
-	IgnoreCtime       bool
-	UseFsSnapshot     bool
-	DryRun            bool
-	ReadConcurrency   uint
-	NoScan            bool
-	SkipIfUnchanged   bool
+	Parent             string
+	GroupBy            data.SnapshotGroupByOptions
+	Force              bool
+	ExcludeOtherFS     bool
+	ExcludeIfPresent   []string
+	ExcludeCaches      bool
+	ExcludeLargerThan  string
+	ExcludeCloudFiles  bool
+	ExcludeMacOSBackup bool
+	Stdin              bool
+	StdinFilename      string
+	StdinCommand       bool
+	Tags               data.TagLists
+	Host               string
+	FilesFrom          []string
+	FilesFromVerbatim  []string
+	FilesFromRaw       []string
+	TimeStamp          string
+	WithAtime          bool
+	IgnoreInode        bool
+	IgnoreCtime        bool
+	UseFsSnapshot      bool
+	DryRun             bool
+	ReadConcurrency    uint
+	NoScan             bool
+	SkipIfUnchanged    bool
 }
 
 func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
@@ -142,6 +143,9 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 	}
 	if runtime.GOOS == "windows" || runtime.GOOS == "darwin" {
 		f.BoolVar(&opts.ExcludeCloudFiles, "exclude-cloud-files", false, "excludes online-only cloud files (such as OneDrive, iCloud drive, …)")
+	}
+	if runtime.GOOS == "darwin" {
+		f.BoolVar(&opts.ExcludeMacOSBackup, "exclude-macos-backup", false, "exclude files and directories marked by macOS as excluded from backups")
 	}
 	f.BoolVar(&opts.SkipIfUnchanged, "skip-if-unchanged", false, "skip snapshot creation if identical to parent snapshot")
 
@@ -361,6 +365,14 @@ func collectRejectFuncs(opts BackupOptions, targets []string, fs fs.FS, warnf fu
 
 	if opts.ExcludeCloudFiles && !opts.Stdin && !opts.StdinCommand {
 		f, err := archiver.RejectCloudFiles(warnf)
+		if err != nil {
+			return nil, err
+		}
+		funcs = append(funcs, f)
+	}
+
+	if opts.ExcludeMacOSBackup && !opts.Stdin && !opts.StdinCommand {
+		f, err := archiver.RejectMacOSBackupExcludes(warnf)
 		if err != nil {
 			return nil, err
 		}

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -313,6 +313,7 @@ the exclude options are:
 -  ``--exclude-if-present foo`` Specified one or more times to exclude a folder's content if it contains a file called ``foo`` (optionally having a given header, no wildcards for the file name supported)
 -  ``--exclude-larger-than size`` Specified once to exclude files larger than the given size
 -  ``--exclude-cloud-files`` Specified once to exclude online-only cloud files (such as OneDrive Files On-Demand, iCloud drive), currently only supported on Windows and macOS
+-  ``--exclude-macos-backup`` Specified once to exclude files and directories marked by macOS as excluded from backups, currently only supported on macOS
 
 Please see ``restic help backup`` for more specific information about each exclude option.
 

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/anacrolix/fuse v0.3.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cespare/xxhash/v2 v2.3.0
+	github.com/ebitengine/purego v0.10.0
 	github.com/elithrar/simple-scrypt v1.4.0
 	github.com/go-ole/go-ole v1.3.0
 	github.com/google/go-cmp v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -77,6 +77,8 @@ github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc/go.mod h1:J7Y8Yc
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/dvyukov/go-fuzz v0.0.0-20220726122315-1d375ef9f9f6/go.mod h1:11Gm+ccJnvAhCNLlf5+cS9KjtbaD5I5zaZpFMsTHWTw=
+github.com/ebitengine/purego v0.10.0 h1:QIw4xfpWT6GWTzaW5XEKy3HXoqrJGx1ijYHzTF0/ISU=
+github.com/ebitengine/purego v0.10.0/go.mod h1:iIjxzd6CiRiOG0UyXP+V1+jWqUXVjPKLAI0mRfJZTmQ=
 github.com/elazarl/go-bindata-assetfs v1.0.0/go.mod h1:v+YaWX3bdea5J/mo8dSETolEo7R71Vk1u8bnjau5yw4=
 github.com/elithrar/simple-scrypt v1.4.0 h1:5sZ4st4bK5wBymv7DaGZFbRasbAj0WrhxECkLSm6q6Y=
 github.com/elithrar/simple-scrypt v1.4.0/go.mod h1:dtDmWT+ijC9sdIbf50kQjgI9xOFmA4LG/8/T6TbmtFY=

--- a/internal/archiver/exclude_macos_backup_darwin.go
+++ b/internal/archiver/exclude_macos_backup_darwin.go
@@ -1,0 +1,132 @@
+//go:build darwin
+
+package archiver
+
+import (
+	"fmt"
+	"sync"
+
+	"github.com/ebitengine/purego"
+	"github.com/restic/restic/internal/debug"
+	"github.com/restic/restic/internal/fs"
+)
+
+const (
+	rtldLazy  = 1
+	rtldLocal = 4
+)
+
+var (
+	backupCoreOnce    sync.Once
+	backupCoreLoadErr error
+
+	cfURLCreateFromFileSystemRepresentation func(allocator uintptr, buffer *byte, bufLen int64, isDirectory byte) uintptr
+	cfRelease                               func(cf uintptr)
+	csBackupIsItemExcluded                  func(item uintptr, byPath *byte) byte
+
+	macOSBackupExcluded = backupCoreIsItemExcluded
+)
+
+func loadBackupCore() error {
+	backupCoreOnce.Do(func() {
+		cf, err := purego.Dlopen("/System/Library/Frameworks/CoreFoundation.framework/CoreFoundation", rtldLazy|rtldLocal)
+		if err != nil {
+			backupCoreLoadErr = fmt.Errorf("open CoreFoundation: %w", err)
+			return
+		}
+
+		cs, err := purego.Dlopen("/System/Library/Frameworks/CoreServices.framework/CoreServices", rtldLazy|rtldLocal)
+		if err != nil {
+			backupCoreLoadErr = fmt.Errorf("open CoreServices: %w", err)
+			return
+		}
+
+		if err := registerLibFunc(&cfURLCreateFromFileSystemRepresentation, cf, "CFURLCreateFromFileSystemRepresentation"); err != nil {
+			backupCoreLoadErr = err
+			return
+		}
+		if err := registerLibFunc(&cfRelease, cf, "CFRelease"); err != nil {
+			backupCoreLoadErr = err
+			return
+		}
+		if err := registerLibFunc(&csBackupIsItemExcluded, cs, "CSBackupIsItemExcluded"); err != nil {
+			backupCoreLoadErr = err
+			return
+		}
+	})
+
+	return backupCoreLoadErr
+}
+
+func registerLibFunc(fptr any, handle uintptr, name string) error {
+	fn, err := purego.Dlsym(handle, name)
+	if err != nil {
+		return fmt.Errorf("load %s: %w", name, err)
+	}
+	purego.RegisterFunc(fptr, fn)
+	return nil
+}
+
+func backupCoreFileURL(path string, isDir bool) (uintptr, error) {
+	if err := loadBackupCore(); err != nil {
+		return 0, err
+	}
+
+	buf := append([]byte(path), 0)
+	dir := byte(0)
+	if isDir {
+		dir = 1
+	}
+
+	url := cfURLCreateFromFileSystemRepresentation(0, &buf[0], int64(len(buf)-1), dir)
+	if url == 0 {
+		return 0, fmt.Errorf("CFURLCreateFromFileSystemRepresentation returned NULL for %q", path)
+	}
+	return url, nil
+}
+
+func backupCoreIsItemExcluded(path string, isDir bool) (bool, error) {
+	url, err := backupCoreFileURL(path, isDir)
+	if err != nil {
+		return false, err
+	}
+	defer cfRelease(url)
+
+	var byPath byte
+	excluded := csBackupIsItemExcluded(url, &byPath) != 0
+	return excluded, nil
+}
+
+// RejectMacOSBackupExcludes returns a reject function for items marked as
+// excluded from macOS backups via Backup Core.
+func RejectMacOSBackupExcludes(warnf func(msg string, args ...interface{})) (RejectFunc, error) {
+	if err := loadBackupCore(); err != nil {
+		return nil, err
+	}
+
+	return rejectMacOSBackupExcludesWithChecker(macOSBackupExcluded, warnf), nil
+}
+
+func rejectMacOSBackupExcludesWithChecker(checker func(path string, isDir bool) (bool, error), warnf func(msg string, args ...interface{})) RejectFunc {
+	var cache sync.Map
+	return func(item string, fi *fs.ExtendedFileInfo, _ fs.FS) bool {
+		if cached, ok := cache.Load(item); ok {
+			return cached.(bool)
+		}
+
+		excluded, err := checker(item, fi.Mode.IsDir())
+		if err != nil {
+			if warnf != nil {
+				warnf("item %v: error checking macOS backup exclusion status: %v\n", item, err)
+			}
+			cache.Store(item, false)
+			return false
+		}
+
+		if excluded {
+			debug.Log("rejecting macOS backup excluded item %s", item)
+		}
+		cache.Store(item, excluded)
+		return excluded
+	}
+}

--- a/internal/archiver/exclude_macos_backup_darwin_test.go
+++ b/internal/archiver/exclude_macos_backup_darwin_test.go
@@ -1,0 +1,115 @@
+//go:build darwin
+
+package archiver
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ebitengine/purego"
+	"github.com/restic/restic/internal/fs"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestRejectMacOSBackupExcludesWithChecker(t *testing.T) {
+	var calls atomic.Int32
+	reject := rejectMacOSBackupExcludesWithChecker(func(path string, isDir bool) (bool, error) {
+		calls.Add(1)
+		rtest.Assert(t, isDir, "expected directory flag")
+		return strings.HasSuffix(path, "excluded"), nil
+	}, t.Logf)
+
+	dirInfo, err := fs.Local{}.Lstat(t.TempDir())
+	rtest.OK(t, err)
+
+	rtest.Assert(t, !reject("/tmp/included", dirInfo, fs.Local{}), "included item was rejected")
+	rtest.Assert(t, reject("/tmp/excluded", dirInfo, fs.Local{}), "excluded item was included")
+	rtest.Assert(t, reject("/tmp/excluded", dirInfo, fs.Local{}), "cached excluded item was included")
+	rtest.Equals(t, int32(2), calls.Load())
+}
+
+func TestRejectMacOSBackupExcludesWarnsAndIncludesOnError(t *testing.T) {
+	var warning string
+	reject := rejectMacOSBackupExcludesWithChecker(func(string, bool) (bool, error) {
+		return false, errors.New("boom")
+	}, func(msg string, args ...interface{}) {
+		warning = msg
+	})
+
+	file, err := os.CreateTemp("", "restic-macos-backup-exclude-")
+	rtest.OK(t, err)
+	defer func() {
+		_ = os.Remove(file.Name())
+	}()
+	rtest.OK(t, file.Close())
+
+	fileInfo, err := fs.Local{}.Lstat(file.Name())
+	rtest.OK(t, err)
+
+	rtest.Assert(t, !reject(file.Name(), fileInfo, fs.Local{}), "item with check error was rejected")
+	rtest.Assert(t, strings.Contains(warning, "macOS backup exclusion"), "unexpected warning %q", warning)
+}
+
+func TestBackupCoreStickyExclusion(t *testing.T) {
+	dir := t.TempDir()
+	filename := filepath.Join(dir, "excluded")
+	rtest.OK(t, os.WriteFile(filename, []byte("test"), 0600))
+
+	excluded, err := backupCoreIsItemExcluded(filename, false)
+	rtest.OK(t, err)
+	rtest.Assert(t, !excluded, "new file is unexpectedly excluded")
+
+	rtest.OK(t, setMacOSBackupExcluded(filename, false, true, false))
+	defer func() {
+		rtest.OK(t, setMacOSBackupExcluded(filename, false, false, false))
+	}()
+
+	excluded, err = backupCoreIsItemExcluded(filename, false)
+	rtest.OK(t, err)
+	rtest.Assert(t, excluded, "Backup Core did not report sticky exclusion")
+
+	reject, err := RejectMacOSBackupExcludes(t.Logf)
+	rtest.OK(t, err)
+
+	fileInfo, err := fs.Local{}.Lstat(filename)
+	rtest.OK(t, err)
+	rtest.Assert(t, reject(filename, fileInfo, fs.Local{}), "Backup Core excluded file was included")
+}
+
+func setMacOSBackupExcluded(path string, isDir bool, exclude bool, excludeByPath bool) error {
+	handle, err := purego.Dlopen("/System/Library/Frameworks/CoreServices.framework/CoreServices", rtldLazy|rtldLocal)
+	if err != nil {
+		return err
+	}
+
+	var csBackupSetItemExcluded func(item uintptr, exclude byte, excludeByPath byte) int32
+	if err := registerLibFunc(&csBackupSetItemExcluded, handle, "CSBackupSetItemExcluded"); err != nil {
+		return err
+	}
+
+	url, err := backupCoreFileURL(path, isDir)
+	if err != nil {
+		return err
+	}
+	defer cfRelease(url)
+
+	excludeByte := byte(0)
+	if exclude {
+		excludeByte = 1
+	}
+
+	excludeByPathByte := byte(0)
+	if excludeByPath {
+		excludeByPathByte = 1
+	}
+
+	if status := csBackupSetItemExcluded(url, excludeByte, excludeByPathByte); status != 0 {
+		return fmt.Errorf("CSBackupSetItemExcluded returned OSStatus %d", status)
+	}
+	return nil
+}

--- a/internal/archiver/exclude_macos_backup_other.go
+++ b/internal/archiver/exclude_macos_backup_other.go
@@ -1,0 +1,10 @@
+//go:build !darwin
+
+package archiver
+
+import "github.com/restic/restic/internal/errors"
+
+// RejectMacOSBackupExcludes is only available on macOS.
+func RejectMacOSBackupExcludes(_ func(msg string, args ...interface{})) (RejectFunc, error) {
+	return nil, errors.New("macOS backup exclusions are only supported on macOS")
+}


### PR DESCRIPTION
## What

Adds a macOS-only backup option, `--exclude-macos-backup`, to exclude files and directories marked by macOS as excluded from backups via Backup Core.

This uses a Darwin-only purego bridge to `CSBackupIsItemExcluded`, preserving restic's `CGO_ENABLED=0` release build model.

Fixes #2180.

## Testing

- `CGO_ENABLED=0 go test ./internal/archiver`
- `CGO_ENABLED=0 go test ./cmd/restic -run 'TestBackupExclude|TestBackupWithRelativePath|TestCollectTargets|TestReadFilenamesRaw'`
- `GOOS=darwin GOARCH=arm64 CGO_ENABLED=0 go build ./cmd/restic`
- `GOOS=darwin GOARCH=amd64 CGO_ENABLED=0 go build ./cmd/restic`
- `GOOS=linux GOARCH=amd64 CGO_ENABLED=0 go build ./cmd/restic`
- `GOOS=windows GOARCH=amd64 CGO_ENABLED=0 go build ./cmd/restic`
