### PR TITLE
rest: fix RESTIC_REST_PASSWORD being ignored when URL sets only a username

### DIFF
--- a/changelog/unreleased/issue-22035
+++ b/changelog/unreleased/issue-22035
@@ -1,0 +1,12 @@
+Bugfix: Respect `RESTIC_REST_PASSWORD` when the REST URL only sets a username
+
+When a `rest:` repository URL specified a username but no password (e.g.
+`rest:http://user@host:8000/repo`), restic ignored the `RESTIC_REST_PASSWORD`
+environment variable, since it only applied environment credentials when
+neither a username nor a password were present in the URL. This caused
+authentication to fail with a 401 error even though the password was set.
+Restic now falls back to the environment for the username and password
+independently, so either one can come from the URL while the other is
+supplied via `RESTIC_REST_USERNAME` / `RESTIC_REST_PASSWORD`.
+
+https://github.com/restic/restic/issues/22035

--- a/internal/backend/rest/config.go
+++ b/internal/backend/rest/config.go
@@ -78,13 +78,18 @@ var _ backend.ApplyEnvironmenter = &Config{}
 // ApplyEnvironment saves values from the environment to the config.
 func (cfg *Config) ApplyEnvironment(prefix string) {
 	username := cfg.URL.User.Username()
-	_, pwdSet := cfg.URL.User.Password()
+	pwd, pwdSet := cfg.URL.User.Password()
 
-	// Only apply env variable values if neither username nor password are provided.
-	if username == "" && !pwdSet {
-		envName := os.Getenv(prefix + "RESTIC_REST_USERNAME")
-		envPwd := os.Getenv(prefix + "RESTIC_REST_PASSWORD")
+	// Fall back to the environment for whichever of username/password is not
+	// already set in the URL, instead of requiring both to be absent.
+	if username == "" {
+		username = os.Getenv(prefix + "RESTIC_REST_USERNAME")
+	}
+	if !pwdSet {
+		pwd = os.Getenv(prefix + "RESTIC_REST_PASSWORD")
+	}
 
-		cfg.URL.User = url.UserPassword(envName, envPwd)
+	if username != "" || pwd != "" {
+		cfg.URL.User = url.UserPassword(username, pwd)
 	}
 }

--- a/internal/backend/rest/config_test.go
+++ b/internal/backend/rest/config_test.go
@@ -111,3 +111,78 @@ func TestStripPassword(t *testing.T) {
 		})
 	}
 }
+
+func TestApplyEnvironment(t *testing.T) {
+	var applyEnvironmentTests = []struct {
+		name         string
+		url          string
+		envUsername  string
+		envPassword  string
+		wantUsername string
+		wantPassword string
+		wantPwdSet   bool
+	}{
+		{
+			name:         "no credentials anywhere",
+			url:          "http://hostname.foo:1234/",
+			wantUsername: "",
+			wantPassword: "",
+			wantPwdSet:   false,
+		},
+		{
+			name:         "env username and password, no URL credentials",
+			url:          "http://hostname.foo:1234/",
+			envUsername:  "user",
+			envPassword:  "password",
+			wantUsername: "user",
+			wantPassword: "password",
+			wantPwdSet:   true,
+		},
+		{
+			name:         "URL username only, env password fills in",
+			url:          "http://user@hostname.foo:1234/",
+			envPassword:  "password",
+			wantUsername: "user",
+			wantPassword: "password",
+			wantPwdSet:   true,
+		},
+		{
+			name:         "URL username only, no env password set",
+			url:          "http://user@hostname.foo:1234/",
+			wantUsername: "user",
+			wantPassword: "",
+			wantPwdSet:   true,
+		},
+		{
+			name:         "URL has full credentials, env ignored",
+			url:          "http://user:pass@hostname.foo:1234/",
+			envUsername:  "envuser",
+			envPassword:  "envpass",
+			wantUsername: "user",
+			wantPassword: "pass",
+			wantPwdSet:   true,
+		},
+	}
+
+	for _, test := range applyEnvironmentTests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Setenv("RESTIC_REST_USERNAME", test.envUsername)
+			t.Setenv("RESTIC_REST_PASSWORD", test.envPassword)
+
+			cfg := NewConfig()
+			cfg.URL = parseURL(test.url)
+			cfg.ApplyEnvironment("")
+
+			if username := cfg.URL.User.Username(); username != test.wantUsername {
+				t.Errorf("expected username '%s', got '%s'", test.wantUsername, username)
+			}
+			pwd, pwdSet := cfg.URL.User.Password()
+			if pwdSet != test.wantPwdSet {
+				t.Errorf("expected password set: %v, got %v", test.wantPwdSet, pwdSet)
+			}
+			if pwd != test.wantPassword {
+				t.Errorf("expected password '%s', got '%s'", test.wantPassword, pwd)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #22035. `restic diff`... no wait — this fixes the REST backend's
`ApplyEnvironment`, which only applied `RESTIC_REST_USERNAME` /
`RESTIC_REST_PASSWORD` when *both* the URL username and password were
absent. As a result, a repository URL like

    rest:http://user@host:8000/repo

(username in the URL, no password) silently ignored
`RESTIC_REST_PASSWORD`, so restic sent requests with no password and the
server returned 401 Unauthorized — even though the password was set via
the environment exactly as documented.

## Fix

`ApplyEnvironment` now resolves the username and password independently:
whichever one is missing from the URL falls back to its environment
variable. If the URL already supplies both, the URL wins for both and
the environment variables are ignored, same as before.

## Test plan

- [x] Added `TestApplyEnvironment` (`internal/backend/rest/config_test.go`)
      covering: no credentials anywhere, env-only credentials, URL username
      + env password (the reported bug), URL username only with no env
      password, and URL with full credentials (env ignored). Verified the
      new test fails against the pre-fix code and passes against the fix.
- [x] `go build ./...`
- [x] `go test ./internal/backend/... -short`
- [x] `gofmt -l` / `go vet ./internal/backend/rest/...` clean

## Changelog

Added `changelog/unreleased/issue-22035` per `changelog/TEMPLATE`.
