### PR TITLE
backup: skip source paths that cannot be accessed

### DIFF
--- a/changelog/unreleased/issue-5667
+++ b/changelog/unreleased/issue-5667
@@ -1,0 +1,9 @@
+Bugfix: Skip inaccessible `backup` source paths
+
+The `backup` command only skipped source paths that did not exist. A path that
+could not be accessed for another reason, such as a malformed path on Windows,
+was kept and produced an empty snapshot. Restic now skips any such path and
+aborts if none remain.
+
+https://github.com/restic/restic/issues/5667
+https://github.com/restic/restic/pull/21852

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -171,13 +171,17 @@ var ErrInvalidSourceData = errors.New("at least one source file could not be rea
 // ErrNoSourceData is used to report that no source data was found
 var ErrNoSourceData = errors.Fatal("all source directories/files do not exist")
 
-// filterExisting returns a slice of all existing items, or an error if no
-// items exist at all.
+// filterExisting returns the items that exist and can be accessed. It returns
+// ErrNoSourceData if none remain, or ErrInvalidSourceData if some were skipped.
 func filterExisting(items []string, warnf func(msg string, args ...interface{})) (result []string, err error) {
 	for _, item := range items {
 		_, err := fs.Lstat(item)
-		if errors.Is(err, os.ErrNotExist) {
-			warnf("%v does not exist, skipping\n", item)
+		if err != nil {
+			if errors.Is(err, os.ErrNotExist) {
+				warnf("%v does not exist, skipping\n", item)
+			} else {
+				warnf("%v cannot be accessed, skipping\n", item)
+			}
 			continue
 		}
 

--- a/cmd/restic/cmd_backup_test.go
+++ b/cmd/restic/cmd_backup_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/restic/restic/internal/errors"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -74,6 +75,28 @@ func TestCollectTargets(t *testing.T) {
 
 	_, err = collectTargets(opts, []string{filepath.Join(dir, "cmdline arg"), filepath.Join(dir, "non-existing-file")}, t.Logf, nil)
 	rtest.Assert(t, err == ErrInvalidSourceData, "expected error when not all targets exist")
+}
+
+func TestFilterExistingUnreadable(t *testing.T) {
+	dir := rtest.TempDir(t)
+
+	existing := filepath.Join(dir, "existing")
+	rtest.OK(t, os.Mkdir(existing, 0755))
+
+	file := filepath.Join(dir, "file")
+	rtest.OK(t, os.WriteFile(file, []byte("x"), 0600))
+
+	// Regression test for #5667. A target whose Lstat fails with an error other
+	// than ErrNotExist must be skipped (ENOTDIR on unix, NUL byte everywhere).
+	for _, unreadable := range []string{filepath.Join(file, "child"), "invalid\x00path"} {
+		result, err := filterExisting([]string{unreadable}, t.Logf)
+		rtest.Assert(t, errors.Is(err, ErrNoSourceData), "input %q: expected ErrNoSourceData; got %v", unreadable, err)
+		rtest.Assert(t, len(result) == 0, "input %q: expected no targets; got %v", unreadable, result)
+
+		result, err = filterExisting([]string{existing, unreadable}, t.Logf)
+		rtest.Assert(t, errors.Is(err, ErrInvalidSourceData), "input %q: expected ErrInvalidSourceData; got %v", unreadable, err)
+		rtest.Equals(t, []string{existing}, result)
+	}
 }
 
 func TestReadFilenamesRaw(t *testing.T) {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The `backup` command only skipped source paths that did not exist. A path that could not be accessed for another reason, such as a malformed path on Windows, was kept and led to an empty snapshot. It now skips any source path it cannot access and aborts with `all source directories/files do not exist` when none are left.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #5667

Checklist
---------

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
