### PR TITLE
global: do not abort when the cache cannot be opened

### DIFF
--- a/changelog/unreleased/issue-4591
+++ b/changelog/unreleased/issue-4591
@@ -1,0 +1,12 @@
+Bugfix: Do not abort when the cache directory cannot be opened
+
+Restic recently started to abort with an error when it could not open its
+local cache directory. This happened for example when restic ran as a systemd
+system service without `$HOME` set, so the cache directory could not be
+located, or when the cache directory was not writable.
+
+Restic now prints a warning and continues without a cache in these cases, as
+it did before. Operations are slower without a cache, but no longer fail.
+
+https://github.com/restic/restic/issues/4591
+https://github.com/restic/restic/pull/21919

--- a/cmd/restic/cmd_init_integration_test.go
+++ b/cmd/restic/cmd_init_integration_test.go
@@ -73,3 +73,31 @@ func TestInitCopyChunkerParams(t *testing.T) {
 		"expected equal chunker polynomials, got %v expected %v", repo.Config().ChunkerPolynomial,
 		otherRepo.Config().ChunkerPolynomial)
 }
+
+// TestOpenRepositoryCacheUnavailable verifies that OpenRepository continues
+// without a cache, rather than aborting, when the cache cannot be opened. This
+// happens for example when restic runs as a systemd system service without
+// $HOME set, or when the cache directory is not writable. Opening the cache is
+// best-effort: restic only prints a warning and proceeds.
+func TestOpenRepositoryCacheUnavailable(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+
+	// Point the cache directory below a regular file so that creating it fails.
+	// cache.New then returns an error at the same spot it does when no cache
+	// directory can be located at all (missing $HOME / $XDG_CACHE_HOME).
+	blocker := filepath.Join(env.base, "not-a-directory")
+	rtest.OK(t, os.WriteFile(blocker, []byte("x"), 0o600))
+	env.gopts.CacheDir = filepath.Join(blocker, "cache")
+
+	var repo *repository.Repository
+	err := withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
+		var err error
+		repo, err = global.OpenRepository(ctx, gopts, restic.NewNoopPrinter())
+		return err
+	})
+	rtest.OK(t, err)
+	rtest.Assert(t, repo != nil, "expected a usable repository even when the cache is unavailable")
+}

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -451,8 +451,9 @@ OS-specific cache folder:
 * macOS: ``~/Library/Caches/restic``
 * Windows: ``%LOCALAPPDATA%/restic``
 
-If the relevant environment variables are not set, restic exits with an error
-message.
+If the relevant environment variables are not set, restic cannot determine the
+cache location. It then prints a warning and continues without a cache, which
+slows down operations that would otherwise benefit from caching.
 
 The command line parameter ``--cache-dir`` or the environment variable
 ``$RESTIC_CACHE_DIR`` can be used to override the default cache location. The

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -421,8 +421,12 @@ func printRepositoryInfo(s *repository.Repository, gopts Options, printer restic
 func setupCache(s *repository.Repository, gopts Options, printer restic.Printer) error {
 	c, err := cache.New(s.Config().ID, gopts.CacheDir)
 	if err != nil {
+		// Failing to open the cache is not fatal: restic can still operate
+		// without a cache, only slower. This in particular happens when restic
+		// runs as a systemd system service without $HOME set, so the cache
+		// directory cannot be located. Warn and continue without a cache.
 		printer.E("unable to open cache: %v", err)
-		return err
+		return nil
 	}
 
 	if c.Created {


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Opening the local cache is best-effort: when it cannot be opened, restic warns
and continues without a cache (slower, but the command still runs). This is
what happens, for example, when restic runs as a systemd system service
without `$HOME` set, so the cache directory cannot be located, or when the
cache directory is not writable.

While splitting `OpenRepository` into smaller functions in #5555, the
cache-open error path in `setupCache` was changed from `return s, nil` to
`return err` (commit b6aef592f). `OpenRepository` propagates that error, so on
current master restic aborts the whole command when the cache cannot be opened,
instead of warning and continuing. The other cache errors in the same function
(cleaning up old cache directories) are still non-fatal, which suggests this
change was unintended.

This PR:

- restores the non-fatal behavior (one line in `setupCache`),
- adds an integration test that opens a repository with an unusable cache
  directory and asserts it still succeeds, and
- corrects the manual, which still stated that restic exits with an error when
  the cache directory cannot be located.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #4591. The discussion there concluded that warning and continuing is
preferable to failing the backup, and that the documentation (which said restic
exits) was wrong. See also #4775, which was closed as a duplicate of #4591.

Checklist
---------

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
