### PR TITLE
repository: reject key and config files that are too short

### DIFF
--- a/changelog/unreleased/pull-21977
+++ b/changelog/unreleased/pull-21977
@@ -1,0 +1,9 @@
+Bugfix: Report an error instead of crashing on a truncated key or config file
+
+Restic crashed with a slice bounds panic when a repository contained a key
+file or a config file that was shorter than the encryption overhead, for
+example after an upload was interrupted. Since every command has to read a
+key file, the whole repository became unusable until the file was removed.
+Restic now reports that the file is too short instead.
+
+https://github.com/restic/restic/pull/21977

--- a/internal/repository/key.go
+++ b/internal/repository/key.go
@@ -98,6 +98,10 @@ func openKey(ctx context.Context, s *Repository, id restic.ID, password string) 
 	}
 
 	// decrypt master keys
+	if len(k.Data) < crypto.CiphertextLength(0) {
+		return nil, errors.New("invalid key file, data too short")
+	}
+
 	nonce, ciphertext := k.Data[:k.user.NonceSize()], k.Data[k.user.NonceSize():]
 	buf, err := k.user.Open(nil, nonce, ciphertext, nil)
 	if err != nil {

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -198,6 +198,10 @@ func (r *Repository) LoadUnpacked(ctx context.Context, t restic.FileType, id res
 		return nil, err
 	}
 
+	if len(buf) < crypto.CiphertextLength(0) {
+		return nil, fmt.Errorf("invalid data in %v file, too short", t)
+	}
+
 	nonce, ciphertext := buf[:r.key.NonceSize()], buf[r.key.NonceSize():]
 	plaintext, err := r.key.Open(ciphertext[:0], nonce, ciphertext, nil)
 	if err != nil {

--- a/internal/repository/repository_internal_test.go
+++ b/internal/repository/repository_internal_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/go-cmp/cmp"
 	"github.com/klauspost/compress/zstd"
 	"github.com/restic/restic/internal/backend"
+	"github.com/restic/restic/internal/backend/mem"
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/repository/crypto"
 	"github.com/restic/restic/internal/repository/index"
@@ -575,4 +576,51 @@ func TestStreamPackFallback(t *testing.T) {
 	t.Run("failed load", func(t *testing.T) {
 		test(t, true)
 	})
+}
+
+// A key file is just JSON in the repository, so its "data" field can be any
+// length an attacker with write access to the backend picks. Make sure a
+// short one is rejected instead of tripping a slice bounds panic.
+func TestOpenKeyShortData(t *testing.T) {
+	for _, data := range [][]byte{nil, {}, make([]byte, 1), make([]byte, crypto.CiphertextLength(0)-1)} {
+		be := mem.New()
+		repo, err := New(be, Options{})
+		rtest.OK(t, err)
+
+		key := Key{
+			KDF:  "scrypt",
+			N:    1024,
+			R:    8,
+			P:    1,
+			Salt: make([]byte, 64),
+			Data: data,
+		}
+		buf, err := json.Marshal(key)
+		rtest.OK(t, err)
+
+		id := restic.Hash(buf)
+		h := backend.Handle{Type: backend.KeyFile, Name: id.String()}
+		rtest.OK(t, be.Save(context.TODO(), h, backend.NewByteReader(buf, be.Hasher())))
+
+		_, err = openKey(context.TODO(), repo, id, "geheim")
+		rtest.Assert(t, err != nil, "expected an error for key data of length %d", len(data))
+		rtest.Assert(t, strings.Contains(err.Error(), "too short"),
+			"expected a 'too short' error, got %v", err)
+	}
+}
+
+// The config file is exempt from the ID check in LoadRaw, so a truncated one
+// reaches the decryption path unfiltered.
+func TestLoadUnpackedShortData(t *testing.T) {
+	be := mem.New()
+	repo, err := New(be, Options{})
+	rtest.OK(t, err)
+
+	h := backend.Handle{Type: backend.ConfigFile, Name: restic.ID{}.String()}
+	rtest.OK(t, be.Save(context.TODO(), h, backend.NewByteReader([]byte{}, be.Hasher())))
+
+	repo.key = crypto.NewRandomKey()
+	_, err = repo.LoadUnpacked(context.TODO(), restic.ConfigFile, restic.ID{})
+	rtest.Assert(t, err != nil && strings.Contains(err.Error(), "too short"),
+		"expected a 'too short' error, got %v", err)
 }


### PR DESCRIPTION
### What does this PR change?

`openKey` slices the key blob at the nonce size without checking how long it is:

```go
nonce, ciphertext := k.Data[:k.user.NonceSize()], k.Data[k.user.NonceSize():]
```

`k.Data` is just the `"data"` field of the JSON key file, so its length is whatever is on disk. A key file with `"data": ""` (or anything shorter than 16 bytes) makes this panic:

```
panic: runtime error: slice bounds out of range [:16] with capacity 0
	/tmp/restic/internal/repository/key.go:101
```

That happens in `searchKey`, which runs for basically every command against the repo, so the repo becomes unusable with a stack trace rather than a message saying what is wrong.

`LoadUnpacked` in `repository.go` has the same slice with no guard. It's reachable for the config file, since `raw.go` skips the ID check for `ConfigFile`, so a truncated `config` panics the same way.

The pattern to copy is already in the tree. `pack.List` does this right before the identical slice:

```go
if len(buf) < crypto.CiphertextLength(0) {
	return nil, 0, errors.New("invalid header, too short")
}
```

So I added the same check in both spots. I left the two `verifyCiphertext` / `verifyUnpacked` slices alone since those run over ciphertext restic just produced itself, and the one in `streamPack` already has a length check.

### Scope

To be clear about how much this matters: getting a short key or config file into a repo needs write access to the backend, so this is not a remote vulnerability and not an auth bypass. The crypto is fine, the MAC is still verified before any plaintext comes back. This is only about a corrupt or hostile repo giving you a clean error instead of a panic. Truncated files from a half-finished upload or a flaky backend seem like the likelier way to hit it in practice.

### Testing

Added `TestOpenKeyShortData` and `TestLoadUnpackedShortData` in `repository_internal_test.go`. Both fail with a panic without the fix:

```
--- FAIL: TestOpenKeyShortData
panic: runtime error: slice bounds out of range [:16] with capacity 0
	internal/repository/key.go:101

--- FAIL: TestLoadUnpackedShortData
panic: runtime error: slice bounds out of range [:16] with capacity 0
	internal/repository/repository.go:201
```

With the guards in place:

```
ok  	github.com/restic/restic/internal/repository	7.487s
ok  	github.com/restic/restic/internal/repository/crypto	1.118s
ok  	github.com/restic/restic/internal/repository/hashing	1.332s
ok  	github.com/restic/restic/internal/repository/index	1.422s
ok  	github.com/restic/restic/internal/repository/pack	0.914s
```

`go build ./...` and `gofmt` are clean.

I'll add the `changelog/unreleased/pull-NNNNN` entry once this has a PR number, unless you'd rather skip it given the change isn't really user-visible outside the error text.

- [x] I have read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md).
- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the changelog).
