### PR TITLE
doc: describe the cadence of JSON status messages

### DIFF
--- a/doc/075_scripting.rst
+++ b/doc/075_scripting.rst
@@ -243,6 +243,13 @@ Several commands, in particular long running ones or those that generate a large
 use a format also known as JSON lines. It consists of a stream of new-line separated JSON
 messages. You can determine the nature of the message using the ``message_type`` field.
 
+Messages with type ``status`` are emitted at a regular interval while the command runs,
+by default about ten times per second, regardless of whether the output is a terminal
+or a pipe. Passing ``--quiet`` disables them. The ``RESTIC_PROGRESS_FPS`` environment
+variable overrides both: it sets the number of status updates per second and re-enables
+them even when ``--quiet`` is set. Values below 1 are allowed, for example ``0.0166``
+results in roughly one status message per minute, which is useful when capturing logs.
+
 backup
 ------
 


### PR DESCRIPTION
What does this PR change? Why is this change needed?

The scripting guide (`doc/075_scripting.rst`) documents the JSON lines message formats in detail, but not *when* `status` messages are emitted. While integrating restic into a backup UI we initially believed (from older behaviour and third-party posts) that piped `--json` output only carries the final summary, and worked around it with `RESTIC_PROGRESS_FPS` - only to find out from the source that backup/restore have emitted status lines over pipes by default for a long time, and that only `--quiet` suppresses them.

This PR adds one short paragraph to the general "JSON lines" section stating the actual behaviour:

- status messages are emitted roughly ten times per second by default, terminal or pipe alike,
- `--quiet` disables them,
- `RESTIC_PROGRESS_FPS` overrides both (including re-enabling them under `--quiet`), and fractional values like `0.0166` give one message per minute for log capture (as recommended in #5245).

Documentation-only change, so no changelog entry per the contribution guidelines.

Was the change previously discussed in an issue?

No separate issue; it codifies maintainer statements from #3194 and #5245 and the behaviour introduced in #3264.

Checklist
- [x] I have added documentation for relevant changes (in the docs subdirectory).
- [x] I'm done! This pull request is ready for review.
