### PR TITLE
restic copy --group-by --latest `n`

### DIFF
--- a/changelog/unreleased/issue-4327
+++ b/changelog/unreleased/issue-4327
@@ -3,7 +3,7 @@ Enhancement: restic copy --group-by --latest `n`
 restic copy could not easily copy the latest snapshot of a snapshot group
 to the destination repository.
 
-With new new options --group-by nad --latest is is now posible to achieve this
+With new new options --group-by and --latest `n` is is now possible to achieve this
 copy process easily. Multiple applications of the same command will not produce
 any new destination snapshots after the first run.
 

--- a/changelog/unreleased/issue-4327
+++ b/changelog/unreleased/issue-4327
@@ -1,0 +1,11 @@
+Enhancement: restic copy --group-by --latest `n`
+
+restic copy could not easily copy the latest snapshot of a snapshot group
+to the destination repository.
+
+With new new options --group-by nad --latest is is now posible to achieve this
+copy process easily. Multiple applications of the same command will not produce
+any new destination snapshots after the first run.
+
+https://github.com/restic/restic/issues/4327
+https://github.com/restic/restic/pull/21814

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -177,8 +177,39 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args [
 
 	selectedSnapshots := collectAllSnapshots(ctx, opts, srcSnapshotLister, srcRepo, dstSnapshotByOriginal, args, printer)
 
-	if err := copyTreeBatched(ctx, srcRepo, dstRepo, selectedSnapshots, printer); err != nil {
-		return err
+		// create snapshot groups from above snapshots
+		snapshotGroups, _, err := data.GroupSnapshots(snapshots, opts.GroupBy)
+		if err != nil {
+			return err
+		}
+
+		err = copyGroupedSnapshots(ctx, srcRepo, dstRepo, snapshotGroups, opts,
+			dstSnapshotByOriginal, srcSnapshotLister, args, printer)
+		if err != nil {
+			return err
+		}
+	} else {
+		selectedSnapshots := collectAllSnapshots(ctx, opts, srcSnapshotLister, srcRepo, dstSnapshotByOriginal, args, nil, printer)
+		if opts.latest > 0 {
+			snList := slices.SortedFunc(selectedSnapshots, func(a, b *data.Snapshot) int {
+				return b.Time.Compare(a.Time)
+			})
+
+			length := len(snList)
+			ended := opts.latest
+			if ended > length {
+				ended = length
+			}
+			err = copyTreeBatched(ctx, srcRepo, dstRepo, slices.Values(snList[:ended]), printer)
+			if err != nil {
+				return err
+			}
+		} else {
+			err = copyTreeBatched(ctx, srcRepo, dstRepo, selectedSnapshots, printer)
+			if err != nil {
+				return err
+			}
+		}
 	}
 
 	return ctx.Err()

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"iter"
+	"slices"
 	"sync"
 	"time"
 
@@ -65,29 +66,47 @@ Exit status is 12 if the password is incorrect.
 type CopyOptions struct {
 	global.SecondaryRepoOptions
 	data.SnapshotFilter
+
+	// group-by copy mode
+	GroupBy data.SnapshotGroupByOptions
+	latest  int
 }
 
 func (opts *CopyOptions) AddFlags(f *pflag.FlagSet) {
 	opts.SecondaryRepoOptions.AddFlags(f, "destination", "to copy snapshots from")
+	f.VarP(&opts.GroupBy, "group-by", "g", "`group` snapshots by host, paths and/or tags, separated by comma")
+	f.IntVar(&opts.latest, "latest", 0, "only copy the last `n` snapshots for each host and path")
 	initMultiSnapshotFilter(f, &opts.SnapshotFilter, true)
 }
 
 var errSentinelEndIteration = errors.New("end iteration")
 
 // collectAllSnapshots: select all snapshot trees to be copied
-func collectAllSnapshots(ctx context.Context, opts CopyOptions,
-	srcSnapshotLister restic.Lister, srcRepo restic.Repository,
-	dstSnapshotByOriginal map[restic.ID][]*data.Snapshot, args []string, printer restic.Printer,
+func collectAllSnapshots(
+	ctx context.Context,
+	opts CopyOptions,
+	srcSnapshotLister restic.Lister,
+	srcRepo restic.Repository,
+	dstSnapshotByOriginal map[restic.ID][]*data.Snapshot,
+	args []string,
+	mapGroupBy restic.IDSet,
+	printer restic.Printer,
 ) iter.Seq2[*data.Snapshot, error] {
 	return func(yield func(*data.Snapshot, error) bool) {
-		err := opts.SnapshotFilter.FindAll(ctx, srcSnapshotLister, srcRepo, args, func(_ string, sn *data.Snapshot, err error) error {
-			// check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
+
+		err := opts.SnapshotFilter.FindAll(ctx, srcSnapshotLister, srcRepo, args, func(_ string, sn *data.Snapshot, err error) error { // check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
 			if err != nil {
 				if !yield(nil, err) {
 					return errSentinelEndIteration
 				}
 				return nil
 			}
+			if mapGroupBy != nil {
+				if _, ok := mapGroupBy[*sn.ID()]; !ok {
+					return nil
+				}
+			}
+
 			srcOriginal := *sn.ID()
 			if sn.Original != nil {
 				srcOriginal = *sn.Original
@@ -96,8 +115,8 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 				isCopy := false
 				for _, originalSn := range originalSns {
 					if similarSnapshots(originalSn, sn) {
-						printer.V("\n%v", sn)
-						printer.V("skipping source snapshot %s, was already copied to snapshot %s", sn.ID().Str(), originalSn.ID().Str())
+						printer.VV("\n%v", sn)
+						printer.VV("skipping source snapshot %s, was already copied to snapshot %s", sn.ID().Str(), originalSn.ID().Str())
 						isCopy = true
 						break
 					}
@@ -117,6 +136,93 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 	}
 }
 
+// copyGroupedSnapshots copies the --latest `n` snapshots by for the defined groups
+// from 'srcRepo' to 'dstRepo' using 'copyTreeBatched()'
+func copyGroupedSnapshots(
+	ctx context.Context,
+	srcRepo *repository.Repository,
+	dstRepo restic.Repository,
+	snapshotGroups map[string]data.Snapshots,
+	opts CopyOptions,
+	dstSnapshotByOriginal map[restic.ID][]*data.Snapshot,
+	srcSnapshotLister restic.Lister,
+	args []string,
+	printer restic.Printer,
+) error {
+	for _, snList := range snapshotGroups {
+		// we need to sort 'snList' for using --latest `n`, descending order
+		slices.SortFunc(snList, func(a, b *data.Snapshot) int {
+			return b.Time.Compare(a.Time)
+		})
+
+		var ended int
+		length := len(snList)
+		if opts.latest > 0 {
+			ended = opts.latest
+			if ended > length {
+				ended = length
+			}
+		}
+		mapGroupBy := restic.NewIDSet()
+		for _, sn := range snList[:ended] {
+			mapGroupBy.Insert(*sn.ID())
+		}
+		// here we have to work in the selection by groups
+		filteredSnapshots := collectAllSnapshots(ctx, opts, srcSnapshotLister, srcRepo,
+			dstSnapshotByOriginal, args, mapGroupBy, printer)
+
+		if err := copyTreeBatched(ctx, srcRepo, dstRepo, filteredSnapshots, printer); err != nil {
+			return err
+		}
+	}
+	return ctx.Err()
+}
+
+// sortSelectedSnapshots collects all snapshots from 'selectedSnapshots',
+// sorts them in time descending order and the hands over the last 'opts.latest' as
+// a new iterator
+// existing errors are passed through
+func sortSelectedSnapshots(selectedSnapshots iter.Seq2[*data.Snapshot, error], opts CopyOptions,
+) iter.Seq2[*data.Snapshot, error] {
+	return func(yield func(*data.Snapshot, error) bool) {
+		next, stop := iter.Pull2(selectedSnapshots)
+		defer stop()
+
+		type SnapshotOrError struct {
+			sn  *data.Snapshot
+			err error
+		}
+
+		// collection loop
+		collectLatest := []SnapshotOrError{}
+		for {
+			sn, err, ok := next()
+			if !ok {
+				break
+			}
+			collectLatest = append(collectLatest, SnapshotOrError{sn, err})
+		}
+
+		// sort by time
+		slices.SortFunc(collectLatest, func(a, b SnapshotOrError) int {
+			return b.sn.Time.Compare(a.sn.Time)
+		})
+		length := len(collectLatest)
+		ended := opts.latest
+		if ended > length {
+			ended = length
+		}
+
+		// create new iterator items
+		for _, item := range collectLatest[:ended] {
+			// just hand out the records as they have been found
+			if !yield(item.sn, item.err) {
+				return
+			}
+		}
+	}
+}
+
 func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args []string, term ui.Terminal) error {
 	printer := progress.NewTerminalPrinter(false, gopts.Verbosity, term)
 	secondaryGopts, isFromRepo, err := opts.SecondaryRepoOptions.FillGlobalOpts(ctx, gopts, "destination")
@@ -126,6 +232,10 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args [
 	if isFromRepo {
 		// swap global options, if the secondary repo was set via from-repo
 		gopts, secondaryGopts = secondaryGopts, gopts
+	}
+
+	if opts.GroupBy.Used() && opts.latest < 1 {
+		return fmt.Errorf("you need to specify --latest `n`, n>0, when using --group-by")
 	}
 
 	ctx, srcRepo, unlock, err := openWithReadLock(ctx, gopts, gopts.NoLock, printer)
@@ -175,7 +285,19 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args [
 		return err
 	}
 
-	selectedSnapshots := collectAllSnapshots(ctx, opts, srcSnapshotLister, srcRepo, dstSnapshotByOriginal, args, printer)
+	if opts.GroupBy.Used() {
+		snapshots := make([]*data.Snapshot, 0, 128)
+		// gather all snapshots from 'srcRepo' passing through the SnapshotFiler
+		err = opts.SnapshotFilter.FindAll(ctx, srcSnapshotLister, srcRepo, args, func(_ string, sn *data.Snapshot, err error) error {
+			if err != nil {
+				return err
+			}
+			snapshots = append(snapshots, sn)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
 
 		// create snapshot groups from above snapshots
 		snapshotGroups, _, err := data.GroupSnapshots(snapshots, opts.GroupBy)
@@ -191,20 +313,16 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args [
 	} else {
 		selectedSnapshots := collectAllSnapshots(ctx, opts, srcSnapshotLister, srcRepo, dstSnapshotByOriginal, args, nil, printer)
 		if opts.latest > 0 {
-			snList := slices.SortedFunc(selectedSnapshots, func(a, b *data.Snapshot) int {
-				return b.Time.Compare(a.Time)
-			})
-
-			length := len(snList)
-			ended := opts.latest
-			if ended > length {
-				ended = length
-			}
-			err = copyTreeBatched(ctx, srcRepo, dstRepo, slices.Values(snList[:ended]), printer)
+			// --latest without --group-by
+			// since there is no slices.SortedFunc for an *iter,Seq2[*data.Snapshot, error]
+			// we better call a helper to do the sorting for us
+			newIterator := sortSelectedSnapshots(selectedSnapshots, opts)
+			err = copyTreeBatched(ctx, srcRepo, dstRepo, newIterator, printer)
 			if err != nil {
 				return err
 			}
 		} else {
+			// no --latest and no --group-by
 			err = copyTreeBatched(ctx, srcRepo, dstRepo, selectedSnapshots, printer)
 			if err != nil {
 				return err

--- a/cmd/restic/cmd_copy_integration_test.go
+++ b/cmd/restic/cmd_copy_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
@@ -26,6 +27,27 @@ func testRunCopy(t testing.TB, srcGopts global.Options, dstGopts global.Options)
 	}
 
 	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		return runCopy(context.TODO(), copyOpts, gopts, nil, gopts.Term)
+	}))
+}
+
+func testRunCopyWithWrapper(t testing.TB, srcGopts global.Options, dstGopts global.Options,
+	wrap func(opts *CopyOptions),
+) {
+	gopts := srcGopts
+	gopts.Repo = dstGopts.Repo
+	gopts.Password = dstGopts.Password
+	gopts.InsecureNoPassword = dstGopts.InsecureNoPassword
+	copyOpts := CopyOptions{
+		SecondaryRepoOptions: global.SecondaryRepoOptions{
+			Repo:               srcGopts.Repo,
+			Password:           srcGopts.Password,
+			InsecureNoPassword: srcGopts.InsecureNoPassword,
+		},
+	}
+
+	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		wrap(&copyOpts)
 		return runCopy(context.TODO(), copyOpts, gopts, nil, gopts.Term)
 	}))
 }
@@ -194,4 +216,93 @@ func TestCopyToEmptyPassword(t *testing.T) {
 	testListSnapshots(t, env.gopts, 1)
 	testListSnapshots(t, env2.gopts, 1)
 	testRunCheck(t, env2.gopts)
+}
+
+func testRunSixBackups(t *testing.T, env *testEnvironment) {
+	opts := BackupOptions{
+		Host: "asterix",
+	}
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "10")}, opts, env.gopts)
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "20")}, opts, env.gopts)
+
+	opts = BackupOptions{
+		Host: "obelix",
+	}
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "10")}, opts, env.gopts)
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "20")}, opts, env.gopts)
+
+	opts = BackupOptions{
+		Host: "idefix",
+	}
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "10")}, opts, env.gopts)
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "20")}, opts, env.gopts)
+
+	// make sure that we have got 6 snapsshots
+	testListSnapshots(t, env.gopts, 6)
+}
+
+func TestCopyGroupByPath(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	env2, cleanup2 := withTestEnvironment(t)
+	defer cleanup2()
+
+	testSetupBackupData(t, env)
+	testRunSixBackups(t, env)
+
+	testRunInit(t, env2.gopts)
+	testRunCopyWithWrapper(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+		opts.latest = 1
+		opts.GroupBy = data.SnapshotGroupByOptions{Path: true}
+	})
+
+	// make sure that we have got 2 snapsshots
+	testListSnapshots(t, env2.gopts, 2)
+
+	// make sure that subsequent copy operations with the same options
+	// does nothing to the target repository
+	testRunCopyWithWrapper(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+		opts.latest = 1
+		opts.GroupBy = data.SnapshotGroupByOptions{Path: true}
+	})
+
+	testListSnapshots(t, env2.gopts, 2)
+}
+
+func TestCopyGroupByHost(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	env2, cleanup2 := withTestEnvironment(t)
+	defer cleanup2()
+
+	testSetupBackupData(t, env)
+	testRunSixBackups(t, env)
+
+	testRunInit(t, env2.gopts)
+	testRunCopyWithWrapper(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+		opts.latest = 1
+		opts.GroupBy = data.SnapshotGroupByOptions{Host: true}
+	})
+
+	// make sure that we have got 3 snapsshots
+	testListSnapshots(t, env2.gopts, 3)
+}
+
+func TestCopyGroupByHostAndPath(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	env2, cleanup2 := withTestEnvironment(t)
+	defer cleanup2()
+
+	testSetupBackupData(t, env)
+	testRunSixBackups(t, env)
+
+	testRunInit(t, env2.gopts)
+	testRunCopyWithWrapper(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+		opts.latest = 1
+		opts.GroupBy = data.SnapshotGroupByOptions{Host: true, Path: true}
+	})
+
+	// make sure that we have got 6 snapsshots
+	testListSnapshots(t, env2.gopts, 6)
 }

