### PR TITLE
cache: write version file atomically

### DIFF
--- a/changelog/unreleased/issue-21940
+++ b/changelog/unreleased/issue-21940
@@ -1,0 +1,13 @@
+Bugfix: Fix cache initialization race between concurrent restic processes
+
+When several restic processes initialized the same cache directory at the same
+time, one of them could fail to start with an error like `unable to open cache:
+readVersion: strconv.ParseUint: parsing "": invalid syntax`. This happened
+because the cache version file was written in place, so a concurrent process
+could read it while it was still empty.
+
+Restic now writes the cache version file atomically, so that multiple processes
+can safely initialize and share a cache directory at the same time.
+
+https://github.com/restic/restic/issues/21940
+https://github.com/restic/restic/pull/21941

--- a/internal/backend/cache/cache.go
+++ b/internal/backend/cache/cache.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"sync"
 	"time"
@@ -38,6 +39,46 @@ func readVersion(dir string) (v uint, err error) {
 	}
 
 	return uint(ver), nil
+}
+
+// writeVersion atomically writes version to the version file in dir. It writes
+// to a temporary file first and then renames it into place, so that a
+// concurrent restic process initializing the same cache dir never observes a
+// partially-written version file. See
+// https://github.com/restic/restic/issues/21940. This mirrors how cache entries
+// are stored in Save().
+func writeVersion(dir string, version uint) error {
+	f, err := os.CreateTemp(dir, "version-")
+	if err != nil {
+		return errors.WithStack(err)
+	}
+
+	_, err = f.Write(fmt.Appendf(nil, "%d", version))
+	if err != nil {
+		_ = f.Close()
+		_ = os.Remove(f.Name())
+		return errors.WithStack(err)
+	}
+
+	// Close, then rename. Windows doesn't like the reverse order.
+	if err = f.Close(); err != nil {
+		_ = os.Remove(f.Name())
+		return errors.WithStack(err)
+	}
+
+	err = os.Rename(f.Name(), filepath.Join(dir, "version"))
+	if err != nil {
+		_ = os.Remove(f.Name())
+	}
+	if runtime.GOOS == "windows" && errors.Is(err, os.ErrPermission) {
+		// On Windows, renaming over an existing file is ok (os.Rename is
+		// MoveFileExW with MOVEFILE_REPLACE_EXISTING since Go 1.5), but not
+		// when someone else has the file open. Assume that's the case and
+		// that the other process has written the desired version.
+		err = nil
+	}
+
+	return errors.WithStack(err)
 }
 
 const cacheVersion = 1
@@ -125,9 +166,8 @@ func New(id string, basedir string) (c *Cache, err error) {
 	}
 
 	if v < cacheVersion {
-		err = os.WriteFile(filepath.Join(cachedir, "version"), fmt.Appendf(nil, "%d", cacheVersion), fileMode)
-		if err != nil {
-			return nil, errors.WithStack(err)
+		if err = writeVersion(cachedir, cacheVersion); err != nil {
+			return nil, err
 		}
 	}
 

--- a/internal/backend/cache/cache_concurrent_test.go
+++ b/internal/backend/cache/cache_concurrent_test.go
@@ -1,0 +1,41 @@
+package cache
+
+import (
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+// TestNewConcurrent verifies that several restic processes may initialize the
+// same cache directory at the same time without any of them failing.
+// Regression test for https://github.com/restic/restic/issues/21940, where a
+// concurrent reader could observe the partially-written "version" file.
+func TestNewConcurrent(t *testing.T) {
+	basedir := filepath.Join(rtest.TempDir(t), "cache")
+
+	for round := 0; round < 20; round++ {
+		id := restic.NewRandomID().String()
+
+		const n = 32
+		var wg sync.WaitGroup
+		errs := make(chan error, n)
+		for i := 0; i < n; i++ {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				if _, err := New(id, basedir); err != nil {
+					errs <- err
+				}
+			}()
+		}
+		wg.Wait()
+		close(errs)
+
+		for err := range errs {
+			t.Errorf("round %d: New failed: %v", round, err)
+		}
+	}
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

When several restic processes initialize the same cache directory at the same
time, one of them could fail to start with:

```
unable to open cache: readVersion: readVersion: strconv.ParseUint: parsing "": invalid syntax
```

`cache.New` created the cache version file with `os.WriteFile`, which truncates
the file before writing its contents. A concurrent process that read the file
during that short window saw an empty file, so `readVersion`'s
`strconv.ParseUint` failed. Because that error is neither `nil` nor
`os.ErrNotExist`, `New` aborted instead of treating the cache as freshly
initialized.

The version file is now written atomically (write to a temporary file, then
rename it into place), mirroring how cache entries are already stored in
`Save()` for the same reason of letting multiple concurrent restics share one
cache directory. A concurrent reader now sees either no version file or the
complete one.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #21940

Checklist
---------

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
