### PR TITLE
backend/retry: stop retrying no-space errors

### DIFF
--- a/internal/backend/retry/backend_retry.go
+++ b/internal/backend/retry/backend_retry.go
@@ -107,7 +107,6 @@ func (be *Backend) retry(ctx context.Context, msg string, f func() error) error 
 
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxElapsedTime = be.MaxElapsedTime
-
 	if feature.Flag.Enabled(feature.BackendErrorRedesign) {
 		bo.InitialInterval = 1 * time.Second
 		bo.Multiplier = 2
@@ -135,14 +134,25 @@ func (be *Backend) retry(ctx context.Context, msg string, f func() error) error 
 	err := retryNotifyErrorWithSuccess(
 		func() error {
 			err := f()
+
+			// Running out of local disk space is not a transient backend
+			// failure. For example, `restic check` can fail while writing to a
+			// temporary cache directory. Retrying only repeats the same local
+			// disk-space error.
+			if isNoSpaceError(err) {
+				return backoff.Permanent(err)
+			}
+
 			// don't retry permanent errors as those very likely cannot be fixed by retrying
 			// TODO remove IsNotExist(err) special cases when removing the feature flag
 			if feature.Flag.Enabled(feature.BackendErrorRedesign) && !errors.Is(err, &backoff.PermanentError{}) && be.Backend.IsPermanentError(err) {
 				permanentErrorAttempts--
 			}
+
 			if permanentErrorAttempts <= 0 {
 				return backoff.Permanent(err)
 			}
+
 			return err
 		},
 		backoff.WithContext(b, ctx),

--- a/internal/backend/retry/backend_retry_test.go
+++ b/internal/backend/retry/backend_retry_test.go
@@ -285,6 +285,31 @@ func TestBackendLoadRetry(t *testing.T) {
 	test.Equals(t, 2, attempt)
 }
 
+func TestBackendLoadNoSpaceNotRetried(t *testing.T) {
+	noSpaceErr := &os.PathError{
+		Op:   "write",
+		Path: "/tmp/restic-check-cache/data/tmp-123",
+		Err:  errNoSpace,
+	}
+
+	attempt := 0
+	be := mock.NewBackend()
+	be.OpenReaderFn = func(ctx context.Context, h backend.Handle, length int, offset int64) (io.ReadCloser, error) {
+		attempt++
+		return nil, noSpaceErr
+	}
+
+	TestFastRetries(t)
+	retryBackend := New(be, time.Second, nil, nil)
+
+	err := retryBackend.Load(context.TODO(), backend.Handle{}, 0, 0, func(rd io.Reader) error {
+		return nil
+	})
+
+	test.Equals(t, noSpaceErr, err)
+	test.Equals(t, 1, attempt)
+}
+
 func testBackendLoadNotExists(t *testing.T, hasFlakyErrors bool) {
 	// load should not retry if the error matches IsNotExist
 	notFound := errors.New("not found")

--- a/internal/backend/retry/backend_retry_test.go
+++ b/internal/backend/retry/backend_retry_test.go
@@ -4,11 +4,13 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"os"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/mock"
 	"github.com/restic/restic/internal/errors"

--- a/internal/backend/retry/no_soace.go
+++ b/internal/backend/retry/no_soace.go
@@ -1,0 +1,14 @@
+//go:build !windows
+
+package retry
+
+import (
+	"errors"
+	"syscall"
+)
+
+var errNoSpace = syscall.ENOSPC
+
+func isNoSpaceError(err error) bool {
+	return errors.Is(err, errNoSpace)
+}

--- a/internal/backend/retry/no_space_windows.go
+++ b/internal/backend/retry/no_space_windows.go
@@ -1,0 +1,13 @@
+package retry
+
+import (
+	"errors"
+	"syscall"
+)
+
+var errNoSpace = syscall.ERROR_DISK_FULL
+
+func isNoSpaceError(err error) bool {
+	return errors.Is(err, errNoSpace) ||
+		errors.Is(err, syscall.ERROR_HANDLE_DISK_FULL)
+}


### PR DESCRIPTION
## Summary

Treat local disk-full errors as permanent retry failures in the retry backend.

When an operation returns a wrapped no-space error, the retry loop now returns the original error immediately instead of continuing through retries.

## Motivation

The retry backend is meant for failures that may succeed on another attempt. A local disk-full condition is different: retrying the same operation usually repeats the same failure.

One visible case is `restic check`, where restic may write to a temporary cache directory. If that directory runs out of space, retrying the same `Load` operation does not make progress and delays the actionable error message.

Failing fast lets the user free space, change the cache directory, or adjust their temporary directory.

Fixes #4558.

## Changes

- Add platform-specific no-space error detection.
- Treat `ENOSPC` / disk-full errors as permanent retry errors.
- Add a regression test confirming `Load` is attempted only once for a wrapped no-space error.

## Testing

```bash
go test ./internal/backend/retry
