### PR TITLE
mount: fix crash in mountpoint validation

### DIFF
--- a/changelog/unreleased/pull-21879
+++ b/changelog/unreleased/pull-21879
@@ -1,0 +1,7 @@
+Bugfix: prevent crash in mountpoint validation if mountpoint is inaccessible
+
+Since restic 0.19.0, the `mount` command validates a mountpoint before loading
+the repository. If restic was unable to stat the mountpoint, this would result
+in a crash. This has been fixed to correctly return an error instead.
+
+https://github.com/restic/restic/pull/21879

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -226,6 +226,8 @@ func validateMountpoint(mountpoint string, gopts global.Options) error {
 	stat, err := os.Stat(mountpoint)
 	if errors.Is(err, os.ErrNotExist) {
 		return errors.Fatal(fmt.Sprintf("mountpoint %s does not exist", mountpoint))
+	} else if err != nil {
+		return errors.Fatal(fmt.Sprintf("mountpoint %s is inaccessible: %v", mountpoint, err))
 	} else if !stat.IsDir() {
 		return errors.Fatal(fmt.Sprintf("mountpoint %s is not a directory", mountpoint))
 	}


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Fix crash if mountpoint is inaccessible. Reproducer:

```
mkdir test
chmod 000 test
restic mount test/test
```
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Found by agent review in Cursor.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
