### PR TITLE
fix(backup): do not follow dir-symlinks in include Glob

### DIFF
--- a/changelog/unreleased/issue-21790
+++ b/changelog/unreleased/issue-21790
@@ -1,0 +1,13 @@
+Bugfix: Do not follow directory symlinks in `backup --files-from` globs
+
+The `backup` command used Go's `filepath.Glob` to expand patterns from
+`--files-from`. That follows directory symbolic links, so a Wine/Proton
+`dosdevices/z:` link (which points at `/`) caused patterns such as
+`compatdata/*/*/*.cfg*` to expand into `/proc` and exhaust memory.
+
+Include globs no longer follow directory symbolic links that were matched
+by a wildcard. Literal path components, including a directory symlink
+named in the pattern after a wildcard, are still followed.
+
+https://github.com/restic/restic/issues/21790
+https://github.com/restic/restic/pull/22039

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"os"
 	"path"
-	"path/filepath"
 	"runtime"
 	"slices"
 	"strconv"
@@ -422,7 +421,7 @@ func collectTargets(opts BackupOptions, args []string, warnf func(msg string, ar
 			}
 
 			var expanded []string
-			expanded, err := filepath.Glob(line)
+			expanded, err := globNoFollow(line)
 			if err != nil {
 				return nil, fmt.Errorf("pattern: %s: %w", line, err)
 			}

--- a/cmd/restic/cmd_backup_test.go
+++ b/cmd/restic/cmd_backup_test.go
@@ -77,6 +77,108 @@ func TestCollectTargets(t *testing.T) {
 	rtest.Assert(t, err == ErrInvalidSourceData, "expected error when not all targets exist")
 }
 
+// TestCollectTargetsGlobDoesNotFollowWildcardDirSymlink is a regression
+// test for #21790. filepath.Glob follows directory symlinks, so a
+// Wine-style dosdevices/z: link is expanded into the target tree.
+// Include Glob must not return matches whose path goes through that
+// symlink (wildcard-matched dirs are not followed).
+func TestCollectTargetsGlobDoesNotFollowWildcardDirSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Wine-style z: symlink is a Unix issue")
+	}
+
+	dir := rtest.TempDir(t)
+
+	// Tiny decoy (NOT /proc) that the z: symlink points at.
+	decoyEtc := filepath.Join(dir, "decoy", "etc")
+	rtest.OK(t, os.MkdirAll(decoyEtc, 0o755))
+	rtest.OK(t, os.WriteFile(filepath.Join(decoyEtc, "rc_maps.cfg"), []byte("x"), 0o644))
+
+	// Wine-shaped prefix/dosdevices/z: -> decoy
+	dosdevices := filepath.Join(dir, "prefix", "dosdevices")
+	rtest.OK(t, os.MkdirAll(dosdevices, 0o755))
+	rtest.OK(t, os.Symlink(filepath.Join(dir, "decoy"), filepath.Join(dosdevices, "z:")))
+
+	// A real directory next to z: so normal include patterns still match.
+	realEtc := filepath.Join(dosdevices, "real", "etc")
+	rtest.OK(t, os.MkdirAll(realEtc, 0o755))
+	rtest.OK(t, os.WriteFile(filepath.Join(realEtc, "local.cfg"), []byte("y"), 0o644))
+
+	// Pattern: prefix/dosdevices/*/*/*.cfg*  — * matches z: then etc then rc_maps.cfg
+	// if Glob follows the symlink.
+	pattern := filepath.Join(dir, "prefix", "dosdevices", "*", "*", "*.cfg*")
+	include := filepath.Join(dir, "include.txt")
+	rtest.OK(t, os.WriteFile(include, []byte(pattern+"\n"), 0o644))
+
+	targets, err := collectTargets(BackupOptions{FilesFrom: []string{include}}, nil, t.Logf, nil)
+	rtest.OK(t, err)
+
+	symlinkMarker := string(os.PathSeparator) + "z:" + string(os.PathSeparator)
+	var through []string
+	for _, tgt := range targets {
+		if strings.Contains(tgt, symlinkMarker) {
+			through = append(through, tgt)
+		}
+	}
+	t.Logf("collectTargets returned %d target(s), %d through z: symlink: %v", len(targets), len(through), through)
+	rtest.Assert(t, len(through) == 0, "include Glob followed z: symlink: %d match(es) through z:: %v", len(through), through)
+
+	// The same pattern must still match through a real (non-symlink) directory.
+	var sawReal bool
+	for _, tgt := range targets {
+		if strings.Contains(tgt, string(os.PathSeparator)+"real"+string(os.PathSeparator)) && strings.HasSuffix(tgt, "local.cfg") {
+			sawReal = true
+			break
+		}
+	}
+	rtest.Assert(t, sawReal, "normal include through a real directory disappeared: %v", targets)
+
+	// Literal symlink prefixes are still followed (pattern names the link).
+	linkdir := filepath.Join(dir, "linkdir")
+	rtest.OK(t, os.Symlink(filepath.Join(dir, "decoy"), linkdir))
+	literal := filepath.Join(linkdir, "etc", "*.cfg*")
+	include2 := filepath.Join(dir, "include-literal.txt")
+	rtest.OK(t, os.WriteFile(include2, []byte(literal+"\n"), 0o644))
+	targets, err = collectTargets(BackupOptions{FilesFrom: []string{include2}}, nil, t.Logf, nil)
+	rtest.OK(t, err)
+	rtest.Assert(t, len(targets) == 1, "literal symlink prefix should still expand: %v", targets)
+}
+
+// TestCollectTargetsGlobFollowsLiteralDirSymlinkAfterWildcard is the
+// counterpart to the Wine case above. The Wine bug is wildcard-expanded
+// directories that are dosdevices-style symlinks (matched by "*"). A
+// *literal* path component after a wildcard must still be followed if it
+// is a directory symlink, so a pattern like tmp/*/foo/bar.cfg still
+// matches when foo is a symlink to a directory.
+func TestCollectTargetsGlobFollowsLiteralDirSymlinkAfterWildcard(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("directory symlink layout is a Unix issue")
+	}
+
+	dir := rtest.TempDir(t)
+
+	// Real tree that the literal "foo" symlink will point at.
+	realFoo := filepath.Join(dir, "realfoo")
+	rtest.OK(t, os.MkdirAll(realFoo, 0o755))
+	rtest.OK(t, os.WriteFile(filepath.Join(realFoo, "bar.cfg"), []byte("z"), 0o644))
+
+	// Wildcard-matched directory containing a literal symlink named foo.
+	wild := filepath.Join(dir, "tmp", "matched")
+	rtest.OK(t, os.MkdirAll(wild, 0o755))
+	rtest.OK(t, os.Symlink(realFoo, filepath.Join(wild, "foo")))
+
+	// Pattern: tmp/*/foo/*.cfg — "*" matches "matched", "foo" is literal.
+	pattern := filepath.Join(dir, "tmp", "*", "foo", "*.cfg")
+	include := filepath.Join(dir, "include-literal-after-wild.txt")
+	rtest.OK(t, os.WriteFile(include, []byte(pattern+"\n"), 0o644))
+
+	targets, err := collectTargets(BackupOptions{FilesFrom: []string{include}}, nil, t.Logf, nil)
+	rtest.OK(t, err)
+	rtest.Assert(t, len(targets) == 1, "literal symlink dir after wildcard should still match: %v", targets)
+	wantSuffix := filepath.Join("foo", "bar.cfg")
+	rtest.Assert(t, strings.HasSuffix(targets[0], wantSuffix), "expected match through literal foo symlink ending in %q, got %v", wantSuffix, targets)
+}
+
 func TestFilterExistingUnreadable(t *testing.T) {
 	dir := rtest.TempDir(t)
 

--- a/cmd/restic/glob.go
+++ b/cmd/restic/glob.go
@@ -1,0 +1,152 @@
+// Copyright 2010 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+//
+// Derived from Go's path/filepath glob (src/path/filepath/match.go).
+// Modified so that directory components matched by a wildcard are not
+// followed when they are symbolic links.
+
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"strings"
+)
+
+// globNoFollow is like filepath.Glob, but does not descend into directory
+// symlinks that were matched by a wildcard. Literal path components,
+// including a directory symlink named after a wildcard (for example
+// tmp/*/foo when foo is a symlink to a directory), are still followed.
+// Literal path prefixes that are themselves symlinks are also followed
+// (so a pattern like "symlink/*.txt" keeps working). This prevents
+// Wine-style dosdevices/z: links from expanding include patterns into
+// /proc and exhausting memory (#21790).
+func globNoFollow(pattern string) ([]string, error) {
+	return globNoFollowLimit(pattern, 0, true)
+}
+
+func globNoFollowLimit(pattern string, depth int, followDir bool) ([]string, error) {
+	// Same recursion cap as path/filepath.Glob (CVE-2022-30632).
+	const pathSeparatorsLimit = 10000
+	if depth == pathSeparatorsLimit {
+		return nil, filepath.ErrBadPattern
+	}
+
+	if _, err := filepath.Match(pattern, ""); err != nil {
+		return nil, err
+	}
+	if !globHasMeta(pattern) {
+		if _, err := os.Lstat(pattern); err != nil {
+			return nil, nil
+		}
+		return []string{pattern}, nil
+	}
+
+	dir, file := filepath.Split(pattern)
+	volumeLen := 0
+	if runtime.GOOS == "windows" {
+		volumeLen, dir = cleanGlobPathWindows(dir)
+	} else {
+		dir = cleanGlobPath(dir)
+	}
+
+	if !globHasMeta(dir[volumeLen:]) {
+		return globInDir(dir, file, followDir)
+	}
+	if dir == pattern {
+		return nil, filepath.ErrBadPattern
+	}
+
+	parents, err := globNoFollowLimit(dir, depth+1, followDir)
+	if err != nil {
+		return nil, err
+	}
+	// followDir is per-component: only wildcard-matched directory
+	// components use Lstat (do not follow). A literal component after a
+	// wildcard still uses Stat, matching filepath.Glob for non-wildcard dirs.
+	_, component := filepath.Split(dir)
+	followComponent := !globHasMeta(component)
+	var matches []string
+	for _, parent := range parents {
+		m, err := globInDir(parent, file, followComponent)
+		if err != nil {
+			return nil, err
+		}
+		matches = append(matches, m...)
+	}
+	return matches, nil
+}
+
+func globInDir(dir, pattern string, followDir bool) ([]string, error) {
+	var (
+		fi  os.FileInfo
+		err error
+	)
+	if followDir {
+		fi, err = os.Stat(dir)
+	} else {
+		fi, err = os.Lstat(dir)
+	}
+	if err != nil || !fi.IsDir() {
+		return nil, nil
+	}
+	d, err := os.Open(dir)
+	if err != nil {
+		return nil, nil
+	}
+	defer d.Close()
+
+	names, _ := d.Readdirnames(-1)
+	slices.Sort(names)
+
+	var matches []string
+	for _, n := range names {
+		ok, err := filepath.Match(pattern, n)
+		if err != nil {
+			return matches, err
+		}
+		if ok {
+			matches = append(matches, filepath.Join(dir, n))
+		}
+	}
+	return matches, nil
+}
+
+func cleanGlobPath(path string) string {
+	switch path {
+	case "":
+		return "."
+	case string(filepath.Separator):
+		return path
+	default:
+		return path[:len(path)-1]
+	}
+}
+
+func cleanGlobPathWindows(path string) (prefixLen int, cleaned string) {
+	vollen := len(filepath.VolumeName(path))
+	switch {
+	case path == "":
+		return 0, "."
+	case vollen+1 == len(path) && os.IsPathSeparator(path[len(path)-1]):
+		return vollen + 1, path
+	case vollen == len(path) && len(path) == 2:
+		return vollen, path + "."
+	default:
+		if vollen >= len(path) {
+			vollen = len(path) - 1
+		}
+		return vollen, path[:len(path)-1]
+	}
+}
+
+func globHasMeta(path string) bool {
+	magicChars := `*?[`
+	if runtime.GOOS != "windows" {
+		magicChars = `*?[\`
+	}
+	return strings.ContainsAny(path, magicChars)
+}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

`--files-from` include patterns are expanded with Go's `filepath.Glob`, which follows directory symbolic links. Wine/Proton prefixes contain `dosdevices/z:` links to `/`, so patterns such as `compatdata/*/*/*.cfg*` walk into `/proc` and exhaust memory.

This adds a small glob helper derived from `path/filepath` that:

- does **not** follow directory symlinks matched by a wildcard (the Wine case)
- still follows **literal** path components, including a directory symlink after a wildcard (so `tmp/*/foo/bar.cfg` still matches when `foo` is a symlink to a directory)
- keeps the same 10000-separator recursion cap as `filepath.Glob` (CVE-2022-30632)

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #21790

Checklist
---------

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.