### PR TITLE
more prune integration tests

### DIFF
--- a/cmd/restic/cmd_prune_integration_test.go
+++ b/cmd/restic/cmd_prune_integration_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/restic/restic/internal/backend"
@@ -21,6 +22,11 @@ func testRunPruneMustFail(t testing.TB, gopts global.Options, opts PruneOptions)
 	t.Helper()
 	err := testRunPruneOutput(t, gopts, opts)
 	rtest.Assert(t, err != nil, "expected non nil error")
+}
+
+func testRunPruneMayFail(t testing.TB, gopts global.Options, opts PruneOptions) error {
+	t.Helper()
+	return testRunPruneOutput(t, gopts, opts)
 }
 
 func testRunPruneOutput(t testing.TB, gopts global.Options, opts PruneOptions) error {
@@ -282,4 +288,102 @@ func TestPruneJSON(t *testing.T) {
 	rtest.Equals(t, "summary", stats.MessageType)
 	rtest.Assert(t, stats.Blobs.Total > 0, "expected non-zero total blobs, got %v", stats.Blobs.Total)
 	rtest.Assert(t, stats.Packs.Total > 0, "expected non-zero total packs, got %v", stats.Packs.Total)
+}
+
+func TestPruneWrongOptions(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9")}, opts, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+
+	type PruneError struct {
+		opts          PruneOptions
+		expectedError string
+	}
+
+	cases := []PruneError{
+		{
+			opts:          PruneOptions{MaxUnused: "500%"},
+			expectedError: "percentage for --max-unused must be below 100%",
+		},
+		{
+			opts:          PruneOptions{MaxUnused: ""},
+			expectedError: "invalid value for --max-unused",
+		},
+		{
+			opts:          PruneOptions{MaxUnused: "-5%"},
+			expectedError: "percentage for --max-unused must be positive",
+		},
+		{
+			opts:          PruneOptions{MaxUnused: "42q%"},
+			expectedError: "invalid percentage",
+		},
+		{
+			opts:          PruneOptions{MaxUnused: "12345678h"},
+			expectedError: "invalid number of bytes",
+		},
+		{
+			opts:          PruneOptions{MaxUnused: "-12345678"},
+			expectedError: "invalid number of bytes",
+		},
+		{
+			opts:          PruneOptions{SmallPackSize: "0", MaxUnused: "5%"},
+			expectedError: "--repack-smaller-than must be larger than zero",
+		},
+		{
+			opts:          PruneOptions{SmallPackSize: "-10000", MaxUnused: "5%"},
+			expectedError: "for --repack-smaller-than",
+		},
+		{
+			opts:          PruneOptions{UnsafeNoSpaceRecovery: "ac08ce34ba4f8123618661bef2425f7028ffb9ac740578a3ee88684d2523fee8", MaxUnused: "5%"},
+			expectedError: "to --unsafe-recover-no-free-space",
+		},
+	}
+	for _, cas := range cases {
+		t.Run(cas.expectedError[2:], func(t *testing.T) {
+			err := testRunPruneMayFail(t, env.gopts, cas.opts)
+			rtest.Assert(t, err != nil, "expected an error")
+			rtest.Assert(t, strings.Contains(err.Error(), cas.expectedError), "expected %q, got %q", cas.expectedError, err.Error())
+		})
+	}
+}
+
+func TestPruneNoCompressionTryCompress(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9")}, opts, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+
+	env.gopts.Compression = repository.CompressionOff
+	pruneOpts := PruneOptions{RepackUncompressed: true, MaxUnused: "5%"}
+	err := testRunPruneMayFail(t, env.gopts, pruneOpts)
+	rtest.Assert(t, err != nil, "expected an error")
+	expectedError := "disabled compression and `--repack-uncompressed` are mutually exclusive"
+	rtest.Assert(t, strings.Contains(err.Error(), expectedError), "expected %q, got %q", expectedError, err.Error())
+}
+
+func TestPruneNoNoLockNoDryRun(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+
+	testRunBackup(t, "", []string{filepath.Join(env.testdata, "0", "0", "9")}, opts, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+
+	env.gopts.NoLock = true
+	pruneOpts := PruneOptions{MaxUnused: "5%"}
+	err := testRunPruneMayFail(t, env.gopts, pruneOpts)
+	rtest.Assert(t, err != nil, "expected an error")
+	expectedError := "nly applicable in combination with --dry-run for prune command"
+	rtest.Assert(t, strings.Contains(err.Error(), expectedError), "expected %q, got %q", expectedError, err.Error())
 }


### PR DESCRIPTION
More test coverage for ``restic prune`` command. Add more tests to test the error exits. I tried to cover all error exits which can be easily reached. Complex errors in the backend are either covered elsewhere or are difficult to simulate.


<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------
Better test covervage for command ``prune``.
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
no.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
~~- [ ] I have added documentation for relevant changes (in the manual).~~
~~- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I'm done! This pull request is ready for review.
