### PR TITLE
documentation: Fix incorrect snapshot ID

### DIFF
--- a/doc/060_forget.rst
+++ b/doc/060_forget.rst
@@ -323,7 +323,7 @@ five days that had a snapshot and remove the other snapshots:
    keep 5 snapshots:
    ID        Time                 Host        Tags        Reasons         Paths
    -------------------------------------------------------------------------------
-   8a603ddf  2025-04-25 23:00:00  mopped                  daily snapshot  /home/user/work
+   ae33bf10  2025-04-25 23:00:00  mopped                  daily snapshot  /home/user/work
    fb8b1418  2025-04-28 11:00:00  mopped                  daily snapshot  /home/user/work
    1db188b4  2025-04-29 11:00:00  mopped                  daily snapshot  /home/user/work
    7baa4f28  2025-05-01 11:00:00  mopped                  daily snapshot  /home/user/work


### PR DESCRIPTION
There are two snapshots for 2025-04-25. The snapshot at 23:00 has the ID ae33bf10 and the snapshot at 11:00:00 has the ID 8a603ddf. The ID 8a603ddf is listed twice (remove and keep) in the example output which is a paradox.

Current documentation: https://restic.readthedocs.io/en/stable/060_forget.html#removing-snapshots-according-to-a-policy

What does this PR change? What problem does it solve?
-----------------------------------------------------

Fix incorrect ID in example output

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

No. I searched for both snapshot IDs and did not find anything

Checklist
---------

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [X] I'm done! This pull request is ready for review.
