### PR TITLE
snapshots: show location name instead of current timezone

### DIFF
--- a/changelog/unreleased/pull-21876
+++ b/changelog/unreleased/pull-21876
@@ -1,0 +1,8 @@
+Bugfix: Show timezone location in `snapshots` output
+
+Since restic 0.19.0, the `snapshots` command printed the current timezone when
+listing snapshots. However, the timezone can change during the year, for example,
+due to daylight saving time. Instead just print the name of the current location.
+
+https://github.com/restic/restic/pull/21876
+https://forum.restic.net/t/possible-bug-in-timezone-naming/10867

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -245,11 +245,8 @@ func PrintSnapshots(stdout io.Writer, list data.Snapshots, reasons []data.KeepRe
 	// Each snapshot can be registered in different timezones,
 	// but we display them all in local timezone on this output.
 	footer := fmt.Sprintf("%d snapshots", len(list))
-	zoneName, _ := time.Now().Local().Zone()
-	if zoneName != "" {
-		footer = fmt.Sprintf("Timestamps shown in %s timezone\n%s", zoneName, footer)
-	}
-	tab.AddFooter(footer)
+	zoneName := time.Now().Local().Location().String()
+	tab.AddFooter(fmt.Sprintf("Timestamps shown in %s timezone\n%s", zoneName, footer))
 
 	if multiline {
 		// print an additional blank line between snapshots


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
The snapshots command footer includes the current timezone since restic 0.19.0. However the time zone change change during the year, e.g. between `CET` and `CEST` for Germany. The printed snapshot time are in local time, that is they correctly use either `CET` or `CEST` in the example. Therefore the correct timezone is actually `Europe/Berlin`. Fix this by switching to the location name. Note that if not `TZ` environment variable is set on Unix systems, then the output will just state `Local`, but that's hopefully also sufficient.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://forum.restic.net/t/possible-bug-in-timezone-naming/10867
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
