### PR TITLE
Update documentation for environment variable syntax

### DIFF
--- a/doc/040_backup.rst
+++ b/doc/040_backup.rst
@@ -399,6 +399,9 @@ sign, write ``$$`` to the file - this has to be done even when there's no
 matching environment variable for the word following a single ``$``. Note
 that tilde (``~``) is not expanded, instead use the ``$HOME`` or equivalent
 environment variable (depending on your operating system).
+For environment variable names with non-alphanumeric characters,
+enclose the name in curly braces (e.g., ``${ProgramFiles(x86)}``).
+Without braces, the parser stops at the first non-alphanumeric character.
 
 Patterns need to match on complete path components. For example, the pattern ``foo``:
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------
This PR is a minor update in the backup documentation to clarify how environment variables containing non-alphanumeric characters (like parentheses) must be formatted. 

Because Go's `os.ExpandEnv` stops scanning at the first non-alphanumeric character, an unbraced variable like `$ProgramFiles(x86)` will incorrectly evaluate the variable `$ProgramFiles` and append `(x86)` literally. This PR adds a brief note with an example explaining that curly braces (e.g., `${ProgramFiles(x86)}`) are required to properly parse these variables.

I can guarantee that this information could have saved at least one new user a lot of time and some of their sanity... 🙄

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------
As far as I know, no.

Checklist
---------
- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [ ] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.