### PR TITLE
check: suggest snapshot repair in JSON summary

### DIFF
--- a/changelog/unreleased/issue-21920
+++ b/changelog/unreleased/issue-21920
@@ -1,0 +1,7 @@
+Enhancement: Suggest snapshot repair in JSON check summaries
+
+The JSON summary from `restic check --json` now sets
+`suggest_repair_snapshots` when damaged snapshot files can be removed with
+`restic repair snapshots --forget`.
+
+https://github.com/restic/restic/issues/21920

--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -418,6 +418,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 	}
 
 	if len(brokenSnapshots) > 0 {
+		summary.HintRepairSnapshots = true
 		printer.E("\nThe repository contains damaged snapshot files. These damaged files must be removed to repair the repository. This can be done using the following commands. Please read the troubleshooting guide at https://restic.readthedocs.io/en/stable/077_troubleshooting.html first.\n\n")
 		printer.E("restic repair snapshots --forget %s\n\n", strings.Join(brokenSnapshots, " "))
 		printer.E("Damaged snapshot files can be caused by backend problems, hardware problems or bugs in restic. Please open an issue at https://github.com/restic/restic/issues/new/choose for further troubleshooting!\n")
@@ -540,11 +541,12 @@ func selectRandomPacksByFileSize(allPacks map[restic.ID]int64, subsetSize int64,
 }
 
 type checkSummary struct {
-	MessageType     string   `json:"message_type"` // "summary"
-	NumErrors       int      `json:"num_errors"`
-	BrokenPacks     []string `json:"broken_packs"`         // run "restic repair packs ID..." and "restic repair snapshots --forget" to remove damaged files
-	HintRepairIndex bool     `json:"suggest_repair_index"` // run "restic repair index"
-	HintPrune       bool     `json:"suggest_prune"`        // run "restic prune"
+	MessageType         string   `json:"message_type"` // "summary"
+	NumErrors           int      `json:"num_errors"`
+	BrokenPacks         []string `json:"broken_packs"`             // run "restic repair packs ID..." and "restic repair snapshots --forget" to remove damaged files
+	HintRepairIndex     bool     `json:"suggest_repair_index"`     // run "restic repair index"
+	HintRepairSnapshots bool     `json:"suggest_repair_snapshots"` // run "restic repair snapshots --forget"
+	HintPrune           bool     `json:"suggest_prune"`            // run "restic prune"
 }
 
 type checkError struct {

--- a/cmd/restic/cmd_check_test.go
+++ b/cmd/restic/cmd_check_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"io/fs"
 	"math"
 	"os"
@@ -13,6 +14,13 @@ import (
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
+
+func TestCheckSummaryJSONSuggestsRepairSnapshots(t *testing.T) {
+	data, err := json.Marshal(checkSummary{HintRepairSnapshots: true})
+	rtest.OK(t, err)
+	rtest.Assert(t, strings.Contains(string(data), `"suggest_repair_snapshots":true`),
+		"expected JSON summary to suggest repairing snapshots, got %s", data)
+}
 
 func TestParsePercentage(t *testing.T) {
 	testCases := []struct {

--- a/cmd/restic/cmd_repair_snapshots_integration_test.go
+++ b/cmd/restic/cmd_repair_snapshots_integration_test.go
@@ -162,6 +162,15 @@ func TestRepairSnapshotsBrokenSnapshots(t *testing.T) {
 	target := hex.EncodeToString(sha256Contents[:])
 	rtest.OK(t, os.WriteFile(filepath.Join(env.repo, "snapshots", target), contents, 0o600))
 
+	var summary checkSummary
+	_, _, err = withCaptureStdoutStderr(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
+		var err error
+		summary, err = runCheck(ctx, CheckOptions{ReadData: true}, gopts, nil, gopts.Term)
+		return err
+	})
+	rtest.Assert(t, err != nil, "expected non nil error after check of damaged repository")
+	rtest.Assert(t, summary.HintRepairSnapshots, "expected check to suggest repairing snapshots")
+
 	// run repair snapshots
 	repairOpts := RepairOptions{Forget: true}
 	env.gopts.BackendTestHook = nil


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

`restic check --json` now sets `suggest_repair_snapshots` in its summary when checking finds damaged snapshot files that can be removed with `restic repair snapshots --forget`.

The human-readable check output already recommended that repair after #21907, but JSON consumers had no equivalent summary signal.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #21920.

Checklist
---------

- [x] Added tests for the JSON contract and damaged-snapshot behavior
- [x] Added an unreleased changelog entry
- [x] Ran focused tests and `go vet ./cmd/restic`
- [x] Ran adjacent `internal/checker` and `internal/data` tests

Validation
----------

- `go test ./cmd/restic -run 'Test(CheckSummaryJSONSuggestsRepairSnapshots|RepairSnapshotsBrokenSnapshots)$' -count=1`
- `go vet ./cmd/restic`
- `go test ./internal/checker ./internal/data -count=1`

The complete `go test ./cmd/restic` suite cannot run cleanly in this Windows checkout because the repository fixture extraction asks Windows `tar.exe` to create a Unix symlink (`testfile-symlink`); the focused integration test itself passes on Windows.
