### PR TITLE
Add codespell support with configuration and fixes

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,6 +1,25 @@
 [codespell]
+
 # Ref: https://github.com/codespell-project/codespell#using-a-config-file
-skip = .git,.gitignore,.gitattributes,go.sum,*.css,.codespellrc
+# Skip historical content (CHANGELOG, release notes archive), auto-generated
+# man pages (which contain troff macros like \(bu that look like typos), and
+# files we don't want to modify (go.sum, css with vendor prefixes).
+skip = .git*,.gitignore,.gitattributes,go.sum,*.css,.codespellrc,CHANGELOG.md,changelog,*.1
 check-hidden = true
-# ignore-regex = 
-# ignore-words-list =
+
+# Protect URLs from corrections (URLs may contain words flagged as typos and
+# must not be changed); also ignore camelCase/PascalCase identifiers like
+# AtLeast which are valid Go identifiers, not typos.
+ignore-regex = https?://\S+|\b[a-z]+[A-Z]\w*\b|\b[A-Z][a-z]+[A-Z]\w*\b
+
+ignore-words-list =
+  # variable name short for "serialized", also matches [uU]ser glob pattern
+  ser,
+  # German word "ist" appearing in test data string
+  ist,
+  # intentional truncated test string in format truncation tests
+  fo,
+  # CLI flag name (--iinclude, case-insensitive include)
+  iinclude,
+  # intentional in fake test path /doesnt/exist
+  doesnt

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,6 @@
+[codespell]
+# Ref: https://github.com/codespell-project/codespell#using-a-config-file
+skip = .git,.gitignore,.gitattributes,go.sum,*.css,.codespellrc
+check-hidden = true
+# ignore-regex = 
+# ignore-words-list =

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,6 @@
 # Actual layer caching is impossible due to .git, but
 # that must be included for provenance reasons.  These ignores
