### PR TITLE
mount: refactor mountpoint validation

### DIFF
--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -21,7 +21,6 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/ui"
-	"github.com/restic/restic/internal/ui/progress"
 
 	"github.com/restic/restic/internal/fuse"
 
@@ -135,7 +134,7 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 	}
 
 	mountpoint := args[0]
-	if err := validateMountpoint(mountpoint, printer, gopts); err != nil {
+	if err := validateMountpoint(mountpoint, gopts); err != nil {
 		return err
 	}
 
@@ -221,22 +220,19 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 	return err
 }
 
-func validateMountpoint(mountpoint string, printer progress.Printer, gopts global.Options) error {
+func validateMountpoint(mountpoint string, gopts global.Options) error {
 	// Check the existence of the mount point at the earliest stage to
 	// prevent unnecessary computations while opening the repository.
 	stat, err := os.Stat(mountpoint)
 	if errors.Is(err, os.ErrNotExist) {
-		printer.P("Mountpoint %s doesn't exist", mountpoint)
-		return errors.Fatal("invalid mountpoint")
+		return errors.Fatal(fmt.Sprintf("mountpoint %s does not exist", mountpoint))
 	} else if !stat.IsDir() {
-		printer.P("Mountpoint %s is not a directory", mountpoint)
-		return errors.Fatal("invalid mountpoint")
+		return errors.Fatal(fmt.Sprintf("mountpoint %s is not a directory", mountpoint))
 	}
 
 	err = unix.Access(mountpoint, unix.W_OK|unix.X_OK)
 	if err != nil {
-		printer.P("Mountpoint %s is not writeable or not executable", mountpoint)
-		return errors.Fatal("inaccessible mountpoint")
+		return errors.Fatal(fmt.Sprintf("mountpoint %s is not writeable or not executable", mountpoint))
 	}
 
 	// Refuse to mount onto (or under, or over) the local repository directory.

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -21,6 +21,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/ui"
+	"github.com/restic/restic/internal/ui/progress"
 
 	"github.com/restic/restic/internal/fuse"
 
@@ -134,35 +135,8 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 	}
 
 	mountpoint := args[0]
-
-	// Check the existence of the mount point at the earliest stage to
-	// prevent unnecessary computations while opening the repository.
-	stat, err := os.Stat(mountpoint)
-	if errors.Is(err, os.ErrNotExist) {
-		printer.P("Mountpoint %s doesn't exist", mountpoint)
-		return errors.Fatal("invalid mountpoint")
-	} else if !stat.IsDir() {
-		printer.P("Mountpoint %s is not a directory", mountpoint)
-		return errors.Fatal("invalid mountpoint")
-	}
-
-	err = unix.Access(mountpoint, unix.W_OK|unix.X_OK)
-	if err != nil {
-		printer.P("Mountpoint %s is not writeable or not executable", mountpoint)
-		return errors.Fatal("inaccessible mountpoint")
-	}
-
-	// Refuse to mount onto (or under, or over) the local repository directory.
-	// Doing so makes the FUSE server read its own backend files through the
-	// mount it just created, deadlocking the kernel (GH #5234).
-	loc, err := location.Parse(gopts.Backends, gopts.Repo)
-	if err != nil {
+	if err := validateMountpoint(mountpoint, printer, gopts); err != nil {
 		return err
-	}
-	if loc.Scheme == "local" {
-		if err := checkMountpointOverlap(loc.Config.(*local.Config).Path, mountpoint); err != nil {
-			return err
-		}
 	}
 
 	debug.Log("start mount")
@@ -245,6 +219,39 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 	}
 
 	return err
+}
+
+func validateMountpoint(mountpoint string, printer progress.Printer, gopts global.Options) error {
+	// Check the existence of the mount point at the earliest stage to
+	// prevent unnecessary computations while opening the repository.
+	stat, err := os.Stat(mountpoint)
+	if errors.Is(err, os.ErrNotExist) {
+		printer.P("Mountpoint %s doesn't exist", mountpoint)
+		return errors.Fatal("invalid mountpoint")
+	} else if !stat.IsDir() {
+		printer.P("Mountpoint %s is not a directory", mountpoint)
+		return errors.Fatal("invalid mountpoint")
+	}
+
+	err = unix.Access(mountpoint, unix.W_OK|unix.X_OK)
+	if err != nil {
+		printer.P("Mountpoint %s is not writeable or not executable", mountpoint)
+		return errors.Fatal("inaccessible mountpoint")
+	}
+
+	// Refuse to mount onto (or under, or over) the local repository directory.
+	// Doing so makes the FUSE server read its own backend files through the
+	// mount it just created, deadlocking the kernel (GH #5234).
+	loc, err := location.Parse(gopts.Backends, gopts.Repo)
+	if err != nil {
+		return err
+	}
+	if loc.Scheme == "local" {
+		if err := checkMountpointOverlap(loc.Config.(*local.Config).Path, mountpoint); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 // checkMountpointOverlap returns an error.Fatal if the local repository at


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
extract validation into helper and unify the error messages.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Follow up to https://github.com/restic/restic/pull/5348
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
