### PR TITLE
Ignore future-dated snapshots when selecting latest

### DIFF
--- a/changelog/unreleased/issue-21956
+++ b/changelog/unreleased/issue-21956
@@ -1,0 +1,7 @@
+Bugfix: Ignore future-dated snapshots when selecting `latest`
+
+When a repository contained a future-dated snapshot, commands that select the
+`latest` snapshot could use it. Restic now ignores those snapshots while
+selecting `latest`.
+
+https://github.com/restic/restic/issues/21956

--- a/internal/data/snapshot_find.go
+++ b/internal/data/snapshot_find.go
@@ -51,13 +51,14 @@ func (f *SnapshotFilter) findLatest(ctx context.Context, be restic.Lister, loade
 	f.Paths = absTargets
 
 	var latest *Snapshot
+	now := time.Now()
 
 	err = ForAllSnapshots(ctx, be, loader, nil, func(id restic.ID, snapshot *Snapshot, err error) error {
 		if err != nil {
 			return errors.Errorf("Error loading snapshot %v: %v", id.Str(), err)
 		}
 
-		if !f.TimestampLimit.IsZero() && snapshot.Time.After(f.TimestampLimit) {
+		if snapshot.Time.After(now) || (!f.TimestampLimit.IsZero() && snapshot.Time.After(f.TimestampLimit)) {
 			return nil
 		}
 

--- a/internal/data/snapshot_find_test.go
+++ b/internal/data/snapshot_find_test.go
@@ -3,6 +3,7 @@ package data_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/repository"
@@ -41,6 +42,21 @@ func TestFindLatestSnapshotWithMaxTimestamp(t *testing.T) {
 	}
 
 	if *sn.ID() != *desiredSnapshot.ID() {
+		t.Errorf("FindLatest returned wrong snapshot ID: %v", *sn.ID())
+	}
+}
+
+func TestFindLatestSnapshotIgnoresFutureTimestamp(t *testing.T) {
+	repo := repository.TestRepository(t)
+	wantedSnapshot := data.TestCreateSnapshot(t, repo, time.Now().Add(-time.Hour), 1)
+	data.TestCreateSnapshot(t, repo, time.Now().Add(time.Hour), 1)
+
+	sn, _, err := (&data.SnapshotFilter{}).FindLatest(context.TODO(), repo, repo, "latest")
+	if err != nil {
+		t.Fatalf("FindLatest returned error: %v", err)
+	}
+
+	if *sn.ID() != *wantedSnapshot.ID() {
 		t.Errorf("FindLatest returned wrong snapshot ID: %v", *sn.ID())
 	}
 }


### PR DESCRIPTION
## Summary

- ignore snapshots dated after the selection start when resolving `latest`
- add a regression test covering a future-dated snapshot alongside a valid snapshot
- add the required unreleased changelog entry

## Root cause

`SnapshotFilter.findLatest` honored an explicit timestamp limit but otherwise
accepted any later snapshot. This differed from the retention policy's existing
behavior, which excludes future timestamps.

## Validation

- `go test ./internal/data -count=1`
- `gofmt -d internal/data/snapshot_find.go internal/data/snapshot_find_test.go`
- `git diff --check`

`go test ./...` was also run on Windows. The modified package passed; unrelated
cross-platform tests expect POSIX helper commands such as `true`, `false`, and
`sleep`, which are not available in the default Windows environment.

Fixes #21956
