### PR TITLE
docs: fix two dead links (PGP key URL, MinIO docs URL)

### DIFF
--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -281,36 +281,6 @@ after the bucket name like this:
           be converted to path-style URLs instead, for example ``s3.us-west-2.amazonaws.com/bucket_name``.
           See below for configuration options for S3-compatible storage from other providers.
 
-Minio Server
-************
-
-`Minio <https://min.io/>`__ is an Open Source Object Storage,
-written in Go and compatible with Amazon S3 API.
-
--  Download and Install `Minio Download <https://min.io/download#/linux>`__.
--  You can also refer to `Minio Docs <https://min.io/docs/minio/linux/index.html>`__ for step by step guidance
-   on installation and getting started on Minio Client and Minio Server.
-
-You must first setup the following environment variables with the
-credentials of your Minio Server.
-
-.. code-block:: console
-
-    $ export AWS_ACCESS_KEY_ID=<YOUR-MINIO-ACCESS-KEY-ID>
-    $ export AWS_SECRET_ACCESS_KEY=<YOUR-MINIO-SECRET-ACCESS-KEY>
-
-Now you can easily initialize restic to use Minio server as a backend with
-this command.
-
-.. code-block:: console
-
-    $ restic -r s3:http://localhost:9000/restic init
-    enter password for new repository:
-    enter password again:
-    created restic repository 6ad29560f5 at s3:http://localhost:9000/restic
-    Please note that knowledge of your password is required to access
-    the repository. Losing your password means that your data is irrecoverably lost.
-
 S3-compatible storage
 *********************
 

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -288,7 +288,7 @@ Minio Server
 written in Go and compatible with Amazon S3 API.
 
 -  Download and Install `Minio Download <https://min.io/download#/linux>`__.
--  You can also refer to `Minio Docs <https://min.io/docs/minio/linux/>`__ for step by step guidance
+-  You can also refer to `Minio Docs <https://min.io/docs/minio/linux/index.html>`__ for step by step guidance
    on installation and getting started on Minio Client and Minio Server.
 
 You must first setup the following environment variables with the

--- a/doc/090_participating.rst
+++ b/doc/090_participating.rst
@@ -237,7 +237,7 @@ Security
 possible critical security problem, please do *not* open a GitHub issue
 but send an email directly to alexander@bumpern.de. If possible, please
 encrypt your email using the following PGP key
-(`0x91A6868BD3F7A907 <https://pgp.mit.edu/pks/lookup?op=get&search=0xCF8F18F2844575973F79D4E191A6868BD3F7A907>`__):
+(`0x91A6868BD3F7A907 <https://restic.net/gpg-key-alex.asc>`__):
 
 ::
 


### PR DESCRIPTION
Found while crawling the external links in `doc/*.rst` (98 unique URLs live-checked):

1. **`doc/090_participating.rst` (Security section):** the MIT PGP keyserver lookup URL for the security-contact key (`https://pgp.mit.edu/pks/lookup?op=get&search=0xCF8F18F...`) no longer resolves. Replaced with `https://restic.net/gpg-key-alex.asc`, which serves HTTP 200 and contains exactly the same key - verified by importing it with GnuPG: fingerprint `CF8F18F2844575973F79D4E191A6868BD3F7A907` (key id `91A6868BD3F7A907`, Alexander Neumann <alexander@bumpern.de>), matching the key block printed below the link in the doc.

2. **`doc/030_preparing_a_new_repo.rst` (Minio Server section):** `https://min.io/docs/minio/linux/` returns 404. Replaced with `https://min.io/docs/minio/linux/index.html` which serves 200 and is the same documentation landing page.

Both replacements were verified with live HTTP checks before committing.
