### PR TITLE
prune: allow clustering repacked tree blobs by group

### DIFF
--- a/changelog/unreleased/pull-21976
+++ b/changelog/unreleased/pull-21976
@@ -1,0 +1,19 @@
+Enhancement: Cluster repacked tree blobs per snapshot group during prune
+
+When `prune` repacks pack files it rewrites the surviving tree (metadata)
+blobs, by default interleaving the metadata of many hosts into shared
+packs. Since the local cache stores whole metadata packs, clients then
+re-download a large set of packs after every prune, inflating the local
+cache several-fold.
+
+The new `prune --group-by` option clusters the repacked tree blobs of the
+same snapshot group into shared pack files, so each client only needs the
+metadata packs of its own group. Without the option `prune` behaves as
+before. The grouping should match the clients' `backup --group-by`
+(default `host,paths`). Data blobs and deduplication are unaffected, and
+the resulting repository stays compatible with older restic versions. The
+number of groups clustered at once scales with the process
+file-descriptor limit (`ulimit -n`).
+
+https://github.com/restic/restic/pull/21976
+https://forum.restic.net/t/about-restic-local-cache-size/10926

--- a/cmd/restic/cmd_prune.go
+++ b/cmd/restic/cmd_prune.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math"
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 
@@ -68,12 +69,21 @@ type PruneOptions struct {
 
 	SmallPackSize  string
 	SmallPackBytes uint64
+
+	// GroupBy clusters repacked tree (metadata) blobs of the same snapshot
+	// group into shared pack files. When empty (the default) prune does not
+	// group and behaves like a classic prune. It should match the
+	// `backup --group-by` value used by the clients. It is not part of the
+	// limited flag set because `forget` already owns an unrelated `--group-by`
+	// flag (which groups snapshots for retention, not tree blobs for repacking).
+	GroupBy data.SnapshotGroupByOptions
 }
 
 func (opts *PruneOptions) AddFlags(f *pflag.FlagSet) {
 	opts.AddLimitedFlags(f)
 	f.BoolVarP(&opts.DryRun, "dry-run", "n", false, "do not modify the repository, just print what would be done")
 	f.StringVarP(&opts.UnsafeNoSpaceRecovery, "unsafe-recover-no-free-space", "", "", "UNSAFE, READ THE DOCUMENTATION BEFORE USING! Try to recover a repository stuck with no free space. Do not use without trying out 'prune --max-repack-size 0' first.")
+	f.Var(&opts.GroupBy, "group-by", "`group` repacked tree blobs by host, paths and/or tags (comma-separated) to reduce client cache churn; should match the clients' `backup --group-by` (default: no grouping)")
 }
 
 func (opts *PruneOptions) AddLimitedFlags(f *pflag.FlagSet) {
@@ -216,8 +226,8 @@ func runPruneWithRepo(ctx context.Context, opts PruneOptions, gopts global.Optio
 		RepackUncompressed:  opts.RepackUncompressed,
 	}
 
-	plan, err := repository.PlanPrune(ctx, popts, repo, func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) error {
-		return getUsedBlobs(ctx, repo, usedBlobs, ignoreSnapshots, printer)
+	plan, err := repository.PlanPrune(ctx, popts, repo, func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) (map[restic.BlobHandle]uint32, error) {
+		return getUsedBlobs(ctx, repo, usedBlobs, ignoreSnapshots, opts.GroupBy, printer)
 	}, printer)
 	if err != nil {
 		return err
@@ -282,8 +292,15 @@ func printPruneStats(printer restic.Printer, stats repository.PruneStats) error 
 	return nil
 }
 
-func getUsedBlobs(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet, ignoreSnapshots restic.IDSet, printer restic.Printer) error {
-	var snapshotTrees restic.IDs
+// getUsedBlobs fills usedBlobs with the blobs still in use by non-ignored
+// snapshots. When a grouping is requested (a non-empty groupBy), it additionally
+// returns a group id per tree blob so that the repack step can cluster tree
+// blobs of the same snapshot group into shared pack files. Otherwise it returns
+// a nil map and behaves as a classic prune.
+func getUsedBlobs(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet, ignoreSnapshots restic.IDSet, groupBy data.SnapshotGroupByOptions, printer restic.Printer) (map[restic.BlobHandle]uint32, error) {
+	grouping := groupBy.Host || groupBy.Path || groupBy.Tag
+
+	var snapshots data.Snapshots
 	printer.P("loading all snapshots...")
 	err := data.ForAllSnapshots(ctx, repo, repo, ignoreSnapshots,
 		func(id restic.ID, sn *data.Snapshot, err error) error {
@@ -292,23 +309,147 @@ func getUsedBlobs(ctx context.Context, repo restic.Repository, usedBlobs restic.
 				return err
 			}
 			debug.Log("add snapshot %v (tree %v)", id, *sn.Tree)
-			snapshotTrees = append(snapshotTrees, *sn.Tree)
+			snapshots = append(snapshots, sn)
 			return nil
 		})
 	if err != nil {
-		return errors.Fatalf("failed loading snapshot: %v", err)
+		return nil, errors.Fatalf("failed loading snapshot: %v", err)
 	}
 
-	printer.P("finding data that is still in use for %d snapshots", len(snapshotTrees))
+	printer.P("finding data that is still in use for %d snapshots", len(snapshots))
 
 	bar := printer.NewCounter("snapshots")
-	bar.SetMax(uint64(len(snapshotTrees)))
+	bar.SetMax(uint64(len(snapshots)))
 	defer bar.Done()
 
-	err = data.FindUsedBlobs(ctx, repo, snapshotTrees, usedBlobs, bar)
-	if err != nil {
-		return errors.Fatalf("failed finding blobs: %v", err)
+	if !grouping {
+		snapshotTrees := make(restic.IDs, 0, len(snapshots))
+		for _, sn := range snapshots {
+			snapshotTrees = append(snapshotTrees, *sn.Tree)
+		}
+		if err := data.FindUsedBlobs(ctx, repo, snapshotTrees, usedBlobs, bar); err != nil {
+			return nil, errors.Fatalf("failed finding blobs: %v", err)
+		}
+		return nil, nil
 	}
 
-	return nil
+	// Grouped mode: assign each tree blob to a snapshot group so the repack step
+	// can cluster tree blobs of the same group into shared pack files. This is a
+	// single global walk: groupingSet tags every tree blob with the first group
+	// that reaches it, and the shared underlying set makes StreamTrees skip trees
+	// already visited by an earlier group, so each tree is walked exactly once.
+	// Data blobs pass through untouched (they are not grouped).
+	groups, _, err := data.GroupSnapshots(snapshots, groupBy)
+	if err != nil {
+		return nil, errors.Fatalf("failed grouping snapshots: %v", err)
+	}
+
+	// deterministic order of group keys
+	keys := make([]string, 0, len(groups))
+	for k := range groups {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+
+	// group id 0 is reserved for the shared/fallback bucket in the packer, so
+	// real groups start at 1.
+	gs := &groupingSet{inner: usedBlobs, treeGroups: make(map[restic.BlobHandle]uint32)}
+	for i, k := range keys {
+		gs.cur = uint32(i) + 1
+		trees := make(restic.IDs, 0, len(groups[k]))
+		for _, sn := range groups[k] {
+			trees = append(trees, *sn.Tree)
+		}
+		if err := data.FindUsedBlobs(ctx, repo, trees, gs, bar); err != nil {
+			return nil, errors.Fatalf("failed finding blobs: %v", err)
+		}
+	}
+	treeGroups := gs.treeGroups
+
+	// The number of groups we can keep open (and hence localize) is bounded by
+	// the file-descriptor limit. When there are no more groups than that, all are
+	// localized.
+	maxGroups := repository.MaxOpenTreeGroups()
+	if len(keys) <= maxGroups {
+		printer.P("clustering repacked tree blobs into %d group(s) by %q", len(keys), groupBy.String())
+		return treeGroups, nil
+	}
+
+	// More groups than we can keep open: keep only the largest ones by tree-blob
+	// count (a proxy for metadata footprint, which dominates client cache) and
+	// demote the rest to the shared bucket (group 0). No extra walk needed, we
+	// already have the per-blob assignment.
+	printer.P("grouping by %q yields %d groups, localizing the %d largest (open-file limit); raise `ulimit -n` to localize more",
+		groupBy.String(), len(keys), maxGroups)
+	demoteSmallGroups(treeGroups, maxGroups)
+
+	return treeGroups, nil
+}
+
+// groupRank pairs a group id with its tree-blob count, used to rank groups when
+// there are more of them than can be localized at once.
+type groupRank struct {
+	id uint32
+	n  int
+}
+
+// demoteSmallGroups keeps only the maxGroups largest groups (by tree-blob count)
+// in treeGroups, remapping their ids to a dense 1..maxGroups range, and drops
+// every other tree blob so it falls back to the shared bucket (group 0) during
+// repacking. It mutates treeGroups in place.
+func demoteSmallGroups(treeGroups map[restic.BlobHandle]uint32, maxGroups int) {
+	counts := make(map[uint32]int)
+	for _, g := range treeGroups {
+		counts[g]++
+	}
+	ranked := make([]groupRank, 0, len(counts))
+	for id, n := range counts {
+		ranked = append(ranked, groupRank{id: id, n: n})
+	}
+	// largest first, tie-break by id for determinism
+	sort.Slice(ranked, func(i, j int) bool {
+		if ranked[i].n != ranked[j].n {
+			return ranked[i].n > ranked[j].n
+		}
+		return ranked[i].id < ranked[j].id
+	})
+
+	// remap the top maxGroups group ids to dense 1..K; ids not in the map are
+	// demoted to the shared bucket
+	remap := make(map[uint32]uint32, maxGroups)
+	for rank, r := range ranked {
+		if rank >= maxGroups {
+			break
+		}
+		remap[r.id] = uint32(rank) + 1
+	}
+	for bh, g := range treeGroups {
+		if ng, ok := remap[g]; ok {
+			treeGroups[bh] = ng
+		} else {
+			delete(treeGroups, bh)
+		}
+	}
+}
+
+// groupingSet wraps the used-blob set and records, for every tree blob, the
+// first snapshot group (cur) that references it. Data blobs pass through
+// untouched. It implements restic.FindBlobSet. It is not safe for concurrent
+// use; FindUsedBlobs serializes access with its own lock and the grouped walk
+// runs the groups sequentially.
+type groupingSet struct {
+	inner      restic.FindBlobSet
+	treeGroups map[restic.BlobHandle]uint32
+	cur        uint32
+}
+
+func (s *groupingSet) Has(bh restic.BlobHandle) bool { return s.inner.Has(bh) }
+
+func (s *groupingSet) Insert(bh restic.BlobHandle) {
+	if bh.Type == restic.TreeBlob {
+		if _, ok := s.treeGroups[bh]; !ok {
+			s.treeGroups[bh] = s.cur
+		}
+	}
+	s.inner.Insert(bh)
 }

--- a/cmd/restic/cmd_prune_integration_test.go
+++ b/cmd/restic/cmd_prune_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/restic/restic/internal/backend"
+	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/repository"
 	rtest "github.com/restic/restic/internal/test"
@@ -257,6 +258,44 @@ func TestPruneRepackSmallerThanSmoke(t *testing.T) {
 		SmallPackSize: "500M",
 		MaxUnused:     "5%",
 	})
+}
+
+// TestPruneGroupBy exercises `prune --group-by` end to end: it repacks tree
+// blobs of two snapshot groups (by host) and verifies that the repository stays
+// sound and fully readable afterwards. The grouping mechanics themselves are
+// covered by the unit tests (demoteSmallGroups, groupingSet, packer buckets);
+// here we only make sure the command path works and does not lose blobs.
+func TestPruneGroupBy(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+
+	// two snapshots under host "foo" and one under host "bar", so grouping by
+	// host yields two groups once the first snapshot is forgotten.
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9")}, BackupOptions{Host: "foo"}, env.gopts)
+	firstSnapshot := testListSnapshots(t, env.gopts, 1)[0]
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "2")}, BackupOptions{Host: "foo"}, env.gopts)
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9", "3")}, BackupOptions{Host: "bar"}, env.gopts)
+	testListSnapshots(t, env.gopts, 3)
+
+	// forget the first snapshot to create unused blobs so that prune repacks
+	testRunForget(t, env.gopts, ForgetOptions{}, firstSnapshot.String())
+
+	// MaxUnused 0% forces repacking of every pack holding unused blobs; grouping
+	// by host clusters the surviving tree blobs of "foo" and "bar" separately.
+	testRunPrune(t, env.gopts, PruneOptions{
+		MaxUnused: "0%",
+		GroupBy:   data.SnapshotGroupByOptions{Host: true},
+	})
+
+	// the remaining snapshots must survive and the repository must still verify
+	// with its data read back in full.
+	testListSnapshots(t, env.gopts, 2)
+	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
+		_, err := runCheck(context.TODO(), CheckOptions{ReadData: true}, gopts, nil, gopts.Term)
+		return err
+	}))
 }
 
 func TestPruneJSON(t *testing.T) {

--- a/cmd/restic/cmd_prune_test.go
+++ b/cmd/restic/cmd_prune_test.go
@@ -1,0 +1,101 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/restic/restic/internal/restic"
+	rtest "github.com/restic/restic/internal/test"
+)
+
+// treeHandle returns a distinct tree-blob handle for the given seed.
+func treeHandle(seed byte) restic.BlobHandle {
+	var id restic.ID
+	id[0] = seed
+	return restic.BlobHandle{ID: id, Type: restic.TreeBlob}
+}
+
+// dataHandle returns a distinct data-blob handle for the given seed.
+func dataHandle(seed byte) restic.BlobHandle {
+	var id restic.ID
+	id[0] = seed
+	return restic.BlobHandle{ID: id, Type: restic.DataBlob}
+}
+
+// buildTreeGroups assigns `count` distinct tree blobs to each listed group id.
+// The seed keeps handles unique across groups.
+func buildTreeGroups(perGroup map[uint32]int) map[restic.BlobHandle]uint32 {
+	tg := make(map[restic.BlobHandle]uint32)
+	seed := byte(0)
+	for g, n := range perGroup {
+		for i := 0; i < n; i++ {
+			tg[treeHandle(seed)] = g
+			seed++
+		}
+	}
+	return tg
+}
+
+func TestDemoteSmallGroups(t *testing.T) {
+	// four groups with 1/3/2/3 tree blobs; keep the two largest. Ranking is by
+	// count, tie broken by ascending id, so groups 2 and 4 (both count 3) win
+	// and are remapped to the dense range 1..2; groups 1 and 3 are dropped so
+	// their blobs fall back to the shared bucket.
+	tg := buildTreeGroups(map[uint32]int{1: 1, 2: 3, 3: 2, 4: 3})
+	demoteSmallGroups(tg, 2)
+
+	counts := make(map[uint32]int)
+	for _, g := range tg {
+		counts[g]++
+	}
+
+	// only the dense ids 1 and 2 must survive, with the original counts (3 each)
+	rtest.Equals(t, map[uint32]int{1: 3, 2: 3}, counts)
+}
+
+func TestDemoteSmallGroupsNoOp(t *testing.T) {
+	// budget >= number of groups: nothing is dropped, but ids are still
+	// remapped to a dense 1..K range (here already dense, so unchanged counts).
+	tg := buildTreeGroups(map[uint32]int{1: 2, 2: 1, 3: 4})
+	demoteSmallGroups(tg, 3)
+
+	counts := make(map[uint32]int)
+	for _, g := range tg {
+		counts[g]++
+	}
+	rtest.Equals(t, map[uint32]int{1: 4, 2: 2, 3: 1}, counts)
+}
+
+// fakeBlobSet is a minimal restic.FindBlobSet backed by a map, used to verify
+// that groupingSet forwards every insert to the underlying set.
+type fakeBlobSet map[restic.BlobHandle]struct{}
+
+func (s fakeBlobSet) Has(bh restic.BlobHandle) bool { _, ok := s[bh]; return ok }
+func (s fakeBlobSet) Insert(bh restic.BlobHandle)   { s[bh] = struct{}{} }
+
+func TestGroupingSet(t *testing.T) {
+	inner := fakeBlobSet{}
+	gs := &groupingSet{inner: inner, treeGroups: make(map[restic.BlobHandle]uint32)}
+
+	tree := treeHandle(1)
+	data := dataHandle(2)
+
+	// group 1 reaches the tree blob and a data blob first
+	gs.cur = 1
+	gs.Insert(tree)
+	gs.Insert(data)
+
+	// group 2 reaches the same tree blob later; the first group must win
+	gs.cur = 2
+	gs.Insert(tree)
+
+	// only tree blobs are recorded, and with the first group that reached them
+	rtest.Equals(t, map[restic.BlobHandle]uint32{tree: 1}, gs.treeGroups)
+
+	// every handle, tree or data, is forwarded to the underlying set
+	rtest.Assert(t, inner.Has(tree), "tree blob not forwarded to inner set")
+	rtest.Assert(t, inner.Has(data), "data blob not forwarded to inner set")
+
+	// Has delegates to the underlying set
+	rtest.Assert(t, gs.Has(tree), "Has should report a forwarded blob as present")
+	rtest.Assert(t, !gs.Has(treeHandle(9)), "Has should report an unknown blob as absent")
+}

