### PR TITLE
`TestNodeRestoreAt` & `TestOverwriteXattr` – filter out `com.apple.provenance`

### DIFF
--- a/internal/fs/node_test.go
+++ b/internal/fs/node_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -16,6 +17,24 @@ import (
 	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
+
+// systemXattrPrefixes lists macOS-managed xattr namespaces that the OS may
+// stamp onto files independently of restic. They are not meaningful to
+// compare against in tests.
+var systemXattrPrefixes = []string{
+	"com.apple.provenance",
+}
+
+func filterSystemXattrs(attrs []data.ExtendedAttribute) []data.ExtendedAttribute {
+	filtered := attrs[:0:0]
+	for _, attr := range attrs {
+		skip := slices.Contains(systemXattrPrefixes, attr.Name)
+		if !skip {
+			filtered = append(filtered, attr)
+		}
+	}
+	return filtered
+}
 
 func BenchmarkNodeFromFileInfo(t *testing.B) {
 	tempfile, err := os.CreateTemp(t.TempDir(), "restic-test-temp-")
@@ -255,6 +274,9 @@ func TestNodeRestoreAt(t *testing.T) {
 
 				AssertFsTimeEqual(t, "AccessTime", test.Type, test.AccessTime, n2.AccessTime)
 				AssertFsTimeEqual(t, "ModTime", test.Type, test.ModTime, n2.ModTime)
+
+				n2.ExtendedAttributes = filterSystemXattrs(n2.ExtendedAttributes)
+
 				if len(n2.ExtendedAttributes) == 0 {
 					n2.ExtendedAttributes = nil
 				}

--- a/internal/fs/node_xattr_all_test.go
+++ b/internal/fs/node_xattr_all_test.go
@@ -35,6 +35,8 @@ func setAndVerifyXattr(t *testing.T, file string, attrs []data.ExtendedAttribute
 	}
 	rtest.OK(t, nodeFillExtendedAttributes(nodeActual, file, false, t.Logf))
 
+	nodeActual.ExtendedAttributes = filterSystemXattrs(nodeActual.ExtendedAttributes)
+
 	rtest.Assert(t, nodeActual.Equals(*node), "xattr mismatch got %v expected %v", nodeActual.ExtendedAttributes, node.ExtendedAttributes)
 }
 


### PR DESCRIPTION
On recent macOS versions, the OS automatically stamps a `com.apple.provenance` extended attribute onto files created by managed/sandboxed processes (part of the App Management / TCC privacy framework). Your test binary gets this stamp, so:

- The **node** (what restic backed up) has e.g. `[{user.foo [98 97 114]}]`
- The **file on disk after restore** has `[{com.apple.provenance [...]} {user.foo [98 97 114]}]`

The test does an exact comparison and fails. This is purely a test-comparison issue — restic's restore logic is correct; macOS is silently adding system metadata after the write.

This PR is a suggestion to filter out `com.apple.provenance`