### PR TITLE
backup: prevent hang using --stdin-from-command if upload fails

### DIFF
--- a/changelog/unreleased/issue-5683
+++ b/changelog/unreleased/issue-5683
@@ -1,0 +1,9 @@
+Bugfix: Prevent `backup --stdin-from-command` from hanging
+
+When using `--stdin-from-command`, the `backup` command could hang until
+manually cancelled if the backup stopped before all subprocess output was
+consumed, for example after a failed upload to the repository. This has been
+fixed.
+
+https://github.com/restic/restic/issues/5683
+https://github.com/restic/restic/pull/21829

--- a/internal/fs/fs_reader_command.go
+++ b/internal/fs/fs_reader_command.go
@@ -97,5 +97,8 @@ func (fp *CommandReader) Close() error {
 		return nil
 	}
 
+	// This line can only be reached if the command was not read until the end. This can, for example,
+	// happen if a backup run is interrupted. Kill the command to avoid hanging.
+	_ = fp.cmd.Cancel()
 	return fp.wait()
 }

--- a/internal/fs/fs_reader_command_test.go
+++ b/internal/fs/fs_reader_command_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/test"
@@ -50,4 +51,15 @@ func TestCommandReaderOutput(t *testing.T) {
 	test.OK(t, reader.Close())
 
 	test.Equals(t, "hello world", strings.TrimSpace(buf.String()))
+}
+
+func TestCommandReaderQuickClose(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.TODO(), 10*time.Second)
+	defer cancel()
+	reader, err := fs.NewCommandReader(ctx, []string{"sleep", "3600"}, func(msg string, args ...interface{}) {})
+	test.OK(t, err)
+
+	// test that close returns before the context expires
+	_ = reader.Close()
+	test.OK(t, ctx.Err())
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
When using `--stdin-from-command`, the `backup` command could hang until
manually cancelled if the backup stopped before all subprocess output was
consumed, for example after a failed upload to the repository. This has been
fixed.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/5683
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
