### PR TITLE
cli: add test-pattern sub-command to test path matching

### DIFF
--- a/cmd/restic/cmd_test_pattern_test.go
+++ b/cmd/restic/cmd_test_pattern_test.go
@@ -1,0 +1,208 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/restic/restic/internal/global"
+	"github.com/restic/restic/internal/ui/termstatus"
+)
+
+func newTestTerm() (*termstatus.Terminal, func()) {
+	ctx, cancel := context.WithCancel(context.Background())
+	term := termstatus.New(io.NopCloser(bytes.NewReader(nil)), io.Discard, io.Discard, true)
+
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		term.Run(ctx)
+	}()
+
+	return term, func() {
+		cancel()
+		wg.Wait()
+	}
+}
+
+func TestTestPatternMatch(t *testing.T) {
+	for _, test := range []struct {
+		name            string
+		pattern         string
+		path            string
+		caseInsensitive bool
+		wantMatch       bool
+		wantErr         bool
+	}{
+		{
+			name:      "simple wildcard match",
+			pattern:   "*.go",
+			path:      "/home/user/main.go",
+			wantMatch: true,
+		},
+		{
+			name:      "simple wildcard no match",
+			pattern:   "*.txt",
+			path:      "/home/user/main.go",
+			wantMatch: false,
+		},
+		{
+			name:      "exact filename match",
+			pattern:   "main.go",
+			path:      "main.go",
+			wantMatch: true,
+		},
+		{
+			name:            "case insensitive match",
+			pattern:         "*.GO",
+			path:            "/home/user/main.go",
+			caseInsensitive: true,
+			wantMatch:       true,
+		},
+		{
+			name:            "case insensitive no match",
+			pattern:         "*.txt",
+			path:            "/home/user/main.go",
+			caseInsensitive: true,
+			wantMatch:       false,
+		},
+		{
+			name:      "recursive wildcard match",
+			pattern:   "**/.git/**",
+			path:      "/home/user/project/.git/config",
+			wantMatch: true,
+		},
+		{
+			name:      "recursive wildcard child match",
+			pattern:   "**/.git/**",
+			path:      "/home/user/project/.git",
+			wantMatch: true,
+		},
+		{
+			name:      "absolute pattern match",
+			pattern:   "/home/user/*.txt",
+			path:      "/home/user/readme.txt",
+			wantMatch: true,
+		},
+		{
+			name:      "absolute pattern no match different dir",
+			pattern:   "/home/user/*.txt",
+			path:      "/home/other/readme.txt",
+			wantMatch: false,
+		},
+		{
+			name:      "single character wildcard",
+			pattern:   "file.?o",
+			path:      "/path/file.go",
+			wantMatch: true,
+		},
+		{
+			name:      "question mark no match",
+			pattern:   "file.?o",
+			path:      "/path/file.py",
+			wantMatch: false,
+		},
+		{
+			name:      "character class match",
+			pattern:   "file.[gx]o",
+			path:      "/path/file.go",
+			wantMatch: true,
+		},
+		{
+			name:      "character class no match",
+			pattern:   "file.[ab]o",
+			path:      "/path/file.go",
+			wantMatch: false,
+		},
+		{
+			name:      "directory wildcard match",
+			pattern:   "/home/*/main.go",
+			path:      "/home/user/main.go",
+			wantMatch: true,
+		},
+		{
+			name:      "directory wildcard no match subdir",
+			pattern:   "/home/*/main.go",
+			path:      "/home/user/sub/main.go",
+			wantMatch: false,
+		},
+		{
+			name:      "directory wildcard multi-level",
+			pattern:   "/home/*/*/main.go",
+			path:      "/home/user/sub/main.go",
+			wantMatch: true,
+		},
+		{
+			name:      "invalid pattern",
+			pattern:   "[",
+			path:      "/home/user/main.go",
+			wantErr:   true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			term, cleanup := newTestTerm()
+			defer cleanup()
+
+			gopts := global.Options{
+				Term: term,
+			}
+
+			opts := TestPatternOptions{
+				CaseInsensitive: test.caseInsensitive,
+			}
+
+			args := []string{test.pattern, test.path}
+			err := runTestPattern(opts, gopts, args)
+
+			if test.wantErr {
+				if err == nil {
+					t.Fatal("expected error but got none")
+				}
+				return
+			}
+
+			if test.wantMatch {
+				if err != nil {
+					t.Fatalf("expected match but got error: %v", err)
+				}
+			} else {
+				if err == nil {
+					t.Fatal("expected no match but got error")
+				}
+				if !strings.Contains(err.Error(), "pattern did not match") {
+					t.Fatalf("expected 'pattern did not match' error, got: %v", err)
+				}
+			}
+		})
+	}
+}
+
+func TestTestPatternWrongArgCount(t *testing.T) {
+	term, cleanup := newTestTerm()
+	defer cleanup()
+
+	gopts := global.Options{
+		Term: term,
+	}
+
+	opts := TestPatternOptions{}
+
+	err := runTestPattern(opts, gopts, []string{})
+	if err == nil || !strings.Contains(err.Error(), "wrong number of arguments") {
+		t.Fatalf("expected 'wrong number of arguments' error, got: %v", err)
+	}
+
+	err = runTestPattern(opts, gopts, []string{"*.go"})
+	if err == nil || !strings.Contains(err.Error(), "wrong number of arguments") {
+		t.Fatalf("expected 'wrong number of arguments' error, got: %v", err)
+	}
+
+	err = runTestPattern(opts, gopts, []string{"*.go", "/path", "extra"})
+	if err == nil || !strings.Contains(err.Error(), "wrong number of arguments") {
+		t.Fatalf("expected 'wrong number of arguments' error, got: %v", err)
+	}
+}

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -101,6 +101,7 @@ The full documentation can be found at https://restic.readthedocs.io/ .
 		newSnapshotsCommand(globalOptions),
 		newStatsCommand(globalOptions),
 		newTagCommand(globalOptions),
