### PR TITLE
Allow skipping folders based on an xattr

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+      - add-skip-dirs
 
   # run tests for all pull requests
   pull_request:

--- a/cmd/restic/cmd_backup.go
+++ b/cmd/restic/cmd_backup.go
@@ -96,7 +96,7 @@ type BackupOptions struct {
 	ReadConcurrency   uint
 	NoScan            bool
 	SkipIfUnchanged   bool
-
+	CompareXattr      string
 	readConcurrencyFlag *pflag.Flag
 }
 
@@ -140,6 +140,7 @@ func (opts *BackupOptions) AddFlags(f *pflag.FlagSet) {
 		f.BoolVar(&opts.ExcludeCloudFiles, "exclude-cloud-files", false, "excludes online-only cloud files (such as OneDrive, iCloud drive, …)")
 	}
 	f.BoolVar(&opts.SkipIfUnchanged, "skip-if-unchanged", false, "skip snapshot creation if identical to parent snapshot")
+	f.StringVar(&opts.CompareXattr, "compare-xattr", "", "skip based on unchanged xattr")
 
 	opts.readConcurrencyFlag = f.Lookup("read-concurrency")
 
@@ -655,6 +656,7 @@ func runBackup(ctx context.Context, opts BackupOptions, gopts global.Options, te
 	arch.SelectByName = selectByNameFilter
 	arch.Select = selectFilter
 	arch.WithAtime = opts.WithAtime
+	arch.CompareXattr = opts.CompareXattr
 
 	arch.Error = func(item string, err error) error {
 		success = false

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -1,6 +1,7 @@
 package archiver
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"os"
@@ -130,8 +131,14 @@ type Archiver struct {
 	// Flags controlling change detection. See doc/040_backup.rst for details.
 	ChangeIgnoreFlags uint
 
+<<<<<<< HEAD
 	// for excluded items
 	ExcludedItem func(path string)
+=======
+	// CompareXattr configures if directories are skipped if the specified xattr
+	// remains consistent between parent and current snapshot
+	CompareXattr string
+>>>>>>> fc7b26107 (Skip checking for files in dirs based on xattr)
 }
 
 // Flags for the ChangeIgnoreFlags bitfield.
@@ -314,6 +321,7 @@ func (arch *Archiver) saveDir(ctx context.Context, snPath string, dir string, me
 		return futureNode{}, err
 	}
 
+	//fmt.Printf("node '%v' with meta '%v' has children: %v\n", treeNode, meta, names)
 	nodes := make([]futureNode, 0, len(names))
 
 	finder := data.NewTreeFinder(previous)
@@ -587,7 +595,27 @@ func (arch *Archiver) save(ctx context.Context, snPath, target string, previous 
 
 	case fi.Mode.IsDir():
 		debug.Log("  %v dir", target)
+		node, err := arch.nodeFromFileInfo(snPath, target, meta, false)
+		if err != nil {
+			return futureNode{}, false, err
+		}
 
+		if previous != nil && !arch.dirChanged(node, previous, arch.ChangeIgnoreFlags) {
+			// if arch.allBlobsPresent(previous) {
+			debug.Log("%v hasn't changed, using old subtree", target)
+			//fmt.Printf("%v hasn't changed, using old subtree (Size: %v Content %v)\n", target, previous.Size, previous.Content)
+			arch.trackItem(snPath, previous, previous, ItemStats{}, time.Since(start))
+
+			// copy subtree
+			node.Subtree = previous.Subtree
+
+			fn = newFutureNodeWithResult(futureNodeResult{
+				snPath: snPath,
+				target: target,
+				node:   node,
+			})
+			return fn, false, nil
+		}
 		snItem := snPath + "/"
 		oldSubtree, err := arch.loadSubtree(ctx, previous)
 		if err != nil {
@@ -656,6 +684,24 @@ func fileChanged(fi *fs.ExtendedFileInfo, node *data.Node, ignoreFlags uint) boo
 	}
 
 	return false
+}
+
+// fileChanged tries to detect whether a file's content has changed compared
+// to the contents of node, which describes the same path in the parent backup.
+// It should only be run for regular files.
+func (arch *Archiver) dirChanged(node, previous *data.Node, ignoreFlags uint) bool {
+	switch {
+	case node == nil:
+		return true
+	case previous.Type != data.NodeTypeDir:
+		// We're only called for dirs, so this is a type change.
+		return true
+	case arch.CompareXattr != "" && bytes.Equal(previous.GetExtendedAttribute(arch.CompareXattr), node.GetExtendedAttribute(arch.CompareXattr)):
+		// if the directories don't actually have the xattr then they shouldn't be skipped based on that
+		return node.GetExtendedAttribute(arch.CompareXattr) == nil
+	}
+
+	return true
 }
 
 // join returns all elements separated with a forward slash.
@@ -889,6 +935,7 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 	if err != nil {
 		return nil, restic.ID{}, nil, err
 	}
+	//fmt.Printf("Looking for changes in paths: %v\n", targets)
 
 	atree, err := newTree(arch.FS, cleanTargets)
 	if err != nil {

--- a/internal/archiver/archiver.go
+++ b/internal/archiver/archiver.go
@@ -131,14 +131,12 @@ type Archiver struct {
 	// Flags controlling change detection. See doc/040_backup.rst for details.
 	ChangeIgnoreFlags uint
 
-<<<<<<< HEAD
 	// for excluded items
 	ExcludedItem func(path string)
-=======
+	
 	// CompareXattr configures if directories are skipped if the specified xattr
 	// remains consistent between parent and current snapshot
 	CompareXattr string
->>>>>>> fc7b26107 (Skip checking for files in dirs based on xattr)
 }
 
 // Flags for the ChangeIgnoreFlags bitfield.
@@ -321,7 +319,6 @@ func (arch *Archiver) saveDir(ctx context.Context, snPath string, dir string, me
 		return futureNode{}, err
 	}
 
-	//fmt.Printf("node '%v' with meta '%v' has children: %v\n", treeNode, meta, names)
 	nodes := make([]futureNode, 0, len(names))
 
 	finder := data.NewTreeFinder(previous)
@@ -600,10 +597,9 @@ func (arch *Archiver) save(ctx context.Context, snPath, target string, previous 
 			return futureNode{}, false, err
 		}
 
-		if previous != nil && !arch.dirChanged(node, previous, arch.ChangeIgnoreFlags) {
+		if previous != nil && !arch.dirChanged(node, previous) {
 			// if arch.allBlobsPresent(previous) {
 			debug.Log("%v hasn't changed, using old subtree", target)
-			//fmt.Printf("%v hasn't changed, using old subtree (Size: %v Content %v)\n", target, previous.Size, previous.Content)
 			arch.trackItem(snPath, previous, previous, ItemStats{}, time.Since(start))
 
 			// copy subtree
@@ -689,7 +685,7 @@ func fileChanged(fi *fs.ExtendedFileInfo, node *data.Node, ignoreFlags uint) boo
 // fileChanged tries to detect whether a file's content has changed compared
 // to the contents of node, which describes the same path in the parent backup.
 // It should only be run for regular files.
-func (arch *Archiver) dirChanged(node, previous *data.Node, ignoreFlags uint) bool {
+func (arch *Archiver) dirChanged(node, previous *data.Node) bool {
 	switch {
 	case node == nil:
 		return true
@@ -935,7 +931,6 @@ func (arch *Archiver) Snapshot(ctx context.Context, targets []string, opts Snaps
 	if err != nil {
 		return nil, restic.ID{}, nil, err
 	}
-	//fmt.Printf("Looking for changes in paths: %v\n", targets)
 
 	atree, err := newTree(arch.FS, cleanTargets)
 	if err != nil {

--- a/internal/archiver/archiver_test.go
+++ b/internal/archiver/archiver_test.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/google/go-cmp/cmp"
+	"github.com/pkg/xattr"
 	"github.com/restic/restic/internal/backend"
 	"github.com/restic/restic/internal/backend/mem"
 	"github.com/restic/restic/internal/checker"
@@ -1045,6 +1046,107 @@ func TestArchiverSaveDirIncremental(t *testing.T) {
 	}
 }
 
+func TestDirChanged(t *testing.T) {
+	var tests = []struct {
+		Name            string
+		GetCurrentNode  func(t testing.TB, localFS *fs.Local, dir string) *data.Node
+		GetPreviousNode func(t testing.TB, localFS *fs.Local, dir string) *data.Node
+		CompareXattr    string
+		DirChanged      bool
+	}{
+		{
+			Name: "nil node",
+			GetCurrentNode: func(t testing.TB, localFS *fs.Local, dir string) *data.Node {
+				return nil
+			},
+			GetPreviousNode: func(t testing.TB, localFS *fs.Local, dir string) *data.Node {
+				return nodeFromFile(t, localFS, dir)
+			},
+			CompareXattr: "foo",
+			DirChanged:   true,
+		},
+		{
+			Name: "same xattr",
+			GetPreviousNode: func(t testing.TB, localFS *fs.Local, dir string) *data.Node {
+				node := nodeFromFile(t, localFS, dir)
+				node.ExtendedAttributes = append(node.ExtendedAttributes, data.ExtendedAttribute{
+					Name:  "foo",
+					Value: []byte("bar"),
+				})
+				return node
+			},
+			CompareXattr: "foo",
+			DirChanged:   false,
+		},
+		{
+			Name: "changed type",
+			GetPreviousNode: func(t testing.TB, localFS *fs.Local, dir string) *data.Node {
+				node := nodeFromFile(t, localFS, dir)
+				node.ExtendedAttributes = append(node.ExtendedAttributes, data.ExtendedAttribute{
+					Name:  "foo",
+					Value: []byte("bar"),
+				})
+				node.Type = data.NodeTypeFile
+				return node
+			},
+			CompareXattr: "foo",
+			DirChanged:   true,
+		},
+		{
+			Name: "added xattr",
+			GetPreviousNode: func(t testing.TB, localFS *fs.Local, dir string) *data.Node {
+				return nodeFromFile(t, localFS, dir)
+			},
+			CompareXattr: "foo",
+			DirChanged:   true,
+		},
+		{
+			Name: "changed xattr",
+			GetPreviousNode: func(t testing.TB, localFS *fs.Local, dir string) *data.Node {
+				node := nodeFromFile(t, localFS, dir)
+				node.ExtendedAttributes = append(node.ExtendedAttributes, data.ExtendedAttribute{
+					Name:  "foo",
+					Value: []byte("foobar"),
+				})
+				return node
+			},
+			CompareXattr: "foo",
+			DirChanged:   true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.Name, func(t *testing.T) {
+			dir := rtest.TempDir(t)
+
+			repo := &blobCountingRepo{
+				archiverRepo: repository.TestRepository(t),
+				saved:        make(map[restic.BlobHandle]uint),
+			}
+
+			localFS := &fs.Local{}
+			testFS := fs.Track{FS: localFS}
+
+			previousNode := test.GetPreviousNode(t, localFS, dir)
+
+			currentNode := nodeFromFile(t, localFS, dir)
+			currentNode.ExtendedAttributes = append(currentNode.ExtendedAttributes, data.ExtendedAttribute{
+				Name:  "foo",
+				Value: []byte("bar"),
+			})
+			if test.GetCurrentNode != nil {
+				currentNode = test.GetCurrentNode(t, localFS, dir)
+			}
+
+			arch := New(repo, testFS, Options{})
+			arch.summary = &Summary{}
+			arch.CompareXattr = test.CompareXattr
+
+			rtest.Equals(t, arch.dirChanged(currentNode, previousNode), test.DirChanged)
+		})
+	}
+}
+
 // bothZeroOrNeither fails the test if only one of exp, act is zero.
 func bothZeroOrNeither(tb testing.TB, exp, act uint64) {
 	tb.Helper()
@@ -1861,11 +1963,13 @@ func checkSnapshotStats(t *testing.T, sn *data.Snapshot, stat Summary) {
 
 func TestArchiverParent(t *testing.T) {
 	var tests = []struct {
-		src         TestDir
-		modify      func(path string)
-		opts        SnapshotOptions
-		statInitial Summary
-		statSecond  Summary
+		src            TestDir
+		setup          func(arch *Archiver, path string)
+		modify         func(path string)
+		SkipForWindows bool
+		opts           SnapshotOptions
+		statInitial    Summary
+		statSecond     Summary
 	}{
 		{
 			src: TestDir{
@@ -1909,6 +2013,9 @@ func TestArchiverParent(t *testing.T) {
 					"targetfile2": TestFile{Content: string(rtest.Random(888, 1235))},
 				},
 			},
+			setup: func(arch *Archiver, path string) {
+				arch.CompareXattr = "invalid.xattr"
+			},
 			statInitial: Summary{
 				Files:          ChangeStats{2, 0, 0},
 				Dirs:           ChangeStats{1, 0, 0},
@@ -1928,7 +2035,68 @@ func TestArchiverParent(t *testing.T) {
 				},
 				"targetfile2": TestFile{Content: string(rtest.Random(888, 1235))},
 			},
+			setup: func(arch *Archiver, path string) {
+				arch.CompareXattr = "invalid.xattr"
+			},
 			modify: func(path string) {
+				remove(t, filepath.Join(path, "targetDir", "targetfile"))
+				save(t, filepath.Join(path, "targetfile2"), []byte("foobar"))
+			},
+			statInitial: Summary{
+				Files:          ChangeStats{2, 0, 0},
+				Dirs:           ChangeStats{1, 0, 0},
+				ProcessedBytes: 2469,
+				ItemStats:      ItemStats{2, 0xe13, 0xcf8, 2, 0, 0},
+			},
+			statSecond: Summary{
+				Files:          ChangeStats{0, 1, 0},
+				Dirs:           ChangeStats{0, 1, 0},
+				ProcessedBytes: 6,
+				ItemStats:      ItemStats{1, 0x305, 0x233, 2, 0, 0},
+			},
+		},
+		{
+			src: TestDir{
+				"targetDir": TestDir{
+					"targetfile": TestFile{Content: string(rtest.Random(888, 1234))},
+				},
+				"targetfile2": TestFile{Content: string(rtest.Random(888, 1235))},
+			},
+			setup: func(arch *Archiver, path string) {
+				arch.CompareXattr = "user.foo"
+				rtest.OK(t, xattr.Set(filepath.Join(path, "targetDir"), "user.foo", []byte("bar")))
+			},
+			modify: func(path string) {
+				remove(t, filepath.Join(path, "targetDir", "targetfile"))
+				save(t, filepath.Join(path, "targetfile2"), []byte("foobar"))
+			},
+			SkipForWindows: true,
+			statInitial: Summary{
+				Files:          ChangeStats{2, 0, 0},
+				Dirs:           ChangeStats{1, 0, 0},
+				ProcessedBytes: 2469,
+				ItemStats:      ItemStats{2, 0xe13, 0xcf8, 2, 0, 0},
+			},
+			statSecond: Summary{
+				Files:          ChangeStats{0, 1, 0},
+				Dirs:           ChangeStats{0, 0, 1},
+				ProcessedBytes: 6,
+				ItemStats:      ItemStats{1, 0x305, 0x233, 2, 0, 0},
+			},
+		},
+		{
+			src: TestDir{
+				"targetDir": TestDir{
+					"targetfile": TestFile{Content: string(rtest.Random(888, 1234))},
+				},
+				"targetfile2": TestFile{Content: string(rtest.Random(888, 1235))},
+			},
+			setup: func(arch *Archiver, path string) {
+				arch.CompareXattr = "user.foo"
+				rtest.OK(t, xattr.Set(filepath.Join(path, "targetDir"), "user.foo", []byte("bar")))
+			},
+			modify: func(path string) {
+				rtest.OK(t, xattr.Set(filepath.Join(path, "targetDir"), "user.foo", []byte("foobar")))
 				remove(t, filepath.Join(path, "targetDir", "targetfile"))
 				save(t, filepath.Join(path, "targetfile2"), []byte("foobar"))
 			},
@@ -1950,6 +2118,11 @@ func TestArchiverParent(t *testing.T) {
 	for _, test := range tests {
 		t.Run("", func(t *testing.T) {
 			ctx := t.Context()
+			if test.SkipForWindows && runtime.GOOS == "windows" {
+				t.Skip("Skipping this test for windows")
+			}
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
 
 			tempdir, repo := prepareTempdirRepoSrc(t, test.src)
 
@@ -1959,6 +2132,9 @@ func TestArchiverParent(t *testing.T) {
 			}
 
 			arch := New(repo, testFS, Options{})
+			if test.setup != nil {
+				test.setup(arch, tempdir)
+			}
 
 			back := rtest.Chdir(t, tempdir)
 			defer back()

--- a/internal/fs/node_xattr.go
+++ b/internal/fs/node_xattr.go
@@ -4,6 +4,8 @@ package fs
 
 import (
 	"os"
+	"slices"
+	"strings"
 	"syscall"
 
 	"github.com/restic/restic/internal/data"
@@ -23,6 +25,14 @@ func getxattr(path, name string) ([]byte, error) {
 // given path in the file system.
 func listxattr(path string) ([]string, error) {
 	l, err := xattr.LList(path)
+	if env := os.Getenv("OS_XATTR"); env != "" {
+		for _, xattr := range strings.Split(env, ",") {
+			xattr = strings.TrimSpace(xattr)
+			if xattr != "" && !slices.Contains(l, xattr) {
+				l = append(l, xattr)
+			}
+		}
+	}
 	return l, handleXattrErr(err)
 }
 

--- a/internal/fs/node_xattr.go
+++ b/internal/fs/node_xattr.go
@@ -25,14 +25,13 @@ func getxattr(path, name string) ([]byte, error) {
 // given path in the file system.
 func listxattr(path string) ([]string, error) {
 	l, err := xattr.LList(path)
-	if env := os.Getenv("OS_XATTR"); env != "" {
-		for _, xattr := range strings.Split(env, ",") {
-			xattr = strings.TrimSpace(xattr)
-			if xattr != "" && !slices.Contains(l, xattr) {
-				l = append(l, xattr)
-			}
+	for _, xname := range strings.Split(os.Getenv("OS_XATTR"), ",") {
+		xname = strings.TrimSpace(xname)
+		if xname != "" && !slices.Contains(l, xname) {
+			l = append(l, xname)
 		}
 	}
+	slices.Sort(l)
 	return l, handleXattrErr(err)
 }
 


### PR DESCRIPTION
<!--
Thank you very much for contributing code or documentation to restic! Please
fill out the following questions to make it easier for us to review your
changes.
-->

What does this PR change? What problem does it solve?
-----------------------------------------------------

At CERN, we run one of our backup appliances using restic, and we currently backup 4 billions of files to more than 50,000 restic repositories, making a total of 10PB handled by the system.

Right now, `restic` needs to crawl the entire filesystem when performing a backup in order to check which entries have changed and need to be stored. Having one single change on a 17 million dataset implies traversing all the entries, which adds noticeable metadata load on mounted filesystems backed by distributed storage systems. 

Some storage platforms like CephFS recursively update extended attributes on parent directories whenever a file changes. We can use this to skip directories when we know that nothing inside them has changed since the previous snapshot, regardless of how deeply nested the files are.

Therefore, this PR aims to leverage those recursive mtimes in filesystems that support them to avoid traversing directory trees that are unmodified, improving backup speed and reducing the impact on production backend.

For files, we already do an initial `stat` to compare metadata and avoid an expensive read of the file. The implementation basically looks like this:

```go
if previous != nil && !fileChanged(...) {
	node, err := arch.nodeFromFileInfo(...) // metadata info
	node.Content = previous.Content         // copy content from previous snapshot
}
```

The logic would be similar for directories, where the main benefit would be skipping an entire branch and avoiding all the unnecessary `stat` calls below it.

```go
if previous != nil && !arch.dirChanged(node, previous) {
	node, err := arch.nodeFromFileInfo(...)
	node.Subtree = previous.Subtree // reuse subtree from previous snapshot
}
```

Here, `dirChanged` compares an xattr specified through the new `--compare-xattr` flag. This leaves the storage-specific xattr selection to the user. For example, with CephFS, the backup could be run as:

```bash
restic backup --compare-xattr ceph.dir.rctime
```

For this to work, a few small changes had to be made to how nodes handle extended attributes. On these storage systems, restic currently does not store these xattrs because `xattr.llist` returns an empty list, as the attributes are not exposed through the normal listing mechanism.

We therefore need to know in advance which attribute names we want to track. This was addressed by appending a list of xattrs specified in the `OS_XATTR` environment variable to the list returned by `xattr.llist`.

Another improvement this PR provides is to parallelise the fetching of extended attributes. On a local filesystem this does not make much difference, but distributed storage systems typically separate metadata from the actual file data. In the case of CephFS, requests are handled by Metadata Servers (MDS), which can process multiple metadata queries concurrently. As a result, there is a significant performance benefit when these `getfattr` requests are issued in parallel. Since before restic wouldn't track the extended attributes at all, this was never a concern. In our testing, this improvement offers a 30% speed-up while fetching the extended attributes.

How was this PR tested? 
-----------------------------------------------------

Decided to add this section because extensive tests of this feature were done.

Testing was done by continuously backing up the git repo of the linux kernel. It was chosen because it has around 100k files over 6k directories. A benefit of choosing a git repo source is that we can simulate valid modifications by simply walking the commit tree and also brings full reproducibility.

Thus, a test iteration would use two copies of the same repository: one running the latest `restic`, and one running these changes.

| Step | Modified `restic` | Latest `restic` |
|---|---|---|
| 1. Reset repository | `git checkout HEAD~N` |  |
| 2. Backup | `restic backup --compare-xattr ...` | `restic backup ...` |
| 3. Restore | `restic restore ...` | `restic restore ...` |
| 4. Check Git state | `git status` | `git status` |
| 5. Check Git objects | `git fsck` | `git fsck` |
| 6. Compare restores | `rsync -lrciIn A/ B/` | |

All integrity checks should return no errors or differences. In particular, the final `rsync` comparison should produce no output.

Here is a snippet of the last month of testing. Each test takes around 40 mins, because of the large git repositories.

What you can see in this plot is that we ran more than 1000 tests that were all successful and show that the changes still lead to the exact same restic state, i.e we get the exact same amount of data added, files/dirs new and changed and that all are still valid. But we see a massive gain of 20x performance both in terms of backup duration and amount of files processed.

<img width="2314" height="1099" alt="Screenshot From 2026-09-16 11-44-22" src="https://github.com/user-attachments/assets/fd355968-aca1-432f-93f7-c9df321ab743" />
After a succesfull testing period, this feature is currently in production at CERN. 

Was the change previously discussed in an issue or on the forum?
----------------------------------------------------------------

A long time ago this was discussed in #3648. Here, two problems were raised:
 - The statistics won't line up. For example now running `restic snapshots`, the size will not be correct. This is because the size we compute = `total_bytes_processed`. Since now we are processing a lot less data by skipping, these numbers no longer match. Technically these storages also expose recursive sizes, which could be displayed instead, but this adds a lot of bookkeeping and storage specific implementation. For CephFS it would be knowing that this number corresponds exactly to `ceph.dir.rbytes`
 - The scanner does not skip anything, but since it is run only for statistics in theory this can be toggled off when runnign the backup that skips, since the statistics of the backup itself wouldn't be entirely accurate in the first place
 - In general, we conclude that are two assumible caveats, taking into account the massive improvement this feature brings. 

Checklist
---------

<!--
You do not need to check all the boxes below all at once. Feel free to take
your time and add more commits. If you're done and ready for review, please
check the last box. Enable a checkbox by replacing [ ] with [x].

Please always follow these steps:
- Read the [contribution guidelines](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#providing-patches).
- Enable [maintainer edits](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork).
- Run `gofmt` on the code in all commits.
- Format all commit messages in the same style as [the other commits in the repository](https://github.com/restic/restic/blob/master/CONTRIBUTING.md#git-commits).
-->

- [x] I have added tests for all code changes, see [writing tests](https://restic.readthedocs.io/en/stable/090_participating.html#writing-tests)
- [x] I have added documentation for relevant changes (in the manual).
- [x] There's a new file in `changelog/unreleased/` that describes the changes for our users (see [template](https://github.com/restic/restic/blob/master/changelog/TEMPLATE)).
- [x] I'm done! This pull request is ready for review.