### PR TITLE
list packs snapshot: include actual error in error message

### DIFF
--- a/cmd/restic/cmd_list.go
+++ b/cmd/restic/cmd_list.go
@@ -97,9 +97,11 @@ func runList(ctx context.Context, gopts global.Options, args []string, term ui.T
 // packfileList handles the list packs <snapshotID> variant.
 // It prints a sorted list of packfiles belonging to this snapshot.
 func packfileList(ctx context.Context, repo restic.Repository, snapshotID string, printer restic.Printer) error {
+	// ignore subpaths as this command is intended to list all packfiles necessary to restore the snapshot
+	// subpaths would require special handling and limit restorability
 	sn, _, err := (&data.SnapshotFilter{}).FindLatest(ctx, repo, repo, snapshotID)
 	if err != nil {
-		return fmt.Errorf("required snapshot ID %q not found", snapshotID)
+		return fmt.Errorf("failed to find snapshot: %v", err)
 	}
 
 	if err = repo.LoadIndex(ctx, printer); err != nil {


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Tweak error message of `list packs snapshot` to include actual error in error message. Example: `failed to find snapshot: failed to load snapshot f6ccfd70: LoadRaw(<snapshot/f6ccfd70c7>): invalid data returned`
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Tweaks https://github.com/restic/restic/pull/5396
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
