### PR TITLE
rest: reject incomplete REST environment credentials

### DIFF
--- a/changelog/unreleased/issue-22035
+++ b/changelog/unreleased/issue-22035
@@ -1,0 +1,5 @@
+Bugfix: Fail early when REST backend credentials are incomplete
+
+Restic now reports a configuration error when `RESTIC_REST_PASSWORD` is set without `RESTIC_REST_USERNAME` instead of silently ignoring the password for a repository URL that contains only a username.
+
+https://github.com/restic/restic/issues/22035

--- a/internal/backend/backend.go
+++ b/internal/backend/backend.go
@@ -141,3 +141,8 @@ type FileInfo struct {
 type ApplyEnvironmenter interface {
 	ApplyEnvironment(prefix string)
 }
+
+// ValidateEnvironmenter validates a backend configuration before environment values are applied.
+type ValidateEnvironmenter interface {
+	ValidateEnvironment(prefix string) error
+}

--- a/internal/backend/rest/config.go
+++ b/internal/backend/rest/config.go
@@ -74,6 +74,16 @@ func prepareURL(s string) string {
 }
 
 var _ backend.ApplyEnvironmenter = &Config{}
+var _ backend.ValidateEnvironmenter = &Config{}
+
+// ValidateEnvironment checks that REST backend credentials are complete before applying environment values.
+func (cfg *Config) ValidateEnvironment(prefix string) error {
+	_, passwordSet := cfg.URL.User.Password()
+	if !passwordSet && os.Getenv(prefix+"RESTIC_REST_PASSWORD") != "" && os.Getenv(prefix+"RESTIC_REST_USERNAME") == "" {
+		return errors.New("RESTIC_REST_PASSWORD requires RESTIC_REST_USERNAME")
+	}
+	return nil
+}
 
 // ApplyEnvironment saves values from the environment to the config.
 func (cfg *Config) ApplyEnvironment(prefix string) {

--- a/internal/backend/rest/config_test.go
+++ b/internal/backend/rest/config_test.go
@@ -44,6 +44,56 @@ func TestParseConfig(t *testing.T) {
 	test.ParseConfigTester(t, ParseConfig, configTests)
 }
 
+func TestValidateEnvironment(t *testing.T) {
+	tests := []struct {
+		name      string
+		url       string
+		username  string
+		password  string
+		wantError bool
+	}{
+		{
+			name:      "URL username and environment password",
+			url:       "rest:http://user@hostname/",
+			password:  "password",
+			wantError: true,
+		},
+		{
+			name:      "environment password without URL credentials",
+			url:       "rest:http://hostname/",
+			password:  "password",
+			wantError: true,
+		},
+		{
+			name:     "complete URL credentials",
+			url:      "rest:http://user:password@hostname/",
+			password: "password",
+		},
+		{
+			name: "no environment password",
+			url:  "rest:http://user@hostname/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			const prefix = "RESTIC_TEST_"
+			t.Setenv(prefix+"RESTIC_REST_USERNAME", tt.username)
+			t.Setenv(prefix+"RESTIC_REST_PASSWORD", tt.password)
+
+			cfg, err := ParseConfig(tt.url)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = cfg.ValidateEnvironment(prefix)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("ValidateEnvironment() error = %v, want error: %t", err, tt.wantError)
+			}
+		})
+	}
+}
+
 var passwordTests = []struct {
 	input    string
 	expected string

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -529,6 +529,11 @@ func parseConfig(backends *location.Registry, s string, opts options.Options) (s
 	}
 
 	cfg := loc.Config
+	if cfg, ok := cfg.(backend.ValidateEnvironmenter); ok {
+		if err := cfg.ValidateEnvironment(""); err != nil {
+			return "", nil, err
+		}
+	}
 	if cfg, ok := cfg.(backend.ApplyEnvironmenter); ok {
 		cfg.ApplyEnvironment("")
 	}


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

The REST backend now fails early when RESTIC_REST_PASSWORD is set without RESTIC_REST_USERNAME, including when the repository URL contains only a username. This avoids silently ignoring the password and sending an unauthorized request.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #22035

Checklist
---------

- [x] I have added tests for all code changes.
- [ ] I have added documentation for relevant changes (in the manual).
- [x] There\'s a new file in changelog/unreleased/ describing the changes.
- [x] I\'m done! This pull request is ready for review.

Validation: go test ./internal/backend/... ./internal/global

This contribution was prepared with AI assistance and reviewed against the repository\'s contribution guidance.