--- a/doc/047_tuning_parameters.rst
+++ b/doc/047_tuning_parameters.rst
@@ -120,6 +120,35 @@ increases the chance of these files being written to disk. This can increase dis
 for SSDs.
 
 
+.. _tuning-prune-group-by:
+
+Reducing client cache churn after prune
+=======================================
+
+When ``prune`` repacks pack files, it rewrites the surviving tree (metadata)
+blobs into new packs. By default the metadata of many hosts ends up interleaved
+in shared packs. Because the local cache stores whole metadata packs, a client
+then has to re-download a large set of packs on its next backup just to read its
+own parent snapshot, which can inflate the local cache size several-fold after
+every prune.
+
+Passing ``prune --group-by`` mitigates this by clustering the repacked tree blobs
+of the same snapshot group into shared pack files (see :ref:`customize-pruning`).
+Without the option, ``prune`` does not group and behaves as before. The grouping
+should match the ``--group-by`` value the clients use for ``backup`` (default
+``host,paths``). Only tree blobs that are actually repacked are affected; data
+blobs and deduplication are unchanged, and the produced repository remains fully
+compatible with older restic versions.
+
+The number of groups that can be clustered at once is bounded by the process
+file-descriptor limit (each open group holds one temporary pack file), so it
+scales with ``ulimit -n`` rather than a dedicated option. When there are more
+groups than the limit allows, the largest groups by metadata footprint are
+clustered and the remainder share a common pack file. The effect is gradual: it
+accrues over repeated backup, ``forget`` and ``prune`` cycles as metadata is
+repacked.
+
+
 Feature flags
 =============
 

