### PR TITLE
backend/sftp: fix removing files on windows sftp

### DIFF
--- a/changelog/unreleased/issue-21895
+++ b/changelog/unreleased/issue-21895
@@ -1,0 +1,9 @@
+Bugfix: Remove read-only files via the SFTP backend on Windows servers
+
+Since restic 0.19.0, repository files on the SFTP backend are marked
+read-only after save. On Windows SFTP servers, removing them failed
+with a permission error. The SFTP backend now clears the read-only flag
+before removing the file.
+
+https://github.com/restic/restic/issues/21895
+https://github.com/restic/restic/pull/21897

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"path"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -37,7 +38,8 @@ type SFTP struct {
 	cmd    *exec.Cmd
 	result <-chan error
 
-	posixRename bool
+	posixRename       bool
+	chmodBeforeRemove atomic.Bool
 
 	layout.Layout
 	Config
@@ -506,7 +508,37 @@ func (r *SFTP) Remove(_ context.Context, h backend.Handle) error {
 		return err
 	}
 
-	return errors.Wrapf(r.c.Remove(r.Filename(h)), "Remove %v", r.Filename(h))
+	path := r.Filename(h)
+
+	if r.chmodBeforeRemove.Load() {
+		return r.removeWithChmod(path)
+	}
+
+	// optimistically try to remove the file
+	err := r.c.Remove(path)
+	if err == nil {
+		return nil
+	}
+	if !errors.Is(err, os.ErrPermission) {
+		return errors.Wrapf(err, "Remove %v", path)
+	}
+
+	// fallback to chmod + remove
+	// this is necessary on Windows where read-only files cannot be deleted without chmod.
+	if err := r.removeWithChmod(path); err != nil {
+		return err
+	}
+	r.chmodBeforeRemove.Store(true)
+	return nil
+}
+
+func (r *SFTP) removeWithChmod(path string) error {
+	err := r.c.Chmod(path, r.Modes.File)
+	if err != nil {
+		return errors.Wrapf(err, "Chmod %v", path)
+	}
+
+	return errors.Wrapf(r.c.Remove(path), "Remove %v", path)
 }
 
 // List runs fn for each file in the backend which has the type t. When an

--- a/internal/backend/sftp/sftp.go
+++ b/internal/backend/sftp/sftp.go
@@ -404,12 +404,11 @@ func (r *SFTP) Save(_ context.Context, h backend.Handle, rd backend.RewindReader
 	} else {
 		err = r.c.Rename(tmpFilename, filename)
 	}
-	err = setFileReadonly(r.c, filename, r.Modes.File)
 	if err != nil {
-		return errors.Errorf("sftp setFileReadonly: %v", err)
+		return errors.Wrapf(err, "Rename %v", tmpFilename)
 	}
-
-	return errors.Wrapf(err, "Rename %v", tmpFilename)
+	err = setFileReadonly(r.c, filename, r.Modes.File)
+	return errors.Wrapf(err, "setFileReadonly %v", filename)
 }
 
 // checkNoSpace checks if err was likely caused by lack of available space


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Fix deleting files via SFTP when repository is stored on a Windows host. Windows doesn't allow deleting read-only files. |Thus, the files have to be marked writable before. To not impact performance of other SFTP targets, the implementation optimistically tries whether a plain remove call also works.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

AI assisted using Cursor Agent.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Fixes https://github.com/restic/restic/issues/21895
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