--- a/cmd/restic/cmd_copy_integration_test.go
+++ b/cmd/restic/cmd_copy_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/restic/restic/internal/data"
@@ -31,9 +32,9 @@ func testRunCopy(t testing.TB, srcGopts global.Options, dstGopts global.Options)
 	}))
 }
 
-func testRunCopyWithWrapper(t testing.TB, srcGopts global.Options, dstGopts global.Options,
+func testRunCopyWithWrapperMayFail(t testing.TB, srcGopts global.Options, dstGopts global.Options,
 	wrap func(opts *CopyOptions),
-) {
+) error {
 	gopts := srcGopts
 	gopts.Repo = dstGopts.Repo
 	gopts.Password = dstGopts.Password
@@ -46,10 +47,10 @@ func testRunCopyWithWrapper(t testing.TB, srcGopts global.Options, dstGopts glob
 		},
 	}
 
-	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
+	return withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		wrap(&copyOpts)
 		return runCopy(context.TODO(), copyOpts, gopts, nil, gopts.Term)
-	}))
+	})
 }
 
 func TestCopy(t *testing.T) {
@@ -251,20 +252,22 @@ func TestCopyGroupByPath(t *testing.T) {
 	testRunSixBackups(t, env)
 
 	testRunInit(t, env2.gopts)
-	testRunCopyWithWrapper(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+	err := testRunCopyWithWrapperMayFail(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
 		opts.latest = 1
 		opts.GroupBy = data.SnapshotGroupByOptions{Path: true}
 	})
+	rtest.OK(t, err)
 
 	// make sure that we have got 2 snapsshots
 	testListSnapshots(t, env2.gopts, 2)
 
 	// make sure that subsequent copy operations with the same options
-	// does nothing to the target repository
-	testRunCopyWithWrapper(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+	// does nothing to theerr := testRunCopyWithWrapperMayFailtestRunCopyWithWrapper(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+	err = testRunCopyWithWrapperMayFail(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
 		opts.latest = 1
 		opts.GroupBy = data.SnapshotGroupByOptions{Path: true}
 	})
+	rtest.OK(t, err)
 
 	testListSnapshots(t, env2.gopts, 2)
 }
