### PR TITLE
more ls integration tests

### DIFF
--- a/cmd/restic/cmd_ls_integration_test.go
+++ b/cmd/restic/cmd_ls_integration_test.go
@@ -23,6 +23,14 @@ func testRunLsWithOpts(t testing.TB, gopts global.Options, opts LsOptions, args 
 	return buf.Bytes()
 }
 
+func testRunLsMayFail(t testing.TB, gopts global.Options, opts LsOptions, args []string) ([]byte, error) {
+	buf, err := withCaptureStdout(t, gopts, func(ctx context.Context, gopts global.Options) error {
+		gopts.Quiet = true
+		return runLs(context.TODO(), opts, gopts, args, gopts.Term)
+	})
+	return buf.Bytes(), err
+}
+
 func testRunLs(t testing.TB, gopts global.Options, snapshotID string) []string {
 	out := testRunLsWithOpts(t, gopts, LsOptions{}, []string{snapshotID})
 	return strings.Split(string(out), "\n")
@@ -162,4 +170,79 @@ func TestRunLsJson(t *testing.T) {
 		rtest.OK(t, json.Unmarshal(nodeLine, &testNode))
 		rtest.Equals(t, pathList[i], testNode.Path)
 	}
+}
+
+func TestLsNoArgs(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+	testRunBackup(t, env.testdata+"/0", []string{"for_cmd_ls"}, opts, env.gopts)
+
+	_, err := testRunLsMayFail(t, env.gopts, LsOptions{}, []string{})
+	expected := "no snapshot ID specified, specify snapshot"
+	rtest.Assert(t, err != nil && strings.Contains(err.Error(), expected), "expected %q, got %q",
+		expected, err.Error())
+}
+
+func TestLsNcduJSON(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+	testRunBackup(t, env.testdata+"/0", []string{"for_cmd_ls"}, opts, env.gopts)
+
+	env.gopts.JSON = true
+	_, err := testRunLsMayFail(t, env.gopts, LsOptions{Ncdu: true}, []string{"latest"})
+	expected := "only either '--json' or '--ncdu' can be specified"
+	rtest.Assert(t, err != nil && strings.Contains(err.Error(), expected), "expected %q, got %q",
+		expected, err.Error())
+}
+
+func TestLsExclusiveOptions(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+	testRunBackup(t, env.testdata+"/0", []string{"for_cmd_ls"}, opts, env.gopts)
+
+	type exclusiveErrors struct {
+		opts          LsOptions
+		expectedError string
+	}
+
+	exclusive := []exclusiveErrors{
+		{
+			opts:          LsOptions{Ncdu: true, Reverse: true},
+			expectedError: "--reverse and --ncdu are mutually exclusive",
+		},
+		{
+			opts:          LsOptions{Ncdu: true, Sort: SortModeCtime},
+			expectedError: "--sort and --ncdu are mutually exclusive",
+		},
+	}
+
+	for _, ex := range exclusive {
+		_, err := testRunLsMayFail(t, env.gopts, ex.opts, []string{"latest"})
+		rtest.Assert(t, err != nil && strings.Contains(err.Error(), ex.expectedError), "expected %q, got %q",
+			ex.expectedError, err.Error())
+	}
+}
+
+func TestLsrelativePath(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	defer cleanup()
+
+	testSetupBackupData(t, env)
+	opts := BackupOptions{}
+	testRunBackup(t, env.testdata+"/0", []string{"for_cmd_ls"}, opts, env.gopts)
+
+	_, err := testRunLsMayFail(t, env.gopts, LsOptions{}, []string{"latest", "look"})
+	rtest.Assert(t, err != nil, "expected error, got none")
+	expected := "All path filters must be absolute, starting with a forward slash"
+	rtest.Assert(t, strings.Contains(err.Error(), expected), "expected %q, got %q",
+		expected, err.Error())
 }


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->
More test coverage for ``restic ls`` command. Add more tests to test the error exits. I tried to cover all error exits which can be easily reached. Complex errors in the backend are either covered elsewhere or are difficult to simulate.

What does this PR change? What problem does it solve?
-----------------------------------------------------
Better coverage for the ``restic ls`` command
<!--
Describe the changes and their purpose here, as detailed as needed.
-->

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
no.
<!--
Link issues and relevant forum posts here.

If this PR resolves an issue on GitHub, use "Closes #1234" so that the issue
is closed automatically when this PR is merged.
-->

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
~~- [ ] I have added documentation for relevant changes (in the manual).~~
~~- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).~~
- [x] I'm done! This pull request is ready for review.
