### PR TITLE
repository: save config before key file during init

### DIFF
--- a/changelog/unreleased/issue-5717
+++ b/changelog/unreleased/issue-5717
@@ -1,15 +1,19 @@
 Bugfix: Save the config file before the key file during `init`
 
 When two `restic init` runs raced against the same empty repository
-location, the backend could end up with two key files but only one config
-file, and the key file that lost the race could remain in the repository
-without ever being tied to a valid config. Depending on which key a client
-picked when opening the repository, this could make `restic` abort with a
-"config or key ... is damaged" error on some clients while others worked
-fine.
+location on a backend that rejects overwriting an existing file (e.g. the
+rest backend), the backend could end up with two key files but only one
+config file, and the key file that lost the race could remain in the
+repository without ever being tied to a valid config. Depending on which
+key a client picked when opening the repository, this could make `restic`
+abort with a "config or key ... is damaged" error on some clients while
+others worked fine.
 
 Restic now writes the config file before the key file during `init`, so
-that a key file is only ever uploaded once its config is already in place.
+that on backends which reject overwrites, a key file is only ever uploaded
+once its config is already in place. This does not help on backends that
+allow in-place overwrites, since the race can then also affect the config
+file itself.
 
 https://github.com/restic/restic/issues/5717
 https://github.com/restic/restic/pull/21944

--- a/changelog/unreleased/issue-5717
+++ b/changelog/unreleased/issue-5717
@@ -12,4 +12,4 @@ Restic now writes the config file before the key file during `init`, so
 that a key file is only ever uploaded once its config is already in place.
 
 https://github.com/restic/restic/issues/5717
-https://github.com/restic/restic/pull/00000
+https://github.com/restic/restic/pull/21944

--- a/changelog/unreleased/issue-5717
+++ b/changelog/unreleased/issue-5717
@@ -1,19 +1,14 @@
 Bugfix: Save the config file before the key file during `init`
 
-When two `restic init` runs raced against the same empty repository
-location on a backend that rejects overwriting an existing file (e.g. the
-rest backend), the backend could end up with two key files but only one
-config file, and the key file that lost the race could remain in the
-repository without ever being tied to a valid config. Depending on which
-key a client picked when opening the repository, this could make `restic`
+When two `restic init` runs raced against the same empty repository on
+the REST backend, the repository could end up with two key files but
+only one config file, leaving a key file that was never tied to a valid
+config. Depending on which key a client picked, this could make `restic`
 abort with a "config or key ... is damaged" error on some clients while
 others worked fine.
 
-Restic now writes the config file before the key file during `init`, so
-that on backends which reject overwrites, a key file is only ever uploaded
-once its config is already in place. This does not help on backends that
-allow in-place overwrites, since the race can then also affect the config
-file itself.
+Restic now writes the config file before the key file during `init`,
+fixing this race for the REST backend.
 
 https://github.com/restic/restic/issues/5717
 https://github.com/restic/restic/pull/21944

--- a/changelog/unreleased/issue-5717
+++ b/changelog/unreleased/issue-5717
@@ -1,0 +1,15 @@
+Bugfix: Save the config file before the key file during `init`
+
+When two `restic init` runs raced against the same empty repository
+location, the backend could end up with two key files but only one config
+file, and the key file that lost the race could remain in the repository
+without ever being tied to a valid config. Depending on which key a client
+picked when opening the repository, this could make `restic` abort with a
+"config or key ... is damaged" error on some clients while others worked
+fine.
+
+Restic now writes the config file before the key file during `init`, so
+that a key file is only ever uploaded once its config is already in place.
+
+https://github.com/restic/restic/issues/5717
+https://github.com/restic/restic/pull/00000

--- a/changelog/unreleased/issue-5717
+++ b/changelog/unreleased/issue-5717
@@ -1,14 +1,12 @@
-Bugfix: Save the config file before the key file during `init`
+Bugfix: Fix damaged repository after concurrent `init` on REST backend
 
 When two `restic init` runs raced against the same empty repository on