+		newTestPatternCommand(globalOptions),
 		newUnlockCommand(globalOptions),
 		newVersionCommand(globalOptions),
 	)
@@ -118,7 +119,7 @@ The full documentation can be found at https://restic.readthedocs.io/ .
 // user for authentication).
 func needsPassword(cmd string) bool {
 	switch cmd {
-	case "cache", "generate", "help", "options", "self-update", "version", "__complete", "__completeNoDesc":
+	case "cache", "generate", "help", "options", "self-update", "test-pattern", "version", "__complete", "__completeNoDesc":
 		return false
 	default:
 		return true

--- a/cmd_test_pattern.go
+++ b/cmd_test_pattern.go
@@ -1,0 +1,99 @@
+package main
+
+import (
+	"strings"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/filter"
+	"github.com/restic/restic/internal/global"
+	"github.com/restic/restic/internal/ui"
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+func newTestPatternCommand(globalOptions *global.Options) *cobra.Command {
+	var opts TestPatternOptions
+
+	cmd := &cobra.Command{
+		Use:   "test-pattern [flags] PATTERN PATH",
+		Short: "Test a pattern against a path",
+		Long: `
+The "test-pattern" command tests whether a given pattern matches a specific
+path. It uses the same pattern matching logic as the "find", "backup", and
+"restore" commands, supporting the '**' recursive wildcard in addition to
+filepath.Match patterns.
+
+This is useful for verifying exclude/include patterns before running a backup.
+
+EXIT STATUS
+===========
+
+Exit status is 0 if the pattern matched the path.
+Exit status is 1 if the pattern did not match.
+`,
+		Example: `restic test-pattern '*.go' /home/user/main.go
+restic test-pattern --ignore-case '*.GO' /home/user/main.go
+restic test-pattern '**/.git/**' /home/user/project/.git/config
+restic test-pattern '/home/user/*.txt' /home/user/readme.txt`,
+		DisableAutoGenTag: true,
+		GroupID:           cmdGroupDefault,
+		RunE: func(_ *cobra.Command, args []string) error {
+			return runTestPattern(opts, *globalOptions, args)
+		},
+	}
+
+	opts.AddFlags(cmd.Flags())
+	return cmd
+}
+
+// TestPatternOptions collects all options for the test-pattern command.
+type TestPatternOptions struct {
+	CaseInsensitive bool
+}
+
+func (opts *TestPatternOptions) AddFlags(f *pflag.FlagSet) {
+	f.BoolVarP(&opts.CaseInsensitive, "ignore-case", "i", false, "ignore case for pattern")
+}
+
+func runTestPattern(opts TestPatternOptions, gopts global.Options, args []string) error {
+	if len(args) != 2 {
+		return errors.Fatal("wrong number of arguments, expecting: test-pattern [flags] PATTERN PATH")
+	}
+
+	pattern := args[0]
+	path := args[1]
+
+	normalizedPattern := pattern
+	normalizedPath := path
+	if opts.CaseInsensitive {
+		normalizedPattern = strings.ToLower(pattern)
+		normalizedPath = strings.ToLower(path)
+	}
+
+	matched, err := filter.Match(normalizedPattern, normalizedPath)
+	if err != nil {
+		return errors.Fatalf("error matching pattern: %v", err)
+	}
+
+	childMayMatch, err := filter.ChildMatch(normalizedPattern, normalizedPath)
+	if err != nil {
+		return errors.Fatalf("error testing child match: %v", err)
+	}
+
+	printer := ui.NewProgressPrinter(gopts.JSON, gopts.Verbosity, gopts.Term)
+
+	if opts.CaseInsensitive {
+		printer.S("pattern    : %s (case-insensitive)\n", pattern)
+	} else {
+		printer.S("pattern    : %s\n", pattern)
+	}
+	printer.S("path       : %s\n", path)
+	printer.S("match      : %v\n", matched)
+	printer.S("child match: %v\n", childMayMatch)
+
+	if !matched {
+		return errors.Fatal("pattern did not match")
+	}
+
+	return nil
+}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Adds restic test-pattern command using the same `filter.Match` and `filter.ChildMatch` logic as find/backup/restore, with optional -i/--ignore-case flag. Requires no repository, matching version/cache/generate commands.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
#5708 

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
