### PR TITLE
backup - show exclude lines in snapshot - now all variants of *exclude*

### DIFF
--- a/changelog/unreleased/pull-21934
+++ b/changelog/unreleased/pull-21934
@@ -1,0 +1,9 @@
+Enhancement: backup --iexclude, --iexclude-file show exclude lists in snapshot
+
+All exclude options are now shown as part of `restic snapshot --json`. The case
+sensitive excludes are shown under the label "excludes" and
+the case insensitive excludes are shown under the label "case_insensitive_excludes".
+
+https://github.com/restic/restic/issues/1181
+https://github.com/restic/restic/pull/21930
+https://github.com/restic/restic/pull/21934

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -331,7 +331,7 @@ func (opts BackupOptions) Check(gopts global.Options, args []string) error {
 
 // collectRejectByNameFuncs returns a list of all functions which may reject data
 // from being saved in a snapshot based on path only
-func collectRejectByNameFuncs(opts BackupOptions, repo *repository.Repository, warnf func(msg string, args ...any)) (fs []archiver.RejectByNameFunc, err error) {
+func collectRejectByNameFuncs(opts *BackupOptions, repo *repository.Repository, warnf func(msg string, args ...any)) (fs []archiver.RejectByNameFunc, err error) {
 	// exclude restic cache
 	if repo.Cache() != nil {
 		f, err := rejectResticCache(repo)
@@ -548,7 +548,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 	defer progressReporter.Done()
 
 	// rejectByNameFuncs collect functions that can reject items from the backup based on path only
-	rejectByNameFuncs, err := collectRejectByNameFuncs(opts, repo, printer.E)
+	rejectByNameFuncs, err := collectRejectByNameFuncs(&opts, repo, printer.E)
 	if err != nil {
 		return err
 	}
@@ -681,14 +681,15 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 	}
 
 	snapshotOpts := archiver.SnapshotOptions{
-		Excludes:        opts.Excludes,
-		Tags:            opts.Tags.Flatten(),
-		BackupStart:     backupStart,
-		Time:            timeStamp,
-		Hostname:        opts.Host,
-		ParentSnapshot:  parentSnapshot,
-		ProgramVersion:  "restic " + global.Version,
-		SkipIfUnchanged: opts.SkipIfUnchanged,
+		Excludes:            opts.Excludes,
+		InsensitiveExcludes: opts.InsensitiveExcludes,
+		Tags:                opts.Tags.Flatten(),
+		BackupStart:         backupStart,
+		Time:                timeStamp,
+		Hostname:            opts.Host,
+		ParentSnapshot:      parentSnapshot,
+		ProgramVersion:      "restic " + global.Version,
+		SkipIfUnchanged:     opts.SkipIfUnchanged,
 	}
 
 	if !gopts.JSON {

--- a/cmd/restic/cmd_snapshots_integration_test.go
+++ b/cmd/restic/cmd_snapshots_integration_test.go
@@ -3,11 +3,14 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/filter"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
@@ -92,4 +95,72 @@ func TestSnapshotsLatest(t *testing.T) {
 	rtest.OK(t, json.Unmarshal(buf.Bytes(), &snapshots))
 	rtest.Assert(t, len(snapshots) == 1, "expected only one snapshot, got %d", len(snapshots))
 	rtest.Equals(t, snapshots[0].ID.String(), secondSnapshotID, "unexpected snapshot ID")
+}
+
+func TestSnapshotsExcludeItems(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	excludePatterns := []string{"*.c", "*.so", "*.h"}
+	// Create an exclude file with above patterns
+	patternsFile := env.base + "/patternsFile"
+	fileErr := os.WriteFile(patternsFile, []byte(strings.Join(excludePatterns, "\n")), 0600)
+	rtest.OK(t, fileErr)
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{
+		ExcludePatternOptions: filter.ExcludePatternOptions{
+			Excludes:     []string{"quatsch"},
+			ExcludeFiles: []string{patternsFile},
+		},
+	}
+
+	testRunBackup(t, "", []string{env.testdata}, opts, env.gopts)
+
+	buf, err := withCaptureStdout(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
+		gopts.JSON = true
+		opts := SnapshotOptions{Latest: 1}
+		return runSnapshots(ctx, opts, gopts, []string{}, gopts.Term)
+	})
+	rtest.OK(t, err)
+
+	snapshots := []Snapshot{}
+	rtest.OK(t, json.Unmarshal(buf.Bytes(), &snapshots))
+	rtest.Assert(t, len(snapshots) == 1, "expected only one snapshot, got %d", len(snapshots))
+	rtest.Assert(t, len(snapshots[0].Excludes) == 4, "expected 4 exclude items, got %d", len(snapshots[0].Excludes))
+	rtest.Equals(t, "*.h", snapshots[0].Excludes[3])
+}
+
+func TestSnapshotsExcludeCaseInsensitiveItems(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	excludePatterns := []string{"*.c", "*.so", "*.h"}
+	// Create an exclude file with above patterns
+	patternsFile := env.base + "/patternsFile"
+	fileErr := os.WriteFile(patternsFile, []byte(strings.Join(excludePatterns, "\n")), 0600)
+	rtest.OK(t, fileErr)
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{
+		ExcludePatternOptions: filter.ExcludePatternOptions{
+			InsensitiveExcludes:     []string{"quack"},
+			InsensitiveExcludeFiles: []string{patternsFile},
+		},
+	}
+
+	testRunBackup(t, "", []string{env.testdata}, opts, env.gopts)
+
+	buf, err := withCaptureStdout(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
+		gopts.JSON = true
+		opts := SnapshotOptions{Latest: 1}
+		return runSnapshots(ctx, opts, gopts, []string{}, gopts.Term)
+	})
+	rtest.OK(t, err)
+
+	snapshots := []Snapshot{}
+	rtest.OK(t, json.Unmarshal(buf.Bytes(), &snapshots))
+	rtest.Assert(t, len(snapshots) == 1, "expected only one snapshot, got %d", len(snapshots))
+	rtest.Assert(t, len(snapshots[0].InsensitiveExcludes) == 4, "expected 4 exclude items, got %d", len(snapshots[0].InsensitiveExcludes))
+	rtest.Equals(t, "*.h", snapshots[0].InsensitiveExcludes[3])
 }

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -828,13 +828,14 @@ func resolveRelativeTargets(filesys fs.FS, targets []string) ([]backupTarget, er
 
 // SnapshotOptions collect attributes for a new snapshot.
 type SnapshotOptions struct {
-	Tags           data.TagList
-	Hostname       string
-	Excludes       []string
-	BackupStart    time.Time
-	Time           time.Time
-	ParentSnapshot *data.Snapshot
-	ProgramVersion string
+	Tags                data.TagList
+	Hostname            string
+	Excludes            []string
+	InsensitiveExcludes []string
+	BackupStart         time.Time
+	Time                time.Time
+	ParentSnapshot      *data.Snapshot
+	ProgramVersion      string
 	// SkipIfUnchanged omits the snapshot creation if it is identical to the parent snapshot.
 	SkipIfUnchanged bool
 }
@@ -958,6 +959,7 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 
 	sn.ProgramVersion = opts.ProgramVersion
 	sn.Excludes = opts.Excludes
+	sn.InsensitiveExcludes = opts.InsensitiveExcludes
 	if opts.ParentSnapshot != nil {
 		sn.Parent = opts.ParentSnapshot.ID()
 	}

--- a/internal/data/snapshot.go
+++ b/internal/data/snapshot.go
@@ -15,17 +15,18 @@ import (
 
 // Snapshot is the state of a resource at one point in time.
 type Snapshot struct {
-	Time     time.Time  `json:"time"`
-	Parent   *restic.ID `json:"parent,omitempty"`
-	Tree     *restic.ID `json:"tree"`
-	Paths    []string   `json:"paths"`
-	Hostname string     `json:"hostname,omitempty"`
-	Username string     `json:"username,omitempty"`
-	UID      uint32     `json:"uid,omitempty"`
-	GID      uint32     `json:"gid,omitempty"`
-	Excludes []string   `json:"excludes,omitempty"`
-	Tags     []string   `json:"tags,omitempty"`
-	Original *restic.ID `json:"original,omitempty"`
+	Time                time.Time  `json:"time"`
+	Parent              *restic.ID `json:"parent,omitempty"`
+	Tree                *restic.ID `json:"tree"`
+	Paths               []string   `json:"paths"`
+	Hostname            string     `json:"hostname,omitempty"`
+	Username            string     `json:"username,omitempty"`
+	UID                 uint32     `json:"uid,omitempty"`
+	GID                 uint32     `json:"gid,omitempty"`
+	Excludes            []string   `json:"excludes,omitempty"`
+	InsensitiveExcludes []string   `json:"case_insensitive_excludes,omitempty"`
+	Tags                []string   `json:"tags,omitempty"`
+	Original            *restic.ID `json:"original,omitempty"`
 
 	ProgramVersion string           `json:"program_version,omitempty"`
 	Summary        *SnapshotSummary `json:"summary,omitempty"`

--- a/internal/filter/exclude.go
+++ b/internal/filter/exclude.go
@@ -115,7 +115,7 @@ func (opts *ExcludePatternOptions) Empty() bool {
 	return len(opts.Excludes) == 0 && len(opts.InsensitiveExcludes) == 0 && len(opts.ExcludeFiles) == 0 && len(opts.InsensitiveExcludeFiles) == 0
 }
 
-func (opts ExcludePatternOptions) CollectPatterns(warnf func(msg string, args ...any)) ([]RejectByNameFunc, error) {
+func (opts *ExcludePatternOptions) CollectPatterns(warnf func(msg string, args ...any)) ([]RejectByNameFunc, error) {
 	var fs []RejectByNameFunc
 	// add patterns from file
 	if len(opts.ExcludeFiles) > 0 {


### PR DESCRIPTION
This is the extension of PR #21930. Backup can now handle all variants of ``*exclude*``. They will be shown in 2 groups when listing a snapshot in --json mode. The groups are called "excludes" and "case_insensitive_excludes".

internal/filter/exclude.go:
take over all changes from PR#21930

cmd/restic/cmd_backup.go
take over all changes from PR#21930 and add case insensitive filters as well

internal/archiver/archiver.go
take over all changes from PR#21930 and add case insensitive filters as well

internal/data/snapshot.go:
add case insensitive filters as well

most of the changes are due to reformatting

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
``snapshot --json`` can now show all variants of *exclude*. 

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
https://github.com/restic/restic/pull/21930

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