--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -503,6 +503,18 @@ The ``prune`` command accepts the following options:
   ``--repack-smaller-than``. This allows repacking packfiles that initially came from a
   repository with a smaller ``--pack-size`` to be compacted into larger packfiles.
 
+- ``--group-by`` clusters the repacked tree (metadata) blobs by snapshot group,
+  so that the metadata of a single group ends up in shared pack files instead of
+  being scattered across packs shared by many hosts. This reduces the local cache
+  churn that clients experience after a prune: each client then only has to
+  download the metadata packs of its own group on the next backup. By default no
+  grouping is performed (a classic prune); when set, the value should match the
+  ``--group-by`` used for ``backup`` (default ``host,paths``). It only affects
+  blobs that are actually repacked, and leaves data blobs and deduplication
+  untouched. The number of groups that can be localized scales with the process
+  file-descriptor limit (see :ref:`tuning-prune-group-by`); groups beyond it
+  share a common pack file.
+
 -  ``--dry-run`` only show what ``prune`` would do.
 
 -  ``--verbose`` increased verbosity shows additional statistics for ``prune``.

--- a/internal/repository/open_groups.go
+++ b/internal/repository/open_groups.go
@@ -1,0 +1,41 @@
+package repository
+
+// These constants govern how many snapshot groups a grouped prune
+// (`prune --group-by`) keeps open simultaneously. Each open group holds one
+// temporary pack file, so the budget is derived from the process
+// file-descriptor limit rather than a dedicated command-line option: operators
+// scale it with `ulimit -n`.
+const (
+	// openFDReserve is the number of file descriptors kept aside for backend
+	// connections, index files and other open handles when deriving the budget
+	// from the file-descriptor limit.
+	openFDReserve = 128
+	// minOpenTreeGroups and maxOpenTreeGroupsCap clamp the derived budget. The
+	// upper bound also limits worst-case temporary disk usage during a grouped
+	// repack (roughly maxOpenTreeGroupsCap * packSize).
+	minOpenTreeGroups    = 32
+	maxOpenTreeGroupsCap = 2048
+	// defaultOpenTreeGroups is used when the file-descriptor limit cannot be
+	// determined (non-Linux platforms or a failed query).
+	defaultOpenTreeGroups = 256
+)
+
+// MaxOpenTreeGroups returns how many snapshot groups may have an open pack file
+// at the same time during a grouped prune, and equivalently how many groups
+// prune will localize. Groups beyond this budget share a common pack (they lose
+// locality but are still packed normally). The value is derived from the process
+// file-descriptor limit so it scales with `ulimit -n` without a dedicated
+// option.
+func MaxOpenTreeGroups() int {
+	return clampOpenTreeGroups(openTreeGroupsBudget())
+}
+
+func clampOpenTreeGroups(n int) int {
+	if n < minOpenTreeGroups {
+		return minOpenTreeGroups
+	}
+	if n > maxOpenTreeGroupsCap {
+		return maxOpenTreeGroupsCap
+	}
+	return n
+}

