### PR TITLE
backup: exclude temporary pack files

### DIFF
--- a/changelog/unreleased/issue-1380
+++ b/changelog/unreleased/issue-1380
@@ -1,0 +1,8 @@
+Bugfix: Exclude restic temporary pack files from backups
+
+On Windows, a backup that included the system temporary directory could try to
+read restic's own temporary pack files and report errors when those files were
+removed during the backup. Restic now places pack files in a directory created
+for the current backup and excludes only that directory from the snapshot.
+
+https://github.com/restic/restic/issues/1380

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -331,7 +331,9 @@ func (opts BackupOptions) Check(gopts global.Options, args []string) error {
 
 // collectRejectByNameFuncs returns a list of all functions which may reject data
 // from being saved in a snapshot based on path only
-func collectRejectByNameFuncs(opts BackupOptions, repo *repository.Repository, warnf func(msg string, args ...any)) (fs []archiver.RejectByNameFunc, err error) {
+func collectRejectByNameFuncs(opts BackupOptions, repo *repository.Repository, tempDir string, warnf func(msg string, args ...any)) (fs []archiver.RejectByNameFunc, err error) {
+	fs = append(fs, rejectResticTempDir(tempDir))
+
 	// exclude restic cache
 	if repo.Cache() != nil {
 		f, err := rejectResticCache(repo)
@@ -544,11 +546,22 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 	}
 	defer unlock()
 
+	tempDir, err := os.MkdirTemp("", "restic-temp-")
+	if err != nil {
+		return errors.Wrap(err, "unable to create temporary directory for pack files")
+	}
+	defer func() {
+		if err := os.RemoveAll(tempDir); err != nil {
+			printer.E("unable to remove temporary directory for pack files: %v\n", err)
+		}
+	}()
+	repo.SetPackTempDir(tempDir)
+
 	progressReporter := backup.NewProgress(printer, gopts.Quiet, gopts.JSON, term.CanUpdateStatus())
 	defer progressReporter.Done()
 
 	// rejectByNameFuncs collect functions that can reject items from the backup based on path only
-	rejectByNameFuncs, err := collectRejectByNameFuncs(opts, repo, printer.E)
+	rejectByNameFuncs, err := collectRejectByNameFuncs(opts, repo, tempDir, printer.E)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_backup_integration_test.go
+++ b/cmd/restic/cmd_backup_integration_test.go
@@ -52,6 +52,33 @@ func TestBackup(t *testing.T) {
 	testBackup(t, false)
 }
 
+func TestBackupExcludesPackTempDir(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+
+	tempRoot := filepath.Join(env.testdata, "tmp")
+	rtest.OK(t, os.MkdirAll(tempRoot, 0o700))
+	rtest.OK(t, os.WriteFile(filepath.Join(env.testdata, "file"), []byte("content"), 0o600))
+
+	t.Setenv("TMPDIR", tempRoot)
+	t.Setenv("TMP", tempRoot)
+	t.Setenv("TEMP", tempRoot)
+
+	testRunBackup(t, env.base, []string{"testdata"}, BackupOptions{}, env.gopts)
+	snapshotID := testListSnapshots(t, env.gopts, 1)[0]
+
+	files := testRunLs(t, env.gopts, snapshotID.String())
+	rtest.Assert(t, includes(files, "/testdata/file"), "test file missing from snapshot")
+	rtest.Assert(t, includes(files, "/testdata/tmp"), "temporary directory root missing from snapshot")
+
+	for _, item := range files {
+		rtest.Assert(t, !strings.HasPrefix(item, "/testdata/tmp/restic-temp-"),
+			"restic temporary directory %q included in snapshot", item)
+	}
+}
+
 func TestBackupWithFilesystemSnapshots(t *testing.T) {
 	if runtime.GOOS == "windows" && fs.HasSufficientPrivilegesForVSS() == nil {
 		testBackup(t, true)

--- a/cmd/restic/exclude.go
+++ b/cmd/restic/exclude.go
@@ -31,3 +31,16 @@ func rejectResticCache(repo *repository.Repository) (archiver.RejectByNameFunc, 
 		return false
 	}, nil
 }
+
+// rejectResticTempDir returns a RejectByNameFunc that rejects the directory
+// containing temporary pack files for the current backup.
+func rejectResticTempDir(tempDir string) archiver.RejectByNameFunc {
+	return func(item string) bool {
+		if tempDir != "" && fs.HasPathPrefix(tempDir, item) {
+			debug.Log("rejecting restic temporary directory %v", item)
+			return true
+		}
+
+		return false
+	}
+}

--- a/cmd/restic/exclude_test.go
+++ b/cmd/restic/exclude_test.go
@@ -1,0 +1,30 @@
+package main
+
+import (
+	"path/filepath"
+	"testing"
+
+	rtest "github.com/restic/restic/internal/test"
+)
+
+func TestRejectResticTempDir(t *testing.T) {
+	parent := t.TempDir()
+	tempDir := filepath.Join(parent, "restic-temp")
+	reject := rejectResticTempDir(tempDir)
+
+	for _, path := range []string{
+		tempDir,
+		filepath.Join(tempDir, "restic-temp-pack-123"),
+		filepath.Join(tempDir, "subdir", "file"),
+	} {
+		rtest.Assert(t, reject(path), "expected %q to be rejected", path)
+	}
+
+	for _, path := range []string{
+		parent,
+		filepath.Join(parent, "restic-temp-sibling"),
+		filepath.Join(parent, "other", "file"),
+	} {
+		rtest.Assert(t, !reject(path), "did not expect %q to be rejected", path)
+	}
+}

--- a/internal/repository/packer_manager.go
+++ b/internal/repository/packer_manager.go
@@ -37,19 +37,21 @@ type packerManager struct {
 	pm       sync.Mutex
 	packers  []*packer
 	packSize uint
+	tempDir  string
 }
 
 const defaultPackerCount = 2
 
 // newPackerManager returns a new packer manager which writes temporary files
 // to a temporary directory
-func newPackerManager(key *crypto.Key, tpe restic.BlobType, packSize uint, packerCount int, queueFn func(ctx context.Context, t restic.BlobType, p *packer) error) *packerManager {
+func newPackerManager(key *crypto.Key, tpe restic.BlobType, packSize uint, packerCount int, tempDir string, queueFn func(ctx context.Context, t restic.BlobType, p *packer) error) *packerManager {
 	return &packerManager{
 		tpe:      tpe,
 		key:      key,
 		queueFn:  queueFn,
 		packers:  make([]*packer, packerCount),
 		packSize: packSize,
+		tempDir:  tempDir,
 	}
 }
 
@@ -201,7 +203,7 @@ func (r *packerManager) forgetPacker(packer *packer) {
 // created or one is returned that already has some blobs.
 func (r *packerManager) newPacker() (pck *packer, err error) {
 	debug.Log("create new pack")
-	tmpfile, err := fileio.TempFile("", "restic-temp-pack-")
+	tmpfile, err := fileio.TempFile(r.tempDir, "restic-temp-pack-")
 	if err != nil {
 		return nil, errors.WithStack(err)
 	}

--- a/internal/repository/packer_manager_test.go
+++ b/internal/repository/packer_manager_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"math/rand"
+	"path/filepath"
 	"sync"
 	"testing"
 
@@ -63,7 +64,7 @@ func testPackerManager(t testing.TB) int64 {
 	rnd := rand.New(rand.NewSource(randomSeed))
 
 	savedBytes := 0
-	pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, DefaultPackSize, defaultPackerCount, func(ctx context.Context, tp restic.BlobType, p *packer) error {
+	pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, DefaultPackSize, defaultPackerCount, "", func(ctx context.Context, tp restic.BlobType, p *packer) error {
 		err := p.Finalize()
 		if err != nil {
 			return err
@@ -85,7 +86,7 @@ func testPackerManager(t testing.TB) int64 {
 func TestPackerManagerWithOversizeBlob(t *testing.T) {
 	packFiles := 0
 	sizeLimit := uint(512 * 1024)
-	pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, sizeLimit, defaultPackerCount, func(ctx context.Context, tp restic.BlobType, p *packer) error {
+	pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, sizeLimit, defaultPackerCount, "", func(ctx context.Context, tp restic.BlobType, p *packer) error {
 		packFiles++
 		return nil
 	})
@@ -98,6 +99,21 @@ func TestPackerManagerWithOversizeBlob(t *testing.T) {
 
 	// oversized blob must be stored in a separate packfile
 	test.Assert(t, packFiles == 2, "unexpected number of packfiles %v, expected 2", packFiles)
+}
+
+func TestPackerManagerTempDir(t *testing.T) {
+	tempDir := t.TempDir()
+	pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, DefaultPackSize, defaultPackerCount, tempDir, func(context.Context, restic.BlobType, *packer) error {
+		return nil
+	})
+
+	p, err := pm.newPacker()
+	test.OK(t, err)
+	t.Cleanup(func() {
+		test.OK(t, p.tmpfile.Close())
+	})
+
+	test.Equals(t, tempDir, filepath.Dir(p.tmpfile.Name()))
 }
 
 func BenchmarkPackerManager(t *testing.B) {
@@ -115,7 +131,7 @@ func BenchmarkPackerManager(t *testing.B) {
 
 	for i := 0; i < t.N; i++ {
 		rnd.Seed(randomSeed)
-		pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, DefaultPackSize, defaultPackerCount, func(ctx context.Context, t restic.BlobType, p *packer) error {
+		pm := newPackerManager(crypto.NewRandomKey(), restic.DataBlob, DefaultPackSize, defaultPackerCount, "", func(ctx context.Context, t restic.BlobType, p *packer) error {
 			return nil
 		})
 		fillPacks(t, rnd, pm, blobBuf)

--- a/internal/repository/repository.go
+++ b/internal/repository/repository.go
@@ -39,6 +39,7 @@ type Repository struct {
 
 	opts Options
 
+	packTempDir string
 	packerWg    *errgroup.Group
 	mainWg      *errgroup.Group
 	blobSaver   *sync.WaitGroup
@@ -145,6 +146,12 @@ func New(be backend.Backend, opts Options) (*Repository, error) {
 	}
 
 	return repo, nil
+}
+
+// SetPackTempDir sets the directory used for temporary pack files. It must be
+// called before WithBlobUploader.
+func (r *Repository) SetPackTempDir(dir string) {
+	r.packTempDir = dir
 }
 
 // setConfig assigns the given config and updates the repository parameters accordingly
@@ -609,8 +616,8 @@ func (r *Repository) startPackUploader(ctx context.Context, wg *errgroup.Group) 
 	innerWg, ctx := errgroup.WithContext(ctx)
 	r.packerWg = innerWg
 	r.uploader = newPackerUploader(ctx, innerWg, r, r.Connections())
-	r.treePM = newPackerManager(r.key, restic.TreeBlob, r.PackSize(), r.packerCount, r.uploader.QueuePacker)
-	r.dataPM = newPackerManager(r.key, restic.DataBlob, r.PackSize(), r.packerCount, r.uploader.QueuePacker)
+	r.treePM = newPackerManager(r.key, restic.TreeBlob, r.PackSize(), r.packerCount, r.packTempDir, r.uploader.QueuePacker)
+	r.dataPM = newPackerManager(r.key, restic.DataBlob, r.PackSize(), r.packerCount, r.packTempDir, r.uploader.QueuePacker)
 
 	wg.Go(func() error {
 		return innerWg.Wait()


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

On Windows, temporary pack files remain visible until they are closed. If a backup includes the system temporary directory, the scanner can encounter restic's own pack files and later report read errors after those files disappear.

This change:

- creates a unique temporary directory for each backup;
- routes both data and tree pack files into that directory;
- excludes exactly that directory from scanning and archiving, without excluding the user's whole system temporary directory;
- removes the directory when the backup finishes; and
- adds unit and integration regression coverage plus an unreleased changelog entry.

The integration test points the OS temporary directory inside the backup source and verifies that normal content and the parent temp directory are included while the per-backup `restic-temp-*` directory is not. The test fails against the old behavior because that directory appears in the snapshot.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #1380.

I announced the implementation approach before starting: https://github.com/restic/restic/issues/1380#issuecomment-5127629620

Validation
----------

- `go test ./internal/repository -count=1`
- `go test ./cmd/restic -count=1`
- `go vet ./internal/repository ./cmd/restic`
- Windows/amd64 test binaries compile for both affected packages
- `calens`

AI assistance disclosure: I used OpenAI Codex to help investigate and implement this change. I reviewed the resulting patch and ran the validation listed above.

Checklist
---------

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (no manual change is needed for this internal bug fix).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
