### PR TITLE
Correct backup progress description

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -57,8 +57,7 @@ still get a nice live status display that looks like this:
 The progress bar shows, from left to right: elapsed time, progress in percent,
 the number of files already processed and their size on the local filesystem,
 followed by the total expected file count and size for the whole backup (these
-totals come from the initial scan used for progress estimation, which can be
-disabled with ``--no-scan``). Next is a counter for the number of files that
+totals come from the initial scan used for progress estimation). Next is a counter for the number of files that
 caused errors (these are logged above the progress bar), and finally an
 estimated time of completion. The file paths displayed below the progress bar
 are the files currently being read by restic.


### PR DESCRIPTION
--no-scan option does not exist

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

<!--
Just aligning the doc with the package : the --no-scan flag is unknown to the package, so should not be in the doc
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
