### PR TITLE
stats: stop progress bar before printing stats

### DIFF
--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -185,6 +185,8 @@ func runStats(ctx context.Context, opts StatsOptions, gopts global.Options, args
 			stats.CompressionSpaceSaving = (1 - float64(stats.TotalSize)/float64(stats.TotalUncompressedSize)) * 100
 		}
 	}
+	// stop progress bar to prevent mangled output
+	updater.Done()
 
 	if gopts.JSON {
 		err = json.NewEncoder(gopts.Term.OutputWriter()).Encode(stats)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Output was mangled:
```
repository a14e5863 opened (version 2, compression level auto)
[0:01] 100.00%  25 / 25 index files loaded
scanning...
Stats in restore-size mode:
     Snapshots processed:  1
        Total File Count:  250196
              Total Size:  8.486 GiB
[0:02] 100.00%  1 / 1 snapshots, 250196 files, 16.832 GiB
```

With this PR:
```
repository a14e5863 opened (version 2, compression level auto)
[0:02] 100.00%  25 / 25 index files loaded
scanning...
[0:02] 100.00%  1 / 1 snapshots, 250196 files, 16.832 GiB
Stats in restore-size mode:
     Snapshots processed:  1
        Total File Count:  250196
              Total Size:  8.486 GiB
```
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