-the REST backend, the repository could end up with two key files but
-only one config file, leaving a key file that was never tied to a valid
-config. Depending on which key a client picked, this could make `restic`
-abort with a "config or key ... is damaged" error on some clients while
-others worked fine.
+the REST backend, the repository could end up with a leftover key file
+that did not belong to the stored config. Clients that happened to pick
+that key failed with a "config or key ... is damaged" error.
 
-Restic now writes the config file before the key file during `init`,
-fixing this race for the REST backend.
+Restic now stores the config file before the key file during `init`, so
+the losing run no longer leaves a key file behind.
 
 https://github.com/restic/restic/issues/5717
 https://github.com/restic/restic/pull/21944

--- a/internal/repository/key.go
+++ b/internal/repository/key.go
@@ -203,11 +203,7 @@ func LoadKey(ctx context.Context, s *Repository, id restic.ID) (k *Key, err erro
 }
 
 // AddKey adds a new key to an already existing repository. masterKey is the
-// master key that will be encrypted with the derived key and stored in the
-// new key file; it must not be nil. Callers that want to add a key that
-// shares its master key with an existing one (e.g. `key add`, `key passwd`)
-// pass that key's master key. Callers that create a brand new key generate
-// a fresh master key themselves via crypto.NewRandomKey().
+// master key encrypted and stored in the new key file; it must not be nil.
 func AddKey(ctx context.Context, s *Repository, password, username, hostname string, masterKey *crypto.Key) (*Key, error) {
 	// make sure we have valid KDF parameters
 	if params == nil {

--- a/internal/repository/key.go
+++ b/internal/repository/key.go
@@ -59,12 +59,6 @@ const (
 	KDFMemory = 60
 )
 
-// createMasterKey creates a new master key in the given backend and encrypts
-// it with the password.
-func createMasterKey(ctx context.Context, s *Repository, password string) (*Key, error) {
-	return AddKey(ctx, s, password, "", "", nil)
-}
-
 // openKey tries do decrypt the key specified by name with the given password.
 func openKey(ctx context.Context, s *Repository, id restic.ID, password string) (*Key, error) {
 	if key, ok := testKeyInjection.Load(id); ok {
@@ -208,8 +202,13 @@ func LoadKey(ctx context.Context, s *Repository, id restic.ID) (k *Key, err erro
 	return k, nil
 }
 
-// AddKey adds a new key to an already existing repository.
-func AddKey(ctx context.Context, s *Repository, password, username, hostname string, template *crypto.Key) (*Key, error) {
+// AddKey adds a new key to an already existing repository. masterKey is the
+// master key that will be encrypted with the derived key and stored in the
+// new key file; it must not be nil. Callers that want to add a key that
+// shares its master key with an existing one (e.g. `key add`, `key passwd`)
+// pass that key's master key. Callers that create a brand new key generate
+// a fresh master key themselves via crypto.NewRandomKey().
+func AddKey(ctx context.Context, s *Repository, password, username, hostname string, masterKey *crypto.Key) (*Key, error) {
 	// make sure we have valid KDF parameters
 	if params == nil {
 		p, err := crypto.Calibrate(KDFTimeout, KDFMemory)
@@ -257,13 +256,7 @@ func AddKey(ctx context.Context, s *Repository, password, username, hostname str
 		return nil, err
 	}
 
-	if template == nil {
-		// generate new random master keys
-		newkey.master = crypto.NewRandomKey()
-	} else {
-		// copy master keys from old key
-		newkey.master = template
-	}
+	newkey.master = masterKey
 
 	// encrypt master keys (as json) with user key
 	buf, err := json.Marshal(newkey.master)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -937,20 +937,21 @@ func (r *Repository) Init(ctx context.Context, version uint, password string, ch
 // init creates a new master key with the supplied password and uses it to save
 // the config into the repo.
 //
-// The config is saved before the key so that if two `restic init` calls race
-// against the same (empty) backend location, whichever config write wins
-// still has its corresponding key file durably stored beforehand. Saving the
-// key first would risk the opposite: a key file lingering in the backend
-// whose config got overwritten by a competing init, which can make clients
-// pick an unusable key when opening the repository afterwards.
+// r.key must be set before SaveConfig, since saveUnpacked encrypts the config
+// file with it. The config is then uploaded before the key file so that if
+// two `restic init` calls race against the same (empty) backend location,
+// only the config write that "wins" ends up with a key file uploaded against
+// it. Saving the key first would risk the opposite: a key file uploaded
+// against a config that then gets overwritten by a competing init, which can
+// make clients pick an unusable key when opening the repository afterwards.
 func (r *Repository) init(ctx context.Context, password string, cfg restic.Config) error {
 	masterKey := crypto.NewRandomKey()
-
 	r.key = masterKey
-	r.setConfig(cfg)
+
 	if err := restic.SaveConfig(ctx, &internalRepository{r}, cfg); err != nil {
 		return err
 	}
+	r.setConfig(cfg)
 
 	key, err := AddKey(ctx, r, password, "", "", masterKey)
 	if err != nil {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -937,15 +937,15 @@ func (r *Repository) Init(ctx context.Context, version uint, password string, ch
 // init creates a new master key with the supplied password and uses it to save
 // the config into the repo.
 //
-// r.key must be set before SaveConfig, since saveUnpacked encrypts the config
-// file with it. The config is then uploaded before the key file so that if
-// two `restic init` calls race against the same (empty) backend location,
-// only the config write that "wins" ends up with a key file uploaded against
-// it. Saving the key first would risk the opposite: a key file uploaded
-// against a config that then gets overwritten by a competing init, which can
-// make clients pick an unusable key when opening the repository afterwards.
+// The config is uploaded before the key file. On a backend that rejects
+// overwriting an existing file (e.g. rest), this means that if two `restic
+// init` calls race against the same empty backend location, only the config
+// write that "wins" can have a key file uploaded against it: the loser's
+// config upload fails, so it never gets to upload its key either.
 func (r *Repository) init(ctx context.Context, password string, cfg restic.Config) error {
 	masterKey := crypto.NewRandomKey()
+	// r.key must be set before SaveConfig, since saveUnpacked encrypts the
+	// config file with it.
 	r.key = masterKey
 
 	if err := restic.SaveConfig(ctx, &internalRepository{r}, cfg); err != nil {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -938,10 +938,8 @@ func (r *Repository) Init(ctx context.Context, version uint, password string, ch
 // the config into the repo.
 //
 // The config is uploaded before the key file. On a backend that rejects
-// overwriting an existing file (e.g. rest), this means that if two `restic
-// init` calls race against the same empty backend location, only the config
-// write that "wins" can have a key file uploaded against it: the loser's
-// config upload fails, so it never gets to upload its key either.
+// overwriting an existing file (e.g. rest), a losing concurrent init then
+// fails at the config upload and leaves no stray key file behind.
 func (r *Repository) init(ctx context.Context, password string, cfg restic.Config) error {
 	masterKey := crypto.NewRandomKey()
 	// r.key must be set before SaveConfig, since saveUnpacked encrypts the

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -936,16 +936,28 @@ func (r *Repository) Init(ctx context.Context, version uint, password string, ch
 
 // init creates a new master key with the supplied password and uses it to save
 // the config into the repo.
+//
+// The config is saved before the key so that if two `restic init` calls race
+// against the same (empty) backend location, whichever config write wins
+// still has its corresponding key file durably stored beforehand. Saving the
+// key first would risk the opposite: a key file lingering in the backend
+// whose config got overwritten by a competing init, which can make clients
+// pick an unusable key when opening the repository afterwards.
 func (r *Repository) init(ctx context.Context, password string, cfg restic.Config) error {
-	key, err := createMasterKey(ctx, r, password)
-	if err != nil {
+	masterKey := crypto.NewRandomKey()
+
+	r.key = masterKey
+	r.setConfig(cfg)
+	if err := restic.SaveConfig(ctx, &internalRepository{r}, cfg); err != nil {
 		return err
 	}
 
-	r.key = key.master
+	key, err := AddKey(ctx, r, password, "", "", masterKey)
+	if err != nil {
+		return err
+	}
 	r.keyID = key.ID()
-	r.setConfig(cfg)
-	return restic.SaveConfig(ctx, &internalRepository{r}, cfg)
+	return nil
 }
 
 // Key returns the current master key.

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -516,7 +516,7 @@ func TestNoDoubleInit(t *testing.T) {
 	rtest.Assert(t, strings.Contains(err.Error(), "repository already contains snapshots"), "expected already contains snapshots error, got %q", err)
 }
 
-// saveOrderBackend records the order in which files of interesting types are saved.
+// saveOrderBackend records the types of files in the order they were saved.
 type saveOrderBackend struct {
 	backend.Backend
 	order []backend.FileType

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"math/rand"
 	"path/filepath"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -518,14 +519,11 @@ func TestNoDoubleInit(t *testing.T) {
 // saveOrderBackend records the order in which files of interesting types are saved.
 type saveOrderBackend struct {
 	backend.Backend
-	m     sync.Mutex
 	order []backend.FileType
 }
 
 func (be *saveOrderBackend) Save(ctx context.Context, h backend.Handle, rd backend.RewindReader) error {
-	be.m.Lock()
 	be.order = append(be.order, h.Type)
-	be.m.Unlock()
 	return be.Backend.Save(ctx, h, rd)
 }
 
@@ -544,22 +542,8 @@ func TestInitSavesConfigBeforeKey(t *testing.T) {
 
 	rtest.OK(t, repo.Init(context.TODO(), restic.StableRepoVersion, rtest.TestPassword, nil))
 
-	be.m.Lock()
-	defer be.m.Unlock()
-
-	var keyIdx, configIdx = -1, -1
-	for i, t := range be.order {
-		switch t {
-		case backend.KeyFile:
-			if keyIdx == -1 {
-				keyIdx = i
-			}
-		case backend.ConfigFile:
-			if configIdx == -1 {
-				configIdx = i
-			}
-		}
-	}
+	keyIdx := slices.Index(be.order, backend.KeyFile)
+	configIdx := slices.Index(be.order, backend.ConfigFile)
 
 	rtest.Assert(t, keyIdx != -1, "key file was never saved")
 	rtest.Assert(t, configIdx != -1, "config file was never saved")

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -515,6 +515,57 @@ func TestNoDoubleInit(t *testing.T) {
 	rtest.Assert(t, strings.Contains(err.Error(), "repository already contains snapshots"), "expected already contains snapshots error, got %q", err)
 }
 
+// saveOrderBackend records the order in which files of interesting types are saved.
+type saveOrderBackend struct {
+	backend.Backend
+	m     sync.Mutex
+	order []backend.FileType
+}
+
+func (be *saveOrderBackend) Save(ctx context.Context, h backend.Handle, rd backend.RewindReader) error {
+	be.m.Lock()
+	be.order = append(be.order, h.Type)
+	be.m.Unlock()
+	return be.Backend.Save(ctx, h, rd)
+}
+
+// TestInitSavesConfigBeforeKey makes sure that Init uploads the config file
+// before the key file. If two clients race to init the same repository, the
+// backend can end up storing two key files but only one config file
+// (whichever config write "wins", the other fails e.g. because the backend
+// refuses to overwrite an existing file). Saving the config first means that
+// by the time a key file is uploaded, the config it belongs to is already
+// final, so a client can no longer end up with a key file that was uploaded
+// against a config that gets overwritten afterwards by a competing init.
+func TestInitSavesConfigBeforeKey(t *testing.T) {
+	be := &saveOrderBackend{Backend: mem.New()}
+	repo, err := repository.New(be, repository.Options{})
+	rtest.OK(t, err)
+
+	rtest.OK(t, repo.Init(context.TODO(), restic.StableRepoVersion, rtest.TestPassword, nil))
+
+	be.m.Lock()
+	defer be.m.Unlock()
+
+	var keyIdx, configIdx = -1, -1
+	for i, t := range be.order {
+		switch t {
+		case backend.KeyFile:
+			if keyIdx == -1 {
+				keyIdx = i
+			}
+		case backend.ConfigFile:
+			if configIdx == -1 {
+				configIdx = i
+			}
+		}
+	}
+
+	rtest.Assert(t, keyIdx != -1, "key file was never saved")
+	rtest.Assert(t, configIdx != -1, "config file was never saved")
+	rtest.Assert(t, configIdx < keyIdx, "expected config file (index %d) to be saved before key file (index %d)", configIdx, keyIdx)
+}
+
 func TestSaveBlobAsync(t *testing.T) {
 	repo, _, _ := repository.TestRepositoryWithVersion(t, 2)
 	ctx := context.Background()

--- a/internal/repository/repository_test.go
+++ b/internal/repository/repository_test.go
@@ -528,13 +528,8 @@ func (be *saveOrderBackend) Save(ctx context.Context, h backend.Handle, rd backe
 }
 
 // TestInitSavesConfigBeforeKey makes sure that Init uploads the config file
-// before the key file. If two clients race to init the same repository, the
-// backend can end up storing two key files but only one config file
-// (whichever config write "wins", the other fails e.g. because the backend
-// refuses to overwrite an existing file). Saving the config first means that
-// by the time a key file is uploaded, the config it belongs to is already
-// final, so a client can no longer end up with a key file that was uploaded
-// against a config that gets overwritten afterwards by a competing init.
+// before the key file, such that a failed config write also prevents the key
+// file upload.
 func TestInitSavesConfigBeforeKey(t *testing.T) {
 	be := &saveOrderBackend{Backend: mem.New()}
 	repo, err := repository.New(be, repository.Options{})


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

`restic init` generates the master key and uploads the key file before saving the config file. If two clients run `init` against the same empty repository location around the same time, the backend can end up with two key files but only one config file, since a backend that refuses to overwrite an existing file only lets one of the two config writes succeed. The losing client's key file stays in the repository even though it was never associated with the config that ended up winning. Depending on which key a client happens to pick when opening the repository, this makes some clients fail with a "config or key ... is damaged" error while others work fine.

This reorders `Repository.init` so the config file is saved before the key file is uploaded, fixing the race for the REST backend (backends that allow overwriting an existing file are unaffected). To make that possible, `AddKey` no longer generates a random master key internally — it now takes the master key as a parameter and just encrypts and stores it, so the caller decides when the key is generated. `init` generates the master key in memory, uses it to save the config, and only then calls `AddKey` to persist the key file. The other two callers of `AddKey` (`key add` and `key passwd`) already pass an existing key from `repo.Key()`, so they're unaffected.

Added `TestInitSavesConfigBeforeKey` in `internal/repository/repository_test.go`, which wraps the backend to record the order files are saved in and checks that the config file save happens before the key file save during init. It fails against the old code and passes with the reorder.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Discussed in #5717, following the fix approach MichaelEischer outlined there.

Fixes #5717

I used Claude (Anthropic) to help write this patch and the accompanying test. I read through the surrounding code myself to confirm the reorder is safe (the config save encrypts with the in-memory master key, so it doesn't need the key file to exist on the backend yet).

Checklist
---------

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
