### PR TITLE
restic check >non-existent-snapshot< - fix error messages 

### DIFF
--- a/cmd/restic/cmd_check.go
+++ b/cmd/restic/cmd_check.go
@@ -351,7 +351,7 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 	}()
 
 	for err := range errChan {
-		errorsFound = true
+		//errorsFound = true
 		switch e := err.(type) {
 		case *checker.TreeError:
 			printer.E("error for tree %v:\n", e.ID.Str())
@@ -359,12 +359,18 @@ func runCheck(ctx context.Context, opts CheckOptions, gopts global.Options, args
 				summary.NumErrors++
 				printer.E("  %v\n", treeErr)
 			}
+			errorsFound = true
+
 		case *checker.SnapshotError:
 			printer.E("snapshot error %v: %v", e.ID, e.Message)
 			brokenSnapshots = append(brokenSnapshots, e.ID)
+			errorsFound = true
+		case *restic.NoIDByPrefixError:
+			printer.E("%v, ignored", err)
 		default:
 			summary.NumErrors++
 			printer.E("error: %v\n", err)
+			errorsFound = true
 		}
 	}
 

--- a/cmd/restic/cmd_check_integration_test.go
+++ b/cmd/restic/cmd_check_integration_test.go
@@ -37,13 +37,13 @@ func testRunCheckOutput(t testing.TB, gopts global.Options, checkUnused bool) (s
 	return stdout.String(), stderr.String(), err
 }
 
-func testRunCheckOutputWithOpts(t testing.TB, gopts global.Options, opts CheckOptions, args []string) (string, error) {
-	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
+func testRunCheckOutputStderrWithOpts(t testing.TB, gopts global.Options, opts CheckOptions, args []string) (string, string, error) {
+	bufStdout, bufStderr, err := withCaptureStdoutStderr(t, gopts, func(ctx context.Context, gopts global.Options) error {
 		gopts.Verbosity = 2
 		_, err := runCheck(ctx, opts, gopts, args, gopts.Term)
 		return err
 	})
-	return buf.String(), err
+	return bufStdout.String(), bufStderr.String(), err
 }
 
 func TestCheckWithSnaphotFilter(t *testing.T) {
@@ -51,36 +51,49 @@ func TestCheckWithSnaphotFilter(t *testing.T) {
 		opts           CheckOptions
 		args           []string
 		expectedOutput string
+		expectedError  string
 	}{
 		{ // full --read-data, all snapshots
 			CheckOptions{ReadData: true},
 			nil,
 			"4 / 4 packs",
+			"",
 		},
 		{ // full --read-data, all snapshots
 			CheckOptions{ReadData: true},
 			nil,
 			"2 / 2 snapshots",
+			"",
 		},
 		{ // full --read-data, latest snapshot
 			CheckOptions{ReadData: true},
 			[]string{"latest"},
 			"2 / 2 packs",
+			"",
 		},
 		{ // full --read-data, latest snapshot
 			CheckOptions{ReadData: true},
 			[]string{"latest"},
 			"1 / 1 snapshots",
+			"",
 		},
 		{ // --read-data-subset, latest snapshot
 			CheckOptions{ReadDataSubset: "1%"},
 			[]string{"latest"},
 			"1 / 1 packs",
+			"",
 		},
 		{ // --read-data-subset, latest snapshot
 			CheckOptions{ReadDataSubset: "1%"},
 			[]string{"latest"},
 			"filtered",
+			"",
+		},
+		{ // full --read-data, wrong snapshot ID 1234567890
+			CheckOptions{ReadData: true},
+			[]string{"1234567890"},
+			"",
+			"no matching ID found for prefix",
 		},
 	}
 
@@ -93,10 +106,13 @@ func TestCheckWithSnaphotFilter(t *testing.T) {
 	testRunBackup(t, env.testdata+"/0", []string{"0/9"}, opts, env.gopts)
 
 	for _, testCase := range testCases {
-		output, err := testRunCheckOutputWithOpts(t, env.gopts, testCase.opts, testCase.args)
+		output, stderr, err := testRunCheckOutputStderrWithOpts(t, env.gopts, testCase.opts, testCase.args)
 		rtest.OK(t, err)
 
 		hasOutput := strings.Contains(output, testCase.expectedOutput)
 		rtest.Assert(t, hasOutput, `expected to find substring %q, but did not find it`, testCase.expectedOutput)
+		if testCase.expectedError != "" {
+			rtest.Assert(t, strings.Contains(stderr, testCase.expectedError), `expected to find substring %q, but did not find it`, testCase.expectedError)
+		}
 	}
 }

--- a/internal/checker/checker.go
+++ b/internal/checker/checker.go
@@ -126,7 +126,12 @@ func (c *Checker) loadActiveTrees(ctx context.Context, snapshotFilter *data.Snap
 
 	err := snapshotFilter.FindAll(ctx, c.snapshots, c.repo, args, func(id string, sn *data.Snapshot, err error) error {
 		if err != nil {
-			errs = append(errs, &SnapshotError{ID: id, Message: err})
+			var notFoundErr *restic.NoIDByPrefixError
+			if errors.As(err, &notFoundErr) {
+				errs = append(errs, err)
+			} else {
+				errs = append(errs, &SnapshotError{ID: id, Message: err})
+			}
 			return nil
 		} else if sn != nil {
 			trees = append(trees, *sn.Tree)


### PR DESCRIPTION
internal/checker/checker.go:
in function loadActiveTrees() handle call results to snapshotFilter.FindAll() differently in case of an *restic.NoIDByPrefixError: just push the error straight through instead of encapsulating it as an *checker.SnapshotError. The non-existent snapshot is just ignored anyway.

cmd/restic/cmd_check.go:
check for new error type *restic.NoIDByPrefixError and issue message on printer.E()

cmd/restic/cmd_check_integration_test.go:
modify test cases slightly for stderr output as well and add error for a non-existent snapshot iD.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
unintelligent error messages when using ``restic check >some-ID<``.

<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
closes https://github.com/restic/restic/issues/21981

<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
~~- [ ] I have added documentation for relevant changes (in the manual).~~
~~- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I'm done! This pull request is ready for review.
