### PR TITLE
add JSON output for copy command

### DIFF
--- a/changelog/unreleased/pull-21921
+++ b/changelog/unreleased/pull-21921
@@ -3,3 +3,4 @@ Enhancement: `restic copy --json` is now enabled
 In the past, `restic copy` did not support JSON output. This is now enabled.
 
 https://github.com/restic/restic/pull/21921
+https://github.com/restic/restic/issues/3324

--- a/changelog/unreleased/pull-21921
+++ b/changelog/unreleased/pull-21921
@@ -1,0 +1,5 @@
+Enhancement: `restic copy --json` is now enabled
+
+In the past, `restic copy` did not support JSON output. This is now enabled.
+
+https://github.com/restic/restic/pull/21921

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -286,7 +286,7 @@ func copyTreeBatched(ctx context.Context, gopts global.Options, srcRepo *reposit
 		}
 
 		// add a newline to separate saved snapshot messages from the other messages
-		if len(batch) > {
+		if len(batch) > 1 {
 			printer.P("")
 		}
 		// save all the snapshots

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"iter"
+	"slices"
 	"sync"
 	"time"
 
@@ -118,7 +120,7 @@ func collectAllSnapshots(ctx context.Context, opts CopyOptions,
 }
 
 func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args []string, term ui.Terminal) error {
-	printer := progress.NewTerminalPrinter(false, gopts.Verbosity, term)
+	printer := progress.NewTerminalPrinter(gopts.JSON, gopts.Verbosity, term)
 	secondaryGopts, isFromRepo, err := opts.SecondaryRepoOptions.FillGlobalOpts(ctx, gopts, "destination")
 	if err != nil {
 		return err
@@ -177,7 +179,7 @@ func runCopy(ctx context.Context, opts CopyOptions, gopts global.Options, args [
 
 	selectedSnapshots := collectAllSnapshots(ctx, opts, srcSnapshotLister, srcRepo, dstSnapshotByOriginal, args, printer)
 
-	if err := copyTreeBatched(ctx, srcRepo, dstRepo, selectedSnapshots, printer); err != nil {
+	if err := copyTreeBatched(ctx, gopts, srcRepo, dstRepo, selectedSnapshots, printer); err != nil {
 		return err
 	}
 
@@ -203,14 +205,26 @@ func similarSnapshots(sna *data.Snapshot, snb *data.Snapshot) bool {
 	return true
 }
 
+type CopyDataJSON struct {
+	SourceSnapshotID restic.ID `json:"source_id"`
+	//SourceShortID       string         `json:"source_short_id"`
+	TargetSnapshotID restic.ID `json:"target_id"`
+	//TargetShortID       string         `json:"target_short_id"`
+	SrcSnapshot         *data.Snapshot `json:"source_snapshot"`
+	CountBlobs          int            `json:"count_blobs"`
+	SizeBlobs           uint64         `json:"size_blobs"`
+	TotalFilesProcessed uint           `json:"total_files_processed"`
+	TotalBytesProcessed uint64         `json:"total_bytes_processed"`
+}
+
 // copyTreeBatched copies multiple snapshots in one go. Snapshots are written after
 // data equivalent to at least 10 packfiles was written.
-func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRepo restic.Repository,
+func copyTreeBatched(ctx context.Context, gopts global.Options, srcRepo *repository.Repository, dstRepo restic.Repository,
 	selectedSnapshots iter.Seq2[*data.Snapshot, error], printer restic.Printer) error {
 
 	// remember already processed trees across all snapshots
 	visitedTrees := srcRepo.NewAssociatedBlobSet()
-
+	copyStatisticsJSON := make(map[*data.Snapshot]CopyDataJSON)
 	targetSize := uint64(dstRepo.PackSize()) * 100
 	minDuration := 1 * time.Minute
 
@@ -238,12 +252,26 @@ func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRep
 
 				printer.P("\n%v", sn)
 				printer.P("  copy started, this may take a while...")
-				sizeBlobs, err := copyTree(ctx, srcRepo, dstRepo, visitedTrees, *sn.Tree, printer, uploader)
+				copyStatisticsEntry, err := copyTree(ctx, srcRepo, dstRepo, visitedTrees, *sn.Tree, printer, uploader)
 				if err != nil {
 					return err
 				}
 				debug.Log("tree copied")
-				batchSize += sizeBlobs
+				temp := CopyDataJSON{
+					SrcSnapshot:      sn,
+					SourceSnapshotID: *sn.ID(),
+					//SourceShortID:       sn.ID().Str(),
+					CountBlobs: copyStatisticsEntry.CountBlobs,
+					SizeBlobs:  copyStatisticsEntry.SizeBlobs,
+				}
+				if sn.Summary != nil {
+					temp.TotalFilesProcessed = sn.Summary.TotalFilesProcessed
+					temp.TotalBytesProcessed = sn.Summary.TotalBytesProcessed
+				}
+				// suppress sn.Summary
+				temp.SrcSnapshot.Summary = nil
+				copyStatisticsJSON[sn] = temp
+				batchSize += copyStatisticsEntry.SizeBlobs
 			}
 
 			return nil
@@ -258,23 +286,45 @@ func copyTreeBatched(ctx context.Context, srcRepo *repository.Repository, dstRep
 		}
 
 		// add a newline to separate saved snapshot messages from the other messages
-		if len(batch) > 1 {
+		if len(batch) > {
 			printer.P("")
 		}
 		// save all the snapshots
 		for _, sn := range batch {
-			err := copySaveSnapshot(ctx, sn, dstRepo, printer)
+			temp := copyStatisticsJSON[sn]
+			err := copySaveSnapshot(ctx, sn, dstRepo, printer, &temp)
 			if err != nil {
 				return err
 			}
+			copyStatisticsJSON[sn] = temp
 		}
+	}
+
+	if gopts.JSON {
+		copyStatisticsJSONSort := make([]CopyDataJSON, 0, len(copyStatisticsJSON))
+		for _, data := range copyStatisticsJSON {
+			copyStatisticsJSONSort = append(copyStatisticsJSONSort, data)
+		}
+		slices.SortFunc(copyStatisticsJSONSort, func(a, b CopyDataJSON) int {
+			return a.SrcSnapshot.Time.Compare(b.SrcSnapshot.Time)
+		})
+
+		err := json.NewEncoder(gopts.Term.OutputWriter()).Encode(copyStatisticsJSONSort)
+		return err
 	}
 
 	return nil
 }
 
-func copyTree(ctx context.Context, srcRepo *repository.Repository, dstRepo restic.Repository,
-	visitedTrees restic.AssociatedBlobSet, rootTreeID restic.ID, printer restic.Printer, uploader restic.BlobSaverWithAsync) (uint64, error) {
+func copyTree(
+	ctx context.Context,
+	srcRepo *repository.Repository,
+	dstRepo restic.Repository,
+	visitedTrees restic.AssociatedBlobSet,
+	rootTreeID restic.ID,
+	printer restic.Printer,
+	uploader restic.BlobSaverWithAsync,
+) (CopyDataJSON, error) {
 
 	copyBlobs := srcRepo.NewAssociatedBlobSet()
 	packList := restic.NewIDSet()
@@ -318,23 +368,24 @@ func copyTree(ctx context.Context, srcRepo *repository.Repository, dstRepo resti
 		return nil
 	})
 	if err != nil {
-		return 0, err
+		return CopyDataJSON{}, err
 	}
 
-	sizeBlobs := copyStats(srcRepo, copyBlobs, packList, printer)
+	copyStatisticsEntry := copyStats(srcRepo, copyBlobs, packList, printer)
 	bar := printer.NewCounter("packs copied")
 	err = repository.CopyBlobs(ctx, srcRepo, dstRepo, uploader, packList, copyBlobs, bar, printer.P)
 	if err != nil {
-		return 0, errors.Fatalf("%s", err)
+		return CopyDataJSON{}, errors.Fatalf("%s", err)
 	}
-	return sizeBlobs, nil
+	return copyStatisticsEntry, nil
 }
 
 // copyStats: print statistics for the blobs to be copied
-func copyStats(srcRepo restic.Repository, copyBlobs restic.AssociatedBlobSet, packList restic.IDSet, printer restic.Printer) uint64 {
+func copyStats(srcRepo restic.Repository, copyBlobs restic.AssociatedBlobSet, packList restic.IDSet, printer restic.Printer) CopyDataJSON {
 	// count and size
 	countBlobs := 0
 	sizeBlobs := uint64(0)
+	result := CopyDataJSON{}
 	for blob := range copyBlobs.Keys() {
 		for _, pb := range srcRepo.LookupBlob(blob) {
 			countBlobs++
@@ -342,13 +393,15 @@ func copyStats(srcRepo restic.Repository, copyBlobs restic.AssociatedBlobSet, pa
 			break
 		}
 	}
+	result.CountBlobs = countBlobs
+	result.SizeBlobs = sizeBlobs
 
 	printer.V("  copy %d blobs with disk size %s in %d packfiles\n",
 		countBlobs, ui.FormatBytes(uint64(sizeBlobs)), len(packList))
-	return sizeBlobs
+	return result
 }
 
-func copySaveSnapshot(ctx context.Context, sn *data.Snapshot, dstRepo restic.Repository, printer restic.Printer) error {
+func copySaveSnapshot(ctx context.Context, sn *data.Snapshot, dstRepo restic.Repository, printer restic.Printer, copyStatisticsEntry *CopyDataJSON) error {
 	sn.Parent = nil // Parent does not have relevance in the new repo.
 	// Use Original as a persistent snapshot ID
 	if sn.Original == nil {
@@ -359,5 +412,7 @@ func copySaveSnapshot(ctx context.Context, sn *data.Snapshot, dstRepo restic.Rep
 		return err
 	}
 	printer.P("snapshot %s saved, copied from source snapshot %s", newID.Str(), sn.ID().Str())
+	copyStatisticsEntry.TargetSnapshotID = newID
+	//copyStatisticsEntry.TargetShortID = newID.Str()
 	return nil
 }

--- a/cmd/restic/cmd_copy.go
+++ b/cmd/restic/cmd_copy.go
@@ -309,8 +309,7 @@ func copyTreeBatched(ctx context.Context, gopts global.Options, srcRepo *reposit
 			return a.SrcSnapshot.Time.Compare(b.SrcSnapshot.Time)
 		})
 
-		err := json.NewEncoder(gopts.Term.OutputWriter()).Encode(copyStatisticsJSONSort)
-		return err
+		return json.NewEncoder(gopts.Term.OutputWriter()).Encode(copyStatisticsJSONSort)
 	}
 
 	return nil

--- a/cmd/restic/cmd_copy_integration_test.go
+++ b/cmd/restic/cmd_copy_integration_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"path/filepath"
 	"testing"
@@ -28,6 +29,27 @@ func testRunCopy(t testing.TB, srcGopts global.Options, dstGopts global.Options)
 	rtest.OK(t, withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		return runCopy(context.TODO(), copyOpts, gopts, nil, gopts.Term)
 	}))
+}
+
+func testRunCopyWithOutput(t testing.TB, srcGopts global.Options, dstGopts global.Options, wantJSON bool) []byte {
+	gopts := srcGopts
+	gopts.Repo = dstGopts.Repo
+	gopts.Password = dstGopts.Password
+	gopts.InsecureNoPassword = dstGopts.InsecureNoPassword
+	copyOpts := CopyOptions{
+		SecondaryRepoOptions: global.SecondaryRepoOptions{
+			Repo:               srcGopts.Repo,
+			Password:           srcGopts.Password,
+			InsecureNoPassword: srcGopts.InsecureNoPassword,
+		},
+	}
+
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		gopts.JSON = wantJSON
+		return runCopy(context.TODO(), copyOpts, gopts, nil, gopts.Term)
+	})
+	rtest.OK(t, err)
+	return buf.Bytes()
 }
 
 func TestCopy(t *testing.T) {
@@ -194,4 +216,31 @@ func TestCopyToEmptyPassword(t *testing.T) {
 	testListSnapshots(t, env.gopts, 1)
 	testListSnapshots(t, env2.gopts, 1)
 	testRunCheck(t, env2.gopts)
+}
+
+func TestCopyJSON(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	env2, cleanup2 := withTestEnvironment(t)
+	defer cleanup2()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "40")}, opts, env.gopts)
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "41")}, opts, env.gopts)
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "42")}, opts, env.gopts)
+
+	testRunInit(t, env2.gopts)
+	buf := testRunCopyWithOutput(t, env.gopts, env2.gopts, true)
+
+	testListSnapshots(t, env.gopts, 3)
+	testListSnapshots(t, env2.gopts, 3)
+
+	matches := []CopyDataJSON{}
+	rtest.OK(t, json.Unmarshal(buf, &matches))
+	rtest.Assert(t, len(matches) == 3, "expected three entries, got %d", len(matches))
+	for _, data := range matches {
+		rtest.Assert(t, data.TotalFilesProcessed == 1, "expected one file per snapshot, got %d", data.TotalFilesProcessed)
+		rtest.Assert(t, data.TotalBytesProcessed == (1<<14), "expected 16 kiB per file, got %d", data.TotalBytesProcessed)
+	}
 }


### PR DESCRIPTION
add JSON output to `restic copy`

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR add JSON output to the copy command


<!--
Describe the changes and their purpose here, as detailed as needed.
-->
JSON data is collected in ``copyTreeBatched()`` and is printed out at the end of the function.

JSON data is a ``[]CopyDataJSON``, sorted by ascending snapshot time.

A ``CopyDataJSON`` is a 
```
type CopyDataJSON struct {
	SourceSnapshotID restic.ID `json:"source_id"`
	//SourceShortID       string         `json:"source_short_id"`
	TargetSnapshotID restic.ID `json:"target_id"`
	//TargetShortID       string         `json:"target_short_id"`
	SrcSnapshot         *data.Snapshot `json:"source_snapshot"`
	CountBlobs          int            `json:"count_blobs"`
	SizeBlobs           uint64         `json:"size_blobs"`
	TotalFilesProcessed uint           `json:"total_files_processed"`
	TotalBytesProcessed uint64         `json:"total_bytes_processed"`
}
```

whereby the short_ids are currently commented since I am not sure if they are needed. They can easily created as source_id[:8].

The rest of the changes is enabling JSON output and then printing it in ``copyTreeBatched()``.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
closes https://github.com/restic/restic/issues/3324

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
