### PR TITLE
recover: fix failure with multiple unreferenced roots

### DIFF
--- a/changelog/unreleased/issue-22018
+++ b/changelog/unreleased/issue-22018
@@ -1,0 +1,10 @@
+Bugfix: Fix `recover` command failing when multiple roots are unreferenced
+
+The `recover` command builds a new snapshot referencing all root trees that
+are not referenced by an existing snapshot. When more than one such root
+existed, `recover` could fail with an error like "nodes are not ordered or
+duplicate" because the roots were processed in a random order. Restic now
+processes the roots in a stable, sorted order, so `recover` succeeds
+regardless of how many unreferenced roots are found.
+
+https://github.com/restic/restic/issues/22018

--- a/cmd/restic/cmd_recover.go
+++ b/cmd/restic/cmd_recover.go
@@ -143,7 +143,7 @@ func runRecover(ctx context.Context, gopts global.Options, term ui.Terminal) err
 	err = repo.WithBlobUploader(ctx, func(ctx context.Context, uploader restic.BlobSaverWithAsync) error {
 		var err error
 		tw := data.NewTreeWriter(uploader)
-		for id := range roots {
+		for _, id := range roots.List() {
 			var subtreeID = id
 			node := data.Node{
 				Type:       data.NodeTypeDir,

--- a/cmd/restic/cmd_recover_integration_test.go
+++ b/cmd/restic/cmd_recover_integration_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/restic/restic/internal/global"
@@ -36,4 +38,35 @@ func TestRecover(t *testing.T) {
 	rtest.OK(t, withTermStatus(t, env.gopts, func(ctx context.Context, gopts global.Options) error {
 		return runCat(context.TODO(), gopts, []string{"tree", ids[0].String() + ":" + sn.Tree.Str()}, gopts.Term)
 	}))
+}
+
+// TestRecoverMultipleRoots covers https://github.com/restic/restic/issues/22018:
+// recover must process unreferenced roots in a stable order, since the node
+// names it derives from them must be added in strictly ascending order. A
+// single root is trivially ordered, so distinct content is backed up here to
+// produce several roots instead of reusing testSetupBackupData's one fixture.
+func TestRecoverMultipleRoots(t *testing.T) {
+	env, cleanup := withTestEnvironment(t)
+	// must list index more than once
+	env.gopts.BackendTestHook = nil
+	defer cleanup()
+
+	testRunInit(t, env.gopts)
+
+	for i := 0; i < 5; i++ {
+		dir := filepath.Join(env.testdata, "data"+string(rune('a'+i)))
+		rtest.OK(t, os.MkdirAll(dir, 0755))
+		rtest.OK(t, os.WriteFile(filepath.Join(dir, "file.txt"), []byte{byte(i), byte(i + 1)}, 0644))
+		testRunBackup(t, "", []string{dir}, BackupOptions{}, env.gopts)
+	}
+
+	ids := testListSnapshots(t, env.gopts, 5)
+	for _, id := range ids {
+		testRunForget(t, env.gopts, ForgetOptions{}, id.String())
+	}
+	testListSnapshots(t, env.gopts, 0)
+
+	testRunRecover(t, env.gopts)
+	testListSnapshots(t, env.gopts, 1)
+	testRunCheck(t, env.gopts)
 }


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The `recover` command builds a new snapshot from all root trees that are
not referenced by an existing snapshot. It iterated over an `IDSet`, which
is backed by a Go map, so the roots were processed in a randomized order.

The tree builder used to assemble the recovered snapshot requires nodes to
be added in strictly ascending order by name. Since the node names are
derived from the root IDs, the randomized order frequently caused
`recover` to fail with `nodes are not ordered or duplicate`, even though
the roots themselves were valid. A single unreferenced root never
triggered the bug, since one entry is trivially ordered, which is why
existing tests did not catch this.

This PR changes `runRecover` to iterate the roots via `IDSet.List()`
instead, which returns them in a stable, sorted order, so `recover` now
succeeds regardless of how many unreferenced roots are found.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #22018

Checklist
---------

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.
