### PR TITLE
stats --mode debug - extend functionality

### DIFF
--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -1,11 +1,16 @@
 package main
 
 import (
+	"cmp"
 	"context"
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
+	"golang.org/x/sync/errgroup"
+	"maps"
 	"path/filepath"
+	"runtime"
+	"slices"
 	"strings"
 
 	"github.com/restic/chunker"
@@ -320,7 +325,16 @@ func statsWalkTree(repo restic.Loader, opts StatsOptions, stats *statsContainer,
 // makeFileIDByContents returns a hash of the blob IDs of the
 // node's Content in sequence.
 func makeFileIDByContents(node *data.Node) fileID {
-	var bb []byte
+	bb := make([]byte, 0, len(node.Content)*32)
+	for _, c := range node.Content {
+		bb = append(bb, c[:]...)
+	}
+	return sha256.Sum256(bb)
+}
+
+// hashOfIDs returns a restic.ID for node.Content input
+func hashOfIDs(node *data.Node) restic.ID {
+	bb := make([]byte, 0, len(node.Content)*32)
 	for _, c := range node.Content {
 		bb = append(bb, c[:]...)
 	}
@@ -400,7 +414,8 @@ func statsDebug(ctx context.Context, repo restic.Repository, printer restic.Prin
 		printer.E("Blob Type: %v\n%v\n\n", t, hist[t])
 	}
 
-	return nil
+	// create statistics for unique files and types
+	return streamAllTreeBlobs(ctx, repo, printer)
 }
 
 func statsDebugFileType(ctx context.Context, repo restic.Lister, tpe restic.FileType) (*sizeHistogram, error) {
@@ -424,6 +439,165 @@ func statsDebugBlobs(ctx context.Context, repo restic.Repository) ([restic.NumBl
 	})
 
 	return hist, err
+}
+
+type countStats struct {
+	sizeFileType  uint64
+	countFileType int
+	extension     string
+}
+
+// getNodesData handles one tree and extracts the following information
+// node.Type for all node
+// node.Content for files: create a restic.ID for aech file and memorize
+// its size for the histogram
+func getNodesData(treeIter data.TreeNodeIterator, countTypes map[data.NodeType]int,
+	allFileIDs restic.IDSet, hist *sizeHistogram, extensionMap map[string]countStats, lock *sync.Mutex,
+) error {
+	for item := range treeIter {
+		if item.Error != nil {
+			return fmt.Errorf("LoadTree returned error %v", item.Error)
+		}
+		node := item.Node
+		lock.Lock()
+		countTypes[node.Type]++
+		lock.Unlock()
+
+		if node.Type != data.NodeTypeFile {
+			continue
+		}
+
+		fileID := hashOfIDs(node)
+		lock.Lock()
+		if !allFileIDs.Has(fileID) {
+			hist.Add(uint64(node.Size))
+			allFileIDs.Insert(fileID)
+
+			extension := filepath.Ext(node.Name)
+			if extension == "" {
+				extension = "<no-extension>"
+			} else if extension[0:1] == "." {
+				// remove leading '.'
+				extension = extension[1:]
+			}
+			oldEntry := extensionMap[extension]
+			extensionMap[extension] = countStats{
+				countFileType: oldEntry.countFileType + 1,
+				sizeFileType:  oldEntry.sizeFileType + node.Size,
+			}
+		}
+		lock.Unlock()
+
+	}
+	return nil
+}
+
+// streamAllTreeBlobs loads all known tree blobs from the index and
+// generates type and unique file size statistics
+func streamAllTreeBlobs(ctx context.Context, repo restic.Repository, printer progress.Printer,
+) error {
+	// load index
+	if err := repo.LoadIndex(ctx, printer); err != nil {
+		return err
+	}
+
+	// load all trees concurrently
+	wg, wgCtx := errgroup.WithContext(ctx)
+	chanTreeBlob := make(chan restic.ID)
+	hist := newSizeHistogram(uint64(1_000_000_000_000_000)) // one petaByte
+	extensionMap := make(map[string]countStats, 4096)
+	allFileIDs := restic.NewIDSet()
+	countTypes := make(map[data.NodeType]int, 16)
+	var lock sync.Mutex
+
+	wg.Go(func() error { // goroutine #1
+		defer close(chanTreeBlob)
+		return repo.ListBlobs(wgCtx, func(blob restic.PackedBlob) {
+			if blob.Type == restic.TreeBlob {
+				chanTreeBlob <- blob.ID
+			}
+		})
+	})
+
+	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
+		wg.Go(func() error { // goroutine #2 ... runtime.GOMAXPROCS(0) + 1
+			for id := range chanTreeBlob {
+				treeIter, err := data.LoadTree(wgCtx, repo, id)
+				if err != nil {
+					return err
+				}
+				err = getNodesData(treeIter, countTypes, allFileIDs, hist, extensionMap, &lock)
+				if err != nil {
+					return err
+				}
+			}
+			return nil
+		})
+	}
+
+	err := wg.Wait()
+	if err != nil {
+		return err
+	}
+
+	printer.E("\nDistinct Logical Files\n%v", hist)
+
+	// ========== node types ====================
+	printer.E("\nNode types")
+	printer.E(strings.Repeat("-", 18))
+	countNodes := 0
+	for _, typ := range slices.Sorted(maps.Keys(countTypes)) {
+		count := countTypes[typ]
+		printer.E("%-10s %7d", typ, count)
+		countNodes += count
+	}
+	printer.E(strings.Repeat("-", 18))
+	printer.E("%-10s %7d", "total", countNodes)
+
+	// ========== extensions: conts and size  ====================
+	printer.E("\nExtensions: the list accounts for 99%% of all files, sorted by descending size")
+	printer.E("%-20s %7s %11s", "extension", "counts", "*sizes*")
+	printer.E(strings.Repeat("-", 40))
+
+	countExtensions := 0
+	sizeExtensions := uint64(0)
+	toSort := make([]countStats, 0, len(extensionMap))
+	for ext, item := range extensionMap {
+		toSort = append(toSort, countStats{
+			extension:     ext,
+			countFileType: item.countFileType,
+			sizeFileType:  item.sizeFileType,
+		})
+		countExtensions += item.countFileType
+		sizeExtensions += item.sizeFileType
+	}
+
+	slices.SortFunc(toSort, func(a, b countStats) int {
+		return cmp.Compare(b.sizeFileType, a.sizeFileType)
+	})
+
+	countRest := 0
+	sizeRest := uint64(0)
+	sizeCutoff := sizeExtensions / 100 * 99
+	currentSize := uint64(0)
+	for _, item := range toSort {
+		if currentSize < sizeCutoff {
+			printer.E("%-20s %7d %11s", item.extension, item.countFileType, ui.FormatBytes(item.sizeFileType))
+		} else {
+			countRest += item.countFileType
+			sizeRest += item.sizeFileType
+		}
+		currentSize += item.sizeFileType
+	}
+
+	printer.E(strings.Repeat("-", 40))
+	if countRest > 0 {
+		printer.E("%-20s %7d %11s", "<rest>", countRest, ui.FormatBytes(sizeRest))
+	}
+	printer.E(strings.Repeat("-", 40))
+	printer.E("%-20s %7d %11s", "total", countExtensions, ui.FormatBytes(sizeExtensions))
+
+	return nil
 }
 
 type sizeClass struct {

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"slices"
 	"strings"
+	"sync"
 
 	"github.com/restic/chunker"
 	"github.com/restic/restic/internal/data"
@@ -492,7 +493,7 @@ func getNodesData(treeIter data.TreeNodeIterator, countTypes map[data.NodeType]i
 
 // streamAllTreeBlobs loads all known tree blobs from the index and
 // generates type and unique file size statistics
-func streamAllTreeBlobs(ctx context.Context, repo restic.Repository, printer progress.Printer,
+func streamAllTreeBlobs(ctx context.Context, repo restic.Repository, printer restic.Printer,
 ) error {
 	// load index
 	if err := repo.LoadIndex(ctx, printer); err != nil {
@@ -522,7 +523,7 @@ func streamAllTreeBlobs(ctx context.Context, repo restic.Repository, printer pro
 	}
 
 	blobs := restic.NewIDSet()
-	err = data.StreamTrees(ctx, repo, treeRoots, nil,
+	err = data.StreamTrees(ctx, repo, treeRoots, restic.NoopCounter,
 		func(treeID restic.ID) bool {
 			visited := blobs.Has(treeID)
 			blobs.Insert(treeID)

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -6,10 +6,8 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 	"fmt"
-	"golang.org/x/sync/errgroup"
 	"maps"
 	"path/filepath"
-	"runtime"
 	"slices"
 	"strings"
 
@@ -502,40 +500,40 @@ func streamAllTreeBlobs(ctx context.Context, repo restic.Repository, printer pro
 	}
 
 	// load all trees concurrently
-	wg, wgCtx := errgroup.WithContext(ctx)
-	chanTreeBlob := make(chan restic.ID)
 	hist := newSizeHistogram(uint64(1_000_000_000_000_000)) // one petaByte
 	extensionMap := make(map[string]countStats, 4096)
 	allFileIDs := restic.NewIDSet()
 	countTypes := make(map[data.NodeType]int, 16)
 	var lock sync.Mutex
+	var err error
 
-	wg.Go(func() error { // goroutine #1
-		defer close(chanTreeBlob)
-		return repo.ListBlobs(wgCtx, func(blob restic.PackedBlob) {
-			if blob.Type == restic.TreeBlob {
-				chanTreeBlob <- blob.ID
-			}
-		})
+	// gather all used tree roots
+	treeRoots := make([]restic.ID, 0, 128)
+	err = data.ForAllSnapshots(ctx, repo, repo, nil, func(_ restic.ID, sn *data.Snapshot, err error) error {
+		if err != nil {
+			return err
+		}
+
+		treeRoots = append(treeRoots, *sn.Tree)
+		return nil
 	})
-
-	for i := 0; i < runtime.GOMAXPROCS(0); i++ {
-		wg.Go(func() error { // goroutine #2 ... runtime.GOMAXPROCS(0) + 1
-			for id := range chanTreeBlob {
-				treeIter, err := data.LoadTree(wgCtx, repo, id)
-				if err != nil {
-					return err
-				}
-				err = getNodesData(treeIter, countTypes, allFileIDs, hist, extensionMap, &lock)
-				if err != nil {
-					return err
-				}
-			}
-			return nil
-		})
+	if err != nil {
+		return err
 	}
 
-	err := wg.Wait()
+	blobs := restic.NewIDSet()
+	err = data.StreamTrees(ctx, repo, treeRoots, nil,
+		func(treeID restic.ID) bool {
+			visited := blobs.Has(treeID)
+			blobs.Insert(treeID)
+			return visited
+		},
+		func(_ restic.ID, err error, nodes data.TreeNodeIterator) error {
+			if err != nil {
+				return err
+			}
+			return getNodesData(nodes, countTypes, allFileIDs, hist, extensionMap, &lock)
+		})
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_stats_integration_test.go
+++ b/cmd/restic/cmd_stats_integration_test.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/restic/restic/internal/global"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+// withCaptureStdoutStderr captures stdout and stderr in a buffer for analysis
+func withCaptureStdoutStderr(t testing.TB, gopts global.Options,
+	callback func(ctx context.Context, gopts global.Options) error,
+) (*bytes.Buffer, *bytes.Buffer, error) {
+
+	bufStdout := bytes.NewBuffer(nil)
+	bufStderr := bytes.NewBuffer(nil)
+	err := withTermStatusRaw(os.Stdin, bufStdout, bufStderr, gopts, callback)
+
+	return bufStdout, bufStderr, err
+}
+
+// testRunStats runs `restic stats` with capturing std and stderr
+func testRunStats(t testing.TB, wantJSON bool, opts StatsOptions, gopts global.Options, args []string,
+) ([]byte, []byte) {
+
+	bufStdout, bufStderr, err := withCaptureStdoutStderr(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		gopts.JSON = wantJSON
+
+		return runStats(ctx, opts, gopts, args, gopts.Term)
+	})
+	rtest.OK(t, err)
+
+	return bufStdout.Bytes(), bufStderr.Bytes()
+}
+
+func TestStatsDebug(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	// backup of subtree 0/0/9
+	testRunBackup(t, env.testdata, []string{filepath.Join(env.testdata, "0", "0", "9")}, BackupOptions{}, env.gopts)
+
+	optsStats := StatsOptions{countMode: "debug"}
+	// allow multiple reads of different restic file types
+	env.gopts.BackendTestHook = nil
+	stdout, stderr := testRunStats(t, false, optsStats, env.gopts, nil)
+
+	rtest.Equals(t, "", string(stdout), "stdout should be empty")
+	offset := bytes.Index(stderr, []byte("Distinct"))
+	rtest.Assert(t, offset > 0, "did not find the word 'Distinct'")
+	lines := strings.Split(string(stderr[offset:]), "\n")
+	rtest.Assert(t, len(lines) > 11, "expected at least 11 lines of output starting here")
+	rtest.Equals(t, "Count: 69", lines[1])
+	rtest.Equals(t, "10000 - 99999 Byte  69", lines[5])
+	rtest.Equals(t, "file            69", lines[11])
+}

--- a/cmd/restic/cmd_stats_integration_test.go
+++ b/cmd/restic/cmd_stats_integration_test.go
@@ -38,7 +38,7 @@ func testRunStats(t testing.TB, wantJSON bool, opts StatsOptions, gopts global.O
 	return bufStdout.Bytes(), bufStderr.Bytes()
 }
 
-func TestStatsDebug(t *testing.T) {
+func TestStatsDebug1(t *testing.T) {
 	env, cleanup := withTestEnvironment(t)
 	defer cleanup()
 
@@ -55,8 +55,29 @@ func TestStatsDebug(t *testing.T) {
 	offset := bytes.Index(stderr, []byte("Distinct"))
 	rtest.Assert(t, offset > 0, "did not find the word 'Distinct'")
 	lines := strings.Split(string(stderr[offset:]), "\n")
-	rtest.Assert(t, len(lines) > 11, "expected at least 11 lines of output starting here")
+	rtest.Assert(t, len(lines) > 11, "expected at least 11 lines of output starting from here")
 	rtest.Equals(t, "Count: 69", lines[1])
 	rtest.Equals(t, "10000 - 99999 Byte  69", lines[5])
 	rtest.Equals(t, "file            69", lines[11])
+}
+
+func TestStatsDebug2(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	// backup of subtree 0/for_cmd_ls
+	testRunBackup(t, env.testdata, []string{filepath.Join(env.testdata, "0", "for_cmd_ls")}, BackupOptions{}, env.gopts)
+
+	env.gopts.BackendTestHook = nil
+	optsStats := StatsOptions{countMode: "debug"}
+	stdout, stderr := testRunStats(t, false, optsStats, env.gopts, nil)
+
+	rtest.Equals(t, "", string(stdout), "stdout should be empty")
+	offset := bytes.Index(stderr, []byte("extension"))
+	rtest.Assert(t, offset > 0, "did not find the word 'extension'")
+	lines := strings.Split(string(stderr[offset:]), "\n")
+	rtest.Assert(t, len(lines) > 6, "expected at least 6 lines of output starting from here")
+	rtest.Equals(t, "txt                        2       118 B", lines[2])
+	rtest.Equals(t, "py                         1       113 B", lines[3])
 }

--- a/cmd/restic/cmd_stats_integration_test.go
+++ b/cmd/restic/cmd_stats_integration_test.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bytes"
 	"context"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -11,18 +10,6 @@ import (
 	"github.com/restic/restic/internal/global"
 	rtest "github.com/restic/restic/internal/test"
 )
-
-// withCaptureStdoutStderr captures stdout and stderr in a buffer for analysis
-func withCaptureStdoutStderr(t testing.TB, gopts global.Options,
-	callback func(ctx context.Context, gopts global.Options) error,
-) (*bytes.Buffer, *bytes.Buffer, error) {
-
-	bufStdout := bytes.NewBuffer(nil)
-	bufStderr := bytes.NewBuffer(nil)
-	err := withTermStatusRaw(os.Stdin, bufStdout, bufStderr, gopts, callback)
-
-	return bufStdout, bufStderr, err
-}
 
 // testRunStats runs `restic stats` with capturing std and stderr
 func testRunStats(t testing.TB, wantJSON bool, opts StatsOptions, gopts global.Options, args []string,


### PR DESCRIPTION
``restic stats --mode debug` now displays more information about the repository

* it displays a histogram for the the unique file sizes in the repo

* it counts the node types in the repo (files, directories, symlinks, ...)

* it displays a (size) sorted list of the file extensions to estimate how much of the repo contains textual versus binary data

All these actions run on the metadata of the repository, so no reading of actual data is needed.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR adds a histogram and counters to the existing set of histograms to understand more about the logical contents of the repository without reading its actual contents and without disclosing personal or private information.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
https://forum.restic.net/t/backup-only-1-smaller-than-the-original/10804

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
~~- [ ] I have added documentation for relevant changes (in the manual).~~
~~- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
--mode debug is an undocumented feature
- [x] I'm done! This pull request is ready for review.
