### PR TITLE
selfupdate: replace deprecated golang.org/x/crypto/openpgp with ProtonMail/go-crypto

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -80,8 +80,6 @@ linters:
       - path: (.+)\.go$
         text: 'SA1019: "golang.org/x/crypto/poly1305" is deprecated'
       - path: (.+)\.go$
-        text: 'SA1019: "golang.org/x/crypto/openpgp" is deprecated'
-      - path: (.+)\.go$
         text: "redefines-builtin-id:"
       # revive: collection of helpers to implement a backend, more descriptive names would be too repetitive
       - path: internal/backend/util/.*.go$

--- a/changelog/unreleased/issue-21973
+++ b/changelog/unreleased/issue-21973
@@ -1,0 +1,8 @@
+Enhancement: Replace deprecated GPG verification library used for self-update
+
+Restic used the unmaintained and insecure golang.org/x/crypto/openpgp
+package to verify GPG signatures during self-update. It now uses the
+actively maintained ProtonMail/go-crypto fork instead, which addresses
+known security weaknesses in the original package.
+
+https://github.com/restic/restic/issues/21973

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v1.7.0
 	github.com/Backblaze/blazer v0.7.2
 	github.com/Microsoft/go-winio v0.6.2
+	github.com/ProtonMail/go-crypto v1.4.1
 	github.com/anacrolix/fuse v0.3.1
 	github.com/cenkalti/backoff/v4 v4.3.0
 	github.com/cespare/xxhash/v2 v2.3.0
@@ -58,6 +59,7 @@ require (
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/detectors/gcp v1.31.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/metric v0.57.0 // indirect
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapping v0.57.0 // indirect
+	github.com/cloudflare/circl v1.6.2 // indirect
 	github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.6 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -49,6 +49,8 @@ github.com/GoogleCloudPlatform/opentelemetry-operations-go/internal/resourcemapp
 github.com/Julusian/godocdown v0.0.0-20170816220326-6d19f8ff2df8/go.mod h1:INZr5t32rG59/5xeltqoCJoNY7e5x/3xoY9WSWVWg74=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
+github.com/ProtonMail/go-crypto v1.4.1 h1:9RfcZHqEQUvP8RzecWEUafnZVtEvrBVL9BiF67IQOfM=
+github.com/ProtonMail/go-crypto v1.4.1/go.mod h1:e1OaTyu5SYVrO9gKOEhTc+5UcXtTUa+P3uLudwcgPqo=
 github.com/anacrolix/envpprof v1.3.0 h1:WJt9bpuT7A/CDCxPOv/eeZqHWlle/Y0keJUvc6tcJDk=
 github.com/anacrolix/envpprof v1.3.0/go.mod h1:7QIG4CaX1uexQ3tqd5+BRa/9e2D02Wcertl6Yh0jCB0=
 github.com/anacrolix/fuse v0.3.1 h1:oT8s3B5HFkBdLe/WKJO5MNo9iIyEtc+BhvTZYp4jhDM=
@@ -65,6 +67,8 @@ github.com/cespare/xxhash/v2 v2.3.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XL
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
 github.com/chzyer/test v0.0.0-20180213035817-a1ea475d72b1/go.mod h1:Q3SI9o4m/ZMnBNeIyt5eFwwo7qiLfzFZmjNmxjkiQlU=
+github.com/cloudflare/circl v1.6.2 h1:hL7VBpHHKzrV5WTfHCaBsgx/HGbBYlgrwvNXEVDYYsQ=
+github.com/cloudflare/circl v1.6.2/go.mod h1:2eXP6Qfat4O/Yhh8BznvKnJ+uzEoTQ6jVKJRn81BiS4=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2 h1:aBangftG7EVZoUb69Os8IaYg++6uMOdKK83QtkkvJik=
 github.com/cncf/xds/go v0.0.0-20260202195803-dba9d589def2/go.mod h1:qwXFYgsP6T7XnJtbKlf1HP8AjxZZyzxMmc+Lq5GjlU4=
 github.com/cpuguy83/go-md2man/v2 v2.0.6 h1:XJtiaUW6dEEqVuZiMTn1ldk455QWwEIsMIJlo5vtkx0=

--- a/internal/selfupdate/verify.go
+++ b/internal/selfupdate/verify.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"fmt"
 
-	"golang.org/x/crypto/openpgp"
+	"github.com/ProtonMail/go-crypto/openpgp"
 )
 
 var key = []byte(`
@@ -177,7 +177,7 @@ func GPGVerify(data, sig []byte) (ok bool, err error) {
 		return false, fmt.Errorf("reading keyring failed: %w", err)
 	}
 
-	_, err = openpgp.CheckArmoredDetachedSignature(keyring, bytes.NewReader(data), bytes.NewReader(sig))
+	_, err = openpgp.CheckArmoredDetachedSignature(keyring, bytes.NewReader(data), bytes.NewReader(sig), nil)
 	if err != nil {
 		return false, err
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
The `golang.org/x/crypto/openpgp` package used by `GPGVerify` to verify GPG
signatures during self-update is unmaintained and flagged as insecure
(GO-2026-5932). This PR replaces it with the actively maintained
ProtonMail/go-crypto fork, which is designed as a drop-in replacement.

Changes:
- Updated the import in `internal/selfupdate/verify.go`
- Added the required `config *packet.Config` argument to
  `CheckArmoredDetachedSignature` (pass `nil` to preserve default behavior)
- Removed the now-obsolete `golangci-lint` exception for the deprecated
  `openpgp` package in `.golangci.yml`

No new tests added — existing selfupdate tests already exercise GPGVerify
and pass.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
Closes #21973 
Announced before opening this PR: [#21973 (comment)](https://github.com/restic/restic/issues/21973#issuecomment-5152133563)

Validation
----------
- `go build ./...` and `./restic version` — builds and runs correctly
- `go test ./internal/selfupdate/...` — passes
- `gofmt -l` and `golangci-lint run` on the changed file — clean

AI assistance disclosure: I used Claude to help understand the PGP verification code and the ProtonMail/go-crypto API, and to work through the implementation. I reviewed, applied, and tested the changes myself.

Checklist
---------
- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
