### PR TITLE
dump: add json progress reporting

### DIFF
--- a/changelog/unreleased/issue-5309
+++ b/changelog/unreleased/issue-5309
@@ -1,0 +1,8 @@
+Enhancement: Add progress reporting for `dump` command
+
+Restic now reports progress for the `dump` command when the `--target` flag
+is specified. At the end of the `dump` command, a summary of the progress is
+reported.
+
+https://github.com/restic/restic/issues/5309
+https://github.com/restic/restic/pull/5366

--- a/changelog/unreleased/issue-5309
+++ b/changelog/unreleased/issue-5309
@@ -1,8 +1,9 @@
 Enhancement: Add progress reporting for `dump` command
 
 Restic now reports progress for the `dump` command when the `--target` flag
-is specified. At the end of the `dump` command, a summary of the progress is
-reported.
+is specified. Progress reporting is also available with the `--json` flag.
+At the end of the `dump` command, a summary of the progress is reported.
 
 https://github.com/restic/restic/issues/5309
 https://github.com/restic/restic/pull/5366
+https://github.com/restic/restic/pull/21933

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -199,11 +199,14 @@ func runDump(ctx context.Context, opts DumpOptions, gopts global.Options, args [
 		canWriteArchiveFunc = func() error { return nil }
 
 		// Initialize progress reporting only when writing to a file
-		if !gopts.JSON {
-			progressPrinter := dumpui.NewTextProgress(term, gopts.Verbosity)
-			progressReporter = dumpui.NewProgress(progressPrinter, gopts.Quiet, gopts.JSON, term.CanUpdateStatus())
-			defer progressReporter.Finish()
+		var progressPrinter dumpui.ProgressPrinter
+		if gopts.JSON {
+			progressPrinter = dumpui.NewJSONProgress(term, gopts.Verbosity)
+		} else {
+			progressPrinter = dumpui.NewTextProgress(term, gopts.Verbosity)
 		}
+		progressReporter = dumpui.NewProgress(progressPrinter, gopts.Quiet, gopts.JSON, term.CanUpdateStatus())
+		defer progressReporter.Finish()
 	}
 
 	d := dump.New(opts.Archive, repo, outputFileWriter)

--- a/cmd/restic/cmd_dump.go
+++ b/cmd/restic/cmd_dump.go
@@ -14,7 +14,10 @@ import (
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	"github.com/restic/restic/internal/ui"
+
 	"github.com/restic/restic/internal/ui/progress"
+
+	dumpui "github.com/restic/restic/internal/ui/dump"
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -181,6 +184,8 @@ func runDump(ctx context.Context, opts DumpOptions, gopts global.Options, args [
 	outputFileWriter := term.OutputRaw()
 	canWriteArchiveFunc := checkStdoutArchive(term)
 
+	// Setup progress reporting for target file
+	var progressReporter *dumpui.Progress
 	if opts.Target != "" {
 		file, err := os.Create(opts.Target)
 		if err != nil {
@@ -192,9 +197,19 @@ func runDump(ctx context.Context, opts DumpOptions, gopts global.Options, args [
 
 		outputFileWriter = file
 		canWriteArchiveFunc = func() error { return nil }
+
+		// Initialize progress reporting only when writing to a file
+		if !gopts.JSON {
+			progressPrinter := dumpui.NewTextProgress(term, gopts.Verbosity)
+			progressReporter = dumpui.NewProgress(progressPrinter, gopts.Quiet, gopts.JSON, term.CanUpdateStatus())
+			defer progressReporter.Finish()
+		}
 	}
 
 	d := dump.New(opts.Archive, repo, outputFileWriter)
+	if progressReporter != nil {
+		d.SetProgressReporter(progressReporter)
+	}
 	err = printFromTree(ctx, tree, repo, "/", splittedPath, d, canWriteArchiveFunc)
 	if err != nil {
 		return errors.Fatalf("cannot dump file: %v", err)

--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -461,6 +461,83 @@ DiffStat object
 | ``bytes``      | Number of bytes                           | uint64 |
 +----------------+-------------------------------------------+--------+
 
+dump
+----
+
+The ``dump`` command uses the JSON lines format with the following message types.
+Progress, error and summary messages are only emitted when ``--target`` is specified;
+without it, the archive is streamed to ``stdout`` and any additional output would
+corrupt it.
+
+Status
+^^^^^^
+
++---------------------+--------------------------------------------------------------------+--------+
+| ``message_type``    | Always "status"                                                    | string |
++---------------------+--------------------------------------------------------------------+--------+
+| ``seconds_elapsed`` | Time since dump started                                            | uint64 |
++---------------------+--------------------------------------------------------------------+--------+
+| ``files_processed`` | Number of files dumped so far                                      | uint64 |
++---------------------+--------------------------------------------------------------------+--------+
+| ``dirs_processed``  | Number of directories dumped so far                                | uint64 |
++---------------------+--------------------------------------------------------------------+--------+
+| ``total_items``     | Total number of items processed (files, directories and symlinks)  | uint64 |
++---------------------+--------------------------------------------------------------------+--------+
+| ``bytes_processed`` | Number of bytes dumped so far                                      | uint64 |
++---------------------+--------------------------------------------------------------------+--------+
+
+Error
+^^^^^
+
+These errors are printed on ``stderr``.
+
++-------------------+-------------------------------------------+--------+
+| ``message_type``  | Always "error"                            | string |
++-------------------+-------------------------------------------+--------+
+| ``error.message`` | Error message                             | string |
++-------------------+-------------------------------------------+--------+
+| ``during``        | Always "dump"                             | string |
++-------------------+-------------------------------------------+--------+
+| ``item``          | Usually, the path of the problematic file | string |
++-------------------+-------------------------------------------+--------+
+
+Verbose Status
+^^^^^^^^^^^^^^
+
+Verbose status provides details about each item as it is dumped.
+Only printed if ``--verbose=2`` is specified.
+
++------------------+-----------------------------------------------+--------+
+| ``message_type`` | Always "verbose_status"                       | string |
++------------------+-----------------------------------------------+--------+
+| ``action``       | Always "dumped"                               | string |
++------------------+-----------------------------------------------+--------+
+| ``node_type``    | Either "file", "dir" or "symlink"             | string |
++------------------+-----------------------------------------------+--------+
+| ``item``         | The path of the item that was dumped          | string |
++------------------+-----------------------------------------------+--------+
+| ``size``         | Size of the item in bytes                     | uint64 |
++------------------+-----------------------------------------------+--------+
+
+Summary
+^^^^^^^
+
+Summary is the last output line of a successful dump.
+
++---------------------+-------------------------------------------------------------------+--------+
+| ``message_type``    | Always "summary"                                                  | string |
++---------------------+-------------------------------------------------------------------+--------+
+| ``seconds_elapsed`` | Total time the dump operation took                                | uint64 |
++---------------------+-------------------------------------------------------------------+--------+
+| ``files_processed`` | Total number of files dumped                                      | uint64 |
++---------------------+-------------------------------------------------------------------+--------+
+| ``dirs_processed``  | Total number of directories dumped                                | uint64 |
++---------------------+-------------------------------------------------------------------+--------+
+| ``total_items``     | Total number of items dumped (files, directories and symlinks)    | uint64 |
++---------------------+-------------------------------------------------------------------+--------+
+| ``bytes_processed`` | Total number of bytes dumped                                      | uint64 |
++---------------------+-------------------------------------------------------------------+--------+
+
 .. _find:
 
 find

--- a/doc/manual_rest.rst
+++ b/doc/manual_rest.rst
@@ -169,7 +169,7 @@ command:
       -v, --verbose                          be verbose (specify multiple times or a level using --verbose=n, max level/times is 2)
 
 Subcommands that support showing progress information such as ``backup``,
-``restore``, ``check`` and ``prune`` will do so unless the quiet flag ``-q``
+``restore``, ``check``, ``dump`` and ``prune`` will do so unless the quiet flag ``-q``
 or ``--quiet`` is set. When running from a non-interactive console progress
 reporting is disabled by default to not fill your logs. For interactive and
 non-interactive consoles the environment variable ``RESTIC_PROGRESS_FPS`` can

--- a/internal/dump/common.go
+++ b/internal/dump/common.go
@@ -15,10 +15,18 @@ import (
 // A Dumper writes trees and files from a repository to a Writer
 // in an archive format.
 type Dumper struct {
-	cache  *bloblru.Cache
-	format string
-	repo   restic.Loader
-	w      io.Writer
+	cache    *bloblru.Cache
+	format   string
+	repo     restic.Loader
+	w        io.Writer
+	progress ProgressReporter
+}
+
+// ProgressReporter is an interface for reporting progress during dump operations
+type ProgressReporter interface {
+	// AddProgress reports progress for any node (file, directory, symlink)
+	AddProgress(item string, size uint64, nodeType data.NodeType)
+	Error(item string, err error) error
 }
 
 func New(format string, repo restic.Loader, w io.Writer) *Dumper {
@@ -28,6 +36,11 @@ func New(format string, repo restic.Loader, w io.Writer) *Dumper {
 		repo:   repo,
 		w:      w,
 	}
+}
+
+// SetProgressReporter sets a progress reporter for the dumper
+func (d *Dumper) SetProgressReporter(progress ProgressReporter) {
+	d.progress = progress
 }
 
 func (d *Dumper) DumpTree(ctx context.Context, tree data.TreeNodeIterator, rootPath string) error {
@@ -109,7 +122,12 @@ func sendNodes(ctx context.Context, repo restic.BlobLoader, root *data.Node, ch 
 // WriteNode writes a file node's contents directly to d's Writer,
 // without caring about d's format.
 func (d *Dumper) WriteNode(ctx context.Context, node *data.Node) error {
-	return d.writeNode(ctx, d.w, node)
+	err := d.writeNode(ctx, d.w, node)
+	if err == nil && d.progress != nil {
+		// Report progress for all node types
+		d.progress.AddProgress(node.Path, node.Size, node.Type)
+	}
+	return err
 }
 
 func (d *Dumper) writeNode(ctx context.Context, w io.Writer, node *data.Node) error {
@@ -126,6 +144,9 @@ func (d *Dumper) writeNode(ctx context.Context, w io.Writer, node *data.Node) er
 				return ctx.Err()
 			case blob := <-ch:
 				if _, err := w.Write(blob); err != nil {
+					if d.progress != nil {
+						_ = d.progress.Error(node.Path, err)
+					}
 					return err
 				}
 			}

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -26,6 +26,9 @@ func (d *Dumper) dumpTar(ctx context.Context, ch <-chan *data.Node) (err error) 
 		if err := d.dumpNodeTar(ctx, node, w); err != nil {
 			return err
 		}
+		if d.progress != nil {
+			d.progress.AddProgress(node.Path, node.Size, node.Type)
+		}
 	}
 	return nil
 }
@@ -51,6 +54,9 @@ func tarIdentifier(id uint32) int {
 func (d *Dumper) dumpNodeTar(ctx context.Context, node *data.Node, w *tar.Writer) error {
 	relPath, err := filepath.Rel("/", node.Path)
 	if err != nil {
+		if d.progress != nil {
+			_ = d.progress.Error(node.Path, err)
+		}
 		return err
 	}
 
@@ -95,6 +101,9 @@ func (d *Dumper) dumpNodeTar(ctx context.Context, node *data.Node, w *tar.Writer
 
 	err = w.WriteHeader(header)
 	if err != nil {
+		if d.progress != nil {
+			_ = d.progress.Error(node.Path, err)
+		}
 		return fmt.Errorf("writing header for %q: %w", node.Path, err)
 	}
 	return d.writeNode(ctx, w, node)

--- a/internal/ui/dump/json.go
+++ b/internal/ui/dump/json.go
@@ -1,0 +1,120 @@
+package dump
+
+import (
+	"time"
+
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/ui"
+	"github.com/restic/restic/internal/ui/progress"
+)
+
+type jsonPrinter struct {
+	restic.Printer
+
+	term      ui.Terminal
+	verbosity uint
+}
+
+// NewJSONProgress creates a new JSON-based progress printer
+func NewJSONProgress(term ui.Terminal, verbosity uint) ProgressPrinter {
+	return &jsonPrinter{
+		Printer:   progress.NewTerminalPrinter(true, verbosity, term),
+		term:      term,
+		verbosity: verbosity,
+	}
+}
+
+func (t *jsonPrinter) print(status interface{}) {
+	t.term.Print(ui.ToJSONString(status))
+}
+
+func (t *jsonPrinter) error(status interface{}) {
+	t.term.Error(ui.ToJSONString(status))
+}
+
+func (t *jsonPrinter) Update(state State, duration time.Duration) {
+	status := statusUpdate{
+		MessageType:    "status",
+		SecondsElapsed: uint64(duration / time.Second),
+		FilesProcessed: state.FilesProcessed,
+		DirsProcessed:  state.DirsProcessed,
+		TotalItems:     state.TotalItems,
+		BytesProcessed: state.BytesProcessed,
+	}
+
+	t.print(status)
+}
+
+func (t *jsonPrinter) Error(item string, err error) error {
+	t.error(errorUpdate{
+		MessageType: "error",
+		Error:       errorObject{err.Error()},
+		During:      "dump",
+		Item:        item,
+	})
+	return nil
+}
+
+func (t *jsonPrinter) CompleteItem(item string, size uint64, nodeType string) {
+	if t.verbosity < 3 {
+		return
+	}
+
+	status := verboseUpdate{
+		MessageType: "verbose_status",
+		Action:      "dumped",
+		NodeType:    nodeType,
+		Item:        item,
+		Size:        size,
+	}
+	t.print(status)
+}
+
+func (t *jsonPrinter) Finish(state State, duration time.Duration) {
+	status := summaryOutput{
+		MessageType:    "summary",
+		SecondsElapsed: uint64(duration / time.Second),
+		FilesProcessed: state.FilesProcessed,
+		DirsProcessed:  state.DirsProcessed,
+		TotalItems:     state.TotalItems,
+		BytesProcessed: state.BytesProcessed,
+	}
+	t.print(status)
+}
+
+type statusUpdate struct {
+	MessageType    string `json:"message_type"` // "status"
+	SecondsElapsed uint64 `json:"seconds_elapsed,omitempty"`
+	FilesProcessed uint64 `json:"files_processed,omitempty"`
+	DirsProcessed  uint64 `json:"dirs_processed,omitempty"`
+	TotalItems     uint64 `json:"total_items,omitempty"`
+	BytesProcessed uint64 `json:"bytes_processed,omitempty"`
+}
+
+type errorObject struct {
+	Message string `json:"message"`
+}
+
+type errorUpdate struct {
+	MessageType string      `json:"message_type"` // "error"
+	Error       errorObject `json:"error"`
+	During      string      `json:"during"`
+	Item        string      `json:"item"`
+}
+
+type verboseUpdate struct {
+	MessageType string `json:"message_type"` // "verbose_status"
+	Action      string `json:"action"`
+	NodeType    string `json:"node_type"`
+	Item        string `json:"item"`
+	Size        uint64 `json:"size"`
+}
+
+type summaryOutput struct {
+	MessageType    string `json:"message_type"` // "summary"
+	SecondsElapsed uint64 `json:"seconds_elapsed,omitempty"`
+	FilesProcessed uint64 `json:"files_processed,omitempty"`
+	DirsProcessed  uint64 `json:"dirs_processed,omitempty"`
+	TotalItems     uint64 `json:"total_items,omitempty"`
+	BytesProcessed uint64 `json:"bytes_processed,omitempty"`
+}

--- a/internal/ui/dump/json_test.go
+++ b/internal/ui/dump/json_test.go
@@ -1,0 +1,50 @@
+package dump
+
+import (
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/ui"
+)
+
+func createJSONProgress() (*ui.MockTerminal, ProgressPrinter) {
+	term := &ui.MockTerminal{}
+	printer := NewJSONProgress(term, 3)
+	return term, printer
+}
+
+func TestJSONPrintUpdate(t *testing.T) {
+	term, printer := createJSONProgress()
+	printer.Update(State{10, 5, 15, 1000}, 5*time.Second)
+	test.Equals(t, []string{"{\"message_type\":\"status\",\"seconds_elapsed\":5,\"files_processed\":10,\"dirs_processed\":5,\"total_items\":15,\"bytes_processed\":1000}\n"}, term.Output)
+}
+
+func TestJSONPrintSummary(t *testing.T) {
+	term, printer := createJSONProgress()
+	printer.Finish(State{20, 10, 30, 2000}, 10*time.Second)
+	test.Equals(t, []string{"{\"message_type\":\"summary\",\"seconds_elapsed\":10,\"files_processed\":20,\"dirs_processed\":10,\"total_items\":30,\"bytes_processed\":2000}\n"}, term.Output)
+}
+
+func TestJSONPrintCompleteItem(t *testing.T) {
+	for _, data := range []struct {
+		nodeType string
+		size     uint64
+		expected string
+	}{
+		{"dir", 0, "{\"message_type\":\"verbose_status\",\"action\":\"dumped\",\"node_type\":\"dir\",\"item\":\"test\",\"size\":0}\n"},
+		{"file", 123, "{\"message_type\":\"verbose_status\",\"action\":\"dumped\",\"node_type\":\"file\",\"item\":\"test\",\"size\":123}\n"},
+		{"symlink", 0, "{\"message_type\":\"verbose_status\",\"action\":\"dumped\",\"node_type\":\"symlink\",\"item\":\"test\",\"size\":0}\n"},
+	} {
+		term, printer := createJSONProgress()
+		printer.CompleteItem("test", data.size, data.nodeType)
+		test.Equals(t, []string{data.expected}, term.Output)
+	}
+}
+
+func TestJSONError(t *testing.T) {
+	term, printer := createJSONProgress()
+	test.Equals(t, printer.Error("/path", errors.New("error \"message\"")), nil)
+	test.Equals(t, []string{"{\"message_type\":\"error\",\"error\":{\"message\":\"error \\\"message\\\"\"},\"during\":\"dump\",\"item\":\"/path\"}\n"}, term.Errors)
+}

--- a/internal/ui/dump/progress.go
+++ b/internal/ui/dump/progress.go
@@ -1,0 +1,114 @@
+package dump
+
+import (
+	"sync"
+	"time"
+
+	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/ui/progress"
+)
+
+// State represents the current progress state of the dump operation
+type State struct {
+	FilesProcessed uint64
+	DirsProcessed  uint64
+	TotalItems     uint64
+	BytesProcessed uint64
+}
+
+// ProgressPrinter is an interface for printing progress information
+type ProgressPrinter interface {
+	Update(state State, duration time.Duration)
+	Error(item string, err error) error
+	CompleteItem(item string, size uint64, nodeType string)
+	Finish(state State, duration time.Duration)
+
+	restic.Printer
+}
+
+// Progress tracks and reports the progress of a dump operation
+type Progress struct {
+	updater progress.Updater
+	m       sync.Mutex
+
+	state   State
+	started time.Time
+
+	printer ProgressPrinter
+}
+
+// NewProgress creates a new Progress tracker
+func NewProgress(printer ProgressPrinter, quiet, json, canUpdateStatus bool) *Progress {
+	return newProgress(printer, progress.CalculateProgressInterval(!quiet, json, canUpdateStatus))
+}
+
+func newProgress(printer ProgressPrinter, interval time.Duration) *Progress {
+	p := &Progress{
+		started: time.Now(),
+		printer: printer,
+	}
+	p.updater = *progress.NewUpdater(interval, p.update)
+	return p
+}
+
+func (p *Progress) update(runtime time.Duration, final bool) {
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	if !final {
+		p.printer.Update(p.state, runtime)
+	} else {
+		p.printer.Finish(p.state, runtime)
+	}
+}
+
+// AddProgress records progress for a node that has been processed
+func (p *Progress) AddProgress(item string, size uint64, nodeType data.NodeType) {
+	if p == nil {
+		return
+	}
+
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	// Increment the appropriate counter based on node type
+	switch nodeType {
+	case data.NodeTypeFile:
+		p.state.FilesProcessed++
+	case data.NodeTypeDir:
+		p.state.DirsProcessed++
+	}
+
+	// Increment total items and bytes for all node types
+	p.state.TotalItems++
+	p.state.BytesProcessed += size
+
+	// Convert nodeType to string for the printer
+	nodeTypeStr := "file"
+	switch nodeType {
+	case data.NodeTypeDir:
+		nodeTypeStr = "dir"
+	case data.NodeTypeSymlink:
+		nodeTypeStr = "symlink"
+	}
+
+	p.printer.CompleteItem(item, size, nodeTypeStr)
+}
+
+// Error reports an error that occurred during the dump operation
+func (p *Progress) Error(item string, err error) error {
+	if p == nil {
+		return nil
+	}
+
+	p.m.Lock()
+	defer p.m.Unlock()
+
+	return p.printer.Error(item, err)
+}
+
+// Finish completes the progress reporting
+func (p *Progress) Finish() {
+	p.updater.Done()
+}

--- a/internal/ui/dump/progress_test.go
+++ b/internal/ui/dump/progress_test.go
@@ -1,0 +1,172 @@
+package dump
+
+import (
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/test"
+)
+
+type printerTraceEntry struct {
+	progress   State
+	duration   time.Duration
+	isFinished bool
+}
+
+type printerTrace []printerTraceEntry
+
+type itemTraceEntry struct {
+	item     string
+	size     uint64
+	nodeType string
+}
+
+type itemTrace []itemTraceEntry
+
+type errorTraceEntry struct {
+	item string
+	err  error
+}
+
+type errorTrace []errorTraceEntry
+
+type mockPrinter struct {
+	restic.Printer
+
+	trace  printerTrace
+	items  itemTrace
+	errors errorTrace
+}
+
+const mockFinishDuration = 42 * time.Second
+
+func (p *mockPrinter) Update(progress State, duration time.Duration) {
+	p.trace = append(p.trace, printerTraceEntry{progress, duration, false})
+}
+
+func (p *mockPrinter) Error(item string, err error) error {
+	p.errors = append(p.errors, errorTraceEntry{item, err})
+	return nil
+}
+
+func (p *mockPrinter) CompleteItem(item string, size uint64, nodeType string) {
+	p.items = append(p.items, itemTraceEntry{item, size, nodeType})
+}
+
+func (p *mockPrinter) Finish(progress State, _ time.Duration) {
+	p.trace = append(p.trace, printerTraceEntry{progress, mockFinishDuration, true})
+}
+
+func testProgress(fn func(progress *Progress) bool) (printerTrace, itemTrace, errorTrace) {
+	printer := &mockPrinter{}
+	progress := newProgress(printer, 0)
+	final := fn(progress)
+	progress.update(0, final)
+	trace := append(printerTrace{}, printer.trace...)
+	items := append(itemTrace{}, printer.items...)
+	errors := append(errorTrace{}, printer.errors...)
+	// cleanup to avoid goroutine leak, but copy trace first
+	progress.Finish()
+	return trace, items, errors
+}
+
+func TestNew(t *testing.T) {
+	result, items, _ := testProgress(func(progress *Progress) bool {
+		return false
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{State{0, 0, 0, 0}, 0, false},
+	}, result)
+	test.Equals(t, itemTrace{}, items)
+}
+
+func TestAddFileProgress(t *testing.T) {
+	fileSize := uint64(100)
+
+	result, items, _ := testProgress(func(progress *Progress) bool {
+		progress.AddProgress("test.txt", fileSize, data.NodeTypeFile)
+		return false
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{State{1, 0, 1, fileSize}, 0, false},
+	}, result)
+	test.Equals(t, itemTrace{
+		itemTraceEntry{item: "test.txt", size: fileSize, nodeType: "file"},
+	}, items)
+}
+
+func TestAddDirProgress(t *testing.T) {
+	result, items, _ := testProgress(func(progress *Progress) bool {
+		progress.AddProgress("test-dir", 0, data.NodeTypeDir)
+		return false
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{State{0, 1, 1, 0}, 0, false},
+	}, result)
+	test.Equals(t, itemTrace{
+		itemTraceEntry{item: "test-dir", size: 0, nodeType: "dir"},
+	}, items)
+}
+
+func TestMultipleItems(t *testing.T) {
+	fileSize := uint64(100)
+
+	result, items, _ := testProgress(func(progress *Progress) bool {
+		progress.AddProgress("test-dir", 0, data.NodeTypeDir)
+		progress.AddProgress("test1.txt", fileSize, data.NodeTypeFile)
+		progress.AddProgress("test2.txt", fileSize*2, data.NodeTypeFile)
+		return false
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{State{2, 1, 3, fileSize * 3}, 0, false},
+	}, result)
+	test.Equals(t, itemTrace{
+		itemTraceEntry{item: "test-dir", size: 0, nodeType: "dir"},
+		itemTraceEntry{item: "test1.txt", size: fileSize, nodeType: "file"},
+		itemTraceEntry{item: "test2.txt", size: fileSize * 2, nodeType: "file"},
+	}, items)
+}
+
+func TestSummaryOnFinish(t *testing.T) {
+	fileSize := uint64(100)
+
+	result, _, _ := testProgress(func(progress *Progress) bool {
+		progress.AddProgress("test-dir", 0, data.NodeTypeDir)
+		progress.AddProgress("test1.txt", fileSize, data.NodeTypeFile)
+		progress.AddProgress("test2.txt", fileSize*2, data.NodeTypeFile)
+		return true
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{State{2, 1, 3, fileSize * 3}, mockFinishDuration, true},
+	}, result)
+}
+
+func TestProgressError(t *testing.T) {
+	err1 := errors.New("err1")
+	err2 := errors.New("err2")
+	_, _, errors := testProgress(func(progress *Progress) bool {
+		test.Equals(t, progress.Error("first", err1), nil)
+		test.Equals(t, progress.Error("second", err2), nil)
+		return true
+	})
+	test.Equals(t, errorTrace{
+		errorTraceEntry{"first", err1},
+		errorTraceEntry{"second", err2},
+	}, errors)
+}
+
+func TestSymlinkProgress(t *testing.T) {
+	result, items, _ := testProgress(func(progress *Progress) bool {
+		progress.AddProgress("test-symlink", 0, data.NodeTypeSymlink)
+		return false
+	})
+	test.Equals(t, printerTrace{
+		printerTraceEntry{State{0, 0, 1, 0}, 0, false},
+	}, result)
+	test.Equals(t, itemTrace{
+		itemTraceEntry{item: "test-symlink", size: 0, nodeType: "symlink"},
+	}, items)
+}

--- a/internal/ui/dump/text.go
+++ b/internal/ui/dump/text.go
@@ -1,0 +1,55 @@
+package dump
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/restic/restic/internal/restic"
+	"github.com/restic/restic/internal/ui"
+	"github.com/restic/restic/internal/ui/progress"
+)
+
+type textPrinter struct {
+	restic.Printer
+
+	term ui.Terminal
+}
+
+// NewTextProgress creates a new text-based progress printer
+func NewTextProgress(term ui.Terminal, verbosity uint) ProgressPrinter {
+	return &textPrinter{
+		Printer: progress.NewTerminalPrinter(false, verbosity, term),
+		term:    term,
+	}
+}
+
+func (t *textPrinter) Update(state State, duration time.Duration) {
+	timeElapsed := ui.FormatDuration(duration)
+	formattedBytesProcessed := ui.FormatBytes(state.BytesProcessed)
+
+	progress := fmt.Sprintf("[%s] %v files, %v dirs, %v total items %s",
+		timeElapsed, state.FilesProcessed, state.DirsProcessed, state.TotalItems, formattedBytesProcessed)
+
+	t.term.SetStatus([]string{progress})
+}
+
+func (t *textPrinter) Error(item string, err error) error {
+	t.E("ignoring error for %s: %s\n", item, err)
+	return nil
+}
+
+func (t *textPrinter) CompleteItem(item string, size uint64, nodeType string) {
+	t.VV("dumped %s %v with size %v", nodeType, item, ui.FormatBytes(size))
+}
+
+func (t *textPrinter) Finish(state State, duration time.Duration) {
+	t.term.SetStatus(nil)
+
+	timeElapsed := ui.FormatDuration(duration)
+	formattedBytesProcessed := ui.FormatBytes(state.BytesProcessed)
+
+	summary := fmt.Sprintf("Summary: Dumped %d files, %d directories, %d total items (%s) in %s",
+		state.FilesProcessed, state.DirsProcessed, state.TotalItems, formattedBytesProcessed, timeElapsed)
+
+	t.term.Print(summary)
+}

--- a/internal/ui/dump/text_test.go
+++ b/internal/ui/dump/text_test.go
@@ -1,0 +1,50 @@
+package dump
+
+import (
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/errors"
+	"github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/ui"
+)
+
+func createTextProgress() (*ui.MockTerminal, ProgressPrinter) {
+	term := &ui.MockTerminal{}
+	printer := NewTextProgress(term, 3)
+	return term, printer
+}
+
+func TestTextPrintUpdate(t *testing.T) {
+	term, printer := createTextProgress()
+	printer.Update(State{10, 5, 15, 1000}, 5*time.Second)
+	test.Equals(t, []string{"[0:05] 10 files, 5 dirs, 15 total items 1000 B"}, term.Output)
+}
+
+func TestTextPrintSummary(t *testing.T) {
+	term, printer := createTextProgress()
+	printer.Finish(State{20, 10, 30, 2000}, 10*time.Second)
+	test.Equals(t, []string{"Summary: Dumped 20 files, 10 directories, 30 total items (1.953 KiB) in 0:10"}, term.Output)
+}
+
+func TestTextPrintCompleteItem(t *testing.T) {
+	for _, data := range []struct {
+		nodeType string
+		size     uint64
+		expected string
+	}{
+		{"dir", 0, "dumped dir test with size 0 B"},
+		{"file", 123, "dumped file test with size 123 B"},
+		{"symlink", 0, "dumped symlink test with size 0 B"},
+	} {
+		term, printer := createTextProgress()
+		printer.CompleteItem("test", data.size, data.nodeType)
+		test.Equals(t, []string{data.expected}, term.Output)
+	}
+}
+
+func TestTextError(t *testing.T) {
+	term, printer := createTextProgress()
+	test.Equals(t, printer.Error("/path", errors.New("error \"message\"")), nil)
+	test.Equals(t, []string{"ignoring error for /path: error \"message\"\n"}, term.Errors)
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
Adds a JSON progress printer for the `dump` command, used when `--json` is specified together with `--target`. It emits JSON lines status, verbose status, error and summary messages, mirroring the format used by `restore`. Also documents the `dump` JSON lines output structure in the scripting manual.

**Depends on #5366** — this is part 3 of 3 of the split of the original PR (see #5366 for context); it is stacked on that branch, so the first commit here belongs to #5366. Marked as draft until #5366 is merged, after which it will be rebased so only the two JSON commits remain.

1. #21932 — integration tests for the existing `dump` behavior
2. #5366 — text progress reporting for `dump --target`
3. **this PR** — JSON progress printer and scripting documentation

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Related to #5309.

Checklist
---------
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (updated in this PR).
- [x] I'm done! This pull request is ready for review. (draft until #5366 is merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
