### PR TITLE
stats: hide progress bar for json output

### DIFF
--- a/changelog/unreleased/issue-21866
+++ b/changelog/unreleased/issue-21866
@@ -1,0 +1,8 @@
+Bugfix: Hide progress bar for stats command in JSON mode
+
+Since restic 0.19.0, the stats command shows a progress bar. However,
+it was also active when given the `--json` option resulting in text
+mixed with JSON. This has been fixed.
+
+https://github.com/restic/restic/issues/21866
+https://github.com/restic/restic/pull/21871

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -141,7 +141,7 @@ func runStats(ctx context.Context, opts StatsOptions, gopts global.Options, args
 		snapshots = append(snapshots, sn)
 	}
 
-	statsProgress := newStatsProgress(term, uint64(len(snapshots)))
+	statsProgress := newStatsProgress(term, !gopts.JSON, uint64(len(snapshots)))
 
 	updater := progress.NewUpdater(ui.CalculateProgressInterval(!gopts.Quiet, gopts.JSON, term.CanUpdateStatus()), func(runtime time.Duration, final bool) {
 		statsProgress.printProgress(runtime, final)
@@ -375,6 +375,7 @@ type statsProgress struct {
 	term          ui.Terminal
 	m             sync.Mutex
 	snapshotCount uint64
+	show          bool
 
 	processedSnapshotCount uint64
 	processedFileCount     uint64
@@ -382,14 +383,18 @@ type statsProgress struct {
 	processedSize          uint64
 }
 
-func newStatsProgress(term ui.Terminal, snapshotCount uint64) *statsProgress {
+func newStatsProgress(term ui.Terminal, show bool, snapshotCount uint64) *statsProgress {
 	return &statsProgress{
 		term:          term,
+		show:          show,
 		snapshotCount: snapshotCount,
 	}
 }
 
 func (s *statsProgress) printProgress(runtime time.Duration, final bool) {
+	if !s.show {
+		return
+	}
 	s.m.Lock()
 
 	progressBase := s.processedSnapshotCount

--- a/cmd/restic/cmd_stats_test.go
+++ b/cmd/restic/cmd_stats_test.go
@@ -66,7 +66,7 @@ func TestSizeHistogramString(t *testing.T) {
 func TestStatsProgress(t *testing.T) {
 	term := &ui.MockTerminal{}
 
-	progress := newStatsProgress(term, 2)
+	progress := newStatsProgress(term, true, 2)
 	progress.printProgress(0*time.Second, false)
 	rtest.Equals(t, []string{"[0:00] 0.00%  0 / 2 snapshots, 0 B"}, term.Output)
 
@@ -87,4 +87,13 @@ func TestStatsProgress(t *testing.T) {
 
 	progress.printProgress(20*time.Second, true)
 	rtest.Equals(t, []string{"[0:20] 100.00%  2 / 2 snapshots, 4 files, 5 blobs, 6 B"}, term.Output)
+}
+
+func TestStatsProgressJSON(t *testing.T) {
+	term := &ui.MockTerminal{}
+
+	progress := newStatsProgress(term, false, 2)
+	progress.printProgress(0*time.Second, false)
+	// JSON output is not available yet, so just make sure to not break normal json output
+	rtest.Equals(t, nil, term.Output)
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The `stats` command can produce JSON output, make sure to disable the text progress bar in that case.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/21866
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- ~~[ ] I have added documentation for relevant changes (in the manual).~~
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
