### PR TITLE
Respect --quiet when RESTIC_PROGRESS_FPS is set

### DIFF
--- a/changelog/unreleased/issue-21988
+++ b/changelog/unreleased/issue-21988
@@ -1,0 +1,8 @@
+Bugfix: Respect `--quiet` when `RESTIC_PROGRESS_FPS` is set
+
+Restic showed backup progress when `--quiet` was used if the environment
+variable `RESTIC_PROGRESS_FPS` was set to a positive value. Restic now keeps
+progress output disabled when `--quiet` is used, regardless of the configured
+progress refresh rate.
+
+https://github.com/restic/restic/issues/21988

--- a/internal/ui/progress/terminal.go
+++ b/internal/ui/progress/terminal.go
@@ -14,6 +14,10 @@ import (
 // or if unset returns an interval for 60fps on interactive terminals and 0 (=disabled)
 // for non-interactive terminals or when run using the --quiet flag
 func CalculateProgressInterval(show bool, json bool, canUpdateStatus bool) time.Duration {
+	if !show {
+		return 0
+	}
+
 	interval := time.Second / 10
 	fps, err := strconv.ParseFloat(os.Getenv("RESTIC_PROGRESS_FPS"), 64)
 	if err == nil && fps > 0 {
@@ -21,7 +25,7 @@ func CalculateProgressInterval(show bool, json bool, canUpdateStatus bool) time.
 			fps = 60
 		}
 		interval = time.Duration(float64(time.Second) / fps)
-	} else if !json && !canUpdateStatus || !show {
+	} else if !json && !canUpdateStatus {
 		interval = 0
 	}
 	return interval

--- a/internal/ui/progress/terminal_test.go
+++ b/internal/ui/progress/terminal_test.go
@@ -1,0 +1,25 @@
+package progress_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/restic/restic/internal/test"
+	"github.com/restic/restic/internal/ui/progress"
+)
+
+func TestCalculateProgressIntervalQuietIgnoresFPS(t *testing.T) {
+	t.Setenv("RESTIC_PROGRESS_FPS", "5")
+
+	interval := progress.CalculateProgressInterval(false, false, true)
+
+	test.Equals(t, time.Duration(0), interval)
+}
+
+func TestCalculateProgressIntervalUsesFPSWhenShown(t *testing.T) {
+	t.Setenv("RESTIC_PROGRESS_FPS", "5")
+
+	interval := progress.CalculateProgressInterval(true, false, true)
+
+	test.Equals(t, 200*time.Millisecond, interval)
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

`--quiet` now disables progress output before checking `RESTIC_PROGRESS_FPS`, so setting the environment variable no longer re-enables progress for quiet commands.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #21988.

Checklist
---------

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
