### PR TITLE
more backup integration tests

### DIFF
--- a/cmd/restic/cmd_backup_integration_test.go
+++ b/cmd/restic/cmd_backup_integration_test.go
@@ -777,3 +777,145 @@ func TestBackupExcludeWithOutput(t *testing.T) {
 	}
 	rtest.Assert(t, foundExclude, "expected at least one excluded item, but found none")
 }
+
+func TestBackupWrongTime(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	backupOptions := BackupOptions{TimeStamp: "YYYY-MM-DD 01:01:01"}
+	err := testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"testdata"}, backupOptions, env.gopts)
+	rtest.Assert(t, err != nil, "expected error")
+	rtest.Assert(t, strings.Contains(err.Error(), "error in time option: parsing time"), "expected time definition failure")
+}
+
+func TestBackupWrongFileDelimeter(t *testing.T) {
+	dir := rtest.TempDir(t)
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	testSetupBackupData(t, env)
+
+	f3, err := os.Create(filepath.Join(dir, "fromfile-raw"))
+	rtest.OK(t, err)
+	for _, filename := range []string{"baz", "quux"} {
+		// \x01 is incorrect, \x00 is correct
+		_, err = fmt.Fprintf(f3, "%s\x01", filepath.Join(dir, filename))
+		rtest.OK(t, err)
+	}
+	rtest.OK(t, err)
+	rtest.OK(t, f3.Close())
+
+	backupOptions := BackupOptions{FilesFromRaw: []string{f3.Name()}}
+	err = testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"testdata"}, backupOptions, env.gopts)
+	rtest.Assert(t, err != nil, "expected an error")
+	expectedError := "--files-from-raw: trailing zero byte missing"
+	rtest.Assert(t, strings.Contains(err.Error(), expectedError), "expected %q, got %q", expectedError, err.Error())
+}
+
+func TestBackupStdinMix(t *testing.T) {
+	dir := rtest.TempDir(t)
+	fooSpace := "foo "
+	barStar := "bar*"              // Must sort before the others, below.
+	if runtime.GOOS == "windows" { // Doesn't allow "*" or trailing space.
+		fooSpace = "foo"
+		barStar = "bar"
+	}
+
+	f1, err := os.Create(filepath.Join(dir, "fromfile"))
+	rtest.OK(t, err)
+	// Empty lines should be ignored. A line starting with '#' is a comment.
+	_, err = fmt.Fprintf(f1, "\n%s*\n # here's a comment\n", f1.Name())
+	rtest.OK(t, err)
+	rtest.OK(t, f1.Close())
+
+	f2, err := os.Create(filepath.Join(dir, "fromfile-verbatim"))
+	rtest.OK(t, err)
+	for _, filename := range []string{fooSpace, barStar} {
+		// Empty lines should be ignored. CR+LF is allowed.
+		_, err = fmt.Fprintf(f2, "%s\r\n\n", filepath.Join(dir, filename))
+		rtest.OK(t, err)
+	}
+	rtest.OK(t, f2.Close())
+
+	f3, err := os.Create(filepath.Join(dir, "fromfile-raw"))
+	rtest.OK(t, err)
+	for _, filename := range []string{"baz", "quux"} {
+		_, err = fmt.Fprintf(f3, "%s\x00", filepath.Join(dir, filename))
+		rtest.OK(t, err)
+	}
+	rtest.OK(t, err)
+	rtest.OK(t, f3.Close())
+
+	f4, err := os.Create(filepath.Join(dir, "fromfile-raw2"))
+	rtest.OK(t, err)
+	nullChar := byte(0)
+	for _, filename := range []string{"baz", "quux"} {
+		_, err = fmt.Fprintf(f4, "%s%c%c", filepath.Join(dir, filename), nullChar, nullChar)
+		rtest.OK(t, err)
+	}
+	rtest.OK(t, err)
+	rtest.OK(t, f4.Close())
+
+	f5, err := os.Create(filepath.Join(dir, "fromfile-raw3"))
+	rtest.OK(t, err)
+	for _, filename := range []string{"baz", "quux"} {
+		_, err = fmt.Fprintf(f5, "%s\x00", filepath.Join(dir, filename))
+		rtest.OK(t, err)
+	}
+	_, err = fmt.Fprintf(f5, "\x01")
+	rtest.OK(t, err)
+	rtest.OK(t, f5.Close())
+
+	type BackupError struct {
+		opts          BackupOptions
+		expectedError string
+	}
+
+	cases := []BackupError{
+		{
+			opts:          BackupOptions{Stdin: true, FilesFrom: []string{f1.Name()}},
+			expectedError: "--stdin and --files-from cannot be used together",
+		},
+		{
+			opts:          BackupOptions{Stdin: true, FilesFromVerbatim: []string{f2.Name()}},
+			expectedError: "--stdin and --files-from-verbatim cannot be used together",
+		},
+		{
+			opts:          BackupOptions{StdinCommand: true, FilesFromRaw: []string{f3.Name()}},
+			expectedError: "--stdin and --files-from-raw cannot be used together",
+		},
+		{
+			opts:          BackupOptions{FilesFromRaw: []string{f4.Name()}},
+			expectedError: "--files-from-raw: empty filename in listing",
+		},
+		{
+			opts:          BackupOptions{FilesFromRaw: []string{f5.Name()}},
+			expectedError: "--files-from-raw: trailing zero byte missing",
+		},
+	}
+
+	for _, cas := range cases {
+		t.Run(cas.expectedError[2:], func(t *testing.T) {
+			env, cleanup := withTestEnvironment(t)
+			defer cleanup()
+			testSetupBackupData(t, env)
+
+			err = testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"testdata"}, cas.opts, env.gopts)
+			rtest.Assert(t, err != nil, "expected an error")
+			rtest.Assert(t, strings.Contains(err.Error(), cas.expectedError), "expected %q, got %q", cas.expectedError, err.Error())
+		})
+	}
+}
+
+func TestBackupMixStdinArgs(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	testSetupBackupData(t, env)
+
+	backupOptions := BackupOptions{Stdin: true}
+	err := testRunBackupAssumeFailure(t, filepath.Dir(env.testdata), []string{"testdata"}, backupOptions, env.gopts)
+	rtest.Assert(t, err != nil, "expected an error")
+	expectedError := "--stdin was specified and files/dirs were listed as arguments"
+	//t.Logf("err; %v", err)
+	rtest.Assert(t, strings.Contains(err.Error(), expectedError), "expected %q, got %q", expectedError, err.Error())
+}


### PR DESCRIPTION
Add more tests to test the error exits. I tried to cover all error exits which can be easily created. Complex errors in the backend are either covered elsewhere or are difficult to simulate.

<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Improve test coverage for the backup command.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
no.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
~~- [ ] I have added documentation for relevant changes (in the manual).~~
~~- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I'm done! This pull request is ready for review.