-# are strictly for hygenic build.
+# are strictly for hygienic build.
 *
 !/*.go
 !/go.*

--- a/.github/workflows/codespell.yml
+++ b/.github/workflows/codespell.yml
@@ -1,0 +1,27 @@
+# Codespell configuration is within .codespellrc
+---
+name: Codespell
+
+on:
+  # run checks on push to master, but not when other branches are pushed to
+  push:
+    branches:
+      - master
+
+  # run checks for all pull requests
+  pull_request:
+  merge_group:
+
+permissions:
+  contents: read
+
+jobs:
+  codespell:
+    name: Check for spelling errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Codespell
+        uses: codespell-project/actions-codespell@8f01853be192eb0f849a5c7d721450e7a467c579  # v2.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,7 +55,7 @@ linters:
         - "-ST1021"
         - "-ST1022"
         # extra disables
-        - "-QF1008" # don't warn about specifing name of embedded field on access
+        - "-QF1008" # don't warn about specifying name of embedded field on access
   exclusions:
     rules:
       # revive: ignore unused parameters in tests

--- a/cmd/restic/cmd_copy_integration_test.go
+++ b/cmd/restic/cmd_copy_integration_test.go
@@ -90,7 +90,7 @@ func TestCopy(t *testing.T) {
 	_, _, countBlobs := testPackAndBlobCounts(t, env.gopts)
 	countTreePacksDst, countDataPacksDst, countBlobsDst := testPackAndBlobCounts(t, env2.gopts)
 
-	rtest.Equals(t, countBlobs, countBlobsDst, "expected blob count in boths repos to be equal")
+	rtest.Equals(t, countBlobs, countBlobsDst, "expected blob count in both repos to be equal")
 	rtest.Equals(t, countTreePacksDst, 1, "expected 1 tree packfile")
 	rtest.Equals(t, countDataPacksDst, 1, "expected 1 data packfile")
 }

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -145,7 +145,7 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 
 	err = unix.Access(mountpoint, unix.W_OK|unix.X_OK)
 	if err != nil {
-		printer.P("Mountpoint %s is not writeable or not excutable", mountpoint)
+		printer.P("Mountpoint %s is not writeable or not executable", mountpoint)
 		return errors.Fatal("inaccessible mountpoint")
 	}
 

--- a/internal/fs/node.go
+++ b/internal/fs/node.go
@@ -137,7 +137,7 @@ var (
 
 // Cached uid lookup by user name. Returns 0 when no id can be found.
 //
-//nolint:revive // captialization is correct as is
+//nolint:revive // capitalization is correct as is
 func lookupUid(userName string) uint32 {
 	userNameLookupCacheMutex.RLock()
 	uid, ok := userNameLookupCache[userName]

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -74,7 +74,7 @@ func (r *packerManager) Flush(ctx context.Context) error {
 
 // mergePackers merges small pack files before those are uploaded by Flush(). The main
 // purpose of this method is to reduce information leaks if a small file is backed up
-// and the blobs end up in spearate pack files. If the file only consists of two blobs
+// and the blobs end up in separate pack files. If the file only consists of two blobs
 // this would leak the size of the individual blobs.
 func (r *packerManager) mergePackers() ([]*packer, error) {
 	pendingPackers := []*packer{}

--- a/internal/repository/prune.go
+++ b/internal/repository/prune.go
@@ -342,7 +342,7 @@ func calculateTargetPacksize(opts PruneOptions, indexPack map[restic.ID]packInfo
 			return cmp.Compare(a.size, b.size)
 		})
 
-		// Using the approximatelly 3rd percentile is just a heuristic and may not always be the optimal choice.
+		// Using the approximately 3rd percentile is just a heuristic and may not always be the optimal choice.
 		// However, using a low percentile ensures that only a small fraction of the repository
 		// may end up being repacked. By using 80% of that perecentile or the minimum pack size,
 		// we ensure that no repacking happens if the repository already has no small pack files.

--- a/internal/repository/prune_test.go
+++ b/internal/repository/prune_test.go
@@ -133,7 +133,7 @@ func TestPruneSmall(t *testing.T) {
 
 	keep := restic.NewBlobSet()
 	rtest.OK(t, repo.WithBlobUploader(context.TODO(), func(ctx context.Context, uploader restic.BlobSaverWithAsync) error {
-		// we need a minum of 11 packfiles, each packfile will be about 5 Mb long
+		// we need a minimum of 11 packfiles, each packfile will be about 5 Mb long
 		for i := 0; i < numBlobsCreated; i++ {
 			buf := make([]byte, blobSize)
 			random.Read(buf)

--- a/internal/restic/lock_unix.go
+++ b/internal/restic/lock_unix.go
@@ -14,7 +14,7 @@ import (
 
 // UidGidInt returns uid, gid of the user as a number.
 //
-//nolint:revive // captialization is correct as is
+//nolint:revive // capitalization is correct as is
 func UidGidInt(u *user.User) (uid, gid uint32, err error) {
 	ui, err := strconv.ParseUint(u.Uid, 10, 32)
 	if err != nil {

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -185,7 +185,7 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 			file.sparse = false
 		}
 
-		// empty file or one with already uptodate content. Make sure that the file size is correct
+		// empty file or one with already up-to-date content. Make sure that the file size is correct
 		if !restoredBlobs {
 			err := r.truncateFileToSize(file.location, file.size)
 			if errFile := r.sanitizeError(file, err); errFile != nil {

--- a/internal/restorer/fileswriter.go
+++ b/internal/restorer/fileswriter.go
@@ -232,7 +232,7 @@ func (w *filesWriter) writeToFile(path string, blob []byte, offset int64, create
 		bucket.files[path].users--
 		if bucket.files[path].users == 0 {
 			delete(bucket.files, path)
-			// Add to cache to allow re-use. Cache will close files on overflow.
+			// Add to cache to allow reuse. Cache will close files on overflow.
 			w.cacheMu.Lock()
 			w.cache.Add(path, wr)
 			w.cacheMu.Unlock()


### PR DESCRIPTION
<details>
<summary>Original description before tuning skil to respect template + contributing guidelines</summary> 

Add [codespell](https://github.com/codespell-project/codespell) spell-checking infrastructure and fix existing typos.

I have introduced codespell to over a hundred of projects already, mostly with positive feedback (see for example [improveit-dashboard's writeup](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)). The CI workflow uses `permissions: contents: read` so it is safe to merge.

Historical context: `git log --grep=typo --grep=spell` shows over 170 prior commits in this repo touching typos manually — automated checking should help catch them in PRs going forward.

## Changes

### Configuration & Infrastructure (already in 4c3fb82, 48fb59a)
- `.codespellrc` with skip patterns, ignore-regex, and ignore-words-list
- `.github/workflows/codespell.yml` runs codespell on push and pull requests to `master`

### Skip patterns
- `CHANGELOG.md`, `changelog/` — historical release notes, not appropriate to edit
- `*.1` — auto-generated man pages (troff macros like `\(bu` look like the word "bu")
- `go.sum`, `*.css`, hidden git files

### ignore-regex
- URLs (`https?://\S+`) — never modify URL contents, even if they contain "typos" (e.g. `programm.froscon.org` is a real hostname)
- camelCase/PascalCase identifiers (`\b[a-z]+[A-Z]\w*\b|\b[A-Z][a-z]+[A-Z]\w*\b`) — covers Go identifiers like `AtLeast`

### ignore-words-list (with rationale comments in config)
- `ser` — variable name (short for "serialized"); also matches `[uU]ser` glob in filter test
- `ist` — German word in a test data string ("Dies ist ein Test!")
- `fo` — intentional truncated "foo" in format-truncation tests
- `iinclude` — CLI flag name (`--iinclude`, case-insensitive include)
- `doesnt` — intentional in fake path `/doesnt/exist` test fixture

### Typo fixes (commit 8473814, applied via `codespell -w`)

All 10 non-ambiguous typo fixes in comments and string messages:

| File | Fix |
|------|-----|
| `.dockerignore` | hygenic → hygienic |
| `.golangci.yml` | specifing → specifying |
| `cmd/restic/cmd_copy_integration_test.go` | boths → both (test message) |
| `cmd/restic/cmd_mount.go` | excutable → executable (user-visible error) |
| `internal/fs/node.go` | captialization → capitalization (nolint comment) |
| `internal/repository/packer_manager.go` | spearate → separate (doc comment) |
| `internal/repository/prune_test.go` | minum → minimum (comment) |
| `internal/restic/lock_unix.go` | captialization → capitalization (nolint comment) |
| `internal/restorer/filerestorer.go` | uptodate → up-to-date (comment) |
| `internal/restorer/fileswriter.go` | re-use → reuse (comment; matches existing usage in `restorer.go:713`) |

No code identifiers or regex patterns were modified — all changes are in comments and human-readable strings.

## Testing

`codespell` passes with zero errors after these changes:

```
$ codespell
$ echo $?
0
```

The two `nolint:revive` directives preserve their exact form (`//nolint:revive // <explanation>`); the explanation text is informational only and does not affect linter behavior.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code) and love to typo-free code.

</details>

<!--
PR body now follows .github/PULL_REQUEST_TEMPLATE.md.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

This PR adds [codespell](https://github.com/codespell-project/codespell) spell-checking infrastructure to the restic repository and fixes the typos it found.

### Configuration & infrastructure (commits 4c3fb82, 48fb59a, 8fa9ffa)

- `.codespellrc` with skip patterns, `ignore-regex`, and `ignore-words-list` (with rationale comments inline)
- `.github/workflows/codespell.yml` runs codespell on push and pull requests to `master`, using `permissions: contents: read` (read-only — safe to merge)

Skip patterns:

- `CHANGELOG.md`, `changelog/` — historical release notes, not appropriate to edit
- `*.1` — auto-generated man pages (troff macros like `\(bu` look like the word "bu")
- `go.sum`, `*.css`, hidden git files

`ignore-regex`:

- URLs (`https?://\S+`) — never modify URL contents, even when they contain "typos" (e.g. `programm.froscon.org` is a real hostname)
- camelCase / PascalCase identifiers (`\b[a-z]+[A-Z]\w*\b|\b[A-Z][a-z]+[A-Z]\w*\b`) — covers Go identifiers like `AtLeast`

`ignore-words-list`:

- `ser` — variable name (short for "serialized"); also matches a `[uU]ser` glob in a filter test
- `ist` — German word in a test data string (`"Dies ist ein Test!"`)
- `fo` — intentional truncated "foo" in format-truncation tests
- `iinclude` — CLI flag name (`--iinclude`, case-insensitive include)
- `doesnt` — intentional in fake path `/doesnt/exist` test fixture

### Typo fixes (commit 8473814)

Applied via `codespell -w`; all 10 fixes are in comments and human-readable strings — **no code identifiers or regex patterns were modified**:

| File | Fix |
|------|-----|
| `.dockerignore` | hygenic → hygienic |
| `.golangci.yml` | specifing → specifying |
| `cmd/restic/cmd_copy_integration_test.go` | boths → both (test message) |
| `cmd/restic/cmd_mount.go` | excutable → executable (user-visible error message) |
| `internal/fs/node.go` | captialization → capitalization (`nolint` comment) |
| `internal/repository/packer_manager.go` | spearate → separate (doc comment) |
| `internal/repository/prune_test.go` | minum → minimum (comment) |
| `internal/restic/lock_unix.go` | captialization → capitalization (`nolint` comment) |
| `internal/restorer/filerestorer.go` | uptodate → up-to-date (comment) |
| `internal/restorer/fileswriter.go` | re-use → reuse (comment; matches existing usage in `restorer.go:713`) |

The two `nolint:revive` directives preserve their exact form (`//nolint:revive // <explanation>`); the explanation text is informational only and does not affect linter behavior.

### Why this is worth doing

`git log --grep=typo --grep=spell` shows ~170 prior commits in this repo fixing typos manually — automated checking should help catch them in PRs going forward.

I have introduced codespell to over a hundred projects already, mostly with positive feedback (see for example [improveit-dashboard's writeup](https://github.com/yarikoptic/improveit-dashboard/blob/master/READMEs/yarikoptic.md)).

### Testing

```
$ codespell
$ echo $?
0
```

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No prior issue. Per `CONTRIBUTING.md` § Providing Patches, small bugfixes are exempt from the issue-first rule; this PR is in the same spirit — infrastructure plus a handful of comment/string spelling fixes, with no behavior change. Happy to open a tracking issue first if maintainers prefer that workflow for tooling PRs.

Checklist
---------

<!--
Boxes are left unchecked where the corresponding item is N/A for this PR;
rationale appears in the comment under each item.
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
  <!-- N/A — no code-logic changes; only CI config plus spelling fixes in comments and strings. -->
- [ ] I have added documentation for relevant changes (in the manual).
  <!-- N/A — no user-facing behavior change to document. -->
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
  <!--
  Per changelog/TEMPLATE ("Documentation-only changes do not get a changelog entry"),
  this PR — CI infrastructure plus typo fixes in comments and one user-visible error
  message — likely does not warrant a changelog entry. Happy to add one if maintainers
  disagree, e.g. for the `cmd_mount.go` error-message spelling fix.
  -->
- [x] I'm done! This pull request is ready for review.

---

Notes for maintainers, per `.github/PULL_REQUEST_TEMPLATE.md`:

- [x] **Maintainer edits** are enabled on this PR 
- **`gofmt`**: no Go source was touched in a way that would change formatting; only inline comments and string literals.
- **Commit messages**: existing commits in this branch follow restic's "terse first line + verbose body" style, except `[DATALAD RUNCMD] Fix typos detected by codespell` which carries a `datalad run` provenance prefix from my local workflow. Happy to amend / squash that prefix away if it's a blocker for merging — please just say the word.
