### PR TITLE
backend/rest: fix flaky test cleanup

### DIFF
--- a/internal/backend/util/defaults.go
+++ b/internal/backend/util/defaults.go
@@ -35,7 +35,12 @@ func DefaultDelete(ctx context.Context, be backend.Backend) error {
 
 	for _, t := range alltypes {
 		err := be.List(ctx, t, func(fi backend.FileInfo) error {
-			return be.Remove(ctx, backend.Handle{Type: t, Name: fi.Name})
+			err := be.Remove(ctx, backend.Handle{Type: t, Name: fi.Name})
+			if err != nil && be.IsNotExist(err) {
+				// deletion of files created by TestSaveError may happen with a delay for the REST server, so we ignore the error
+				err = nil
+			}
+			return err
 		})
 		if err != nil {
 			return err


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
After https://github.com/restic/restic/pull/21884 the following test is flaky:
```
    --- FAIL: TestBackendREST/TestZZZDelete (0.01s)
        tests.go:910: error deleting backend: <data/f84f0c9329> does not exist
```

Ignore missing files during cleanup. Files created by TestSaveError might not be deleted synchronously, such that the rest-server might clean them up while TestZZZDelete runs.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Verified using `go test ./internal/backend/rest -count 10`.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Follow up fix for https://github.com/restic/restic/pull/21884
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
