### PR TITLE
restorer: report missing blobs without a stack trace

### DIFF
--- a/changelog/unreleased/issue-21953
+++ b/changelog/unreleased/issue-21953
@@ -1,7 +1,8 @@
 Bugfix: Improve restore errors for missing blobs
 
 Restic printed an internal stack trace when `restore` encountered a data blob
-that was missing from the repository index. It now reports that the repository
-is damaged and directs users to the troubleshooting guide.
+that was missing from the repository index. It now identifies the affected
+file, reports that the repository is damaged, and recommends running
+`restic check` before consulting the troubleshooting guide.
 
 https://github.com/restic/restic/issues/21953

--- a/changelog/unreleased/issue-21953
+++ b/changelog/unreleased/issue-21953
@@ -1,0 +1,7 @@
+Bugfix: Improve restore errors for missing blobs
+
+Restic printed an internal stack trace when `restore` encountered a data blob
+that was missing from the repository index. It now reports that the repository
+is damaged and directs users to the troubleshooting guide.
+
+https://github.com/restic/restic/issues/21953

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -110,7 +110,9 @@ func (r *fileRestorer) forEachBlob(blobIDs []restic.ID, fn func(blob restic.Pack
 	for i, blobID := range blobIDs {
 		packs := r.idx(restic.BlobHandle{Type: restic.DataBlob, ID: blobID})
 		if len(packs) == 0 {
-			return errors.Errorf("Unknown blob %s", blobID.String())
+			return errors.Fatalf(
+				"data blob %s is missing; the repository is damaged. Please follow the troubleshooting guide at https://restic.readthedocs.io/en/stable/077_troubleshooting.html",
+				blobID.String())
 		}
 		pb := packs[0]
 		fn(pb, i, fileOffset)

--- a/internal/restorer/filerestorer.go
+++ b/internal/restorer/filerestorer.go
@@ -101,7 +101,7 @@ func (r *fileRestorer) targetPath(location string) string {
 	return filepath.Join(r.dst, location)
 }
 
-func (r *fileRestorer) forEachBlob(blobIDs []restic.ID, fn func(blob restic.PackBlob, idx int, fileOffset int64)) error {
+func (r *fileRestorer) forEachBlob(location string, blobIDs []restic.ID, fn func(blob restic.PackBlob, idx int, fileOffset int64)) error {
 	if len(blobIDs) == 0 {
 		return nil
 	}
@@ -111,8 +111,8 @@ func (r *fileRestorer) forEachBlob(blobIDs []restic.ID, fn func(blob restic.Pack
 		packs := r.idx(restic.BlobHandle{Type: restic.DataBlob, ID: blobID})
 		if len(packs) == 0 {
 			return errors.Fatalf(
-				"data blob %s is missing; the repository is damaged. Please follow the troubleshooting guide at https://restic.readthedocs.io/en/stable/077_troubleshooting.html",
-				blobID.String())
+				"data blob %s for file %q is missing; the repository is damaged. Run `restic check` to identify repair steps, then follow the troubleshooting guide at https://restic.readthedocs.io/en/stable/077_troubleshooting.html",
+				blobID.String(), location)
 		}
 		pb := packs[0]
 		fn(pb, i, fileOffset)
@@ -144,7 +144,7 @@ func (r *fileRestorer) restoreFiles(ctx context.Context) error {
 			file.blobs = packsMap
 		}
 		restoredBlobs := false
-		err := r.forEachBlob(fileBlobs, func(blob restic.PackBlob, idx int, fileOffset int64) {
+		err := r.forEachBlob(file.location, fileBlobs, func(blob restic.PackBlob, idx int, fileOffset int64) {
 			packID := blob.PackID()
 			if !file.state.HasMatchingBlob(idx) {
 				if largeFile {
@@ -280,7 +280,7 @@ func (r *fileRestorer) downloadPack(ctx context.Context, pack *packInfo) error {
 			blobInfo.files[file] = append(blobInfo.files[file], fileOffset)
 		}
 		if fileBlobs, ok := file.blobs.(restic.IDs); ok {
-			err := r.forEachBlob(fileBlobs, func(blob restic.PackBlob, idx int, fileOffset int64) {
+			err := r.forEachBlob(file.location, fileBlobs, func(blob restic.PackBlob, idx int, fileOffset int64) {
 				if blob.PackID().Equal(pack.id) && !file.state.HasMatchingBlob(idx) {
 					addBlob(blob.Handle(), fileOffset)
 				}

--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -370,11 +370,14 @@ func TestErrorRestoreFiles(t *testing.T) {
 
 func TestFileRestorerMissingBlobError(t *testing.T) {
 	missingBlobID := restic.Hash([]byte("data1-1"))
+	location := "path/to/file"
 	r := fileRestorer{idx: func(restic.BlobHandle) []restic.PackBlob { return nil }}
 
-	err := r.forEachBlob(restic.IDs{missingBlobID}, func(restic.PackBlob, int, int64) {})
+	err := r.forEachBlob(location, restic.IDs{missingBlobID}, func(restic.PackBlob, int, int64) {})
 	rtest.Assert(t, errors.IsFatal(err), "expected fatal error, got %v", err)
 	rtest.Assert(t, strings.Contains(err.Error(), missingBlobID.String()), "missing blob ID in error: %v", err)
+	rtest.Assert(t, strings.Contains(err.Error(), location), "missing file location in error: %v", err)
+	rtest.Assert(t, strings.Contains(err.Error(), "restic check"), "missing check guidance in error: %v", err)
 	rtest.Assert(t, strings.Contains(err.Error(), "troubleshooting"), "missing troubleshooting guidance in error: %v", err)
 }
 

--- a/internal/restorer/filerestorer_test.go
+++ b/internal/restorer/filerestorer_test.go
@@ -368,6 +368,16 @@ func TestErrorRestoreFiles(t *testing.T) {
 	rtest.Assert(t, errors.Is(err, loadError), "got %v, expected contained error %v", err, loadError)
 }
 
+func TestFileRestorerMissingBlobError(t *testing.T) {
+	missingBlobID := restic.Hash([]byte("data1-1"))
+	r := fileRestorer{idx: func(restic.BlobHandle) []restic.PackBlob { return nil }}
+
+	err := r.forEachBlob(restic.IDs{missingBlobID}, func(restic.PackBlob, int, int64) {})
+	rtest.Assert(t, errors.IsFatal(err), "expected fatal error, got %v", err)
+	rtest.Assert(t, strings.Contains(err.Error(), missingBlobID.String()), "missing blob ID in error: %v", err)
+	rtest.Assert(t, strings.Contains(err.Error(), "troubleshooting"), "missing troubleshooting guidance in error: %v", err)
+}
+
 func TestFatalDownloadError(t *testing.T) {
 	tempdir := rtest.TempDir(t)
 	content := []TestFile{


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

When restore cannot find a referenced data blob in the repository index, report a concise fatal error instead of exposing an internal stack trace. The message identifies the missing blob and affected file, states that the repository is damaged, and directs the user to run `restic check` before the troubleshooting guide.

The regression test verifies the error classification, file location, and user-facing guidance.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #21953.

Checklist
---------

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
