### PR TITLE
Return helpful error if subfolder syntax fails on Windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -707,7 +707,7 @@ restic users. The changes are ordered by importance.
    correctly.
 
    Specifying volume names is now handled correctly. To restore snapshots created
-   before this bugfix, use the <snapshot>:<subpath> syntax. For example, to restore
+   before this bugfix, use the <snapshot>:<subfolder> syntax. For example, to restore
    a snapshot with ID `12345678` that backed up `C:`, use the following command:
 
    ```

--- a/changelog/0.17.1_2024-09-05/issue-2004
+++ b/changelog/0.17.1_2024-09-05/issue-2004
@@ -6,7 +6,7 @@ resulting snapshot would result in an error. Note that using `C:\`
 as backup target worked correctly.
 
 Specifying volume names is now handled correctly. To restore snapshots
-created before this bugfix, use the <snapshot>:<subpath> syntax. For
+created before this bugfix, use the <snapshot>:<subfolder> syntax. For
 example, to restore a snapshot with ID `12345678` that backed up `C:`,
 use the following command:
 

--- a/cmd/restic/cmd_diff.go
+++ b/cmd/restic/cmd_diff.go
@@ -39,7 +39,7 @@ Metadata comparison will likely not work if a backup was created using the
 
 To only compare files in specific subfolders, you can use the
 "snapshotID:subfolder" syntax, where "subfolder" is a path within the
-snapshot.
+snapshot tree as shown by "restic ls".
 
 EXIT STATUS
 ===========

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -35,7 +35,7 @@ repository.
 
 To include the folder content at the root of the archive, you can use the
 "snapshotID:subfolder" syntax, where "subfolder" is a path within the
-snapshot.
+snapshot tree as shown by "restic ls".
 
 EXIT STATUS
 ===========

--- a/cmd/restic/cmd_restore.go
+++ b/cmd/restic/cmd_restore.go
@@ -34,7 +34,8 @@ The special snapshotID "latest" can be used to restore the latest snapshot in th
 repository.
 
 To only restore a specific subfolder, you can use the "snapshotID:subfolder"
-syntax, where "subfolder" is a path within the snapshot.
+syntax, where "subfolder" is a path within the snapshot tree as shown by
+"restic ls".
 
 POSIX ACLs are always restored by their numeric value, while file ownership can optionally be restored by name instead of numeric value.
 

--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -609,8 +609,8 @@ and displays a small statistic, just pass the command two snapshot IDs:
 
 To only compare files in specific subfolders, you can use the ``<snapshot>:<subfolder>``
 syntax, where ``snapshot`` is the ID of a snapshot (or the string ``latest``) and ``subfolder``
-is a path within the snapshot. For example, to only compare files in the ``/restic``
-folder, you could use the following command:
+is a path within the snapshot tree as shown by ``restic ls``. For example, to only compare files in
+the ``/restic`` folder, you could use the following command:
 
 .. code-block:: console
 

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -54,10 +54,10 @@ This will restore the file to ``/tmp/restore/home/user/work/foo``.
 
 To only restore a specific subfolder, you can use the ``<snapshot>:<subfolder>``
 syntax, where ``snapshot`` is the ID of a snapshot (or the string ``latest``)
-and ``subfolder`` is a path within the snapshot. Note that the subfolder syntax
-also affects options like ``--include`` and ``--exclude``, such that their
-arguments should be specified relative to ``subfolder`` (e.g. ``/foo`` instead
-of ``/home/user/work/foo``).
+and ``subfolder`` is a path within the snapshot tree as shown by ``restic ls``.
+Note that the subfolder syntax also affects options like ``--include`` and
+``--exclude``, such that their arguments should be specified relative to
+``subfolder`` (e.g. ``/foo`` instead of ``/home/user/work/foo``).
 
 .. code-block:: console
 

--- a/internal/data/tree.go
+++ b/internal/data/tree.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"runtime"
 
 	"io"
 	"iter"
@@ -311,6 +312,9 @@ func FindTreeDirectory(ctx context.Context, repo restic.BlobLoader, id *restic.I
 			return nil, fmt.Errorf("path %s: %w", subfolder, err)
 		}
 		if node == nil {
+			if runtime.GOOS == "windows" && strings.Contains(dir, "\\") {
+				return nil, fmt.Errorf("path %s: not found; subfolder syntax currently requires forward slashes; check the output of `restic ls` for valid paths", subfolder)
+			}
 			return nil, fmt.Errorf("path %s: not found", subfolder)
 		}
 		if node.Type != NodeTypeDir || node.Subtree == nil {

--- a/internal/data/tree_test.go
+++ b/internal/data/tree_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -399,6 +400,22 @@ func TestFindTreeDirectory(t *testing.T) {
 
 	_, err := data.FindTreeDirectory(context.TODO(), repo, nil, "")
 	rtest.Assert(t, err != nil, "missing error on null tree id")
+}
+
+func TestFindTreeDirectoryWindowsBackslashHint(t *testing.T) {
+	repo := repository.TestRepository(t)
+	sn := data.TestCreateSnapshot(t, repo, parseTimeUTC("2017-07-07 07:07:08"), 1)
+
+	_, err := data.FindTreeDirectory(context.TODO(), repo, sn.Tree, `missing\path`)
+	rtest.Assert(t, err != nil, "expected error")
+
+	if runtime.GOOS == "windows" {
+		rtest.Assert(t, strings.Contains(err.Error(), "forward slashes"),
+			"expected backslash hint on Windows, got %v", err)
+	} else {
+		rtest.Assert(t, err.Error() == `path missing\path: not found`,
+			"unexpected err: %v", err)
+	}
 }
 
 func TestDualTreeIterator(t *testing.T) {


### PR DESCRIPTION

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Windows users expect to use Windows paths in the `snapshot:subfolder` syntax. However, currently only Unix style paths are supported.

Extend the "not found" error with a helpful error on Windows if the user used a backslash.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Test written by Cursor.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/21806
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
