### PR TITLE
cmd/mount: add --open-file-manager flag

### DIFF
--- a/changelog/unreleased/pull-21893
+++ b/changelog/unreleased/pull-21893
@@ -1,0 +1,8 @@
+Enhancement: Add `--open-file-manager` flag to `mount` command
+
+The `mount` command now supports the `--open-file-manager` flag, which
+automatically opens the system file manager at the mountpoint once the
+repository is ready to browse. This uses `open` on macOS and `xdg-open`
+on Linux and FreeBSD.
+
+https://github.com/restic/restic/pull/21893

--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -6,7 +6,9 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -101,6 +103,7 @@ type MountOptions struct {
 	OwnerRoot            bool
 	AllowOther           bool
 	NoDefaultPermissions bool
+	OpenFileManager      bool
 	data.SnapshotFilter
 	TimeTemplate  string
 	PathTemplates []string
@@ -110,6 +113,7 @@ func (opts *MountOptions) AddFlags(f *pflag.FlagSet) {
 	f.BoolVar(&opts.OwnerRoot, "owner-root", false, "use 'root' as the owner of files and dirs")
 	f.BoolVar(&opts.AllowOther, "allow-other", false, "allow other users to access the data in the mounted directory")
 	f.BoolVar(&opts.NoDefaultPermissions, "no-default-permissions", false, "for 'allow-other', ignore Unix permissions and allow users to read all snapshot files")
+	f.BoolVar(&opts.OpenFileManager, "open-file-manager", false, "open file manager at the mountpoint after the repository is ready")
 
 	initMultiSnapshotFilter(f, &opts.SnapshotFilter, true)
 
@@ -205,6 +209,10 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 	printer.S("When finished, quit with Ctrl-c here or umount the mountpoint.")
 	debug.Log("serving mount at %v", mountpoint)
 
+	if opts.OpenFileManager {
+		go openFileManager(mountpoint)
+	}
+
 	select {
 	case <-ctx.Done():
 		debug.Log("running umount cleanup handler for mount at %v", mountpoint)
@@ -219,6 +227,21 @@ func runMount(ctx context.Context, opts MountOptions, gopts global.Options, args
 	}
 
 	return err
+}
+
+func fileManagerCmd(path string) *exec.Cmd {
+	switch runtime.GOOS {
+	case "darwin":
+		return exec.Command("open", path)
+	default: // linux, freebsd
+		return exec.Command("xdg-open", path)
+	}
+}
+
+func openFileManager(path string) {
+	if err := fileManagerCmd(path).Run(); err != nil {
+		debug.Log("open file manager: %v", err)
+	}
 }
 
 func validateMountpoint(mountpoint string, gopts global.Options) error {

--- a/cmd/restic/cmd_mount_test.go
+++ b/cmd/restic/cmd_mount_test.go
@@ -1,0 +1,33 @@
+//go:build darwin || freebsd || linux
+
+package main
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/restic/restic/internal/global"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestFileManagerCmd(t *testing.T) {
+	cmd := fileManagerCmd("/mnt/repo")
+
+	var wantBin string
+	switch runtime.GOOS {
+	case "darwin":
+		wantBin = "open"
+	default:
+		wantBin = "xdg-open"
+	}
+
+	rtest.Equals(t, []string{wantBin, "/mnt/repo"}, cmd.Args)
+}
+
+func TestOpenFileManagerFlag(t *testing.T) {
+	gopts := global.Options{}
+	cmd := newMountCommand(&gopts)
+	f := cmd.Flags().Lookup("open-file-manager")
+	rtest.Assert(t, f != nil, "flag --open-file-manager must be registered")
+	rtest.Equals(t, "false", f.DefValue)
+}

--- a/doc/050_restore.rst
+++ b/doc/050_restore.rst
@@ -202,6 +202,13 @@ command to serve the repository with FUSE:
     Use another terminal or tool to browse the contents of this folder.
     When finished, quit with Ctrl-c here or umount the mountpoint.
 
+To automatically open the mounted directory in your file manager, add
+the ``--open-file-manager`` flag:
+
+.. code-block:: console
+
+    $ restic -r /srv/restic-repo mount --open-file-manager /mnt/restic
+
 Mounting repositories via FUSE is only possible on Linux, macOS and FreeBSD.
 On Linux, the ``fuse`` kernel module needs to be loaded and the ``fusermount``
 command needs to be in the ``PATH``. On macOS, you need `FUSE-T


### PR DESCRIPTION
**What does this PR change? What problem does it solve?**

Add a `--open-file-manager` flag to the `mount` command. When set, restic launches the system file manager at the mountpoint once the repository is ready to browse. This uses `xdg-open` on Linux and FreeBSD, and `open` on macOS. The file manager is launched in a goroutine so it does not block the mount process. If launching fails (e.g. no desktop environment), the error is logged at debug level only and does not affect the mount.

**Was the change previously discussed in an issue or on the forum?**

No.

**Checklist**

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.