### PR TITLE
dump: continue after oversized tar headers

### DIFF
--- a/changelog/unreleased/issue-4307
+++ b/changelog/unreleased/issue-4307
@@ -1,0 +1,9 @@
+Bugfix: Continue `dump` after oversized tar headers
+
+The `dump` command stopped writing a tar archive when a file's extended
+attributes exceeded the PAX header size limit. This caused every subsequent
+entry to be absent from the archive. Restic now skips the affected entry,
+reports its path, and continues writing a valid archive. The command still
+exits with an error to signal that the output is incomplete.
+
+https://github.com/restic/restic/issues/4307

--- a/internal/dump/tar.go
+++ b/internal/dump/tar.go
@@ -4,6 +4,7 @@ import (
 	"archive/tar"
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 
@@ -12,22 +13,37 @@ import (
 	"github.com/restic/restic/internal/errors"
 )
 
-func (d *Dumper) dumpTar(ctx context.Context, ch <-chan *data.Node) (err error) {
+func (d *Dumper) dumpTar(ctx context.Context, ch <-chan *data.Node) error {
 	w := tar.NewWriter(d.w)
-
-	defer func() {
-		if err == nil {
-			err = w.Close()
-			err = errors.Wrap(err, "Close")
-		}
-	}()
+	var skippedErrors []error
 
 	for node := range ch {
-		if err := d.dumpNodeTar(ctx, node, w); err != nil {
+		header, err := tarHeader(node)
+		if err != nil {
+			return err
+		}
+
+		// A tar.Writer cannot be used after WriteHeader returns an error. Check
+		// the header with a throwaway writer first so that an oversized PAX
+		// header cannot prevent later nodes from being written.
+		if err := tar.NewWriter(io.Discard).WriteHeader(header); err != nil {
+			err = fmt.Errorf("writing header for %q: %w", node.Path, err)
+			if errors.Is(err, tar.ErrFieldTooLong) {
+				skippedErrors = append(skippedErrors, err)
+				continue
+			}
+			return err
+		}
+
+		if err := d.writeNodeTar(ctx, node, header, w); err != nil {
 			return err
 		}
 	}
-	return nil
+
+	if err := w.Close(); err != nil {
+		return errors.Wrap(err, "Close")
+	}
+	return errors.Join(skippedErrors...)
 }
 
 // copied from archive/tar.FileInfoHeader
@@ -49,9 +65,17 @@ func tarIdentifier(id uint32) int {
 }
 
 func (d *Dumper) dumpNodeTar(ctx context.Context, node *data.Node, w *tar.Writer) error {
-	relPath, err := filepath.Rel("/", node.Path)
+	header, err := tarHeader(node)
 	if err != nil {
 		return err
+	}
+	return d.writeNodeTar(ctx, node, header, w)
+}
+
+func tarHeader(node *data.Node) (*tar.Header, error) {
+	relPath, err := filepath.Rel("/", node.Path)
+	if err != nil {
+		return nil, err
 	}
 
 	header := &tar.Header{
@@ -93,8 +117,11 @@ func (d *Dumper) dumpNodeTar(ctx context.Context, node *data.Node, w *tar.Writer
 		header.Name += "/"
 	}
 
-	err = w.WriteHeader(header)
-	if err != nil {
+	return header, nil
+}
+
+func (d *Dumper) writeNodeTar(ctx context.Context, node *data.Node, header *tar.Header, w *tar.Writer) error {
+	if err := w.WriteHeader(header); err != nil {
 		return fmt.Errorf("writing header for %q: %w", node.Path, err)
 	}
 	return d.writeNode(ctx, w, node)

--- a/internal/dump/tar_test.go
+++ b/internal/dump/tar_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	"github.com/restic/restic/internal/data"
+	"github.com/restic/restic/internal/repository"
+	"github.com/restic/restic/internal/restic"
 	rtest "github.com/restic/restic/internal/test"
 )
 
@@ -140,4 +142,85 @@ func TestFieldTooLong(t *testing.T) {
 	rtest.Assert(t, errors.Is(err, tar.ErrFieldTooLong), "wrong type %T", err)
 	rtest.Assert(t, strings.Contains(err.Error(), node.Path),
 		"no filename in %q", err)
+}
+
+func TestTarContinuesAfterFieldTooLong(t *testing.T) {
+	const maxSpecialFileSize = 1 << 20 // Unexported limit in archive/tar.
+
+	contents := []string{"before contents", "after contents"}
+	contentIDs := make([]restic.ID, len(contents))
+	repo := repository.TestRepository(t)
+	err := repo.WithBlobUploader(t.Context(), func(ctx context.Context, uploader restic.BlobSaverWithAsync) error {
+		for i, content := range contents {
+			id, _, _, err := uploader.SaveBlob(ctx, restic.DataBlob, []byte(content), restic.ID{}, false)
+			if err != nil {
+				return err
+			}
+			contentIDs[i] = id
+		}
+		return nil
+	})
+	rtest.OK(t, err)
+
+	nodes := []*data.Node{
+		{
+			Name:    "before",
+			Path:    "/before",
+			Type:    data.NodeTypeFile,
+			Mode:    0o644,
+			Size:    uint64(len(contents[0])),
+			Content: restic.IDs{contentIDs[0]},
+		},
+		{
+			Name: "oversized-xattr",
+			Path: "/oversized-xattr",
+			Type: data.NodeTypeFile,
+			Mode: 0o644,
+			ExtendedAttributes: []data.ExtendedAttribute{
+				{
+					Name:  "user.way_too_large",
+					Value: make([]byte, 2*maxSpecialFileSize),
+				},
+			},
+		},
+		{
+			Name:    "after",
+			Path:    "/after",
+			Type:    data.NodeTypeFile,
+			Mode:    0o644,
+			Size:    uint64(len(contents[1])),
+			Content: restic.IDs{contentIDs[1]},
+		},
+	}
+
+	ch := make(chan *data.Node, len(nodes))
+	for _, node := range nodes {
+		ch <- node
+	}
+	close(ch)
+
+	var dst bytes.Buffer
+	d := New("tar", repo, &dst)
+	err = d.dumpTar(t.Context(), ch)
+	rtest.Assert(t, errors.Is(err, tar.ErrFieldTooLong), "wrong type %T", err)
+	rtest.Assert(t, strings.Contains(err.Error(), nodes[1].Path),
+		"no filename in %q", err)
+
+	tr := tar.NewReader(bytes.NewReader(dst.Bytes()))
+	var names []string
+	var gotContents []string
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		rtest.OK(t, err)
+		names = append(names, hdr.Name)
+		content, err := io.ReadAll(tr)
+		rtest.OK(t, err)
+		gotContents = append(gotContents, string(content))
+	}
+
+	rtest.Equals(t, []string{"before", "after"}, names)
+	rtest.Equals(t, contents, gotContents)
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

`archive/tar.Writer` enters an unusable state when an oversized PAX header
causes `WriteHeader` to return `tar.ErrFieldTooLong`. As a result, `restic
dump` stopped at that node and omitted every later entry from the archive.

This change validates each tar header with a throwaway writer before touching
the archive writer. Entries whose headers exceed the PAX size limit are
skipped, while later entries and their contents are still written to a valid
tar archive. The skipped, path-aware errors are returned after the archive is
closed, so the command continues to exit non-zero and clearly signals that the
output is incomplete. Other header, repository, and output errors remain
fail-fast.

The regression test writes real blob contents before and after an entry with
oversized extended attributes, then verifies both the returned error and the
contents of the resulting archive.

Validation:

- `go test ./internal/dump -count=1`
- `go test -race ./internal/dump -count=1`
- `go test ./cmd/restic -run Dump -count=1`
- `go run build.go`
- `golangci-lint run --timeout 5m --new-from-rev origin/master`

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #4307.

Checklist
---------

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
