### PR TITLE
docs: add FAQ entry for "stale NFS file handle" on network mounts

### DIFF
--- a/doc/faq.rst
+++ b/doc/faq.rst
@@ -223,6 +223,35 @@ The following may work:
 
     $ restic -r sftp:user@nas:/restic-repo init
 
+Repository on a network filesystem fails with "stale NFS file handle"
+---------------------------------------------------------------------
+
+When the repository is stored on a network filesystem mounted from a consumer
+NAS device or a router with built-in file sharing, restic may retry
+indefinitely with errors similar to the following:
+
+::
+
+    Load(<key/1234567890>, 0, 0) returned error, retrying after 1.234s:
+        open /mnt/nas/restic-repo/keys/1234567890: stale NFS file handle
+
+On Linux, ``stale NFS file handle`` is the generic message for the ``ESTALE``
+error and is also reported for CIFS (SMB) mounts, so it does not necessarily
+indicate that NFS is involved.
+
+The error is usually caused by the file server reporting inode numbers that
+are not stable, which some embedded SMB implementations do. Remounting the
+share does not help in this case. For a CIFS mount, adding the ``noserverino``
+mount option tells the Linux client to generate inode numbers itself instead of
+trusting the server:
+
+::
+
+    //nas/share /mnt/nas cifs credentials=/etc/creds,noserverino 0 0
+
+Please note that this is a workaround for a defect in the file server. If you
+run into this problem, please also report it to the vendor of your NAS device.
+
 Why does restic perform so poorly on Windows?
 ---------------------------------------------
 


### PR DESCRIPTION
What does this PR change? What problem does it solve?
-----------------------------------------------------

Adds a FAQ entry about repositories stored on network filesystems failing with
`stale NFS file handle`.

The entry covers three things:

- that on Linux this message is the generic text for `ESTALE` and is reported
  for CIFS/SMB mounts too, so it does not mean NFS is involved
- that the usual cause is a file server reporting unstable inode numbers, which
  some embedded SMB implementations do, and that remounting does not help
- the `noserverino` mount option as a workaround, plus a note that this is a
  server-side defect worth reporting to the NAS vendor

It is placed next to the existing Synology NAS entry, since it is the same kind
of device-specific workaround.

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

Yes, in #22023. The suggestion there was to document this in the main
documentation, and the response was that it does not belong there but that
something similar to the Synology NAS FAQ entry would be an option. This PR
implements that.

Checklist
---------

- [ ] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [ ] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.

This is a documentation-only change, so there are no tests and no changelog
entry.
