### PR TITLE
more restore integration tests

### DIFF
--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -189,7 +189,7 @@ func filterExisting(items []string, warnf func(msg string, args ...any)) (result
 			if errors.Is(err, os.ErrNotExist) {
 				warnf("%v does not exist, skipping\n", item)
 			} else {
-				warnf("%v cannot be accessed, skipping\n", item)
+				warnf("%q cannot be accessed, skipping\n", item)
 			}
 			continue
 		}

--- a/cmd/restic/cmd_restore_integration_test.go
+++ b/cmd/restic/cmd_restore_integration_test.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"syscall"
 	"testing"
@@ -486,6 +487,11 @@ func TestRestoreMulti(t *testing.T) {
 
 	cases := []RestoreError{
 		{
+			// excluded from windows test
+			opts:          RestoreOptions{Delete: true, Target: "/"},
+			expectedError: "'--target / --delete' must be combined with an include or exclude filter",
+		},
+		{
 			opts:          RestoreOptions{},
 			expectedError: "please specify a directory to restore to (--target)",
 		},
@@ -498,10 +504,6 @@ func TestRestoreMulti(t *testing.T) {
 			expectedError: "exclude and include xattr patterns are mutually exclusive",
 		},
 		{
-			opts:          RestoreOptions{Delete: true, Target: "/"},
-			expectedError: "'--target / --delete' must be combined with an include or exclude filter",
-		},
-		{
 			opts:          RestoreOptions{Target: "/tmp", ExcludeXattrPattern: []string{"[]a]"}},
 			expectedError: "--exclude-xattr:",
 		},
@@ -511,7 +513,10 @@ func TestRestoreMulti(t *testing.T) {
 		},
 	}
 
-	for _, cas := range cases {
+	for i, cas := range cases {
+		if i == 0 && runtime.GOOS == "windows" {
+			continue
+		}
 		t.Run(cas.expectedError, func(t *testing.T) {
 			err := testRunRestoreMayFail(t, cas.opts, env.gopts, []string{"latest"})
 			rtest.Assert(t, err != nil, "expected an error")

--- a/cmd/restic/cmd_restore_integration_test.go
+++ b/cmd/restic/cmd_restore_integration_test.go
@@ -425,21 +425,6 @@ func TestRestoreDefaultLayout(t *testing.T) {
 	rtest.RemoveAll(t, target)
 }
 
-/* from grep -n "errors\." cmd/restic/cmd_restore.go
-DONE:		return errors.Fatal("no snapshot ID specified")
-DONE:		return errors.Fatalf("more than one snapshot ID specified: %v", args)
-DONE:		return errors.Fatal("please specify a directory to restore to (--target)")
-DONE:		return errors.Fatal("exclude and include patterns are mutually exclusive")
-DONE:		return errors.Fatal("--dry-run and --verify are mutually exclusive")
-DONE:		return errors.Fatal("'--target / --delete' must be combined with an include or exclude filter")
-DONE:		return errors.Fatalf("failed to find snapshot: %v", err)
-NO:		return errors.Fatalf("There were %d errors", totalErrors)
-NO:			return errors.Fatalf("There were %d errors", totalErrors)
-DONE:		return nil, errors.Fatal("exclude and include xattr patterns are mutually exclusive")
-294:			return nil, errors.Fatalf("--exclude-xattr: %s", err)
-306:			return nil, errors.Fatalf("--include-xattr: %s", err)
-*/
-
 func TestRestoreNoSnapshot(t *testing.T) {
 	env, cleanup := withTestEnvironment(t)
 	defer cleanup()
@@ -465,6 +450,20 @@ func TestRestoreMoreThanOneSnapshot(t *testing.T) {
 	err := testRunRestoreMayFail(t, RestoreOptions{}, env.gopts, []string{"12345678", "abcdef01"})
 	rtest.Assert(t, err != nil, "expected error")
 	expectedError := "more than one snapshot ID specified"
+	rtest.Assert(t, strings.Contains(err.Error(), expectedError), "expected %q, got %q", expectedError, err.Error())
+}
+
+func TestRestoreinvalidSnapshotID(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	testRunInit(t, env.gopts)
+
+	testRunBackup(t, filepath.Dir(env.testdata), []string{filepath.Base(env.testdata)}, BackupOptions{}, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+
+	err := testRunRestoreMayFail(t, RestoreOptions{Target: "/tmp"}, env.gopts, []string{"12345678"})
+	rtest.Assert(t, err != nil, "expected error")
+	expectedError := "failed to find snapshot:"
 	rtest.Assert(t, strings.Contains(err.Error(), expectedError), "expected %q, got %q", expectedError, err.Error())
 }
 
@@ -498,6 +497,14 @@ func TestRestoreMulti(t *testing.T) {
 			opts:          RestoreOptions{Delete:true, Target: "/"},
 			expectedError: "'--target / --delete' must be combined with an include or exclude filter",
 		},
+		{
+			opts:          RestoreOptions{Target: "/tmp", ExcludeXattrPattern: []string{"[]a]"}},
+			expectedError: "--exclude-xattr:",
+		},
+		{
+			opts:          RestoreOptions{Target: "/tmp", IncludeXattrPattern: []string{"[]a]"}},
+			expectedError: "--include-xattr:",
+		},
 	}
 
 	for _, cas := range cases {
@@ -507,18 +514,4 @@ func TestRestoreMulti(t *testing.T) {
 			rtest.Assert(t, strings.Contains(err.Error(), cas.expectedError), "expected %q, got %q", cas.expectedError, err.Error())
 		})
 	}
-}
-
-func TestRestoreinvalidSnapshotID(t *testing.T) {
-	env, cleanup := withTestEnvironment(t)
-	defer cleanup()
-	testRunInit(t, env.gopts)
-
-	testRunBackup(t, filepath.Dir(env.testdata), []string{filepath.Base(env.testdata)}, BackupOptions{}, env.gopts)
-	testListSnapshots(t, env.gopts, 1)
-
-	err := testRunRestoreMayFail(t, RestoreOptions{Target: "/tmp"}, env.gopts, []string{"12345678"})
-	rtest.Assert(t, err != nil, "expected error")
-	expectedError := "failed to find snapshot:"
-	rtest.Assert(t, strings.Contains(err.Error(), expectedError), "expected %q, got %q", expectedError, err.Error())
 }

--- a/cmd/restic/cmd_restore_integration_test.go
+++ b/cmd/restic/cmd_restore_integration_test.go
@@ -55,6 +55,10 @@ func testRunRestoreLatest(t testing.TB, gopts global.Options, dir string, paths 
 	rtest.OK(t, testRunRestoreAssumeFailure(t, "latest", opts, gopts))
 }
 
+func testRunRestoreLatestWithOpts(t testing.TB, gopts global.Options, opts RestoreOptions) {
+	rtest.OK(t, testRunRestoreAssumeFailure(t, "latest", opts, gopts))
+}
+
 func testRunRestoreIncludes(t testing.TB, gopts global.Options, dir string, snapshotID restic.ID, includes []string) {
 	opts := RestoreOptions{
 		Target: dir,
@@ -514,4 +518,27 @@ func TestRestoreMulti(t *testing.T) {
 			rtest.Assert(t, strings.Contains(err.Error(), cas.expectedError), "expected %q, got %q", cas.expectedError, err.Error())
 		})
 	}
+}
+
+
+func TestRestoreVerify(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+
+	for i := range 10 {
+		p := filepath.Join(env.testdata, fmt.Sprintf("foo/bar/testfile%v", i))
+		rtest.OK(t, os.MkdirAll(filepath.Dir(p), 0755))
+		rtest.OK(t, appendRandomData(p, uint(rand.Intn(2<<21))))
+	}
+	testRunBackup(t, filepath.Dir(env.testdata), []string{filepath.Base(env.testdata)}, BackupOptions{}, env.gopts)
+
+	// Restore latest without any filters
+	restoredir := filepath.Join(env.base, "restore")
+	restOpts := RestoreOptions{Target: restoredir, Verify: true}
+	testRunRestoreLatestWithOpts(t, env.gopts, restOpts)
+
+	diff := directoriesContentsDiff(t, env.testdata, filepath.Join(restoredir, filepath.Base(env.testdata)))
+	rtest.Assert(t, diff == "", "directories are not equal %v", diff)
 }

--- a/cmd/restic/cmd_restore_integration_test.go
+++ b/cmd/restic/cmd_restore_integration_test.go
@@ -490,7 +490,7 @@ func TestRestoreMulti(t *testing.T) {
 			expectedError: "please specify a directory to restore to (--target)",
 		},
 		{
-			opts:          RestoreOptions{DryRun: true, Verify:true, Target: "/tmp"},
+			opts:          RestoreOptions{DryRun: true, Verify: true, Target: "/tmp"},
 			expectedError: "--dry-run and --verify are mutually exclusive",
 		},
 		{
@@ -498,7 +498,7 @@ func TestRestoreMulti(t *testing.T) {
 			expectedError: "exclude and include xattr patterns are mutually exclusive",
 		},
 		{
-			opts:          RestoreOptions{Delete:true, Target: "/"},
+			opts:          RestoreOptions{Delete: true, Target: "/"},
 			expectedError: "'--target / --delete' must be combined with an include or exclude filter",
 		},
 		{
@@ -519,7 +519,6 @@ func TestRestoreMulti(t *testing.T) {
 		})
 	}
 }
-
 
 func TestRestoreVerify(t *testing.T) {
 	env, cleanup := withTestEnvironment(t)

--- a/cmd/restic/cmd_restore_integration_test.go
+++ b/cmd/restic/cmd_restore_integration_test.go
@@ -37,6 +37,12 @@ func testRunRestoreAssumeFailure(t testing.TB, snapshotID string, opts RestoreOp
 	})
 }
 
+func testRunRestoreMayFail(t testing.TB, opts RestoreOptions, gopts global.Options, args []string) error {
+	return withTermStatus(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		return runRestore(ctx, opts, gopts, gopts.Term, args)
+	})
+}
+
 func testRunRestoreLatest(t testing.TB, gopts global.Options, dir string, paths []string, hosts []string) {
 	opts := RestoreOptions{
 		Target: dir,
@@ -417,4 +423,102 @@ func TestRestoreDefaultLayout(t *testing.T) {
 
 	rtest.RemoveAll(t, filepath.Join(env.base, "repo"))
 	rtest.RemoveAll(t, target)
+}
+
+/* from grep -n "errors\." cmd/restic/cmd_restore.go
+DONE:		return errors.Fatal("no snapshot ID specified")
+DONE:		return errors.Fatalf("more than one snapshot ID specified: %v", args)
+DONE:		return errors.Fatal("please specify a directory to restore to (--target)")
+DONE:		return errors.Fatal("exclude and include patterns are mutually exclusive")
+DONE:		return errors.Fatal("--dry-run and --verify are mutually exclusive")
+DONE:		return errors.Fatal("'--target / --delete' must be combined with an include or exclude filter")
+DONE:		return errors.Fatalf("failed to find snapshot: %v", err)
+NO:		return errors.Fatalf("There were %d errors", totalErrors)
+NO:			return errors.Fatalf("There were %d errors", totalErrors)
+DONE:		return nil, errors.Fatal("exclude and include xattr patterns are mutually exclusive")
+294:			return nil, errors.Fatalf("--exclude-xattr: %s", err)
+306:			return nil, errors.Fatalf("--include-xattr: %s", err)
+*/
+
+func TestRestoreNoSnapshot(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	testRunInit(t, env.gopts)
+
+	testRunBackup(t, filepath.Dir(env.testdata), []string{filepath.Base(env.testdata)}, BackupOptions{}, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+
+	err := testRunRestoreMayFail(t, RestoreOptions{}, env.gopts, []string{})
+	rtest.Assert(t, err != nil, "expected error")
+	expectedError := "no snapshot ID specified"
+	rtest.Assert(t, strings.Contains(err.Error(), expectedError), "expected %q, got %q", expectedError, err.Error())
+}
+
+func TestRestoreMoreThanOneSnapshot(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	testRunInit(t, env.gopts)
+
+	testRunBackup(t, filepath.Dir(env.testdata), []string{filepath.Base(env.testdata)}, BackupOptions{}, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+
+	err := testRunRestoreMayFail(t, RestoreOptions{}, env.gopts, []string{"12345678", "abcdef01"})
+	rtest.Assert(t, err != nil, "expected error")
+	expectedError := "more than one snapshot ID specified"
+	rtest.Assert(t, strings.Contains(err.Error(), expectedError), "expected %q, got %q", expectedError, err.Error())
+}
+
+func TestRestoreMulti(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	testRunInit(t, env.gopts)
+
+	testRunBackup(t, filepath.Dir(env.testdata), []string{filepath.Base(env.testdata)}, BackupOptions{}, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+
+	type RestoreError struct {
+		opts          RestoreOptions
+		expectedError string
+	}
+
+	cases := []RestoreError{
+		{
+			opts:          RestoreOptions{},
+			expectedError: "please specify a directory to restore to (--target)",
+		},
+		{
+			opts:          RestoreOptions{DryRun: true, Verify:true, Target: "/tmp"},
+			expectedError: "--dry-run and --verify are mutually exclusive",
+		},
+		{
+			opts:          RestoreOptions{ExcludeXattrPattern: []string{"abc"}, IncludeXattrPattern: []string{"def"}, Target: "/tmp"},
+			expectedError: "exclude and include xattr patterns are mutually exclusive",
+		},
+		{
+			opts:          RestoreOptions{Delete:true, Target: "/"},
+			expectedError: "'--target / --delete' must be combined with an include or exclude filter",
+		},
+	}
+
+	for _, cas := range cases {
+		t.Run(cas.expectedError, func(t *testing.T) {
+			err := testRunRestoreMayFail(t, cas.opts, env.gopts, []string{"latest"})
+			rtest.Assert(t, err != nil, "expected an error")
+			rtest.Assert(t, strings.Contains(err.Error(), cas.expectedError), "expected %q, got %q", cas.expectedError, err.Error())
+		})
+	}
+}
+
+func TestRestoreinvalidSnapshotID(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+	testRunInit(t, env.gopts)
+
+	testRunBackup(t, filepath.Dir(env.testdata), []string{filepath.Base(env.testdata)}, BackupOptions{}, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+
+	err := testRunRestoreMayFail(t, RestoreOptions{Target: "/tmp"}, env.gopts, []string{"12345678"})
+	rtest.Assert(t, err != nil, "expected error")
+	expectedError := "failed to find snapshot:"
+	rtest.Assert(t, strings.Contains(err.Error(), expectedError), "expected %q, got %q", expectedError, err.Error())
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
More test coverage for ``restic restore`` command. Add more tests to test the error exits. I tried to cover all error exits which can be easily reached. Complex errors in the backend are either covered elsewhere or are difficult to simulate.

I modified cmd_backup for a format string, because that particular test checks for filesnames with unprintable characters, which then can create confusion in text editors.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
no.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
~~- [ ] I have added documentation for relevant changes (in the manual).~~
~~- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [ ] I'm done! This pull request is ready for review.
