### PR TITLE
replace FindFilteredSnapshots() with (*data.SnapshotFilter).FindAll() 

### DIFF
--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -72,20 +72,14 @@ func (opts *CopyOptions) AddFlags(f *pflag.FlagSet) {
 	initMultiSnapshotFilter(f, &opts.SnapshotFilter, true)
 }
 
-var errSentinelEndIteration = errors.New("end iteration")
-
 // collectAllSnapshots: select all snapshot trees to be copied
 func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 	srcSnapshotLister restic.Lister, srcRepo restic.Repository,
 	dstSnapshotByOriginal map[restic.ID][]*data.Snapshot, args []string, printer restic.Printer,
-) iter.Seq2[*data.Snapshot, error] {
-	return func(yield func(*data.Snapshot, error) bool) {
-		err := opts.SnapshotFilter.FindAll(ctx, srcSnapshotLister, srcRepo, args, func(_ string, sn *data.Snapshot, err error) error {
+) iter.Seq[*data.Snapshot] {
+	return func(yield func(*data.Snapshot) bool) {
+		for sn := range FindFilteredSnapshots(ctx, srcSnapshotLister, srcRepo, &opts.SnapshotFilter, args, printer) {
 			// check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
-			if err != nil {
-				yield(nil, err)
-				return errSentinelEndIteration
-			}
 			srcOriginal := *sn.ID()
 			if sn.Original != nil {
 				srcOriginal = *sn.Original
@@ -101,17 +95,12 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 					}
 				}
 				if isCopy {
-					return nil
+					continue
 				}
 			}
-			if !yield(sn, nil) {
-				return errSentinelEndIteration
+			if !yield(sn) {
+				return
 			}
-			return nil
-		})
-		if err != nil && !errors.Is(err, errSentinelEndIteration) {
-			yield(nil, err)
-			return
 		}
 	}
 }
@@ -159,19 +148,15 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args [
 	}
 
 	dstSnapshotByOriginal := make(map[restic.ID][]*data.Snapshot)
-	err = opts.SnapshotFilter.FindAll(ctx, dstSnapshotLister, dstRepo, nil, func(_ string, sn *data.Snapshot, err error) error {
-		if err != nil {
-			return err
-		}
+	for sn := range FindFilteredSnapshots(ctx, dstSnapshotLister, dstRepo, &opts.SnapshotFilter, nil, printer) {
 		if sn.Original != nil && !sn.Original.IsNull() {
 			dstSnapshotByOriginal[*sn.Original] = append(dstSnapshotByOriginal[*sn.Original], sn)
 		}
 		// also consider identical snapshot copies
 		dstSnapshotByOriginal[*sn.ID()] = append(dstSnapshotByOriginal[*sn.ID()], sn)
-		return nil
-	})
-	if err != nil {
-		return err
+	}
+	if ctx.Err() != nil {
+		return ctx.Err()
 	}
 
 	selectedSnapshots := collectAllSnapshots(ctx, opts, srcSnapshotLister, srcRepo, dstSnapshotByOriginal, args, printer)
@@ -205,7 +190,7 @@ func similarSnapshots(sna *data.Snapshot, snb *data.Snapshot) bool {
 // copyTreeBatched copies multiple snapshots in one go. Snapshots are written after
 // data equivalent to at least 10 packfiles was written.
 func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRepo restic.Repository,
-	selectedSnapshots iter.Seq2[*data.Snapshot, error], printer restic.Printer) error {
+	selectedSnapshots iter.Seq[*data.Snapshot], printer restic.Printer) error {
 
 	// remember already processed trees across all snapshots
 	visitedTrees := srcRepo.NewAssociatedBlobSet()
@@ -214,7 +199,7 @@ func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRep
 	minDuration := 1 * time.Minute
 
 	// use pull-based iterator to allow iteration in multiple steps
-	next, stop := iter.Pull2(selectedSnapshots)
+	next, stop := iter.Pull(selectedSnapshots)
 	defer stop()
 
 	for {
@@ -225,10 +210,7 @@ func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRep
 		// call WithBlobUploader() once and then loop over all selectedSnapshots
 		err := dstRepo.WithBlobUploader(ctx, func(ctx context.Context, uploader restic.BlobSaverWithAsync) error {
 			for batchSize < targetSize || time.Since(startTime) < minDuration {
-				sn, err, ok := next()
-				if err != nil {
-					return err
-				}
+				sn, ok := next()
 				if !ok {
 					break
 				}

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -72,6 +72,8 @@ func (opts *CopyOptions) AddFlags(f *pflag.FlagSet) {
 	initMultiSnapshotFilter(f, &opts.SnapshotFilter, true)
 }
 
+var sentinelError = errors.New("end iteration")
+
 // collectAllSnapshots: select all snapshot trees to be copied
 func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 	srcSnapshotLister restic.Lister, srcRepo restic.Repository,
@@ -82,7 +84,7 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 			// check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
 			if err != nil {
 				yield(nil, err)
-				return err
+				return sentinelError
 			}
 			srcOriginal := *sn.ID()
 			if sn.Original != nil {
@@ -103,11 +105,11 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 				}
 			}
 			if !yield(sn, nil) {
-				return nil
+				return sentinelError
 			}
 			return nil
 		})
-		if err != nil {
+		if err != nil && !errors.Is(err, sentinelError) {
 			yield(nil, err)
 			return
 		}
@@ -168,9 +170,6 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args [
 		dstSnapshotByOriginal[*sn.ID()] = append(dstSnapshotByOriginal[*sn.ID()], sn)
 		return nil
 	})
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -72,7 +72,7 @@ func (opts *CopyOptions) AddFlags(f *pflag.FlagSet) {
 	initMultiSnapshotFilter(f, &opts.SnapshotFilter, true)
 }
 
-var sentinelError = errors.New("end iteration")
+var errSentinelEndIteration = errors.New("end iteration")
 
 // collectAllSnapshots: select all snapshot trees to be copied
 func collectAllSnapshots(ctx context.Context, opts CopyOptions,
@@ -84,7 +84,7 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 			// check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
 			if err != nil {
 				yield(nil, err)
-				return sentinelError
+				return errSentinelEndIteration
 			}
 			srcOriginal := *sn.ID()
 			if sn.Original != nil {
@@ -105,11 +105,11 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 				}
 			}
 			if !yield(sn, nil) {
-				return sentinelError
+				return errSentinelEndIteration
 			}
 			return nil
 		})
-		if err != nil && !errors.Is(err, sentinelError) {
+		if err != nil && !errors.Is(err, errSentinelEndIteration) {
 			yield(nil, err)
 			return
 		}

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -83,8 +83,9 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 		err := opts.SnapshotFilter.FindAll(ctx, srcSnapshotLister, srcRepo, args, func(_ string, sn *data.Snapshot, err error) error {
 			// check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
 			if err != nil {
-				yield(nil, err)
-				return errSentinelEndIteration
+				if !yield(nil, err) {
+					return errSentinelEndIteration
+				}
 			}
 			srcOriginal := *sn.ID()
 			if sn.Original != nil {
@@ -111,7 +112,6 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 		})
 		if err != nil && !errors.Is(err, errSentinelEndIteration) {
 			yield(nil, err)
-			return
 		}
 	}
 }

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -82,10 +82,8 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 	return func(yield func(*data.Snapshot, error) bool) {
 		err := opts.SnapshotFilter.FindAll(ctx, srcSnapshotLister, srcRepo, args, func(_ string, sn *data.Snapshot, err error) error {
 			// check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
-			if err != nil {
-				if !yield(nil, err) {
-					return errSentinelEndIteration
-				}
+			if err != nil && !yield(nil, err) {
+				return errSentinelEndIteration
 			}
 			srcOriginal := *sn.ID()
 			if sn.Original != nil {

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -76,10 +76,14 @@ func (opts *CopyOptions) AddFlags(f *pflag.FlagSet) {
 func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 	srcSnapshotLister restic.Lister, srcRepo restic.Repository,
 	dstSnapshotByOriginal map[restic.ID][]*data.Snapshot, args []string, printer restic.Printer,
-) iter.Seq[*data.Snapshot] {
-	return func(yield func(*data.Snapshot) bool) {
-		for sn := range FindFilteredSnapshots(ctx, srcSnapshotLister, srcRepo, &opts.SnapshotFilter, args, printer) {
+) iter.Seq2[*data.Snapshot, error] {
+	return func(yield func(*data.Snapshot, error) bool) {
+		err := opts.SnapshotFilter.FindAll(ctx, srcSnapshotLister, srcRepo, args, func(_ string, sn *data.Snapshot, err error) error {
 			// check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
+			if err != nil {
+				yield(nil, err)
+				return err
+			}
 			srcOriginal := *sn.ID()
 			if sn.Original != nil {
 				srcOriginal = *sn.Original
@@ -95,12 +99,17 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 					}
 				}
 				if isCopy {
-					continue
+					return nil
 				}
 			}
-			if !yield(sn) {
-				return
+			if !yield(sn, nil) {
+				return nil
 			}
+			return nil
+		})
+		if err != nil {
+			yield(nil, err)
+			return
 		}
 	}
 }
@@ -148,15 +157,22 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args [
 	}
 
 	dstSnapshotByOriginal := make(map[restic.ID][]*data.Snapshot)
-	for sn := range FindFilteredSnapshots(ctx, dstSnapshotLister, dstRepo, &opts.SnapshotFilter, nil, printer) {
+	err = opts.SnapshotFilter.FindAll(ctx, dstSnapshotLister, dstRepo, nil, func(_ string, sn *data.Snapshot, err error) error {
+		if err != nil {
+			return err
+		}
 		if sn.Original != nil && !sn.Original.IsNull() {
 			dstSnapshotByOriginal[*sn.Original] = append(dstSnapshotByOriginal[*sn.Original], sn)
 		}
 		// also consider identical snapshot copies
 		dstSnapshotByOriginal[*sn.ID()] = append(dstSnapshotByOriginal[*sn.ID()], sn)
-	}
+		return nil
+	})
 	if ctx.Err() != nil {
 		return ctx.Err()
+	}
+	if err != nil {
+		return err
 	}
 
 	selectedSnapshots := collectAllSnapshots(ctx, opts, srcSnapshotLister, srcRepo, dstSnapshotByOriginal, args, printer)
@@ -190,7 +206,7 @@ func similarSnapshots(sna *data.Snapshot, snb *data.Snapshot) bool {
 // copyTreeBatched copies multiple snapshots in one go. Snapshots are written after
 // data equivalent to at least 10 packfiles was written.
 func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRepo restic.Repository,
-	selectedSnapshots iter.Seq[*data.Snapshot], printer restic.Printer) error {
+	selectedSnapshots iter.Seq2[*data.Snapshot, error], printer restic.Printer) error {
 
 	// remember already processed trees across all snapshots
 	visitedTrees := srcRepo.NewAssociatedBlobSet()
@@ -199,7 +215,7 @@ func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRep
 	minDuration := 1 * time.Minute
 
 	// use pull-based iterator to allow iteration in multiple steps
-	next, stop := iter.Pull(selectedSnapshots)
+	next, stop := iter.Pull2(selectedSnapshots)
 	defer stop()
 
 	for {
@@ -210,7 +226,10 @@ func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRep
 		// call WithBlobUploader() once and then loop over all selectedSnapshots
 		err := dstRepo.WithBlobUploader(ctx, func(ctx context.Context, uploader restic.BlobSaverWithAsync) error {
 			for batchSize < targetSize || time.Since(startTime) < minDuration {
-				sn, ok := next()
+				sn, err, ok := next()
+				if err != nil {
+					return err
+				}
 				if !ok {
 					break
 				}

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -82,8 +82,11 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 	return func(yield func(*data.Snapshot, error) bool) {
 		err := opts.SnapshotFilter.FindAll(ctx, srcSnapshotLister, srcRepo, args, func(_ string, sn *data.Snapshot, err error) error {
 			// check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
-			if err != nil && !yield(nil, err) {
-				return errSentinelEndIteration
+			if err != nil {
+				if !yield(nil, err) {
+					return errSentinelEndIteration
+				}
+				return nil
 			}
 			srcOriginal := *sn.ID()
 			if sn.Original != nil {

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -72,14 +72,20 @@ func (opts *CopyOptions) AddFlags(f *pflag.FlagSet) {
 	initMultiSnapshotFilter(f, &opts.SnapshotFilter, true)
 }
 
+var errSentinelEndIteration = errors.New("end iteration")
+
 // collectAllSnapshots: select all snapshot trees to be copied
 func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 	srcSnapshotLister restic.Lister, srcRepo restic.Repository,
 	dstSnapshotByOriginal map[restic.ID][]*data.Snapshot, args []string, printer restic.Printer,
-) iter.Seq[*data.Snapshot] {
-	return func(yield func(*data.Snapshot) bool) {
-		for sn := range FindFilteredSnapshots(ctx, srcSnapshotLister, srcRepo, &opts.SnapshotFilter, args, printer) {
+) iter.Seq2[*data.Snapshot, error] {
+	return func(yield func(*data.Snapshot, error) bool) {
+		err := opts.SnapshotFilter.FindAll(ctx, srcSnapshotLister, srcRepo, args, func(_ string, sn *data.Snapshot, err error) error {
 			// check whether the destination has a snapshot with the same persistent ID which has similar snapshot fields
+			if err != nil {
+				yield(nil, err)
+				return errSentinelEndIteration
+			}
 			srcOriginal := *sn.ID()
 			if sn.Original != nil {
 				srcOriginal = *sn.Original
@@ -95,12 +101,17 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 					}
 				}
 				if isCopy {
-					continue
+					return nil
 				}
 			}
-			if !yield(sn) {
-				return
+			if !yield(sn, nil) {
+				return errSentinelEndIteration
 			}
+			return nil
+		})
+		if err != nil && !errors.Is(err, errSentinelEndIteration) {
+			yield(nil, err)
+			return
 		}
 	}
 }
@@ -148,15 +159,19 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args [
 	}
 
 	dstSnapshotByOriginal := make(map[restic.ID][]*data.Snapshot)
-	for sn := range FindFilteredSnapshots(ctx, dstSnapshotLister, dstRepo, &opts.SnapshotFilter, nil, printer) {
+	err = opts.SnapshotFilter.FindAll(ctx, dstSnapshotLister, dstRepo, nil, func(_ string, sn *data.Snapshot, err error) error {
+		if err != nil {
+			return err
+		}
 		if sn.Original != nil && !sn.Original.IsNull() {
 			dstSnapshotByOriginal[*sn.Original] = append(dstSnapshotByOriginal[*sn.Original], sn)
 		}
 		// also consider identical snapshot copies
 		dstSnapshotByOriginal[*sn.ID()] = append(dstSnapshotByOriginal[*sn.ID()], sn)
-	}
-	if ctx.Err() != nil {
-		return ctx.Err()
+		return nil
+	})
+	if err != nil {
+		return err
 	}
 
 	selectedSnapshots := collectAllSnapshots(ctx, opts, srcSnapshotLister, srcRepo, dstSnapshotByOriginal, args, printer)
@@ -190,7 +205,7 @@ func similarSnapshots(sna *data.Snapshot, snb *data.Snapshot) bool {
 // copyTreeBatched copies multiple snapshots in one go. Snapshots are written after
 // data equivalent to at least 10 packfiles was written.
 func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRepo restic.Repository,
-	selectedSnapshots iter.Seq[*data.Snapshot], printer restic.Printer) error {
+	selectedSnapshots iter.Seq2[*data.Snapshot, error], printer restic.Printer) error {
 
 	// remember already processed trees across all snapshots
 	visitedTrees := srcRepo.NewAssociatedBlobSet()
@@ -199,7 +214,7 @@ func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRep
 	minDuration := 1 * time.Minute
 
 	// use pull-based iterator to allow iteration in multiple steps
-	next, stop := iter.Pull(selectedSnapshots)
+	next, stop := iter.Pull2(selectedSnapshots)
 	defer stop()
 
 	for {
@@ -210,7 +225,10 @@ func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRep
 		// call WithBlobUploader() once and then loop over all selectedSnapshots
 		err := dstRepo.WithBlobUploader(ctx, func(ctx context.Context, uploader restic.BlobSaverWithAsync) error {
 			for batchSize < targetSize || time.Since(startTime) < minDuration {
-				sn, ok := next()
+				sn, err, ok := next()
+				if err != nil {
+					return err
+				}
 				if !ok {
 					break
 				}

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -682,9 +682,6 @@ func runFind(ctx context.Context, opts FindOptions, gopts global.Options, args [
 		filteredSnapshots = append(filteredSnapshots, sn)
 		return nil
 	})
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_find.go
+++ b/cmd/restic/cmd_find.go
@@ -675,11 +675,18 @@ func runFind(ctx context.Context, opts FindOptions, gopts global.Options, args [
 	}
 
 	var filteredSnapshots []*data.Snapshot
-	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &opts.SnapshotFilter, opts.Snapshots, printer) {
+	err = opts.SnapshotFilter.FindAll(ctx, snapshotLister, repo, opts.Snapshots, func(_ string, sn *data.Snapshot, err error) error {
+		if err != nil {
+			return err
+		}
 		filteredSnapshots = append(filteredSnapshots, sn)
-	}
+		return nil
+	})
 	if ctx.Err() != nil {
 		return ctx.Err()
+	}
+	if err != nil {
+		return err
 	}
 
 	sort.Slice(filteredSnapshots, func(i, j int) bool {

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -200,11 +200,18 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 	var snapshots data.Snapshots
 	removeSnIDs := restic.NewIDSet()
 
-	for sn := range FindFilteredSnapshots(ctx, repo, repo, &opts.SnapshotFilter, args, printer) {
+	err = opts.SnapshotFilter.FindAll(ctx, repo, repo, args, func(_ string, sn *data.Snapshot, err error) error {
+		if err != nil {
+			return err
+		}
 		snapshots = append(snapshots, sn)
-	}
+		return nil
+	})
 	if ctx.Err() != nil {
 		return ctx.Err()
+	}
+	if err != nil {
+		return err
 	}
 
 	var jsonGroups []*ForgetGroup

--- a/cmd/restic/cmd_forget.go
+++ b/cmd/restic/cmd_forget.go
@@ -207,9 +207,6 @@ func runForget(ctx context.Context, opts ForgetOptions, pruneOptions PruneOption
 		snapshots = append(snapshots, sn)
 		return nil
 	})
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -341,9 +341,6 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, 
 		}
 		return nil
 	})
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -327,7 +327,10 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, 
 	}
 
 	changedCount := 0
-	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &opts.SnapshotFilter, args, printer) {
+	err = opts.SnapshotFilter.FindAll(ctx, snapshotLister, repo, args, func(_ string, sn *data.Snapshot, err error) error {
+		if err != nil {
+			return err
+		}
 		printer.P("\n%v", sn)
 		changed, err := rewriteSnapshot(ctx, repo, sn, opts, printer)
 		if err != nil {
@@ -336,9 +339,13 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, 
 		if changed {
 			changedCount++
 		}
-	}
+		return nil
+	})
 	if ctx.Err() != nil {
 		return ctx.Err()
+	}
+	if err != nil {
+		return err
 	}
 
 	printer.P("")

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -90,7 +90,7 @@ func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts global.Option
 	defer unlock()
 
 	var snapshots data.Snapshots
-	_ = opts.SnapshotFilter.FindAll(ctx, repo, repo, args, func(_ string, sn *data.Snapshot, err error) error {
+	err = opts.SnapshotFilter.FindAll(ctx, repo, repo, args, func(_ string, sn *data.Snapshot, err error) error {
 		if err == nil {
 			snapshots = append(snapshots, sn)
 		} else {
@@ -98,8 +98,8 @@ func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts global.Option
 		}
 		return nil
 	})
-	if ctx.Err() != nil {
-		return ctx.Err()
+	if err != nil {
+		return err
 	}
 
 	snapshotGroups, grouped, err := data.GroupSnapshots(snapshots, opts.GroupBy)

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -90,12 +90,18 @@ func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts global.Option
 	defer unlock()
 
 	var snapshots data.Snapshots
-	for sn := range FindFilteredSnapshots(ctx, repo, repo, &opts.SnapshotFilter, args, printer) {
-		snapshots = append(snapshots, sn)
-	}
+	_ = opts.SnapshotFilter.FindAll(ctx, repo, repo, args, func(_ string, sn *data.Snapshot, err error) error {
+		if err == nil {
+			snapshots = append(snapshots, sn)
+		} else {
+			printer.E("%v", err)
+		}
+		return nil
+	})
 	if ctx.Err() != nil {
 		return ctx.Err()
 	}
+
 	snapshotGroups, grouped, err := data.GroupSnapshots(snapshots, opts.GroupBy)
 	if err != nil {
 		return err

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -300,10 +300,7 @@ func PrintSnapshots(stdout io.Writer, list data.Snapshots, reasons []data.KeepRe
 	// but we display them all in local timezone on this output.
 	footer := fmt.Sprintf("%d snapshots", len(list))
 	zoneName := time.Now().Local().Location().String()
-	if zoneName == "Local" {
-		zoneName = "local time"
-	}
-	tab.AddFooter(fmt.Sprintf("Timestamps shown in %s\n%s", zoneName, footer))
+	tab.AddFooter(fmt.Sprintf("Timestamps shown in %s timezone\n%s", zoneName, footer))
 
 	if multiline {
 		// print an additional blank line between snapshots

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -299,7 +299,10 @@ func PrintSnapshots(stdout io.Writer, list data.Snapshots, reasons []data.KeepRe
 	// but we display them all in local timezone on this output.
 	footer := fmt.Sprintf("%d snapshots", len(list))
 	zoneName := time.Now().Local().Location().String()
-	tab.AddFooter(fmt.Sprintf("Timestamps shown in %s timezone\n%s", zoneName, footer))
+	if zoneName == "Local" {
+		zoneName = "local time"
+	}
+	tab.AddFooter(fmt.Sprintf("Timestamps shown in %s\n%s", zoneName, footer))
 
 	if multiline {
 		// print an additional blank line between snapshots

--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -91,11 +91,10 @@ func runSnapshots(ctx context.Context, opts SnapshotOptions, gopts global.Option
 
 	var snapshots data.Snapshots
 	err = opts.SnapshotFilter.FindAll(ctx, repo, repo, args, func(_ string, sn *data.Snapshot, err error) error {
-		if err == nil {
-			snapshots = append(snapshots, sn)
-		} else {
-			printer.E("%v", err)
+		if err != nil {
+			return err
 		}
+		snapshots = append(snapshots, sn)
 		return nil
 	})
 	if err != nil {

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -31,13 +31,13 @@ func newStatsCommand(globalOptions *global.Options) *cobra.Command {
 		Short: "Scan the repository and show basic statistics",
 		Long: `
 The "stats" command walks one or multiple snapshots in a repository
-and accumulates statistics about the data stored therein. It reports 
+and accumulates statistics about the data stored therein. It reports
 on the number of unique files and their sizes, according to one of
 the counting modes as given by the --mode flag.
 
 It operates on all snapshots matching the selection criteria or all
 snapshots if nothing is specified. The special snapshot ID "latest"
-is also supported. Some modes make more sense over 
+is also supported. Some modes make more sense over
 just a single snapshot, while others are useful across all snapshots,
 depending on what you are trying to calculate.
 
@@ -134,8 +134,18 @@ func runStats(ctx context.Context, opts StatsOptions, gopts global.Options, args
 	}
 
 	var snapshots data.Snapshots
-	for sn := range FindFilteredSnapshots(ctx, snapshotLister, repo, &opts.SnapshotFilter, args, printer) {
+	err = opts.SnapshotFilter.FindAll(ctx, snapshotLister, repo, args, func(_ string, sn *data.Snapshot, err error) error {
+		if err != nil {
+			return err
+		}
 		snapshots = append(snapshots, sn)
+		return nil
+	})
+	if ctx.Err() != nil {
+		return ctx.Err()
+	}
+	if err != nil {
+		return err
 	}
 
 	statsProgress := statsui.NewProgress(term, gopts.Quiet, gopts.JSON, uint64(len(snapshots)))

--- a/cmd/restic/cmd_stats.go
+++ b/cmd/restic/cmd_stats.go
@@ -141,9 +141,6 @@ func runStats(ctx context.Context, opts StatsOptions, gopts global.Options, args
 		snapshots = append(snapshots, sn)
 		return nil
 	})
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -159,19 +159,26 @@ func runTag(ctx context.Context, opts TagOptions, gopts global.Options, term ui.
 		}
 	}
 
-	for sn := range FindFilteredSnapshots(ctx, repo, repo, &opts.SnapshotFilter, args, printer) {
+	err = opts.SnapshotFilter.FindAll(ctx, repo, repo, args, func(_ string, sn *data.Snapshot, err error) error {
+		if err != nil {
+			return err
+		}
 		changed, err := changeTags(ctx, repo, sn, opts.SetTags.Flatten(), opts.AddTags.Flatten(), opts.RemoveTags.Flatten(), printFunc)
 		if err != nil {
 			printer.E("unable to modify the tags for snapshot ID %q, ignoring: %v", sn.ID(), err)
-			continue
+			return nil
 		}
 		if changed {
 			summary.ChangedSnapshots++
 		}
-	}
+		return nil
+	})
 
 	if ctx.Err() != nil {
 		return ctx.Err()
+	}
+	if err != nil {
+		return err
 	}
 
 	printSummary(summary)

--- a/cmd/restic/cmd_tag.go
+++ b/cmd/restic/cmd_tag.go
@@ -173,10 +173,6 @@ func runTag(ctx context.Context, opts TagOptions, gopts global.Options, term ui.
 		}
 		return nil
 	})
-
-	if ctx.Err() != nil {
-		return ctx.Err()
-	}
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/find.go
+++ b/cmd/restic/find.go
@@ -1,16 +1,14 @@
 package main
 
 import (
-	"context"
 	"os"
 
 	"github.com/restic/restic/internal/data"
-	"github.com/restic/restic/internal/restic"
 	"github.com/spf13/pflag"
 )
 
 // initMultiSnapshotFilter is used for commands that work on multiple snapshots
-// MUST be combined with FindFilteredSnapshots
+// MUST be combined with (*data,SnapshotFilter).FindAll
 // MUST be followed by finalizeSnapshotFilter after flag parsing
 func initMultiSnapshotFilter(flags *pflag.FlagSet, filt *data.SnapshotFilter, addHostShorthand bool) {
 	hostShorthand := "H"
@@ -45,34 +43,4 @@ func finalizeSnapshotFilter(filt *data.SnapshotFilter) {
 	if len(filt.Hosts) == 1 && filt.Hosts[0] == "" {
 		filt.Hosts = nil
 	}
-}
-
-// FindFilteredSnapshots yields Snapshots, either given explicitly by `snapshotIDs` or filtered from the list of all snapshots.
-func FindFilteredSnapshots(ctx context.Context, be restic.Lister, loader restic.LoaderUnpacked, f *data.SnapshotFilter, snapshotIDs []string, printer restic.Printer) <-chan *data.Snapshot {
-	out := make(chan *data.Snapshot)
-	go func() {
-		defer close(out)
-		be, err := restic.MemorizeList(ctx, be, restic.SnapshotFile)
-		if err != nil {
-			printer.E("could not load snapshots: %v", err)
-			return
-		}
-
-		err = f.FindAll(ctx, be, loader, snapshotIDs, func(id string, sn *data.Snapshot, err error) error {
-			if err != nil {
-				printer.E("Ignoring %q: %v", id, err)
-			} else {
-				select {
-				case <-ctx.Done():
-					return ctx.Err()
-				case out <- sn:
-				}
-			}
-			return nil
-		})
-		if err != nil {
-			printer.E("could not load snapshots: %v", err)
-		}
-	}()
-	return out
 }

--- a/cmd/restic/integration_test.go
+++ b/cmd/restic/integration_test.go
@@ -174,13 +174,25 @@ func TestFindListOnce(t *testing.T) {
 
 		snapshotIDs = restic.NewIDSet()
 		// specify the two oldest snapshots explicitly and use "latest" to reference the newest one
-		for sn := range FindFilteredSnapshots(ctx, repo, repo, &data.SnapshotFilter{}, []string{
-			secondSnapshot[0].String(),
-			secondSnapshot[1].String()[:8],
-			"latest",
-		}, printer) {
-			snapshotIDs.Insert(*sn.ID())
+		err = (&data.SnapshotFilter{}).FindAll(ctx, repo, repo,
+			[]string{
+				secondSnapshot[0].String(),
+				secondSnapshot[1].String()[:8],
+				"latest",
+			},
+
+			func(id string, sn *data.Snapshot, err error) error {
+				if err != nil {
+					return err
+				}
+				snapshotIDs.Insert(*sn.ID())
+
+				return nil
+			})
+		if err != nil {
+			return err
 		}
+
 		return nil
 	}))
 


### PR DESCRIPTION
Continuation of https://github.com/restic/restic/pull/21909.

replace remove FindFilteredSnapshots() with equivalent call to opts.FindAll()

mostly trivial changes except
cmd/restic/cmd_copy.go:
had to replace iter.Seq with iter.Seq2 to propagate the error in case it exists.

internal/data/snapshot_find.go:
add call to restic.MemorizeList()
added the code to check for transaction errors to FindAll().

cmd/restic/find.go:
remove func FindFilteredSnapshots()

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR removes all calls to FindFilteredSnapshots()`` and replaces them with calls to (*data.SnapshotFilter).FindAll()``.
This PR is dependent on https://github.com/restic/restic/pull/21907.

The error handling in FindFilteredSnapshots() is not fit for purpose and needs to be replaced
with something better. Most command will terminate on a snapshot file error. restic snapshots will ignore the error since it is used in a lot of tests - and would therefore break existing behaviour if it were to fail.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
No.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

~~- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)~~
~~- [ ] I have added documentation for relevant changes (in the manual).~~
~~- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
No visible changes for the user.
- [x] I'm done! This pull request is ready for review.
