### PR TITLE
doc: add Cloudflare R2 as S3-compatible backend setup instructions

### DIFF
--- a/changelog/unreleased/issue-21855
+++ b/changelog/unreleased/issue-21855
@@ -1,0 +1,8 @@
+Enhancement: Add documentation for Cloudflare R2 as S3-compatible backend
+
+Cloudflare R2 can be used as a restic backend via the s3: backend type.
+Added a dedicated section to the repository preparation docs including
+the required environment variables and the non-obvious AWS_DEFAULT_REGION=auto
+setting.
+
+https://github.com/restic/restic/issues/21855

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -358,6 +358,61 @@ S3 storage from `Wasabi <https://wasabi.com>`__ can be used as follows.
     $ export AWS_SECRET_ACCESS_KEY=<YOUR-WASABI-SECRET-ACCESS-KEY>
     $ restic -r s3:https://<WASABI-SERVICE-URL>/<WASABI-BUCKET-NAME> init
 
+Cloudflare R2
+~~~~~~~~~~~~~
+
+`Cloudflare R2 <https://developers.cloudflare.com/r2/>`__ is an S3-compatible
+object storage service. To use it with restic, you need an R2 bucket and an
+API token with at least **Object Read & Write** permissions.
+
+Find your **Account ID** in the Cloudflare dashboard under :menuselection:`R2 --> Overview`.
+Generate an **API token** under :menuselection:`R2 --> Manage R2 API Tokens`.
+
+Set the following environment variables:
+
+.. code-block:: console
+
+    $ export AWS_ACCESS_KEY_ID=<R2_ACCESS_KEY_ID>
+    $ export AWS_SECRET_ACCESS_KEY=<R2_SECRET_ACCESS_KEY>
+    $ export AWS_DEFAULT_REGION=auto
+
+.. note::
+
+    ``AWS_DEFAULT_REGION`` must be set to ``auto`` for Cloudflare R2. Without
+    it, restic will fail to connect to the endpoint.
+
+Initialize the repository using your Account ID and bucket name:
+
+.. code-block:: console
+
+    $ restic -r s3:https://<ACCOUNT_ID>.r2.cloudflarestorage.com/<BUCKET_NAME> init
+    enter password for new repository:
+    enter password again:
+    created restic repository 9fbe7e3f8a at s3:https://<ACCOUNT_ID>.r2.cloudflarestorage.com/<BUCKET_NAME>
+    Please note that knowledge of your password is required to access the repository.
+    Losing your password means that your data is irrecoverably lost.
+
+For automated backups, store credentials and the repository URL in an
+environment file and source it before running restic:
+
+.. code-block:: console
+
+    $ source ~/.restic_env
+    $ restic backup ~/important-data
+
+After backing up, it is recommended to verify the repository integrity:
+
+.. code-block:: console
+
+    $ restic check
+
+To restore data to a specific path:
+
+.. code-block:: console
+
+    $ restic restore latest --target /path/to/restore
+
+
 Alibaba Cloud (Aliyun) Object Storage System (OSS)
 **************************************************
 


### PR DESCRIPTION
Fixes #21855

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Adds a dedicated section for Cloudflare R2 to the repository preparation 
docs, between the Wasabi and Alibaba OSS sections.

R2 works with restic's s3: backend via its S3-compatible API, but was 
not documented anywhere. The key non-obvious requirement is setting 
AWS_DEFAULT_REGION=auto — without it restic fails to connect to the 
R2 endpoint. The section covers environment variables, init, backup, 
check, and restore commands.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Closes #21855
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests) (documentation-only change, no code modified)
- [x ] I have added documentation for relevant changes (in the manual).
- [ x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ x] I'm done! This pull request is ready for review.
