### PR TITLE
windows: try to fix flaky tests

### DIFF
--- a/internal/fs/file_windows.go
+++ b/internal/fs/file_windows.go
@@ -76,6 +76,10 @@ func TempFile(dir, prefix string) (f *os.File, err error) {
 		if os.IsExist(err) {
 			continue
 		}
+		// Access denied error can occur if the tmp files conflict with each other.
+		if isAccessDeniedError(err) {
+			continue
+		}
 		return os.NewFile(uintptr(h), path), err
 	}
 

--- a/internal/fs/file_windows.go
+++ b/internal/fs/file_windows.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"time"
 
 	"github.com/restic/restic/internal/data"
 	"golang.org/x/sys/windows"
@@ -63,9 +62,8 @@ func TempFile(dir, prefix string) (f *os.File, err error) {
 	share := uint32(0) // prevent other processes from accessing the file
 	flags := uint32(windows.FILE_ATTRIBUTE_TEMPORARY | windows.FILE_FLAG_DELETE_ON_CLOSE)
 
-	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 	for i := 0; i < 10000; i++ {
-		randSuffix := strconv.Itoa(int(1e9 + rnd.Intn(1e9)%1e9))[1:]
+		randSuffix := strconv.Itoa(int(1e9 + rand.Intn(1e9)%1e9))[1:]
 		path := filepath.Join(dir, prefix+randSuffix)
 
 		ptr, err := windows.UTF16PtrFromString(path)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The unit tests on Windows fail from time to time with error:
```
2026-05-10T19:22:59.8628469Z         testing.go:123: [31munexpected error: Access is denied.
2026-05-10T19:22:59.8628846Z             github.com/restic/restic/internal/repository.(*packerManager).newPacker
2026-05-10T19:22:59.8629196Z             	D:/a/restic/restic/internal/repository/packer_manager.go:206
```

The line in `packer_manager.go` is the error log directly after the call to `fs.TempFile`. I see two main culprits here: the used RNG could generate the same filename if called in roughly the same microsecond. As this happens a few thousand times during the TestEmptyFileAttributeCombinationsOverwrite and related test cases, the chances of a collision aren't particularly low.

In addition, in case of a name collision, the retry would not work. The temp file is created without sharing and uses `FILE_FLAG_DELETE_ON_CLOSE` which prevents opening new handles to that file. However, this triggers an access denied error. Thus, ignore that particular error code.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No. But see the PR build history for examples of the test failures.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