@@ -279,10 +282,11 @@ func TestCopyGroupByHost(t *testing.T) {
 	testRunSixBackups(t, env)
 
 	testRunInit(t, env2.gopts)
-	testRunCopyWithWrapper(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+	err := testRunCopyWithWrapperMayFail(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
 		opts.latest = 1
 		opts.GroupBy = data.SnapshotGroupByOptions{Host: true}
 	})
+	rtest.OK(t, err)
 
 	// make sure that we have got 3 snapsshots
 	testListSnapshots(t, env2.gopts, 3)
@@ -298,11 +302,37 @@ func TestCopyGroupByHostAndPath(t *testing.T) {
 	testRunSixBackups(t, env)
 
 	testRunInit(t, env2.gopts)
-	testRunCopyWithWrapper(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+	err := testRunCopyWithWrapperMayFail(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
 		opts.latest = 1
 		opts.GroupBy = data.SnapshotGroupByOptions{Host: true, Path: true}
 	})
+	rtest.OK(t, err)
 
 	// make sure that we have got 6 snapsshots
 	testListSnapshots(t, env2.gopts, 6)
+}
+
+func TestCopyGroupByHostFailure(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	env2, cleanup2 := withTestEnvironment(t)
+	defer cleanup2()
+
+	testSetupBackupData(t, env)
+	testRunSixBackups(t, env)
+
+	testRunInit(t, env2.gopts)
+	err := testRunCopyWithWrapperMayFail(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+		opts.GroupBy = data.SnapshotGroupByOptions{Host: true, Path: true}
+	})
+	rtest.Assert(t, err != nil, "expected error, got none")
+	rtest.Assert(t, strings.Contains(err.Error(), "you need to specify --latest `n`"),
+		"expected error message %q", "you need to specify --latest `n` ...")
+
+	err = testRunCopyWithWrapperMayFail(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+		opts.latest = 1
+	})
+	rtest.Assert(t, err != nil, "expected error, got none")
+	rtest.Assert(t, strings.Contains(err.Error(), "--latest `n`, has no effect without using --group-by"),
+		"expected error message %q", "--latest `n`, has no effect without using --group-by")
 }

