### PR TITLE
rest: clarify error when the server returns a non-restic response

### DIFF
--- a/changelog/unreleased/issue-5687
+++ b/changelog/unreleased/issue-5687
@@ -1,0 +1,13 @@
+Enhancement: Improve REST backend error when a list response cannot be decoded
+
+When the REST backend URL pointed at a server that does not speak the
+restic REST protocol, for example a reverse proxy or web application that
+replies with an HTML page and HTTP status 200, restic failed with the
+confusing message `Decode: invalid character '<' looking for beginning of
+value`.
+
+Restic now reports that it could not decode the server response and
+includes the returned Content-Type, making it easier to spot a misconfigured
+URL that does not point to a restic REST server.
+
+https://github.com/restic/restic/issues/5687

--- a/internal/backend/rest/rest.go
+++ b/internal/backend/rest/rest.go
@@ -355,6 +355,16 @@ func (b *Backend) List(ctx context.Context, t backend.FileType, fn func(backend.
 	return err
 }
 
+// unexpectedListResponse wraps a failure to decode a directory listing with
+// the response's Content-Type. The most common cause is pointing restic at a
+// URL that does not serve the restic REST API (for example a reverse proxy or
+// web application), which typically answers with an HTML page and HTTP status
+// 200. Without this hint the bare JSON decoding error (e.g. "invalid character
+// '<' looking for beginning of value") is hard to interpret. See #5687.
+func unexpectedListResponse(resp *http.Response, err error) error {
+	return errors.Wrapf(err, "List: failed to decode server response, the URL may not point to a restic REST server (Content-Type %q)", resp.Header.Get("Content-Type"))
+}
+
 // listv1 uses the REST protocol v1, where a list HTTP request (e.g. `GET
 // /data/`) only returns the names of the files, so we need to issue an HTTP
 // HEAD request for each file.
@@ -363,7 +373,7 @@ func (b *Backend) listv1(ctx context.Context, t backend.FileType, resp *http.Res
 	dec := json.NewDecoder(resp.Body)
 	var list []string
 	if err := dec.Decode(&list); err != nil {
-		return errors.Wrap(err, "Decode")
+		return unexpectedListResponse(resp, err)
 	}
 
 	for _, m := range list {
@@ -401,7 +411,7 @@ func (b *Backend) listv2(ctx context.Context, resp *http.Response, fn func(backe
 		Size int64  `json:"size"`
 	}
 	if err := dec.Decode(&list); err != nil {
-		return errors.Wrap(err, "Decode")
+		return unexpectedListResponse(resp, err)
 	}
 
 	for _, item := range list {

--- a/internal/backend/rest/rest_int_test.go
+++ b/internal/backend/rest/rest_int_test.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/restic/restic/internal/backend"
@@ -146,5 +147,60 @@ func TestListAPI(t *testing.T) {
 				}
 			}()
 		})
+	}
+}
+
+// TestListAPIInvalidResponse verifies that a List against a server which does
+// not speak the restic REST protocol (here: an HTML page returned with HTTP
+// status 200, as a reverse proxy or unrelated web application would) fails
+// with an error that mentions the response Content-Type, instead of a bare
+// JSON decoding error such as "invalid character '<' looking for beginning of
+// value". See #5687.
+func TestListAPIInvalidResponse(t *testing.T) {
+	numRequests := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		numRequests++
+		if req.Method != "GET" {
+			t.Errorf("unexpected request %v %v", req.Method, req.URL.Path)
+			return
+		}
+		res.Header().Set("Content-Type", "text/html")
+		if _, err := res.Write([]byte("<html><body>not a restic REST server</body></html>")); err != nil {
+			t.Fatal(err)
+		}
+	}))
+	defer srv.Close()
+
+	srvURL, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := rest.Config{
+		Connections: 5,
+		URL:         srvURL,
+	}
+
+	be, err := rest.Open(context.TODO(), cfg, http.DefaultTransport, t.Logf)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if err := be.Close(); err != nil {
+			t.Fatal(err)
+		}
+	}()
+
+	err = be.List(context.TODO(), backend.PackFile, func(_ backend.FileInfo) error {
+		return nil
+	})
+	if err == nil {
+		t.Fatal("expected List to fail for a non-restic server response, got nil")
+	}
+	if !strings.Contains(err.Error(), "text/html") {
+		t.Fatalf("error should mention the response Content-Type, got: %v", err)
+	}
+	if numRequests != 1 {
+		t.Fatalf("wrong number of HTTP requests executed, want 1, got %d", numRequests)
 	}
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

When the REST backend's URL points at a server that does not speak the restic
REST protocol — for example a reverse proxy or web application that returns an
HTML page with HTTP status 200 — `restic` failed with an opaque error:

```
List(...) returned error, retrying after ...: Decode: invalid character '<' looking for beginning of value
```

`List` validates the HTTP status code but not the body before handing it to
`json.Decode`, so a non-JSON 200 response surfaced as a bare JSON parse error
that gives no hint about the actual cause.

This wraps the decode failure in both `listv1` and `listv2` with the response
`Content-Type`, turning it into:

```
List: failed to decode server response, the URL may not point to a restic REST server (Content-Type "text/html"): invalid character '<' looking for beginning of value
```

Only the error path changes — successful listings (including v1 responses with
non-restic content types such as `application/octet-stream`) are unaffected.
Added `TestListAPIInvalidResponse` covering the HTML-200 case.

Note on changelog category: I filed this as `Enhancement` to match the issue's
`type: feature enhancement` label, but since the previous message was actively
misleading it could equally be a `Bugfix` — happy to flip it if you prefer.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #5687

Checklist
---------

- [x] I have added tests for all code changes
- [ ] I have added documentation for relevant changes (in the manual) — n/a, error message only
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users
- [x] I'm done! This pull request is ready for review.