--- a/internal/repository/open_groups_linux.go
+++ b/internal/repository/open_groups_linux.go
@@ -1,0 +1,21 @@
+//go:build linux
+
+package repository
+
+import "golang.org/x/sys/unix"
+
+// openTreeGroupsBudget derives the grouped-repack budget from the soft
+// file-descriptor limit (RLIMIT_NOFILE), reserving some descriptors for other
+// open handles. The result is clamped by the caller (MaxOpenTreeGroups).
+func openTreeGroupsBudget() int {
+	var rlim unix.Rlimit
+	if err := unix.Getrlimit(unix.RLIMIT_NOFILE, &rlim); err != nil {
+		return defaultOpenTreeGroups
+	}
+	// rlim.Cur is the soft limit (uint64 on Linux). Guard against very large or
+	// "infinity" values before narrowing to int; the clamp caps it anyway.
+	if rlim.Cur > uint64(maxOpenTreeGroupsCap+openFDReserve) {
+		return maxOpenTreeGroupsCap
+	}
+	return int(rlim.Cur) - openFDReserve
+}

--- a/internal/repository/open_groups_other.go
+++ b/internal/repository/open_groups_other.go
@@ -1,0 +1,11 @@
+//go:build !linux
+
+package repository
+
+// openTreeGroupsBudget returns a fixed default on platforms where the
+// file-descriptor limit is not queried. The grouped-repack feature is primarily
+// targeted at Linux backup servers; extending this to other unix systems is a
+// matter of adding a Getrlimit call analogous to the Linux implementation.
+func openTreeGroupsBudget() int {
+	return defaultOpenTreeGroups
+}

