### PR TITLE
backup --time option - allow different time formats

### DIFF
--- a/changelog/unreleased/issue-2065
+++ b/changelog/unreleased/issue-2065
@@ -1,0 +1,9 @@
+Change: Allow more flexible formats of the ``restic backup --time`` option
+
+Restic backup --time allowed in the past only the format "2006-01-02 15:04:05".
+
+backup --time can now use the full range of time formats as used in the
+``restic find`` command for the options ``--oldest`` and ``--newest``.
+
+https://github.com/restic/restic/issues/2065
+https://github.com/restic/restic/pull/21867

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -529,7 +529,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 	timeStamp := time.Now()
 	backupStart := timeStamp
 	if opts.TimeStamp != "" {
-		timeStamp, err = time.ParseInLocation(global.TimeFormat, opts.TimeStamp, time.Local)
+		timeStamp, err = parseTime(opts.TimeStamp)
 		if err != nil {
 			return errors.Fatalf("error in time option: %v", err)
 		}

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -115,6 +115,7 @@ var timeFormats = []string{
 	"02.01.2006 15:04:05 -0700",
 	"02.01.2006 15:04:05 MST",
 	"Mon Jan 2 15:04:05 -0700 MST 2006",
+	"2006-01-02 15:04:05-07:00",
 }
 
 func parseTime(str string) (time.Time, error) {


### PR DESCRIPTION
Instead of only allowing one time format global.TimeFormat="2006-01-02 15:04:05" for the ``restic backup --time`` option allow multiple time formats as in the ``restic find`` command for the options ``--oldest`` and ``--newest``.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR fixes the old issue https://github.com/restic/restic/issues/2065

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Fix: replace the call to time.ParseInLocation() with a call to parseTime() in cmd_find.go. Add the requested format to list of allowed formats.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
closes https://github.com/restic/restic/issues/2065

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
