### PR TITLE
snapshots: remove trailing slashes for paths

### DIFF
--- a/cmd/restic/cmd_snapshots.go
+++ b/cmd/restic/cmd_snapshots.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -77,6 +78,10 @@ func (opts *SnapshotOptions) AddFlags(f *pflag.FlagSet) {
 func (opts *SnapshotOptions) Finalize() error {
 	if opts.last && opts.Latest == 0 {
 		opts.Latest = 1
+	}
+	// strip trailing slashes
+	for i := 0; i < len(opts.SnapshotFilter.Paths); i++ {
+		opts.SnapshotFilter.Paths[i] = filepath.Clean(opts.SnapshotFilter.Paths[i])
 	}
 	return nil
 }


### PR DESCRIPTION
Shell completion would add a trailing slash for a directory, and then one would currently get an empty list for `snapshots --path /foo/bar/`, because the `paths` are stored without the trailing slash.


Checklist
---------

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [ ] I'm done! This pull request is ready for review.
