### PR TITLE
global: reject empty repository location files

### DIFF
--- a/changelog/unreleased/issue-22051
+++ b/changelog/unreleased/issue-22051
@@ -1,0 +1,7 @@
+Bugfix: Reject empty repository location files
+
+An empty file passed via `--repository-file` or `RESTIC_REPOSITORY_FILE`
+was treated as the current directory. Restic now reports an error if the
+file is empty or contains only whitespace.
+
+https://github.com/restic/restic/issues/22051

--- a/doc/030_preparing_a_new_repo.rst
+++ b/doc/030_preparing_a_new_repo.rst
@@ -30,7 +30,8 @@ section here.
 For automated backups, restic supports specifying the repository location in the
 environment variable ``RESTIC_REPOSITORY``. Restic can also read the repository
 location from a file specified via the ``--repository-file`` option or the
-environment variable ``RESTIC_REPOSITORY_FILE``.
+environment variable ``RESTIC_REPOSITORY_FILE``. The file must contain a
+repository location; empty or whitespace-only files are rejected.
 
 For automating the supply of the repository password to restic, several options
 exist:

--- a/internal/global/global.go
+++ b/internal/global/global.go
@@ -289,6 +289,9 @@ func readRepo(gopts Options) (string, error) {
 		}
 
 		repo = strings.TrimSpace(string(s))
+		if repo == "" {
+			return "", errors.Fatalf("repository file %s is empty", gopts.RepositoryFile)
+		}
 	}
 
 	return repo, nil

--- a/internal/global/global_test.go
+++ b/internal/global/global_test.go
@@ -42,6 +42,28 @@ func TestReadRepo(t *testing.T) {
 	}
 }
 
+func TestReadRepoEmptyFile(t *testing.T) {
+	for _, tc := range []struct {
+		name    string
+		content string
+	}{
+		{"empty", ""},
+		{"newline", "\n"},
+		{"whitespace", " \t\r\n"},
+		{"utf8-bom", "\xef\xbb\xbf"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			filename := filepath.Join(t.TempDir(), "repository")
+			rtest.OK(t, os.WriteFile(filename, []byte(tc.content), 0600))
+
+			repo, err := readRepo(Options{RepositoryFile: filename})
+			rtest.Assert(t, errors.IsFatal(err), "expected fatal error for empty repository file, got %v", err)
+			rtest.Equals(t, "", repo)
+			rtest.Assert(t, strings.Contains(err.Error(), filename), "error should identify repository file, got %v", err)
+		})
+	}
+}
+
 func TestReadEmptyPassword(t *testing.T) {
 	opts := Options{InsecureNoPassword: true}
 	password, err := readPassword(context.TODO(), opts, "test")


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Reject a repository file that is empty after decoding and trimming whitespace, instead of passing an empty path to the backend and treating the current directory as the repository. The fatal error identifies the file and is returned before opening or initializing a repository.

Add regression cases for empty, newline-only, whitespace-only and BOM-only files, plus a manual clarification and changelog entry.

Validation with Go 1.26.8:
- `go test ./internal/global -count=1` passed. All four new cases failed against the original implementation.
- `golangci-lint` v2.12.2 passed for `./internal/global/...` with the repository configuration.
- `go run github.com/restic/calens@latest` passed.
- Built the CLI and verified all four invalid inputs fail without creating files in the working directory. A valid repository path containing spaces and a trailing newline still initializes successfully.

The full cross-platform/backend test suite was not run locally.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Closes #22051.

Checklist
---------

- [x] I have added tests for all code changes.
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users.
- [x] I'm done! This pull request is ready for review.
