### PR TITLE
docs: clarify backup step in troubleshooting guide

### DIFF
--- a/doc/077_troubleshooting.rst
+++ b/doc/077_troubleshooting.rst
@@ -157,6 +157,11 @@ if the missing data is also contained in the new snapshot.
 Therefore, it is recommended to run all your ``backup`` tasks again. In some
 cases, this is enough to fully repair the repository.
 
+To check if the repository is fully repaired, you can run ``restic check``
+(without options) again.
+
+To get a list of still damaged files, you can run ``restic repair snapshots --dry-run``.
+Look for ``would save new snapshot`` messages to find affected snapshots.
 
 5. Remove missing data from snapshots
 *************************************


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Add further explanations how to check whether a repository is still damaged after the running the backup step of the troubleshooting guide and how to find out which files and snapshots are damaged.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/21799
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
