### PR TITLE
add JSON support for rewrite command

### DIFF
--- a/changelog/unreleased/issue-5702
+++ b/changelog/unreleased/issue-5702
@@ -1,0 +1,13 @@
+Enhancement: ``restic rewrite --json`` is now supported
+
+In the past it was not possible to use the --json option together with ``restic rewrite``.
+
+This issue has now been resolved. Using the --verbose=2 option the command will
+generate JSON "excluded_item" / JSON "included_item" records depending on whether variants
+of --exclude* or variants of --include* have been called.
+
+If any changes have been made to the snapshot(s), a JSON "rewrite" summary record
+will be created for each changed snapshot.
+
+https://github.com/restic/restic/issues/5702
+https://github.com/restic/restic/pull/21928

--- a/cmd/restic/cmd_repair_snapshots.go
+++ b/cmd/restic/cmd_repair_snapshots.go
@@ -188,7 +188,7 @@ func runRepairSnapshots(ctx context.Context, gopts global.Options, opts RepairOp
 		}
 
 		printer.P("\n%v", sn)
-		changed, err := filterAndReplaceSnapshot(ctx, repo, sn,
+		changed, err := filterAndReplaceSnapshot(ctx, gopts, repo, sn,
 			func(ctx context.Context, sn *data.Snapshot, uploader restic.BlobSaver) (restic.ID, *data.SnapshotSummary, error) {
 				id, err := rewriter.RewriteTree(ctx, repo, uploader, "/", *sn.Tree)
 				return id, nil, err

--- a/cmd/restic/cmd_rewrite.go
+++ b/cmd/restic/cmd_rewrite.go
@@ -15,6 +15,7 @@ import (
 	"github.com/restic/restic/internal/repository"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
+	"github.com/restic/restic/internal/ui/backup"
 	"github.com/restic/restic/internal/ui/progress"
 	"github.com/restic/restic/internal/walker"
 )
@@ -129,7 +130,14 @@ func (opts *RewriteOptions) AddFlags(f *pflag.FlagSet) {
 // be updated accordingly.
 type rewriteFilterFunc func(ctx context.Context, sn *data.Snapshot, uploader restic.BlobSaver) (restic.ID, *data.SnapshotSummary, error)
 
-func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *data.Snapshot, opts RewriteOptions, printer restic.Printer) (bool, error) {
+func rewriteSnapshot(
+	ctx context.Context,
+	gopts global.Options,
+	repo *repository.Repository,
+	sn *data.Snapshot,
+	opts RewriteOptions,
+	printer restic.Printer,
+) (bool, error) {
 	if sn.Tree == nil {
 		return false, errors.Errorf("snapshot %v has nil tree", sn.ID().Str())
 	}
@@ -158,9 +166,9 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *data.
 		var rewriteNode walker.NodeRewriteFunc
 		var keepEmptyDirectoryFunc walker.NodeKeepEmptyDirectoryFunc
 		if condInclude {
-			rewriteNode, keepEmptyDirectoryFunc = gatherIncludeFilters(includeByNameFuncs, printer)
+			rewriteNode, keepEmptyDirectoryFunc = gatherIncludeFilters(includeByNameFuncs, printer, gopts)
 		} else {
-			rewriteNode = gatherExcludeFilters(rejectByNameFuncs, printer)
+			rewriteNode = gatherExcludeFilters(rejectByNameFuncs, printer, gopts)
 		}
 
 		rewriter, querySize := walker.NewSnapshotSizeRewriter(rewriteNode, keepEmptyDirectoryFunc)
@@ -186,13 +194,32 @@ func rewriteSnapshot(ctx context.Context, repo *repository.Repository, sn *data.
 		}
 	}
 
-	return filterAndReplaceSnapshot(ctx, repo, sn,
+	return filterAndReplaceSnapshot(ctx, gopts, repo, sn,
 		filter, opts.DryRun, opts.Forget, metadata, "rewrite", printer, len(includeByNameFuncs) > 0)
 }
 
-func filterAndReplaceSnapshot(ctx context.Context, repo restic.Repository, sn *data.Snapshot,
-	filter rewriteFilterFunc, dryRun bool, forget bool, newMetadata *snapshotMetadata, addTag string, printer restic.Printer,
-	keepEmptySnapshot bool) (bool, error) {
+type RewriteJSON struct {
+	MessageType         string         `json:"message_type"`
+	SnapshotID          restic.ID      `json:"original_snapshot_ID"`
+	NewSnapshotID       restic.ID      `json:"rewritten_snapshot_ID"`
+	Snapshot            *data.Snapshot `json:"snapshot"`
+	TotalFilesProcessed uint           `json:"total_files_processed"`
+	TotalBytesProcessed uint64         `json:"total_bytes_processed"`
+}
+
+func filterAndReplaceSnapshot(
+	ctx context.Context,
+	gopts global.Options,
+	repo restic.Repository,
+	sn *data.Snapshot,
+	filter rewriteFilterFunc,
+	dryRun bool,
+	forget bool,
+	newMetadata *snapshotMetadata,
+	addTag string,
+	printer restic.Printer,
+	keepEmptySnapshot bool,
+) (bool, error) {
 
 	var filteredTree restic.ID
 	var summary *data.SnapshotSummary
@@ -277,7 +304,20 @@ func filterAndReplaceSnapshot(ctx context.Context, repo restic.Repository, sn *d
 	if err != nil {
 		return false, err
 	}
-	printer.P("saved new snapshot %v", id.Str())
+	if gopts.JSON {
+		rewriteJSON := RewriteJSON{
+			MessageType:         "rewrite",
+			SnapshotID:          *sn.ID(),
+			NewSnapshotID:       id,
+			Snapshot:            sn,
+			TotalFilesProcessed: sn.Summary.TotalFilesProcessed,
+			TotalBytesProcessed: sn.Summary.TotalBytesProcessed,
+		}
+		sn.Summary = nil
+		gopts.Term.Print(ui.ToJSONString(rewriteJSON))
+	} else {
+		printer.P("saved new snapshot %v", id.Str())
+	}
 
 	if forget {
 		if err = repo.RemoveUnpacked(ctx, restic.WriteableSnapshotFile, *sn.ID()); err != nil {
@@ -298,7 +338,7 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, 
 		return errors.Fatal("exclude and include patterns are mutually exclusive")
 	}
 
-	printer := progress.NewTerminalPrinter(false, gopts.Verbosity, term)
+	printer := progress.NewTerminalPrinter(gopts.JSON, gopts.Verbosity, term)
 
 	var (
 		repo   *repository.Repository
@@ -332,7 +372,7 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, 
 			return err
 		}
 		printer.P("\n%v", sn)
-		changed, err := rewriteSnapshot(ctx, repo, sn, opts, printer)
+		changed, err := rewriteSnapshot(ctx, gopts, repo, sn, opts, printer)
 		if err != nil {
 			return errors.Fatalf("unable to rewrite snapshot ID %q: %v", sn.ID().Str(), err)
 		}
@@ -363,7 +403,7 @@ func runRewrite(ctx context.Context, opts RewriteOptions, gopts global.Options, 
 	return nil
 }
 
-func gatherIncludeFilters(includeByNameFuncs []filter.IncludeByNameFunc, printer restic.Printer) (rewriteNode walker.NodeRewriteFunc, keepEmptyDirectory walker.NodeKeepEmptyDirectoryFunc) {
+func gatherIncludeFilters(includeByNameFuncs []filter.IncludeByNameFunc, printer restic.Printer, gopts global.Options) (rewriteNode walker.NodeRewriteFunc, keepEmptyDirectory walker.NodeKeepEmptyDirectoryFunc) {
 	inSelectByName := func(nodepath string, node *data.Node) bool {
 		for _, include := range includeByNameFuncs {
 			matched, childMayMatch := include(nodepath)
@@ -382,7 +422,15 @@ func gatherIncludeFilters(includeByNameFuncs []filter.IncludeByNameFunc, printer
 	rewriteNode = func(node *data.Node, path string) *data.Node {
 		if inSelectByName(path, node) {
 			if node.Type != data.NodeTypeDir {
-				printer.VV("including %q\n", path)
+				if !gopts.JSON {
+					printer.VV("including %q\n", path)
+				} else if gopts.Verbosity >= 2 {
+					include := backup.VerboseExclude{
+						MessageType: "included_item",
+						Item:        path,
+					}
+					gopts.Term.Print(ui.ToJSONString(include))
+				}
 			}
 			return node
 		}
@@ -402,7 +450,15 @@ func gatherIncludeFilters(includeByNameFuncs []filter.IncludeByNameFunc, printer
 	keepEmptyDirectory = func(path string) bool {
 		keep := inSelectByNameDir(path)
 		if keep {
-			printer.VV("including directory %q\n", path)
+			if !gopts.JSON {
+				printer.VV("including directory %q\n", path)
+			} else if gopts.Verbosity >= 2 {
+				include := backup.VerboseExclude{
+					MessageType: "included_directory",
+					Item:        path,
+				}
+				gopts.Term.Print(ui.ToJSONString(include))
+			}
 		}
 		return keep
 	}
@@ -410,7 +466,7 @@ func gatherIncludeFilters(includeByNameFuncs []filter.IncludeByNameFunc, printer
 	return rewriteNode, keepEmptyDirectory
 }
 
-func gatherExcludeFilters(excludeByNameFuncs []filter.RejectByNameFunc, printer restic.Printer) (rewriteNode walker.NodeRewriteFunc) {
+func gatherExcludeFilters(excludeByNameFuncs []filter.RejectByNameFunc, printer restic.Printer, gopts global.Options) (rewriteNode walker.NodeRewriteFunc) {
 	exSelectByName := func(nodepath string) bool {
 		for _, reject := range excludeByNameFuncs {
 			if reject(nodepath) {
@@ -425,7 +481,15 @@ func gatherExcludeFilters(excludeByNameFuncs []filter.RejectByNameFunc, printer 
 			return node
 		}
 
-		printer.VV("excluding %q\n", path)
+		if !gopts.JSON {
+			printer.VV("excluding %q\n", path)
+		} else if gopts.Verbosity >= 2 {
+			exclude := backup.VerboseExclude{
+				MessageType: "excluded_item",
+				Item:        path,
+			}
+			gopts.Term.Print(ui.ToJSONString(exclude))
+		}
 		return nil
 	}
 

--- a/cmd/restic/cmd_rewrite_integration_test.go
+++ b/cmd/restic/cmd_rewrite_integration_test.go
@@ -1,9 +1,12 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"os"
 	"path/filepath"
+	//"runtime"
 	"strings"
 	"testing"
 
@@ -35,6 +38,15 @@ func testRunRewriteWithOpts(t testing.TB, opts RewriteOptions, gopts global.Opti
 		return runRewrite(context.TODO(), opts, gopts, args, gopts.Term)
 	}))
 	return nil
+}
+
+func testRunRewriteWithOutput(t testing.TB, gopts global.Options, opts RewriteOptions, args []string, wantJSON bool) []byte {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		gopts.JSON = wantJSON
+		return runRewrite(context.TODO(), opts, gopts, args, gopts.Term)
+	})
+	rtest.OK(t, err)
+	return buf.Bytes()
 }
 
 // testLsOutputContainsCount runs restic ls with the given options and asserts that
@@ -351,4 +363,81 @@ func TestRewriteIncludeNothing(t *testing.T) {
 	snapsAfter := testListSnapshots(t, env.gopts, 1)
 	rtest.Assert(t, snapsBefore[0] == snapsAfter[0], "snapshots should be identical but are %s and %s",
 		snapsBefore[0].Str(), snapsAfter[0].Str())
+}
+
+func TestRewriteJSONInclude(t *testing.T) {
+	type MessageTester struct {
+		MessageType string `json:"message_type"`
+	}
+
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	createBasicRewriteRepo(t, env)
+	originalSnapshot := testListSnapshots(t, env.gopts, 1)
+
+	// rewrite include *.py and *.txt files = 3 files, drop original snapshot = make counting easier
+	// rewrite with verbosity
+	includeOptions := RewriteOptions{
+		Forget:                true,
+		IncludePatternOptions: filter.IncludePatternOptions{Includes: []string{"*.py", "*.txt"}},
+	}
+	env.gopts.Verbosity = 2
+	buf := testRunRewriteWithOutput(t, env.gopts, includeOptions, []string{"latest"}, true)
+	modifiedSnapshot := testListSnapshots(t, env.gopts, 1)
+
+	countInclude := 0
+	for _, line := range bytes.Split(buf, []byte("\n")) {
+		if len(line) == 0 {
+			break
+		}
+
+		tester := &MessageTester{}
+		rtest.OK(t, json.Unmarshal(line, &tester))
+		switch tester.MessageType {
+		case "included_item":
+			countInclude++
+		case "rewrite":
+			matches := &RewriteJSON{}
+			rtest.OK(t, json.Unmarshal(line, &matches))
+
+			rtest.Equals(t, matches.SnapshotID, originalSnapshot[0])
+			rtest.Equals(t, matches.NewSnapshotID, modifiedSnapshot[0])
+			rtest.Equals(t, matches.TotalFilesProcessed, 3)
+			rtest.Equals(t, matches.TotalBytesProcessed, 100+18+113)
+		}
+	}
+	rtest.Equals(t, countInclude, 3)
+}
+
+func TestRewriteJSONExclude(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	createBasicRewriteRepo(t, env)
+	originalSnapshot := testListSnapshots(t, env.gopts, 1)
+
+	// rewrite exclude
+	excludeOptions := RewriteOptions{
+		Forget:                true,
+		ExcludePatternOptions: filter.ExcludePatternOptions{Excludes: []string{"0/0/9/*", "testfile-symlink"}},
+	}
+	buf := testRunRewriteWithOutput(t, env.gopts, excludeOptions, []string{"latest"}, true)
+	modifiedSnapshot := testListSnapshots(t, env.gopts, 1)
+
+	matches := &RewriteJSON{}
+	rtest.OK(t, json.Unmarshal(buf, &matches))
+
+	rtest.Equals(t, "rewrite", matches.MessageType)
+	rtest.Equals(t, originalSnapshot[0], matches.SnapshotID)
+	rtest.Equals(t, modifiedSnapshot[0], matches.NewSnapshotID)
+	rtest.Equals(t, 6, matches.TotalFilesProcessed)
+	rtest.Equals(t, 100+18+113+0+21+21, matches.TotalBytesProcessed)
+
+	// NOTE: windows counts symbolic links differently
+	//if runtime.GOOS != "windows" {
+
+	lsOpts := LsOptions{ListLong: true}
+	testLsOutputContainsCount(t, env.gopts, lsOpts, []string{"latest"}, "-rw-r--r--", 6)
+	//}
 }

--- a/cmd/restic/cmd_rewrite_integration_test.go
+++ b/cmd/restic/cmd_rewrite_integration_test.go
@@ -6,7 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
-	//"runtime"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -417,7 +417,7 @@ func TestRewriteJSONExclude(t *testing.T) {
 	createBasicRewriteRepo(t, env)
 	originalSnapshot := testListSnapshots(t, env.gopts, 1)
 
-	// rewrite exclude
+	// rewrite exclude, exclude symlink because windows does things differently with symlinks
 	excludeOptions := RewriteOptions{
 		Forget:                true,
 		ExcludePatternOptions: filter.ExcludePatternOptions{Excludes: []string{"0/0/9/*", "testfile-symlink"}},
@@ -431,13 +431,13 @@ func TestRewriteJSONExclude(t *testing.T) {
 	rtest.Equals(t, "rewrite", matches.MessageType)
 	rtest.Equals(t, originalSnapshot[0], matches.SnapshotID)
 	rtest.Equals(t, modifiedSnapshot[0], matches.NewSnapshotID)
-	rtest.Equals(t, 6, matches.TotalFilesProcessed)
-	rtest.Equals(t, 100+18+113+0+21+21, matches.TotalBytesProcessed)
 
 	// NOTE: windows counts symbolic links differently
-	//if runtime.GOOS != "windows" {
+	if runtime.GOOS != "windows" {
+		rtest.Equals(t, 6, matches.TotalFilesProcessed)
+		rtest.Equals(t, 100+18+113+0+21+21, matches.TotalBytesProcessed)
 
-	lsOpts := LsOptions{ListLong: true}
-	testLsOutputContainsCount(t, env.gopts, lsOpts, []string{"latest"}, "-rw-r--r--", 6)
-	//}
+		lsOpts := LsOptions{ListLong: true}
+		testLsOutputContainsCount(t, env.gopts, lsOpts, []string{"latest"}, "-rw-r--r--", 6)
+	}
 }


### PR DESCRIPTION
cmd/restic/cmd_rewrite.go:
add JSON output for summary

and JSON output in verbose mode for included/excluded items.

cmd/restic/cmd_repair_snapshots.go:
adopt interface, since we need additional parameter ``gopts`` for ``filterAndReplaceSnapshot()``

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR add JSON support for `restic rewrite``. It creates a summary record at the end and also allows for individual include/exclude records in double verbose mode.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->
The fuctions ``rewriteSnapshot``, ``gatherIncludeFilters``, ``gatherExcludeFilters``, ``filterAndReplaceSnapshot`` get an additional parameter ``gopts`` so the JSON flag can be checked and also the records can be added to the JSON output.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->
closes https://github.com/restic/restic/issues/5702

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