--- a/cmd/restic/cmd_copy_integration_test.go
+++ b/cmd/restic/cmd_copy_integration_test.go
@@ -288,7 +288,6 @@ func TestCopyGroupByHost(t *testing.T) {
 	})
 	rtest.OK(t, err)
 
-	// make sure that we have got 3 snapsshots
 	testListSnapshots(t, env2.gopts, 3)
 }
 
@@ -308,8 +307,25 @@ func TestCopyGroupByHostAndPath(t *testing.T) {
 	})
 	rtest.OK(t, err)
 
-	// make sure that we have got 6 snapsshots
 	testListSnapshots(t, env2.gopts, 6)
+}
+
+func TestCopyLatest(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	env2, cleanup2 := withTestEnvironment(t)
+	defer cleanup2()
+
+	testSetupBackupData(t, env)
+	testRunSixBackups(t, env)
+
+	testRunInit(t, env2.gopts)
+	err := testRunCopyWithWrapperMayFail(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
+		opts.latest = 3
+	})
+	rtest.OK(t, err)
+
+	testListSnapshots(t, env2.gopts, 3)
 }
 
 func TestCopyGroupByHostFailure(t *testing.T) {
@@ -328,11 +344,4 @@ func TestCopyGroupByHostFailure(t *testing.T) {
 	rtest.Assert(t, err != nil, "expected error, got none")
 	rtest.Assert(t, strings.Contains(err.Error(), "you need to specify --latest `n`"),
 		"expected error message %q", "you need to specify --latest `n` ...")
-
-	err = testRunCopyWithWrapperMayFail(t, env.gopts, env2.gopts, func(opts *CopyOptions) {
-		opts.latest = 1
-	})
-	rtest.Assert(t, err != nil, "expected error, got none")
-	rtest.Assert(t, strings.Contains(err.Error(), "--latest `n`, has no effect without using --group-by"),
-		"expected error message %q", "--latest `n`, has no effect without using --group-by")
 }

--- a/doc/045_working_with_repos.rst
+++ b/doc/045_working_with_repos.rst
@@ -286,6 +286,48 @@ which case only these instead of all snapshots will be copied:
 
     $ restic -r /srv/restic-repo-copy copy --from-repo /srv/restic-repo 410b18a2 4e5d5487 latest
 
+A different method of filtering can be applied by using the options ``--group-by`` together
+with ``--latest``. This filtering makes it possible to copy only the latest snapshot of such a group,
+using ``--latest 1``. Group filtering works the same way as it does for ``restic snapshots`` and
+``restic forget``.
+
+Here is an example: Having created 6 backups from 3 hosts and 2 files each, the source
+repository looks like this:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo snapshots
+    ID        Time                 Host        Tags        Paths                                   Size
+    -----------------------------------------------------------------------------------------------------
+    9945174e  2026-05-18 06:54:14  asterix                 /home/user/restic/testdata/0/0/9/3  16.000 KiB
+    4c2d470d  2026-05-18 06:54:23  asterix                 /home/user/restic/testdata/0/0/9/5  16.000 KiB
+    b2b5d40d  2026-05-18 06:54:40  obelix                  /home/user/restic/testdata/0/0/9/3  16.000 KiB
+    e54ba388  2026-05-18 06:54:44  obelix                  /home/user/restic/testdata/0/0/9/5  16.000 KiB
+    5427e325  2026-05-18 06:54:54  idefix                  /home/user/restic/testdata/0/0/9/3  16.000 KiB
+    612122d8  2026-05-18 06:54:57  idefix                  /home/user/restic/testdata/0/0/9/5  16.000 KiB
+    -----------------------------------------------------------------------------------------------------
+    Timestamps shown in BST timezone
+    6 snapshots
+
+One can now copy these snapshots to ``/srv/restic-repo-copy`` using a group filter ``--group-by path --latest 1``:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo-copy copy --from-repo /srv/restic-repo --group-by path --latest 1 --quiet
+
+The snapshots of the target repository are:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo-copy snapshots
+    ID        Time                 Host        Tags        Paths                                   Size
+    -----------------------------------------------------------------------------------------------------
+    309e8bd4  2026-05-18 06:54:54  idefix                  /home/user/restic/testdata/0/0/9/3  16.000 KiB
+    9481b704  2026-05-18 06:54:57  idefix                  /home/user/restic/testdata/0/0/9/5  16.000 KiB
+    -----------------------------------------------------------------------------------------------------
+    Timestamps shown in BST timezone
+    2 snapshots
+
 .. _copy-deduplication:
 
 Ensuring deduplication for copied snapshots

--- a/internal/data/snapshot_group.go
+++ b/internal/data/snapshot_group.go
@@ -58,6 +58,10 @@ func (l *SnapshotGroupByOptions) Type() string {
 	return "group"
 }
 
+func (l *SnapshotGroupByOptions) Used() bool {
+	return l.Tag || l.Host || l.Path
+}
+
 // SnapshotGroupKey is the structure for identifying groups in a grouped
 // snapshot list. This is used by GroupSnapshots()
 type SnapshotGroupKey struct {
@@ -115,5 +119,5 @@ func GroupSnapshots(snapshots Snapshots, groupBy SnapshotGroupByOptions) (map[st
 		snapshotGroups[string(k)] = append(snapshotGroups[string(k)], sn)
 	}
 
-	return snapshotGroups, groupBy.Tag || groupBy.Host || groupBy.Path, nil
+	return snapshotGroups, groupBy.Used(), nil
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
restic copy now allows copying snapshots grouped by host / path / tag. You can specify grouping by using option ``--group-by`` and the number of snapshots to be copied per group by using option ``--latest n``. The usage is the same as for `restic forget` and `restic snapshot`.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

In order to maintain the correct order of snapshots, irrespective if they have been previously copied, the algorithm makes sure that multiple runs of ``restic copy`` with the same options does not produce any new snapshots in the destination repository.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
close https://github.com/restic/restic/issues/4327

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
