### PR TITLE
Fix default grouping of `snapshots --latest <n>`

### DIFF
--- a/changelog/unreleased/issue-21869
+++ b/changelog/unreleased/issue-21869
@@ -1,0 +1,11 @@
+Bugfix: Restore old behavior of `snapshots --latest <n>` without `--group-by`
+
+Restic 0.19.0 changed the behavior of `snapshots --latest <n>` to no longer
+group snapshots by default.
+
+`snapshots --latest <n>` has been reverted to the old behavior if `--group-by`
+is not specified. When specifying `--group-by`, the output is still grouped as
+requested like in restic 0.19.0.
+
+https://github.com/restic/restic/issues/21869
+https://github.com/restic/restic/pull/21875

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -53,22 +53,7 @@ Exit status is 11 if the repository is already locked.
 Exit status is 12 if the password is incorrect.
 `,
 		PreRunE: func(_ *cobra.Command, _ []string) error {
-			if envVal := os.Getenv("RESTIC_READ_CONCURRENCY"); envVal != "" && !opts.readConcurrencyFlag.Changed {
-				n, err := strconv.ParseUint(envVal, 10, 32)
-				if err != nil {
-					return errors.Fatalf("invalid value for RESTIC_READ_CONCURRENCY %q: %v", envVal, err)
-				}
-				opts.ReadConcurrency = uint(n)
-			}
-			if opts.Host == "" {
-				hostname, err := os.Hostname()
-				if err != nil {
-					debug.Log("os.Hostname() returned err: %v", err)
-					return nil
-				}
-				opts.Host = hostname
-			}
-			return nil
+			return opts.Finalize()
 		},
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
@@ -161,6 +146,25 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 	if host := os.Getenv("RESTIC_HOST"); host != "" {
 		opts.Host = host
 	}
+}
+
+func (opts *BackupOptions) Finalize() error {
+	if envVal := os.Getenv("RESTIC_READ_CONCURRENCY"); envVal != "" && !opts.readConcurrencyFlag.Changed {
+		n, err := strconv.ParseUint(envVal, 10, 32)
+		if err != nil {
+			return errors.Fatalf("invalid value for RESTIC_READ_CONCURRENCY %q: %v", envVal, err)
+		}
+		opts.ReadConcurrency = uint(n)
+	}
+	if opts.Host == "" {
+		hostname, err := os.Hostname()
+		if err != nil {
+			debug.Log("os.Hostname() returned err: %v", err)
+			return nil
+		}
+		opts.Host = hostname
+	}
+	return nil
 }
 
 var backupFSTestHook func(fs fs.FS) fs.FS

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -107,7 +107,11 @@ func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts global.Option
 		}
 
 		if opts.Latest > 0 {
-			list = filterLatestSnapshotsInGroup(list, opts.Latest)
+			if grouped {
+				list = filterLatestSnapshotsInGroup(list, opts.Latest)
+			} else {
+				list = filterLatestSnapshots(list, opts.Latest)
+			}
 		}
 		sort.Sort(sort.Reverse(list))
 		snapshotGroups[k] = list
@@ -139,6 +143,43 @@ func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts global.Option
 	}
 
 	return nil
+}
+
+// filterLastSnapshotsKey is used by FilterLastSnapshots.
+type filterLastSnapshotsKey struct {
+	Hostname    string
+	JoinedPaths string
+}
+
+// newFilterLastSnapshotsKey initializes a filterLastSnapshotsKey from a Snapshot
+func newFilterLastSnapshotsKey(sn *data.Snapshot) filterLastSnapshotsKey {
+	// Shallow slice copy
+	var paths = make([]string, len(sn.Paths))
+	copy(paths, sn.Paths)
+	sort.Strings(paths)
+	return filterLastSnapshotsKey{sn.Hostname, strings.Join(paths, "|")}
+}
+
+// filterLatestSnapshots filters a list of snapshots to only return
+// the limit last entries for each hostname and path. If the snapshot
+// contains multiple paths, they will be joined and treated as one
+// item.
+func filterLatestSnapshots(list data.Snapshots, limit int) data.Snapshots {
+	// Sort the snapshots so that the newer ones are listed first
+	sort.SliceStable(list, func(i, j int) bool {
+		return list[i].Time.After(list[j].Time)
+	})
+
+	var results data.Snapshots
+	seen := make(map[filterLastSnapshotsKey]int)
+	for _, sn := range list {
+		key := newFilterLastSnapshotsKey(sn)
+		if seen[key] < limit {
+			seen[key]++
+			results = append(results, sn)
+		}
+	}
+	return results
 }
 
 // filterLatestSnapshotsInGroup filters a list of snapshots to only return

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -39,6 +39,9 @@ Exit status is 12 if the password is incorrect.
 `,
 		GroupID:           cmdGroupDefault,
 		DisableAutoGenTag: true,