--- a/internal/repository/open_groups_test.go
+++ b/internal/repository/open_groups_test.go
@@ -1,0 +1,30 @@
+package repository
+
+import "testing"
+
+func TestClampOpenTreeGroups(t *testing.T) {
+	for _, tc := range []struct {
+		in, want int
+	}{
+		{-100, minOpenTreeGroups},
+		{0, minOpenTreeGroups},
+		{minOpenTreeGroups - 1, minOpenTreeGroups},
+		{minOpenTreeGroups, minOpenTreeGroups},
+		{500, 500},
+		{maxOpenTreeGroupsCap, maxOpenTreeGroupsCap},
+		{maxOpenTreeGroupsCap + 1, maxOpenTreeGroupsCap},
+		{1 << 30, maxOpenTreeGroupsCap},
+	} {
+		if got := clampOpenTreeGroups(tc.in); got != tc.want {
+			t.Errorf("clampOpenTreeGroups(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}
+
+func TestMaxOpenTreeGroups(t *testing.T) {
+	// whatever the platform / limit, the result must be within the clamp range
+	n := MaxOpenTreeGroups()
+	if n < minOpenTreeGroups || n > maxOpenTreeGroupsCap {
+		t.Errorf("MaxOpenTreeGroups() = %d, want within [%d, %d]", n, minOpenTreeGroups, maxOpenTreeGroupsCap)
+	}
+}

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -29,27 +29,47 @@ type packer struct {
 }
 
 // packerManager keeps a list of open packs and creates new on demand.
+//
+// Open packers are bucketed by a caller-supplied group id. Blobs written with
+// the same group id end up in the same pack files, blobs of different groups are
+// kept apart. Regular callers (backup, copy) always use group 0, so there is a
+// single bucket and the behaviour is identical to a flat list of packers.
+// `prune --group-by` uses this to cluster repacked tree blobs of the same
+// snapshot group.
 type packerManager struct {
 	tpe     restic.BlobType
 	key     *crypto.Key
 	queueFn func(ctx context.Context, t restic.BlobType, p *packer) error
 
-	pm       sync.Mutex
-	packers  []*packer
-	packSize uint
+	pm          sync.Mutex
+	packers     map[uint32][]*packer
+	packerCount int
+	packSize    uint
+
+	// maxOpenGroups bounds the number of groups with open packers. Each open
+	// packer holds an open temporary file, so this limits file-descriptor and
+	// temp-disk usage, not memory (packers stream to a tmpfile). Once the limit
+	// is reached, blobs of further new groups fall back to the shared bucket
+	// (group 0), i.e. they lose locality but are still packed normally. Groups
+	// are never flushed early, so this never produces undersized packs. Zero
+	// means unlimited.
+	maxOpenGroups int
 }
 
 const defaultPackerCount = 2
 
 // newPackerManager returns a new packer manager which writes temporary files
-// to a temporary directory
+// to a temporary directory. The number of groups kept open simultaneously is
+// derived from the process file-descriptor limit, see MaxOpenTreeGroups.
 func newPackerManager(key *crypto.Key, tpe restic.BlobType, packSize uint, packerCount int, queueFn func(ctx context.Context, t restic.BlobType, p *packer) error) *packerManager {
 	return &packerManager{
-		tpe:      tpe,
-		key:      key,
-		queueFn:  queueFn,
-		packers:  make([]*packer, packerCount),
-		packSize: packSize,
+		tpe:           tpe,
+		key:           key,
+		queueFn:       queueFn,
+		packers:       make(map[uint32][]*packer),
+		packerCount:   packerCount,
+		packSize:      packSize,
+		maxOpenGroups: MaxOpenTreeGroups(),
 	}
 }
 
@@ -57,7 +77,18 @@ func (r *packerManager) Flush(ctx context.Context) error {
 	r.pm.Lock()
 	defer r.pm.Unlock()
 
-	pendingPackers, err := r.mergePackers()
+	for group := range r.packers {
+		if err := r.flushGroup(ctx, group); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// flushGroup merges and queues all open packers of a single group. The caller
+// must hold r.pm.
+func (r *packerManager) flushGroup(ctx context.Context, group uint32) error {
+	pendingPackers, err := r.mergePackers(group)
 	if err != nil {
 		return err
 	}
@@ -72,19 +103,24 @@ func (r *packerManager) Flush(ctx context.Context) error {
 	return nil
 }
 
-// mergePackers merges small pack files before those are uploaded by Flush(). The main
-// purpose of this method is to reduce information leaks if a small file is backed up
-// and the blobs end up in separate pack files. If the file only consists of two blobs
-// this would leak the size of the individual blobs.
-func (r *packerManager) mergePackers() ([]*packer, error) {
+// mergePackers merges small pack files of the given group before those are
+// uploaded by Flush(). The main purpose of this method is to reduce information
+// leaks if a small file is backed up and the blobs end up in separate pack
+// files. If the file only consists of two blobs this would leak the size of the
+// individual blobs. Only packers of the same group are merged so that grouping
+// is preserved. The caller must hold r.pm.
+func (r *packerManager) mergePackers(group uint32) ([]*packer, error) {
+	packers := r.packers[group]
+	// the group's packers are consumed here, drop the now-empty bucket
+	delete(r.packers, group)
+
 	pendingPackers := []*packer{}
 	var p *packer
-	for i, packer := range r.packers {
+	for _, packer := range packers {
 		if packer == nil {
 			continue
 		}
 
-		r.packers[i] = nil
 		if p == nil {
 			p = packer
 		} else if p.Size()+packer.Size() < r.packSize {
@@ -113,11 +149,13 @@ func (r *packerManager) mergePackers() ([]*packer, error) {
 	return pendingPackers, nil
 }
 
-func (r *packerManager) SaveBlob(ctx context.Context, t restic.BlobType, id restic.ID, ciphertext []byte, uncompressedLength int) (int, error) {
+func (r *packerManager) SaveBlob(ctx context.Context, t restic.BlobType, id restic.ID, ciphertext []byte, uncompressedLength int, group uint32) (int, error) {
 	r.pm.Lock()
 	defer r.pm.Unlock()
 
-	packer, err := r.pickPacker(len(ciphertext))
+	// pickPacker may remap the blob to the shared bucket (group 0) when too many
+	// groups are already open, so use the returned effective group afterwards.
+	packer, effGroup, err := r.pickPacker(len(ciphertext), group)
 	if err != nil {
 		return 0, err
 	}
@@ -136,7 +174,7 @@ func (r *packerManager) SaveBlob(ctx context.Context, t restic.BlobType, id rest
 	}
 
 	// forget full packer
-	r.forgetPacker(packer)
+	r.forgetPacker(packer, effGroup)
 
 	// call while holding lock to prevent findPacker from creating new packers if the uploaders are busy
 	// else write the pack to the backend
@@ -157,43 +195,99 @@ func randomInt(max int) (int, error) {
 	return int(randomInt.Int64()), nil
 }
 
-// pickPacker returns or creates a randomly selected packer into which the blob should be stored. If the
-// ciphertext is larger than the packSize, a new packer is returned.
-func (r *packerManager) pickPacker(ciphertextLen int) (*packer, error) {
+// pickPacker returns or creates a randomly selected packer for the given group
+// into which the blob should be stored, together with the effective group it was
+// placed in (which may differ from the requested one, see below). If the
+// ciphertext is larger than the packSize, a new standalone packer is returned.
+// The caller must hold r.pm.
+func (r *packerManager) pickPacker(ciphertextLen int, group uint32) (*packer, uint32, error) {
 	// use separate packer if compressed length is larger than the packsize
 	// this speeds up the garbage collection of oversized blobs and reduces the cache size
 	// as the oversize blobs are only downloaded if necessary
 	if ciphertextLen >= int(r.packSize) {
-		return r.newPacker()
+		p, err := r.newPacker()
+		return p, group, err
+	}
+
+	// Once too many groups are open, further new groups fall back to the shared
+	// bucket (group 0). This bounds open temporary files and, crucially, avoids
+	// flushing partially filled packers early (which would create many tiny
+	// packs). Overflow groups simply lose locality, they are packed as before.
+	// The shared bucket itself is always allowed and does not count against the
+	// budget, so exactly maxOpenGroups groups can be localized.
+	//
+	// In the prune path this fallback is normally never hit: getUsedBlobs
+	// already caps the number of distinct groups to MaxOpenTreeGroups() (the
+	// same value maxOpenGroups is derived from) before assigning them. This
+	// second cap is a safety net that also bounds any other/future caller that
+	// hands out group ids without pre-capping.
+	if group != 0 {
+		if _, ok := r.packers[group]; !ok && r.maxOpenGroups > 0 && r.openGroupCount() >= r.maxOpenGroups {
+			group = 0
+		}
+	}
+
+	slots, ok := r.packers[group]
+	if !ok {
+		// The shared bucket keeps packerCount packers so the anti-chunking-attack
+		// mitigation (random distribution) applies to regular backups. Grouped
+		// buckets use a single packer: it packs tighter (fewer partial packs) and
+		// halves the open-file count, and the mitigation is not relevant for
+		// already-chunked blobs that are merely being repacked.
+		slotCount := 1
+		if group == 0 {
+			slotCount = r.packerCount
+		}
+		slots = make([]*packer, slotCount)
+		r.packers[group] = slots
 	}
 
 	// randomly distribute blobs onto multiple packer instances. This makes it harder for
 	// an attacker to learn at which points a file was chunked and therefore mitigates the attack described in
 	// https://www.daemonology.net/blog/chunking-attacks.pdf .
 	// See https://github.com/restic/restic/issues/5291#issuecomment-2746146193 for details on the mitigation.
-	idx, err := randomInt(len(r.packers))
+	idx, err := randomInt(len(slots))
 	if err != nil {
-		return nil, err
+		return nil, group, err
 	}
 
 	// retrieve packer or get a new one
-	packer := r.packers[idx]
+	packer := slots[idx]
 	if packer == nil {
 		packer, err = r.newPacker()
 		if err != nil {
-			return nil, err
+			return nil, group, err
 		}
-		r.packers[idx] = packer
+		slots[idx] = packer
 	}
-	return packer, nil
+	return packer, group, nil
 }
 
-// forgetPacker drops the given packer from the internal list. This is used to forget full packers.
-func (r *packerManager) forgetPacker(packer *packer) {
-	for i, p := range r.packers {
+// openGroupCount returns the number of localized groups that currently have an
+// open packer, excluding the shared bucket (group 0). The caller must hold r.pm.
+func (r *packerManager) openGroupCount() int {
+	n := len(r.packers)
+	if _, ok := r.packers[0]; ok {
+		n--
+	}
+	return n
+}
+
+// forgetPacker drops the given packer from the given group. This is used to forget full packers.
+func (r *packerManager) forgetPacker(packer *packer, group uint32) {
+	slots := r.packers[group]
+	allNil := true
+	for i, p := range slots {
 		if packer == p {
-			r.packers[i] = nil
+			slots[i] = nil
 		}
+		if slots[i] != nil {
+			allNil = false
+		}
+	}
+	// drop the bucket once empty so it no longer counts against maxOpenGroups
+	if allNil {
+		delete(r.packers, group)
 	}
 }
 

--- a/internal/repository/packer_manager_test.go
+++ b/internal/repository/packer_manager_test.go
@@ -31,7 +31,7 @@ func fillPacks(t testing.TB, rnd *rand.Rand, pm *packerManager, buf []byte) (byt
 		// Only change a few bytes so we know we're not benchmarking the RNG.
 		rnd.Read(buf[:min(l, 4)])
 
-		n, err := pm.SaveBlob(context.TODO(), restic.DataBlob, id, buf, 0)
+		n, err := pm.SaveBlob(context.TODO(), restic.DataBlob, id, buf, 0, 0)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -91,13 +91,109 @@ func TestPackerManagerWithOversizeBlob(t *testing.T) {
 	})
 
 	for _, i := range []uint{sizeLimit / 2, sizeLimit, sizeLimit / 3} {
-		_, err := pm.SaveBlob(context.TODO(), restic.DataBlob, restic.ID{}, make([]byte, i), 0)
+		_, err := pm.SaveBlob(context.TODO(), restic.DataBlob, restic.ID{}, make([]byte, i), 0, 0)
 		test.OK(t, err)
 	}
 	test.OK(t, pm.Flush(context.TODO()))
 
 	// oversized blob must be stored in a separate packfile
 	test.Assert(t, packFiles == 2, "unexpected number of packfiles %v, expected 2", packFiles)
+}
+
+// TestPackerManagerGroups verifies that blobs of different groups are packed
+// separately when the open-group budget allows it, that a too-small budget
+// degrades gracefully to the shared bucket without losing blobs, and that no
+// blobs are ever dropped. Real groups are numbered from 1; group 0 is the
+// shared/fallback bucket.
+func TestPackerManagerGroups(t *testing.T) {
+	const (
+		packSize  = uint(4096)
+		blobSize  = 512
+		numGroups = 4
+		perGroup  = 12
+	)
+
+	// maxOpenGroups >= numGroups keeps every group in its own bucket (fully
+	// pure packs); a smaller budget forces overflow groups into the shared
+	// bucket 0.
+	for _, tc := range []struct {
+		name          string
+		maxOpenGroups int
+		wantPure      bool
+	}{
+		{"unlimited", 0, true},
+		{"exact", numGroups, true},
+		{"capped", 1, false},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			blobGroup := make(map[restic.ID]uint32)
+			var mu sync.Mutex
+			var packs [][]uint32 // per queued pack: the original groups of its blobs
+			totalPacked := 0
+
+			pm := newPackerManager(crypto.NewRandomKey(), restic.TreeBlob, packSize, 1,
+				func(ctx context.Context, tp restic.BlobType, p *packer) error {
+					if err := p.Finalize(); err != nil {
+						return err
+					}
+					var groups []uint32
+					for _, b := range p.Blobs() {
+						g, ok := blobGroup[b.ID]
+						test.Assert(t, ok, "unknown blob %v in pack", b.ID)
+						groups = append(groups, g)
+					}
+					mu.Lock()
+					packs = append(packs, groups)
+					totalPacked += len(groups)
+					mu.Unlock()
+					return nil
+				})
+			pm.maxOpenGroups = tc.maxOpenGroups
+
+			rnd := rand.New(rand.NewSource(randomSeed))
+			buf := make([]byte, blobSize)
+			// interleave groups so blobs of different groups are in flight together
+			for i := 0; i < perGroup; i++ {
+				for g := uint32(1); g <= numGroups; g++ {
+					id := randomID(rnd)
+					blobGroup[id] = g
+					_, err := pm.SaveBlob(context.TODO(), restic.TreeBlob, id, buf, 0, g)
+					test.OK(t, err)
+				}
+			}
+			test.OK(t, pm.Flush(context.TODO()))
+
+			// no blob may be lost, regardless of budget
+			test.Equals(t, numGroups*perGroup, totalPacked)
+
+			pureGroups := make(map[uint32]bool)
+			mixedSeen := false
+			for _, groups := range packs {
+				g0 := groups[0]
+				pure := true
+				for _, g := range groups {
+					if g != g0 {
+						pure = false
+					}
+				}
+				if pure {
+					pureGroups[g0] = true
+				} else {
+					mixedSeen = true
+				}
+			}
+
+			if tc.wantPure {
+				// with enough budget every pack is pure and every group appears
+				test.Assert(t, !mixedSeen, "unexpected pack mixing groups with budget %d", tc.maxOpenGroups)
+				test.Equals(t, numGroups, len(pureGroups))
+			} else {
+				// with a tiny budget the overflow groups must have been merged
+				// into the shared bucket, i.e. at least one mixed pack exists
+				test.Assert(t, mixedSeen, "expected fallback to shared bucket with budget %d", tc.maxOpenGroups)
+			}
+		})
+	}
 }
 
 func BenchmarkPackerManager(t *testing.B) {

--- a/internal/repository/prune.go
+++ b/internal/repository/prune.go
@@ -73,11 +73,12 @@ type PruneStats struct {
 }
 
 type PrunePlan struct {
-	removePacksFirst restic.IDSet                // packs to remove first (unreferenced packs)
-	repackPacks      restic.IDSet                // packs to repack
-	keepBlobs        *index.AssociatedSet[uint8] // blobs to keep during repacking
-	removePacks      restic.IDSet                // packs to remove
-	ignorePacks      restic.IDSet                // packs to ignore when rebuilding the index
+	removePacksFirst restic.IDSet                 // packs to remove first (unreferenced packs)
+	repackPacks      restic.IDSet                 // packs to repack
+	keepBlobs        *index.AssociatedSet[uint8]  // blobs to keep during repacking
+	removePacks      restic.IDSet                 // packs to remove
+	ignorePacks      restic.IDSet                 // packs to ignore when rebuilding the index
+	treeGroups       map[restic.BlobHandle]uint32 // optional group id per tree blob for locality-aware repacking
 
 	repo  *Repository
 	stats PruneStats
@@ -103,7 +104,15 @@ type packInfoWithID struct {
 
 // PlanPrune selects which files to rewrite and which to delete and which blobs to keep.
 // Also some summary statistics are returned.
-func PlanPrune(ctx context.Context, opts PruneOptions, repo *Repository, getUsedBlobs func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) error, printer restic.Printer) (*PrunePlan, error) {
+// getUsedBlobs fills usedBlobs with the blobs still in use. It may additionally
+// return a group id per tree blob (keyed by blob handle) which, when the
+// feature is enabled, is used to cluster repacked tree blobs of the same
+// snapshot group into shared pack files. Returning a nil map disables grouping.
+type getUsedBlobsFn func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) (treeGroups map[restic.BlobHandle]uint32, err error)
+
+// PlanPrune selects which files to rewrite and which to delete and which blobs to keep.
+// Also some summary statistics are returned.
+func PlanPrune(ctx context.Context, opts PruneOptions, repo *Repository, getUsedBlobs getUsedBlobsFn, printer restic.Printer) (*PrunePlan, error) {
 	stats := PruneStats{MessageType: "summary"}
 
 	if opts.UnsafeRecovery {
@@ -121,7 +130,7 @@ func PlanPrune(ctx context.Context, opts PruneOptions, repo *Repository, getUsed
 	}
 
 	usedBlobs := index.NewAssociatedSet[uint8](repo.idx)
-	err := getUsedBlobs(ctx, repo, usedBlobs)
+	treeGroups, err := getUsedBlobs(ctx, repo, usedBlobs)
 	if err != nil {
 		return nil, err
 	}
@@ -171,6 +180,10 @@ func PlanPrune(ctx context.Context, opts PruneOptions, repo *Repository, getUsed
 	plan.repo = repo
 	plan.stats = stats
 	plan.opts = opts
+	// grouping information is only relevant when packs are actually repacked
+	if len(plan.repackPacks) != 0 {
+		plan.treeGroups = treeGroups
+	}
 
 	return &plan, nil
 }
@@ -623,7 +636,7 @@ func (plan *PrunePlan) Execute(ctx context.Context, printer restic.Printer) erro
 		printer.P("repacking packs\n")
 		bar := printer.NewCounter("packs repacked")
 		err := repo.WithBlobUploader(ctx, func(ctx context.Context, uploader restic.BlobSaverWithAsync) error {
-			return CopyBlobs(ctx, repo, repo, uploader, plan.repackPacks, plan.keepBlobs, bar, printer.P)
+			return copyBlobs(ctx, repo, repo, uploader, plan.repackPacks, plan.keepBlobs, plan.treeGroups, bar, printer.P)
 		})
 		if err != nil {
 			return errors.Fatalf("%s", err)

--- a/internal/repository/prune_internal_test.go
+++ b/internal/repository/prune_internal_test.go
@@ -64,11 +64,11 @@ func TestPruneMaxUnusedDuplicate(t *testing.T) {
 		MaxUnusedBytes: func(used uint64) (unused uint64) { return blobSize / 2 },
 	}
 
-	plan, err := PlanPrune(context.TODO(), opts, repo, func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) error {
+	plan, err := PlanPrune(context.TODO(), opts, repo, func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) (map[restic.BlobHandle]uint32, error) {
 		for blob := range keep {
 			usedBlobs.Insert(blob)
 		}
-		return nil
+		return nil, nil
 	}, restic.NewNoopPrinter())
 	rtest.OK(t, err)
 

--- a/internal/repository/prune_test.go
+++ b/internal/repository/prune_test.go
@@ -191,3 +191,95 @@ func TestPruneSmall(t *testing.T) {
 	rtest.Equals(t, lenPackfilesBefore > lenPackfilesAfter, true,
 		fmt.Sprintf("the number packfiles before %d and after repack %d", lenPackfilesBefore, lenPackfilesAfter))
 }
+
+/*
+1.) create a repository with a small packsize so the tree blobs land in several small packs.
+2.) assign every tree blob to one of a few groups (as `prune --group-by` would).
+3.) run PlanPrune/Execute with SmallPackBytes so all packs are repacked, feeding the group assignment to the repack step.
+4.) reopen the repository and check its integrity.
+5.) verify that grouping took effect: every resulting pack contains tree blobs of a single group only, and there is exactly one pack per group.
+*/
+func TestPruneGroupBy(t *testing.T) {
+	t.Parallel()
+	seed := time.Now().UnixNano()
+	random := rand.New(rand.NewSource(seed))
+	t.Logf("rand initialized with seed %d", seed)
+
+	be := repository.TestBackend(t)
+	repo, _ := repository.TestRepositoryWithBackend(t, be, 0, repository.Options{PackSize: repository.MinPackSize, Compression: repository.CompressionOff})
+
+	const blobSize = 1000 * 1000
+	const numBlobs = 55
+	const numGroups = 4
+
+	// Create tree blobs and assign each to one of numGroups groups. Group ids
+	// start at 1; 0 is the shared/fallback bucket. numGroups is well below the
+	// open-group budget (MaxOpenTreeGroups clamps to at least 32), so no group is
+	// demoted and every group stays localized. The assignment is kept so we can
+	// verify pack purity after the repack.
+	keep := restic.NewBlobSet()
+	treeGroups := make(map[restic.BlobHandle]uint32)
+	rtest.OK(t, repo.WithBlobUploader(context.TODO(), func(ctx context.Context, uploader restic.BlobSaverWithAsync) error {
+		for i := 0; i < numBlobs; i++ {
+			buf := make([]byte, blobSize)
+			random.Read(buf)
+
+			id, _, _, err := uploader.SaveBlob(ctx, restic.TreeBlob, buf, restic.ID{}, false)
+			rtest.OK(t, err)
+			bh := restic.BlobHandle{Type: restic.TreeBlob, ID: id}
+			keep.Insert(bh)
+			treeGroups[bh] = uint32(i%numGroups) + 1
+		}
+		return nil
+	}))
+	rtest.OK(t, repo.Close())
+
+	// reopen with the default (larger) packsize
+	repo = repository.TestOpenBackend(t, be)
+	rtest.OK(t, repo.LoadIndex(context.TODO(), restic.NoopTerminalCounterFactory))
+
+	opts := repository.PruneOptions{
+		MaxRepackBytes: math.MaxUint64,
+		MaxUnusedBytes: func(used uint64) (unused uint64) { return blobSize / 4 },
+		// treat every pack as small so all of them get repacked
+		SmallPackBytes: 5 * 1024 * 1024,
+	}
+	plan, err := repository.PlanPrune(context.TODO(), opts, repo, func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) (map[restic.BlobHandle]uint32, error) {
+		for blob := range keep {
+			usedBlobs.Insert(blob)
+		}
+		return treeGroups, nil
+	}, restic.NewNoopPrinter())
+	rtest.OK(t, err)
+	rtest.OK(t, plan.Execute(context.TODO(), restic.NewNoopPrinter()))
+
+	// reopen repository and check integrity
+	repo = repository.TestOpenBackend(t, be)
+	repository.TestCheckRepo(t, repo)
+
+	// all kept blobs must still be loadable
+	for blob := range keep {
+		_, err := repo.LoadBlob(context.TODO(), blob, nil)
+		rtest.OK(t, err)
+	}
+
+	// every pack must hold tree blobs of a single group; no pack may mix groups
+	packGroup := make(map[restic.ID]uint32)
+	rtest.OK(t, repo.ListBlobs(context.TODO(), func(pb restic.PackBlob) {
+		bh := pb.Handle()
+		if bh.Type != restic.TreeBlob {
+			return
+		}
+		g, ok := treeGroups[bh]
+		rtest.Assert(t, ok, "tree blob %v missing from the group assignment", bh)
+		if prev, seen := packGroup[pb.PackID()]; seen {
+			rtest.Assert(t, prev == g, "pack %v mixes groups %d and %d", pb.PackID(), prev, g)
+		} else {
+			packGroup[pb.PackID()] = g
+		}
+	}))
+
+	// with each group's blobs fitting in a single pack, we expect exactly one
+	// pure pack per group
+	rtest.Equals(t, numGroups, len(packGroup))
+}

--- a/internal/repository/prune_test.go
+++ b/internal/repository/prune_test.go
@@ -35,11 +35,11 @@ func testPrune(t *testing.T, opts repository.PruneOptions, errOnUnused bool) {
 		return nil
 	}))
 
-	plan, err := repository.PlanPrune(context.TODO(), opts, repo, func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) error {
+	plan, err := repository.PlanPrune(context.TODO(), opts, repo, func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) (map[restic.BlobHandle]uint32, error) {
 		for blob := range keep {
 			usedBlobs.Insert(blob)
 		}
-		return nil
+		return nil, nil
 	}, restic.NewNoopPrinter())
 	rtest.OK(t, err)
 
@@ -160,11 +160,11 @@ func TestPruneSmall(t *testing.T) {
 		MaxUnusedBytes: func(used uint64) (unused uint64) { return blobSize / 4 },
 		SmallPackBytes: 5 * 1024 * 1024,
 	}
-	plan, err := repository.PlanPrune(context.TODO(), opts, repo, func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) error {
+	plan, err := repository.PlanPrune(context.TODO(), opts, repo, func(ctx context.Context, repo restic.Repository, usedBlobs restic.FindBlobSet) (map[restic.BlobHandle]uint32, error) {
 		for blob := range keep {
 			usedBlobs.Insert(blob)
 		}
-		return nil
+		return nil, nil
 	}, restic.NewNoopPrinter())
 	rtest.OK(t, err)
 	rtest.OK(t, plan.Execute(context.TODO(), restic.NewNoopPrinter()))

--- a/internal/repository/repack.go
+++ b/internal/repository/repack.go
@@ -39,6 +39,23 @@ func CopyBlobs(
 	p restic.Counter,
 	logf LogFunc,
 ) error {
+	return copyBlobs(ctx, repo, dstRepo, dstUploader, packs, keepBlobs, nil, p, logf)
+}
+
+// copyBlobs is the implementation of CopyBlobs with optional grouping. When
+// treeGroups is set and the uploader supports it, repacked tree blobs are
+// clustered into pack files per group id (used by `prune --group-by`).
+func copyBlobs(
+	ctx context.Context,
+	repo *Repository,
+	dstRepo restic.Repository,
+	dstUploader restic.BlobSaverWithAsync,
+	packs restic.IDSet,
+	keepBlobs repackBlobSet,
+	treeGroups map[restic.BlobHandle]uint32,
+	p restic.Counter,
+	logf LogFunc,
+) error {
 	debug.Log("repacking %d packs while keeping %d blobs", len(packs), keepBlobs.Len())
 
 	if logf == nil {
@@ -51,7 +68,7 @@ func CopyBlobs(
 		return errors.New("repack step requires a backend connection limit of at least two")
 	}
 
-	return repack(ctx, repo, dstRepo, dstUploader, packs, keepBlobs, p, logf)
+	return repack(ctx, repo, dstRepo, dstUploader, packs, keepBlobs, treeGroups, p, logf)
 }
 
 func repack(
@@ -61,9 +78,16 @@ func repack(
 	uploader restic.BlobSaverWithAsync,
 	packs restic.IDSet,
 	keepBlobs repackBlobSet,
+	treeGroups map[restic.BlobHandle]uint32,
 	p restic.Counter,
 	logf LogFunc,
 ) error {
+
+	// grouped repacking clusters tree blobs of the same snapshot group into the
+	// same pack files. It is only active when a group assignment was passed and
+	// the uploader supports the grouped save extension.
+	groupedUploader, _ := uploader.(restic.GroupedBlobSaver)
+	useGroups := treeGroups != nil && groupedUploader != nil
 
 	wg, wgCtx := errgroup.WithContext(ctx)
 
@@ -126,7 +150,15 @@ func repack(
 				}
 
 				// We do want to save already saved blobs!
-				_, _, _, err = uploader.SaveBlob(wgCtx, blob.Type, buf, blob.ID, true)
+				if useGroups && blob.Type == restic.TreeBlob {
+					// treeGroups maps every repacked tree blob except those whose
+					// group was demoted to the shared bucket because the group
+					// count exceeded the localization budget; a missing entry
+					// falls back to group 0 (the shared bucket).
+					_, _, _, err = groupedUploader.SaveBlobGrouped(wgCtx, blob.Type, buf, blob.ID, true, treeGroups[blob])
+				} else {
+					_, _, _, err = uploader.SaveBlob(wgCtx, blob.Type, buf, blob.ID, true)
+				}
 				if err != nil {
 					return err
 				}

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -377,7 +377,7 @@ func (r *Repository) getZstdDecoder() *zstd.Decoder {
 // is small enough, it will be packed together with other small blobs. The
 // caller must ensure that the id matches the data. Returned is the size data
 // occupies in the repo (compressed or not, including the encryption overhead).
-func (r *Repository) saveAndEncrypt(ctx context.Context, t restic.BlobType, data []byte, id restic.ID) (size int, err error) {
+func (r *Repository) saveAndEncrypt(ctx context.Context, t restic.BlobType, data []byte, id restic.ID, group uint32) (size int, err error) {
 	debug.Log("save id %v (%v, %d bytes)", id, t, len(data))
 
 	uncompressedLength := 0
@@ -419,7 +419,7 @@ func (r *Repository) saveAndEncrypt(ctx context.Context, t restic.BlobType, data
 		panic(fmt.Sprintf("invalid type: %v", t))
 	}
 
-	return pm.SaveBlob(ctx, t, id, ciphertext, uncompressedLength)
+	return pm.SaveBlob(ctx, t, id, ciphertext, uncompressedLength, group)
 }
 
 func (r *Repository) verifyCiphertext(buf []byte, uncompressedLength int, id restic.ID) error {
@@ -618,7 +618,15 @@ type blobSaverRepo struct {
 }
 
 func (r *blobSaverRepo) SaveBlob(ctx context.Context, t restic.BlobType, buf []byte, id restic.ID, storeDuplicate bool) (newID restic.ID, known bool, size int, err error) {
-	return r.repo.saveBlob(ctx, t, buf, id, storeDuplicate)
+	return r.repo.saveBlob(ctx, t, buf, id, storeDuplicate, 0)
+}
+
+// SaveBlobGrouped stores a blob and assigns it to the given packing group, so
+// that blobs sharing a group id are collected into the same pack files. It
+// implements restic.GroupedBlobSaver and is used by prune to cluster repacked
+// tree blobs of the same snapshot group.
+func (r *blobSaverRepo) SaveBlobGrouped(ctx context.Context, t restic.BlobType, buf []byte, id restic.ID, storeDuplicate bool, group uint32) (newID restic.ID, known bool, size int, err error) {
+	return r.repo.saveBlob(ctx, t, buf, id, storeDuplicate, group)
 }
 
 func (r *blobSaverRepo) SaveBlobAsync(ctx context.Context, t restic.BlobType, buf []byte, id restic.ID, storeDuplicate bool, cb func(newID restic.ID, known bool, size int, err error)) {
@@ -1014,7 +1022,7 @@ func (r *Repository) Close() error {
 // Also returns if the blob was already known before.
 // If the blob was not known before, it returns the number of bytes the blob
 // occupies in the repo (compressed or not, including encryption overhead).
-func (r *Repository) saveBlob(ctx context.Context, t restic.BlobType, buf []byte, id restic.ID, storeDuplicate bool) (newID restic.ID, known bool, size int, err error) {
+func (r *Repository) saveBlob(ctx context.Context, t restic.BlobType, buf []byte, id restic.ID, storeDuplicate bool, group uint32) (newID restic.ID, known bool, size int, err error) {
 
 	if int64(len(buf)) > math.MaxUint32 {
 		return restic.ID{}, false, 0, fmt.Errorf("blob is larger than 4GB")
@@ -1039,7 +1047,7 @@ func (r *Repository) saveBlob(ctx context.Context, t restic.BlobType, buf []byte
 
 	// only save when needed or explicitly told
 	if !known || storeDuplicate {
-		size, err = r.saveAndEncrypt(ctx, t, buf, newID)
+		size, err = r.saveAndEncrypt(ctx, t, buf, newID, group)
 	}
 
 	return newID, known, size, err
@@ -1052,7 +1060,7 @@ func (r *Repository) saveBlobAsync(ctx context.Context, t restic.BlobType, buf [
 			cb(restic.ID{}, false, 0, ctx.Err())
 			return ctx.Err()
 		}
-		newID, known, size, err := r.saveBlob(ctx, t, buf, id, storeDuplicate)
+		newID, known, size, err := r.saveBlob(ctx, t, buf, id, storeDuplicate, 0)
 		cb(newID, known, size, err)
 		return err
 	})

--- a/internal/restic/repository.go
+++ b/internal/restic/repository.go
@@ -136,6 +136,14 @@ type BlobSaverAsync interface {
 	SaveBlobAsync(ctx context.Context, tpe BlobType, buf []byte, id ID, storeDuplicate bool, cb func(newID ID, known bool, sizeInRepo int, err error))
 }
 
+// GroupedBlobSaver is an optional extension of BlobSaver. Blobs saved with the
+// same group id are collected into the same pack files. It is used by prune to
+// keep repacked tree blobs of the same snapshot group together. Callers that do
+// not care about grouping should keep using BlobSaver.SaveBlob (group 0).
+type GroupedBlobSaver interface {
+	SaveBlobGrouped(ctx context.Context, tpe BlobType, buf []byte, id ID, storeDuplicate bool, group uint32) (newID ID, known bool, sizeInRepo int, err error)
+}
+
 // Loader loads a blob from a repository.
 type Loader interface {
 	LoadBlob(context.Context, BlobHandle, []byte) ([]byte, error)


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

When we're repacking in prune, we're putting different hosts' metadata in the same pack. And because restic stores whole metadata packs on client on backup, this causes "big cache" on repositories with many hosts: Every client then has to re-download all related packs just to get their own parent snapshot. Depending of the aggressiveness of the prune/repacking this might get worse (or better) by each prune.

This is an attempt to solve this by adding a `--group-by` flag to the prune command, which clusters the repacked tree blobs of the same "snapshot group" into shared pack files, so a client can get away with less packs in its cache. Data blobs and deduplication is not touched.

No behavior change on default prune operation and the new flag is only for prune command (also `forget --prune` is untouched, mostly because it has its own --group-by for forget actions).

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

This was kind of our itch on big repositories, but the full explanation (+ the references of other topics) can be found in [this topic](https://forum.restic.net/t/about-restic-local-cache-size/10926).

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
