### PR TITLE
mount: honor --repository-file when checking local overlap

### DIFF
--- a/cmd/restic/cmd_mount.go
+++ b/cmd/restic/cmd_mount.go
@@ -21,6 +21,7 @@ import (
 	"github.com/restic/restic/internal/errors"
 	"github.com/restic/restic/internal/fs"
 	"github.com/restic/restic/internal/global"
+	"github.com/restic/restic/internal/textfile"
 	"github.com/restic/restic/internal/ui"
 	"github.com/restic/restic/internal/ui/progress"
 
@@ -242,7 +243,23 @@ func validateMountpoint(mountpoint string, gopts global.Options) error {
 	// Refuse to mount onto (or under, or over) the local repository directory.
 	// Doing so makes the FUSE server read its own backend files through the
 	// mount it just created, deadlocking the kernel (GH #5234).
-	loc, err := location.Parse(gopts.Backends, gopts.Repo)
+	//
+	// Resolve -r / --repository-file the same way OpenRepository does. Parsing
+	// the empty gopts.Repo string as a local path treats cwd as the repo, so
+	// `restic --repository-file ... mount ./mount` refused every mount under
+	// the working directory even for rest: (and other remote) backends (#22025).
+	repo := gopts.Repo
+	if repo == "" && gopts.RepositoryFile != "" {
+		s, err := textfile.Read(gopts.RepositoryFile)
+		if err != nil {
+			return err
+		}
+		repo = strings.TrimSpace(string(s))
+	}
+	if repo == "" {
+		return nil
+	}
+	loc, err := location.Parse(gopts.Backends, repo)
 	if err != nil {
 		return err
 	}

--- a/cmd/restic/cmd_mount_integration_test.go
+++ b/cmd/restic/cmd_mount_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	systemFuse "github.com/anacrolix/fuse"
+	"github.com/restic/restic/internal/backend/all"
 	"github.com/restic/restic/internal/data"
 	"github.com/restic/restic/internal/global"
 	"github.com/restic/restic/internal/restic"
@@ -210,6 +211,37 @@ func TestMount(t *testing.T) {
 		"expected three snapshots, got %v", snapshotIDs)
 
 	checkSnapshots(t, env.gopts, env.mountpoint, snapshotIDs, 4)
+}
+
+func TestValidateMountpointRepositoryFile(t *testing.T) {
+	tempdir := t.TempDir()
+	mount := filepath.Join(tempdir, "mount")
+	rtest.OK(t, os.MkdirAll(mount, 0700))
+	repoFile := filepath.Join(tempdir, "repository-file")
+
+	t.Run("rest url is not treated as local cwd", func(t *testing.T) {
+		rtest.OK(t, os.WriteFile(repoFile, []byte("rest:http://example.com:8000/\n"), 0600))
+		gopts := global.Options{
+			RepositoryFile: repoFile,
+			Backends:       all.Backends(),
+		}
+		rtest.OK(t, validateMountpoint(mount, gopts))
+	})
+
+	t.Run("local path in repository-file still overlaps", func(t *testing.T) {
+		rtest.OK(t, os.WriteFile(repoFile, []byte(tempdir+"\n"), 0600))
+		gopts := global.Options{
+			RepositoryFile: repoFile,
+			Backends:       all.Backends(),
+		}
+		err := validateMountpoint(mount, gopts)
+		if err == nil {
+			t.Fatal("expected overlap error for local repository-file path")
+		}
+		if !strings.Contains(err.Error(), "is inside the local repository directory") {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func TestCheckMountpointOverlap(t *testing.T) {


### PR DESCRIPTION
`validateMountpoint` parsed `gopts.Repo` to decide whether the mountpoint overlaps a local repository. That field is empty when the location comes from `--repository-file`, and an empty location is treated as a local path (cwd).

So this failed even for a rest-server backend:

```
restic --repository-file repository-file mount ./mount
Fatal: mountpoint .../mount is inside the local repository directory ...; refusing to mount to avoid deadlocking the FUSE server
```

The same command with `-r rest:http://...` worked. The overlap check now reads the repository-file the same way `OpenRepository` does, and still rejects a real local path that overlaps the mountpoint.

Fixes #22025

## Testing

`go test ./cmd/restic -run 'TestCheckMountpointOverlap|TestValidateMountpointRepositoryFile' -count=1`