### PR TITLE
backup:fix misleading recovery warning

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -172,6 +172,9 @@ var backupFSTestHook func(fs fs.FS) fs.FS
 // ErrInvalidSourceData is used to report an incomplete backup
 var ErrInvalidSourceData = errors.New("at least one source file could not be read")
 
+// ErrRepositoryRecovered is used to report that the repository was restored
+var ErrRepositoryRecovered = errors.New("repository successfully recovered")
+
 // ErrNoSourceData is used to report that no source data was found
 var ErrNoSourceData = errors.Fatal("all source directories/files do not exist")
 
@@ -706,6 +709,10 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 
 	// Report finished execution
 	progressReporter.Finish(id, summary, opts.DryRun)
+
+	if arch.RepositoryRecovered {
+		return ErrRepositoryRecovered
+	}
 	if !success {
 		return ErrInvalidSourceData
 	}

--- a/cmd/restic/main.go
+++ b/cmd/restic/main.go
@@ -201,6 +201,8 @@ func main() {
 		exitMessage = fmt.Sprintf("%v\nthe `unlock` command can be used to remove stale locks", err)
 	case err == ErrInvalidSourceData:
 		exitMessage = fmt.Sprintf("Warning: %v", err)
+	case errors.Is(err, ErrRepositoryRecovered):
+		exitMessage = fmt.Sprintf("Success: %v", err)
 	case errors.IsFatal(err):
 		exitMessage = err.Error()
 	case errors.Is(err, repository.ErrNoKeyFound):
@@ -225,6 +227,8 @@ func main() {
 		exitCode = 3
 	case errors.Is(err, ErrFailedToRemoveOneOrMoreSnapshots):
 		exitCode = 3
+	case errors.Is(err, ErrRepositoryRecovered):
+		exitCode = 4
 	case errors.Is(err, global.ErrNoRepository):
 		exitCode = 10
 	case repository.IsAlreadyLocked(err):

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -132,6 +132,9 @@ type Archiver struct {
 
 	// for excluded items
 	ExcludedItem func(path string)
+
+	//
+	RepositoryRecovered bool
 }
 
 // Flags for the ChangeIgnoreFlags bitfield.
@@ -548,6 +551,7 @@ func (arch *Archiver) save(ctx context.Context, snPath, target string, previous 
 			debug.Log("%v hasn't changed, but contents are missing!", target)
 			// There are contents missing - inform user!
 			err := errors.Errorf("parts of %v not found in the repository index; storing the file again", target)
+			arch.RepositoryRecovered = true
 			err = arch.error(abstarget, err)
 			if err != nil {
 				return futureNode{}, false, err


### PR DESCRIPTION
## What does this PR change? What problem does it solve?

When backing up a file whose data is partially missing from the repository index, restic correctly detects the inconsistency, warns that the file will be stored again, and successfully re-uploads the missing data.

However, the final backup summary currently prints:

> Warning: at least one source file could not be read

This message is misleading because the source file was read successfully as explained in https://github.com/restic/restic/issues/5376 . 

This PR updates the backup warning message and tracks where recovery was attempted to accurately describe the situation, making it clearer to users that the warning is related to the repository state rather than the source data.

I'd also like to get feedback on whether this is the preferred direction. While working on this, I wondered whether this scenario should also use a different exit code, I'm currently returning exit status 4 but since the backup succeeds but indicates a repository inconsistency, I'm not sure whether to return a new code or simply return 0. I would greatly appreciate maintainers' thoughts on that aspect.

## Was the change previously discussed in an issue or on the forum?

Yes. Here https://github.com/restic/restic/issues/5376

## Checklist

* [ ] I have added tests for all code changes, see writing tests
* [ ] I have added documentation for relevant changes (in the manual).
* [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see template).
* [x] I'm done! This pull request is ready for review.