+		PreRunE: func(_ *cobra.Command, _ []string) error {
+			return opts.Finalize()
+		},
 		RunE: func(cmd *cobra.Command, args []string) error {
 			finalizeSnapshotFilter(&opts.SnapshotFilter)
 			return runSnapshots(cmd.Context(), opts, *globalOptions, args, globalOptions.Term)
@@ -53,7 +56,7 @@ Exit status is 12 if the password is incorrect.
 type SnapshotOptions struct {
 	data.SnapshotFilter
 	Compact bool
-	Last    bool // This option should be removed in favour of Latest.
+	last    bool // Deprecated in favour of Latest.
 	Latest  int
 	GroupBy data.SnapshotGroupByOptions
 }
@@ -61,7 +64,7 @@ type SnapshotOptions struct {
 func (opts *SnapshotOptions) AddFlags(f *pflag.FlagSet) {
 	initMultiSnapshotFilter(f, &opts.SnapshotFilter, true)
 	f.BoolVarP(&opts.Compact, "compact", "c", false, "use compact output format")
-	f.BoolVar(&opts.Last, "last", false, "only show the last snapshot for each host and path")
+	f.BoolVar(&opts.last, "last", false, "only show the last snapshot for each host and path")
 	err := f.MarkDeprecated("last", "use --latest 1")
 	if err != nil {
 		// MarkDeprecated only returns an error when the flag is not found
@@ -69,6 +72,13 @@ func (opts *SnapshotOptions) AddFlags(f *pflag.FlagSet) {
 	}
 	f.IntVar(&opts.Latest, "latest", 0, "only show the last `n` snapshots for each host and path")
 	f.VarP(&opts.GroupBy, "group-by", "g", "`group` snapshots by host, paths and/or tags, separated by comma")
+}
+
+func (opts *SnapshotOptions) Finalize() error {
+	if opts.last && opts.Latest == 0 {
+		opts.Latest = 1
+	}
+	return nil
 }
 
 func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts global.Options, args []string, term ui.Terminal) error {
@@ -96,11 +106,7 @@ func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts global.Option
 			return ctx.Err()
 		}
 
-		if opts.Last {
-			// This branch should be removed in the same time
-			// that --last.
-			list = filterLatestSnapshotsInGroup(list, 1)
-		} else if opts.Latest > 0 {
+		if opts.Latest > 0 {
 			list = filterLatestSnapshotsInGroup(list, opts.Latest)
 		}
 		sort.Sort(sort.Reverse(list))

--- a/cmd/restic/cmd_snapshots_integration_test.go
+++ b/cmd/restic/cmd_snapshots_integration_test.go
@@ -35,10 +35,7 @@ func testRunSnapshots(t testing.TB, gopts global.Options) (newest *Snapshot, sna
 	return
 }
 
-func TestSnapshotsGroupByAndLatest(t *testing.T) {
-	env, cleanup := withTestEnvironment(t)
-	defer cleanup()
-
+func snapshotsGroupTestData(t *testing.T, env *testEnvironment, keepPath bool) string {
 	testSetupBackupData(t, env)
 	// two backups on the same host but with different paths
 	opts := BackupOptions{Host: "testhost", TimeStamp: time.Now().Format(time.DateTime)}
@@ -46,9 +43,22 @@ func TestSnapshotsGroupByAndLatest(t *testing.T) {
 	// Use later timestamp for second backup
 	opts.TimeStamp = time.Now().Add(time.Second).Format(time.DateTime)
 	snapshotsIDs := loadSnapshotMap(t, env.gopts)
-	testRunBackup(t, filepath.Dir(env.testdata), []string{"testdata/0"}, opts, env.gopts)
+
+	targets := []string{"testdata/0"}
+	if keepPath {
+		targets = []string{"testdata"}
+	}
+	testRunBackup(t, filepath.Dir(env.testdata), targets, opts, env.gopts)
 	_, secondSnapshotID := lastSnapshot(snapshotsIDs, loadSnapshotMap(t, env.gopts))
 
+	return secondSnapshotID
+}
+
+func TestSnapshotsGroupByAndLatest(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	secondSnapshotID := snapshotsGroupTestData(t, env, false)
 	buf, err := withCaptureStdout(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		gopts.JSON = true
 		// only group by host but not path
@@ -64,4 +74,22 @@ func TestSnapshotsGroupByAndLatest(t *testing.T) {
 	rtest.Assert(t, snapshots[0].GroupKey.Tags == nil, "expected group_key.tags to be set to nil, got %s", snapshots[0].GroupKey.Tags)
 	rtest.Assert(t, len(snapshots[0].Snapshots) == 1, "expected only one latest snapshot, got %d", len(snapshots[0].Snapshots))
 	rtest.Equals(t, snapshots[0].Snapshots[0].ID.String(), secondSnapshotID, "unexpected snapshot ID")
+}
+
+func TestSnapshotsLatest(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	secondSnapshotID := snapshotsGroupTestData(t, env, true)
+
+	buf, err := withCaptureStdout(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
+		gopts.JSON = true
+		opts := SnapshotOptions{Latest: 1}
+		return runSnapshots(ctx, opts, gopts, []string{}, gopts.Term)
+	})
+	rtest.OK(t, err)
+	snapshots := []Snapshot{}
+	rtest.OK(t, json.Unmarshal(buf.Bytes(), &snapshots))
+	rtest.Assert(t, len(snapshots) == 1, "expected only one snapshot, got %d", len(snapshots))
+	rtest.Equals(t, snapshots[0].ID.String(), secondSnapshotID, "unexpected snapshot ID")
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
According to the description, `--latest <n>` groups by host and paths. This was no longer the case after https://github.com/restic/restic/pull/5601 . Revert to the pre-0.19.0 behavior if no/an empty `--group-by` is given. Use the new behavior otherwise.

Test written by Cursor.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/21869
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
